### PR TITLE
Simplify `docs/conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,11 +6,6 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath("../"))
-
 project = "C-Star"
 copyright = "2024, [C]Worthy"
 author = "C-Star developers"


### PR DESCRIPTION
Another attempt to solve issue #66. 

This PR undoes the modification of the Python module search path in `docs/conf.py`. This should have been really part of #65, when we switched to installing C-Star as part of the conda environment.