### PR TITLE
Split `ROMSComponent.input_datasets` attribute up

### DIFF
--- a/cstar/base/__init__.py
+++ b/cstar/base/__init__.py
@@ -1,4 +1,5 @@
-from cstar.base.component import Component, Discretization
+from cstar.base.component import Component
+from cstar.base.discretization import Discretization
 from cstar.base.base_model import BaseModel
 from cstar.base.additional_code import AdditionalCode
 from cstar.base.input_dataset import InputDataset

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -3,7 +3,6 @@ import tempfile
 from typing import Optional, List
 from pathlib import Path
 from cstar.base.datasource import DataSource
-from cstar.base.base_model import BaseModel
 from cstar.base.utils import _clone_and_checkout, _list_to_concise_str
 
 
@@ -27,8 +26,6 @@ class AdditionalCode:
 
     Attributes:
     -----------
-    base_model: BaseModel
-        The base model with which this additional code is associated
     source: DataSource
         Describes the location and type of source data (e.g. repository,directory)
     subdir: str
@@ -59,7 +56,6 @@ class AdditionalCode:
 
     def __init__(
         self,
-        base_model: BaseModel,
         location: str,
         subdir: str = "",
         checkout_target: Optional[str] = None,
@@ -71,8 +67,6 @@ class AdditionalCode:
 
         Parameters:
         -----------
-        base_model: BaseModel
-            The base model with which this additional code is associated
         location: str
             url or path pointing to the additional code directory or repository, used to set `source` attribute
         subdir: str
@@ -94,7 +88,6 @@ class AdditionalCode:
 
         """
 
-        self.base_model: BaseModel = base_model
         self.source: DataSource = DataSource(location)
         self.subdir: str = subdir
         self.checkout_target: Optional[str] = checkout_target
@@ -110,7 +103,6 @@ class AdditionalCode:
     def __str__(self) -> str:
         base_str = self.__class__.__name__ + "\n"
         base_str += "-" * (len(base_str) - 1)
-        base_str += f"\nBase model: {self.base_model.name}"
         base_str += f"\nLocation: {self.source.location}"
         base_str += f"\nsubdirectory: {self.subdir}"
         base_str += f"\nWorking path: {self.working_path}"
@@ -132,7 +124,6 @@ class AdditionalCode:
     def __repr__(self) -> str:
         # Constructor-style section:
         repr_str = f"{self.__class__.__name__}("
-        repr_str += f"\nbase_model = <{self.base_model.__class__.__name__} instance>,"
         repr_str += f"\nlocation = {self.source.location!r},"
         repr_str += f"\nsubdir = {self.subdir!r}"
         if hasattr(self, "checkout_target"):

--- a/cstar/base/component.py
+++ b/cstar/base/component.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Optional, TYPE_CHECKING, Sequence
+from typing import Optional, TYPE_CHECKING, get_type_hints
 
 from cstar.base.base_model import BaseModel
-from cstar.base.input_dataset import InputDataset
-from cstar.base.utils import _list_to_concise_str
 
 if TYPE_CHECKING:
     from cstar.base.additional_code import AdditionalCode
@@ -11,63 +9,55 @@ if TYPE_CHECKING:
 
 class Component(ABC):
     """
-    A model component that contributes to a unique Case instance.
+     A model component that contributes to a unique Case instance.
 
-    Attributes:
-    ----------
-    base_model: BaseModel
-        An object pointing to the unmodified source code of a model handling an individual
-        aspect of the simulation such as biogeochemistry or ocean circulation
-    additional_code: AdditionalCode
-        Additional code contributing to a unique instance of a base model,
-        e.g. namelists, source modifications, etc.
-    input_datasets: list of InputDatasets
-        Any spatiotemporal data needed to run this instance of the base model
-        e.g. initial conditions, surface forcing, etc.
+     Attributes:
+     ----------
+     base_model: BaseModel
+         An object pointing to the unmodified source code of a model handling an individual
+         aspect of the simulation such as biogeochemistry or ocean circulation
     discretization: Discretization
-        Any information related to the discretization of this Component
-        e.g. time step, number of vertical levels, etc.
+         Any information related to the discretization of this Component
+         e.g. time step, number of vertical levels, etc.
+     additional_code: AdditionalCode
+         Additional code contributing to a unique instance of a base model,
+         e.g. namelists, source modifications, etc.
 
-    Methods:
-    -------
-    build()
-        Compile any component-specific code on this machine
-    pre_run()
-        Execute any pre-processing actions necessary to run this component
-    run()
-        Run this component
-    post_run()
-        Execute any post-processing actions associated with this component
+     Methods:
+     -------
+     build()
+         Compile any component-specific code on this machine
+     pre_run()
+         Execute any pre-processing actions necessary to run this component
+     run()
+         Run this component
+     post_run()
+         Execute any post-processing actions associated with this component
     """
 
     base_model: BaseModel
-    additional_code: Optional["AdditionalCode"]
-    input_datasets: Sequence[InputDataset]
     discretization: Optional["Discretization"]
+    additional_code: Optional["AdditionalCode"]
 
     def __init__(
         self,
         base_model: BaseModel,
         additional_code: Optional["AdditionalCode"] = None,
-        input_datasets: Optional[Sequence["InputDataset"]] = None,
         discretization: Optional["Discretization"] = None,
     ):
         """
-        Initialize a Component object from a base model and any additional_code or input_datasets
+        Initialize a Component object from a base model and any discretization information and additional_code
 
         Parameters:
         -----------
         base_model: BaseModel
             An object pointing to the unmodified source code of a model handling an individual
             aspect of the simulation such as biogeochemistry or ocean circulation
+        discretization: Discretization (Optional, default None)
+            Any information related to the discretization of this Component (e.g. time step)
         additional_code: AdditionalCode (Optional, default None)
             Additional code contributing to a unique instance of a base model,
             e.g. namelists, source modifications, etc.
-        input_datasets: list of InputDatasets (Optional, default [])
-            Any spatiotemporal data needed to run this instance of the base model
-            e.g. initial conditions, surface forcing, etc.
-        discretization: Discretization (Optional, default None)
-            Any information related to the discretization of this Component (e.g. time step)
 
         Returns:
         --------
@@ -80,8 +70,81 @@ class Component(ABC):
             )
         self.base_model = base_model
         self.additional_code = additional_code or None
