### PR TITLE
Change python version for RTD docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,18 +9,14 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
+    python: "mambaforge-22.9"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 conda:
-    environment: ci/environment.yml
+  environment: ci/environment.yml
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:


### PR DESCRIPTION
RTD fails to build the documentation with this error:

![Screenshot 2024-09-04 at 12 24 19 PM](https://github.com/user-attachments/assets/4205d04a-a052-4138-b673-34184e4313de)

I haven't seen the weird `virtualenv` error when building the `roms-tools` docs, so I'm switching to the same python version that we are using in the ROMS-Tools `.readthedocs.yaml` 