### PR TITLE
Update environments

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -23,7 +23,7 @@ jobs:
         shell: micromamba-shell {0}
         run: |
            python - V
-           python -m pip install -e . --no-deps --force-reinstall
+           python -m pip install -e . --force-reinstall
       - name: Build Docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,12 +35,6 @@ jobs:
           conda info
           printenv
 
-        #Necessary to correctly install roms-tool in the next step
-      - name: Upgrade pip, setuptools, and wheel
-        shell: micromamba-shell {0}        
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-
       - name: Install C-Star
         shell: micromamba-shell {0}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,17 +41,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
 
-        # Install roms-tools directly from GitHub to have the latest version
-      - name: Install roms_tools
-        shell: micromamba-shell {0}
-        run: |
-          python -m pip install git+https://github.com/CWorthy-ocean/roms-tools.git
-    
       - name: Install C-Star
         shell: micromamba-shell {0}
         run: |
            python - V
-           python -m pip install -e . --force-reinstall --no-deps
+           python -m pip install -e . --force-reinstall
 
       - name: Running Tests
         shell: micromamba-shell {0}        

--- a/ci/environment_hpc.yml
+++ b/ci/environment_hpc.yml
@@ -5,9 +5,6 @@ dependencies:
   - python>=3.10
   - coverage
   - numpy
-  - compilers
-  - netcdf-fortran
-  - mpich
   - xarray
   - netCDF4
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-dateutil>=2.8.2",
     "PyYAML==6.0.2",
     "pooch>=1.8.1",
+    "roms_tools[dask]>=1.3.0"
 ]
 
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]


### PR DESCRIPTION
This PR updates the pyproject.toml file to include roms_tools as a dependency, and removes direct install of roms_tools from github in the workflows/tests.yaml workflow. It also removes any direct dependencies of C-Star from ci/environment.yml (as these are handled by pip install/pyproject.toml) and includes a new ci/environment_hpc.yml for using on systems where conda is not needed to manage non-python dependencies such as netcdf-fortran.