-        self.input_datasets = [] if input_datasets is None else input_datasets
         self.discretization = discretization or None
+
+    @classmethod
+    def from_dict(cls, component_dict):
+        """docstring"""
+
+        base_model_entry = component_dict.get("base_model", None)
+        if base_model_entry is None:
+            raise ValueError("Component 'base_model' entry is missing.")
+
+        # BaseModel
+        base_model_class = get_type_hints(cls).get("base_model")
+        if isinstance(base_model_entry, base_model_class):
+            base_model = base_model_entry
+        elif isinstance(base_model_entry, dict):
+            base_model = base_model_class(**base_model_entry)
+
+        # AdditionalCode
+        additional_code_entry = component_dict.get("additional_code", None)
+        if isinstance(additional_code_entry, AdditionalCode) or (
+            additional_code_entry is None
+        ):
+            additional_code = additional_code_entry
+        elif isinstance(additional_code_entry, dict):
+            additional_code = AdditionalCode(**additional_code_entry)
+
+        # Discretization
+        discretization_entry = component_dict.get("discretization", None)
+        discretization_class = get_type_hints(cls).get("discretization")
+        if isinstance(discretization_entry, discretization_class) or (
+            discretization_entry is None
+        ):
+            discretization = discretization_entry
+        elif isinstance(discretization_entry, dict):
+            discretization = discretization_class(**discretization_entry)
+
+        return cls(
+            base_model=base_model,
+            additional_code=additional_code,
+            discretization=discretization,
+        )
+
+    def to_dict(self) -> dict:
+        component_dict = {}
+
+        # BaseModel
+        base_model_info = {}
+        base_model_info["name"] = self.base_model.name
+        base_model_info["source_repo"] = self.base_model.source_repo
+        base_model_info["checkout_target"] = self.base_model.checkout_target
+
+        component_dict["base_model"] = base_model_info
+
+        # Discretization
+        if self.discretization is not None:
+            discretization_info = {}
+            for thisattr in vars(self.discretization).keys():
+                discretization_info[thisattr] = getattr(self.discretization, thisattr)
+            component_dict["discretization"] = discretization_info
+
+        # AdditionalCode
+        if self.additional_code is not None:
+            additional_code_info: dict = {}
+            additional_code_info["location"] = self.additional_code.source.location
+            additional_code_info["subdir"] = self.additional_code.subdir
+            additional_code_info["checkout_target"] = (
+                self.additional_code.checkout_target
+            )
+            if self.additional_code.source_mods is not None:
+                additional_code_info["source_mods"] = self.additional_code.source_mods
+            if self.additional_code.namelists is not None:
+                additional_code_info["namelists"] = self.additional_code.namelists
+
+            component_dict["additional_code"] = additional_code_info
+        return component_dict
 
     def __str__(self) -> str:
         # Header
