### PR TITLE
Separate conda environment for building the docs

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -21,6 +21,8 @@ jobs:
             python=${{ matrix.python-version }}
       - name: Install C-Star
         shell: micromamba-shell {0}
+        run: |
+           python - V
       - name: Build Docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -16,14 +16,11 @@ jobs:
           cache-downloads: true
           cache-environment: true
           micromamba-version: 'latest'
-          environment-file: ci/environment.yml
+          environment-file: docs/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
       - name: Install C-Star
         shell: micromamba-shell {0}
-        run: |
-           python - V
-           python -m pip install -e . --no-deps --force-reinstall
       - name: Build Docs
         shell: bash -l {0}
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ sphinx:
   configuration: docs/conf.py
 
 conda:
-  environment: ci/environment.yml
+  environment: docs/environment.yml
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,13 +13,5 @@ dependencies:
   - mpich
   - xarray
   - netCDF4
-  # docs
-  - sphinx
-  - nbsphinx
-  - sphinx-book-theme
-  - sphinxcontrib-bibtex
-  - myst-parser
-  - pip:
-    - readthedocs-sphinx-ext
   # for running jupyter notebooks
   - ipykernel

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,6 @@ This conda environment is useful for any of the following steps:
 
 1. Running the example notebooks
 2. Contributing code and running the testing suite
-3. Building the documentation locally
 
 
 ## Running the tests
@@ -37,10 +36,13 @@ Some things will automatically be reformatted, others need manual fixes. Follow 
 
 ## Building the documentation locally
 
-Activate the environment:
+There is a separate conda environment for building the docs.
+Install and activate the environment:
 
 ```
-conda activate cstar_env
+cd C-Star
+conda env create -f docs/environment.yml
+conda activate cstar-docs
 ```
 Then navigate to the docs folder and build the docs via:
 ```

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,17 @@
+name: cstar-docs
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python>=3.10
+  - pooch
+  - pyyaml
+  # docs
+  - sphinx
+  - nbsphinx
+  - sphinx-book-theme
+  - sphinxcontrib-bibtex
+  - myst-parser
+  - pip:
+    - readthedocs-sphinx-ext
+    - -e "."

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,6 +6,8 @@ dependencies:
   - python>=3.10
   - pooch
   - pyyaml
+  - pip
+  - ipython
   # docs
   - sphinx
   - nbsphinx
@@ -14,4 +16,4 @@ dependencies:
   - myst-parser
   - pip:
     - readthedocs-sphinx-ext
-    - -e "."
+    - -e "../."


### PR DESCRIPTION
Another attempt to fix the RTD build, this time with a different approach. I added a separate conda environment for building the documentation (that is cleaner anyway), and that conda environment installs the package C-Star itself.

Let's see if this works.