### PR TITLE
Add readthedocs-sphinx-ext to conda env

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -19,5 +19,7 @@ dependencies:
   - sphinx-book-theme
   - sphinxcontrib-bibtex
   - myst-parser
+  - pip:
+    - readthedocs-sphinx-ext
   # for running jupyter notebooks
   - ipykernel


### PR DESCRIPTION
![Screenshot 2024-09-04 at 1 21 16 PM](https://github.com/user-attachments/assets/1c486d98-09a6-4600-95e6-7ac7f7845231)

Now RTD complains about something else. Apparently it can't import `cstar` even though I have put 
```
import os
import sys

sys.path.insert(0, os.path.abspath("../"))
```
at the top of `docs.conf.py`. This is different from
```
pip install -e .
```
that happens in the CI test, but the first solution worked for `roms-tools`.

Let's try if adding the `readthedocs-sphinx-ext` helps.