@@ -95,12 +158,9 @@ class Component(ABC):
 
         NAC = 0 if self.additional_code is None else 1
 
-        NID = len(self.input_datasets)
-
         base_str += (
             f"\n{NAC} AdditionalCode instances (query using Component.additional_code)"
         )
-        base_str += f"\n{NID} Input datasets (query using Component.input_datasets)"
         if hasattr(self, "discretization") and self.discretization is not None:
             base_str += "\n\nDiscretization:\n"
             base_str += self.discretization.__str__()
@@ -116,11 +176,6 @@ class Component(ABC):
             repr_str += f"\nadditional_code = <{self.additional_code.__class__.__name__} instance>, "
         else:
             repr_str += "\n additional_code = None"
-        ID_list = []
-        for i, inp in enumerate(self.input_datasets):
-            ID_list.append(f"<{inp.__class__.__name__} from {inp.source.basename}>")
-
-        repr_str += f"\ninput_datasets = {_list_to_concise_str(ID_list,pad=18,items_are_strs=False)}"
         repr_str += f"\ndiscretization = {self.discretization.__repr__()}"
         repr_str += "\n)"
 

--- a/cstar/case.py
+++ b/cstar/case.py
@@ -3,25 +3,19 @@ import warnings
 import datetime as dt
 import dateutil.parser
 from pathlib import Path
-from typing import List, Type, Any, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
-from cstar.base.component import Component, Discretization
-from cstar.base.additional_code import AdditionalCode
+from cstar.base.component import Component
 from cstar.base.environment import _CSTAR_SYSTEM_MAX_WALLTIME
 from cstar.base.utils import _dict_to_tree
-from cstar.base.input_dataset import InputDataset
 from cstar.roms.input_dataset import (
     ROMSInputDataset,
-    ROMSModelGrid,
-    ROMSInitialConditions,
-    ROMSTidalForcing,
-    ROMSBoundaryForcing,
-    ROMSSurfaceForcing,
 )
-from cstar.roms.component import ROMSComponent, ROMSDiscretization
+from cstar.roms.component import ROMSComponent
+from cstar.marbl.component import MARBLComponent
 
 if TYPE_CHECKING:
-    from cstar.base import BaseModel
+    pass
 
 
 class Case:
@@ -434,88 +428,21 @@ class Case:
                 f"No 'components' entry found in blueprint {blueprint}. "
                 + "Cannot create a Case with no components!"
             )
-        for component in bp_dict["components"]:
-            component_info = component.get("component")
-            component_kwargs: dict[str, Any] = {}
+        for component_entry in bp_dict["components"]:
+            component_info = component_entry.get("component")
+            base_model_name = component_info.get("base_model")["name"].casefold()
 
-            ThisComponent: Type["Component"]
-            ThisBaseModel: Type["BaseModel"]
-            ThisDiscretization: Type["Discretization"]
-
-            # Construct the BaseModel instance
-            base_model_info = component_info.get("base_model")
-            match base_model_info["name"].casefold():
-                case "roms":
-                    from cstar.roms import ROMSBaseModel, ROMSComponent
-
-                    ThisComponent = ROMSComponent
-                    ThisBaseModel = ROMSBaseModel
-                    ThisDiscretization = ROMSDiscretization
-                case "marbl":
-                    from cstar.marbl import MARBLBaseModel, MARBLComponent
-
-                    ThisComponent = MARBLComponent
-                    ThisBaseModel = MARBLBaseModel
+            match base_model_name:
+                case "ROMS":
+                    component = ROMSComponent.from_dict(component_info)
+                case "MARBL":
+                    component = MARBLComponent.from_dict(component_info)
                 case _:
                     raise ValueError(
-                        f'Base model name {base_model_info["name"]} in blueprint '
-                        + f"{blueprint}  does not match a value that is supported by C-Star. "
-                        + 'Currently supported values are "ROMS" and "MARBL"'
+                        f"unrecognized base model name '{base_model_name}'"
                     )
 
-            base_model = ThisBaseModel(
-                base_model_info["source_repo"], base_model_info["checkout_target"]
-            )
-            component_kwargs["base_model"] = base_model
-
-            # Construct the Discretization instance
-            discretization: Optional[Discretization] = None
-            if "discretization" in component_info.keys():
-                discretization_info = component_info.get("discretization")
-                discretization = ThisDiscretization(**discretization_info)
-                component_kwargs["discretization"] = discretization
-
-            # Construct any AdditionalCode instances
-            additional_code: Optional[AdditionalCode] = None
-            if "additional_code" in component_info.keys():
-                additional_code_info = component_info.get("additional_code")
-                additional_code = AdditionalCode(
-                    base_model=base_model, **additional_code_info
-                )
-                component_kwargs["additional_code"] = additional_code
-
-            # Construct any InputDataset instances:
-            input_datasets: List[InputDataset] | None
-            input_dataset_info = component_info.get("input_datasets", {})
-            input_datasets = []
-
-            if base_model.name.casefold() == "roms":
-                idtype_class_map = {
-                    "model_grid": ROMSModelGrid,
-                    "initial_conditions": ROMSInitialConditions,
-                    "tidal_forcing": ROMSTidalForcing,
-                    "boundary_forcing": ROMSBoundaryForcing,
-                    "surface_forcing": ROMSSurfaceForcing,
-                }
-
-                ## Loop over input_datasets entries,initialise appropriate class, append to list
-                for idtype, dataset_info in input_dataset_info.items():
-                    if idtype in idtype_class_map:
-                        # Get the class to be instantiated
-                        ThisInputDataset = idtype_class_map[idtype]
-
-                        for file_info in dataset_info["files"]:
-                            input_datasets.append(
-                                ThisInputDataset(base_model=base_model, **file_info)
-                            )
-                    else:
-                        raise ValueError(
-                            f"InputDataset type {idtype} in {blueprint} not recognized"
-                        )
-            if len(input_datasets) > 0:
-                component_kwargs["input_datasets"] = input_datasets
-
-            components.append(ThisComponent(**component_kwargs))
+            components.append(component)
 
         caseinstance = cls(
             components=components,
@@ -564,93 +491,8 @@ class Case:
         bp_dict["components"] = []
 
         for component in self.components:
-            component_info: dict = {}
-            # This will be bp_dict["components"]["component"]=component_info
-
-            base_model_info: dict = {}
-            # This will be component_info["base_model"] = base_model_info
-            base_model_info = {}
-            base_model_info["name"] = component.base_model.name
-            base_model_info["source_repo"] = component.base_model.source_repo
-            base_model_info["checkout_target"] = component.base_model.checkout_target
-
-            component_info["base_model"] = base_model_info
-
-            # discretization info (if present)
-            discretization_info = {}
-            if (
-                hasattr(component, "discretization")
-                and component.discretization is not None
-            ):
-                for thisattr in vars(component.discretization).keys():
-                    discretization_info[thisattr] = getattr(
-                        component.discretization, thisattr
-                    )
-            if len(discretization_info) > 0:
-                component_info["discretization"] = discretization_info
-
-            # AdditionalCode instances - can also be None
-            # Loop over additional code
-            additional_code = component.additional_code
-
-            if additional_code is not None:
-                additional_code_info: dict = {}
-                # This will be component_info["component"]["additional_code"]=additional_code_info
-                additional_code_info["location"] = additional_code.source.location
-                additional_code_info["subdir"] = additional_code.subdir
-                additional_code_info["checkout_target"] = (
-                    additional_code.checkout_target
-                )
-                if additional_code.source_mods is not None:
-                    additional_code_info["source_mods"] = (
-                        additional_code.source_mods
-                    )  # this is a list
-                if additional_code.namelists is not None:
-                    additional_code_info["namelists"] = additional_code.namelists
-
-                component_info["additional_code"] = additional_code_info
-
-            # InputDataset
-            input_datasets = component.input_datasets
-
-            input_dataset_info: dict = {}
-            for ind in input_datasets:
-                # Determine what kind of input dataset we are adding
-                if isinstance(ind, ROMSModelGrid):
-                    dct_key = "model_grid"
-                elif isinstance(ind, ROMSInitialConditions):
-                    dct_key = "initial_conditions"
-                elif isinstance(ind, ROMSTidalForcing):
-                    dct_key = "tidal_forcing"
-                elif isinstance(ind, ROMSBoundaryForcing):
-                    dct_key = "boundary_forcing"
-                elif isinstance(ind, ROMSSurfaceForcing):
-                    dct_key = "surface_forcing"
-                else:
-                    raise ValueError(f"Unknown dataset type: {type(ind)}")
-
-                # If there is not already an instance of this input dataset type,
-                # add an empty dict as the key so we can access/build it
-                if dct_key not in input_dataset_info.keys():
-                    input_dataset_info[dct_key] = {}
-
-                # Create a dictionary of file_info for each dataset file:
-                if "files" not in input_dataset_info[dct_key].keys():
-                    input_dataset_info[dct_key]["files"] = []
-                file_info = {}
-                file_info["location"] = ind.source.location
-                if hasattr(ind, "file_hash") and (ind.file_hash is not None):
-                    file_info["file_hash"] = ind.file_hash
-                if hasattr(ind, "start_date") and (ind.start_date is not None):
-                    file_info["start_date"] = str(ind.start_date)
-                if hasattr(ind, "end_date") and (ind.end_date is not None):
-                    file_info["end_date"] = str(ind.end_date)
-
-                input_dataset_info[dct_key]["files"].append(file_info)
-
-                component_info["input_datasets"] = input_dataset_info
-
-            bp_dict["components"].append({"component": component_info})
+            component_dict = component.to_dict()
+            bp_dict["components"].append({"component": component_dict})
 
         with open(filename, "w") as yaml_file:
             yaml.dump(bp_dict, yaml_file, default_flow_style=False, sort_keys=False)

--- a/cstar/marbl/base_model.py
+++ b/cstar/marbl/base_model.py
@@ -22,7 +22,7 @@ class MARBLBaseModel(BaseModel):
     get()
         overrides BaseModel.get() to clone the MARBL repository, set environment, and compile library.
     """
-
+    
     @property
     def name(self) -> str:
         return "MARBL"

--- a/cstar/marbl/component.py
+++ b/cstar/marbl/component.py
@@ -1,9 +1,27 @@
+from typing import TYPE_CHECKING
 from cstar.base import Component
 
 
+from cstar.marbl.base_model import MARBLBaseModel
+from cstar.base.additional_code import AdditionalCode
+    
 class MARBLComponent(Component):
+    base_model : "MARBLBaseModel"
+    additional_code: "AdditionalCode"
     # Inherits its docstring from Component
 
+    def __init__(self,
+                 base_model: "MARBLBaseModel",
+                 additional_code: "AdditionalCode" = None):
+
+        self.base_model = base_model
+        self.additional_code = additional_code
+    
+    @classmethod
+    def from_dict(cls, component_dict):
+        """docstring"""
+        return super().from_dict(component_dict)
+        
     def build(self) -> None:
         print("No build steps to be completed for MARBLComponent")
         pass

--- a/cstar/roms/__init__.py
+++ b/cstar/roms/__init__.py
@@ -1,5 +1,6 @@
 from cstar.roms.base_model import ROMSBaseModel
-from cstar.roms.component import ROMSComponent, ROMSDiscretization
+from cstar.roms.component import ROMSComponent
+from cstar.roms.discretization import ROMSDiscretization
 from cstar.roms.input_dataset import (
     ROMSInputDataset,
     ROMSModelGrid,

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -6,14 +6,14 @@ registry_attrs:
 
 components:
   - component:
+      name: 'MARBL'
       base_model:
-        name: 'MARBL'
         source_repo: 'https://github.com/marbl-ecosys/MARBL.git'
         checkout_target: 'marbl0.45.0'
 
   - component:
+      name: 'ROMS'
       base_model:
-        name: 'ROMS'
         source_repo: 'https://github.com/CESR-lab/ucla-roms.git'
         checkout_target: '594ac425e9dbe663ce48ced0915c0007c6cca843'
       discretization:
@@ -40,83 +40,81 @@ components:
           - "namelists/marbl_in"
           - "namelists/marbl_tracer_output_list"
           - "namelists/marbl_diagnostic_output_list"
-          
-      input_datasets:
-        model_grid:
-          files:
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_grd.nc'
-              file_hash: 'fd537ef8159fabb18e38495ec8d44e2fa1b7fb615fcb1417dd4c0e1bb5f4e41d'
-        initial_conditions:
-          files:
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/MARBL_rst.20120103120000.nc'
-              file_hash: 'fc3bbd039256edc89c898efda0eebc5c53773995598d59310bc6d57f454a6ddd'
-              start_date: 2012-01-03 11:59:24
-              end_date: 2012-01-03 12:00:00
-        tidal_forcing:
-          files:
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_tides.nc'
-              file_hash: '90db174ab174909f9bf27c13fa19995c03f680bcb80e7d012268505b48590338'
-        boundary_forcing:
-          files:
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_2012.nc'
-              file_hash: 'c3b0e14aae6dd5a0d54703fa04cf95960c1970e732c0a230427bf8b0fbbd8bf1'
-              start_date: 2012-01-01 01:00:00
-              end_date: 2012-12-30 00:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_bgc_MARBL.nc'
-              file_hash: '897a8df8ed45841a98b3906f2dd07750decc5c2b50095ba648a855c869c7d3ee'
-              start_date: 2012-01-01 01:00:00
-              end_date: 2012-12-01 01:00:00
-        surface_forcing:
-          files:
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc_bgc.nc'
-              file_hash: '621dd23691d87aa93c5cc582daf6c5f18333ed062ff934777d50b63346c3f84d'
-              start_date: 2012-01-01 01:00:00
-              end_date: 2012-11-30 19:30:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201201.nc'
-              file_hash: '923049a9c2ab9ce77fa4a0211585e6848a12e87bf237e7aa310f693c3ac6abfa'
-              start_date: 2012-01-01 01:00:00
-              end_date: 2012-01-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201202.nc'
-              file_hash: '5a5d99cdfaacdcda7b531916f6af0f7cef4aea595ea634dac809226ea2a8a4fe'
-              start_date: 2012-02-01 00:00:00
-              end_date: 2012-02-29 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201203.nc'
-              file_hash: '8251bd08d435444da7c38fe11eba082365ee7b68453b6dc61460ddcb72c07671'
-              start_date: 2012-03-01 00:00:00
-              end_date: 2012-03-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201204.nc'
-              file_hash: '0b62ab974bd718af1d421a715dc2b0968f65ec99856513f2ee988d996ff3d059'
-              start_date: 2012-04-01 00:00:00
-              end_date: 2012-04-30 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201205.nc'
-              file_hash: 'b82797f91c0741245e58b90f787c9597f342faa49c45ebb27e2df964006d6df5'
-              start_date: 2012-05-01 00:00:00
-              end_date: 2012-05-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201206.nc'
-              file_hash: '8cf6f2413ae45dddc1680a19aea0d40a04def82366d626a7fe33dfe5eef7ea7f'
-              start_date: 2012-06-01 00:00:00
-              end_date: 2012-06-30 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201207.nc'
-              file_hash: '4ec7284f2bdc222b961483af5f6a01ecd6feea5236bb57d2101171f38ea8653b'
-              start_date: 2012-07-01 00:00:00
-              end_date: 2012-07-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201208.nc'
-              file_hash: '4eec008592337e0da87c2fac8c41a1400cc7067fcdc146a665db5b3a74213828'
-              start_date: 2012-08-01 00:00:00
-              end_date: 2012-08-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201209.nc'
-              file_hash: 'feb5718c45c4d0874919367fbadfca6784dfddaa2b193ef767a37d92a554eed4'
-              start_date: 2012-09-01 00:00:00
-              end_date: 2012-09-30 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201210.nc'
-              file_hash: '74538789218a2815c5a5532756e1282958d22026da7513ced0131febfce1012b'
-              start_date: 2012-10-01 00:00:00
-              end_date: 2012-10-31 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201211.nc'
-              file_hash: 'c79d4b2a9d1c41f9c603454c2b023995a6c3ea78c01d17b7428257c3c66f8750'
-              start_date: 2012-11-01 00:00:00
-              end_date: 2012-11-30 23:00:00
-            - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201212.nc'
-              file_hash: '477d1c0f2abcb0d5227594777521ce30d30c2376f5a8b2f08c25e25a77fd1fa5'
-              start_date: 2012-12-01 00:00:00
-              end_date: 2012-12-31 23:00:00
+      model_grid:
+        files:
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_grd.nc'
+            file_hash: 'fd537ef8159fabb18e38495ec8d44e2fa1b7fb615fcb1417dd4c0e1bb5f4e41d'
+      initial_conditions:
+        files:
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/MARBL_rst.20120103120000.nc'
+            file_hash: 'fc3bbd039256edc89c898efda0eebc5c53773995598d59310bc6d57f454a6ddd'
+            start_date: 2012-01-03 11:59:24
+            end_date: 2012-01-03 12:00:00
+      tidal_forcing:
+        files:
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_tides.nc'
+            file_hash: '90db174ab174909f9bf27c13fa19995c03f680bcb80e7d012268505b48590338'
+      boundary_forcing:
+        files:
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_2012.nc'
+            file_hash: 'c3b0e14aae6dd5a0d54703fa04cf95960c1970e732c0a230427bf8b0fbbd8bf1'
+            start_date: 2012-01-01 01:00:00
+            end_date: 2012-12-30 00:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_bgc_MARBL.nc'
+            file_hash: '897a8df8ed45841a98b3906f2dd07750decc5c2b50095ba648a855c869c7d3ee'
+            start_date: 2012-01-01 01:00:00
+            end_date: 2012-12-01 01:00:00
+      surface_forcing:
+        files:
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc_bgc.nc'
+            file_hash: '621dd23691d87aa93c5cc582daf6c5f18333ed062ff934777d50b63346c3f84d'
+            start_date: 2012-01-01 01:00:00
+            end_date: 2012-11-30 19:30:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201201.nc'
+            file_hash: '923049a9c2ab9ce77fa4a0211585e6848a12e87bf237e7aa310f693c3ac6abfa'
+            start_date: 2012-01-01 01:00:00
+            end_date: 2012-01-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201202.nc'
+            file_hash: '5a5d99cdfaacdcda7b531916f6af0f7cef4aea595ea634dac809226ea2a8a4fe'
+            start_date: 2012-02-01 00:00:00
+            end_date: 2012-02-29 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201203.nc'
+            file_hash: '8251bd08d435444da7c38fe11eba082365ee7b68453b6dc61460ddcb72c07671'
+            start_date: 2012-03-01 00:00:00
+            end_date: 2012-03-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201204.nc'
+            file_hash: '0b62ab974bd718af1d421a715dc2b0968f65ec99856513f2ee988d996ff3d059'
+            start_date: 2012-04-01 00:00:00
+            end_date: 2012-04-30 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201205.nc'
+            file_hash: 'b82797f91c0741245e58b90f787c9597f342faa49c45ebb27e2df964006d6df5'
+            start_date: 2012-05-01 00:00:00
+            end_date: 2012-05-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201206.nc'
+            file_hash: '8cf6f2413ae45dddc1680a19aea0d40a04def82366d626a7fe33dfe5eef7ea7f'
+            start_date: 2012-06-01 00:00:00
+            end_date: 2012-06-30 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201207.nc'
+            file_hash: '4ec7284f2bdc222b961483af5f6a01ecd6feea5236bb57d2101171f38ea8653b'
+            start_date: 2012-07-01 00:00:00
+            end_date: 2012-07-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201208.nc'
+            file_hash: '4eec008592337e0da87c2fac8c41a1400cc7067fcdc146a665db5b3a74213828'
+            start_date: 2012-08-01 00:00:00
+            end_date: 2012-08-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201209.nc'
+            file_hash: 'feb5718c45c4d0874919367fbadfca6784dfddaa2b193ef767a37d92a554eed4'
+            start_date: 2012-09-01 00:00:00
+            end_date: 2012-09-30 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201210.nc'
+            file_hash: '74538789218a2815c5a5532756e1282958d22026da7513ced0131febfce1012b'
+            start_date: 2012-10-01 00:00:00
+            end_date: 2012-10-31 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201211.nc'
+            file_hash: 'c79d4b2a9d1c41f9c603454c2b023995a6c3ea78c01d17b7428257c3c66f8750'
+            start_date: 2012-11-01 00:00:00
+            end_date: 2012-11-30 23:00:00
+          - location: 'https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_frc.201212.nc'
+            file_hash: '477d1c0f2abcb0d5227594777521ce30d30c2376f5a8b2f08c25e25a77fd1fa5'
+            start_date: 2012-12-01 00:00:00
+            end_date: 2012-12-31 23:00:00


### PR DESCRIPTION
The key goal here is to split `ROMSComponent.input_datasets` up into several more specific attributes, e.g. `ROMSComponent.model_grid`, closing #94 . This has implications in other places in the code.

It's already clear this is leading to a lot of reshuffling. I pondered for a good while yesterday how to split the various obstacles up, but they're pretty entangled, so I'm going to open this as a draft and push (non-working) commits to hopefully make it easier to follow along.

#### Problem 1
- **Description** 
`Case.from_blueprint` creates all the objects that go into a component, **including InputDataset objects**, before creating the Component object itself from those objects. As such it already has some nasty logic that is hyper-specific to, e.g. ROMSComponent. Implementing this change to `ROMSComponent.input_datasets` will involve rewriting large parts of `Case.from_blueprint`, and it would make sense to hand off component-specific aspects like this to the relevant Component subclasses.

 - **Attempted solution**
To start, I'm attempting to create a `Component.from_dict` class method, so that `Case.from_blueprint` can just call this method on each component in turn, passing the relevant subsection of the blueprint yaml file.