### PR TITLE
more consistent/robust handling of ROMS namelists relating to MARBL

### DIFF
--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -141,7 +141,7 @@ class InputDataset(ABC):
                 self.working_path = target_path
         else:
             if self.source.location_type == "path":
-                target_path.symlink_to(self.source.location)
+                target_path.symlink_to(Path(self.source.location).resolve())
             elif self.source.location_type == "url":
                 if hasattr(self, "file_hash") and self.file_hash is not None:
                     downloader = pooch.HTTPDownloader(timeout=120)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -162,7 +162,7 @@ def _calculate_node_distribution(
     return n_nodes_to_request, cores_to_request_per_node
 
 
-def _replace_text_in_file(file_path: str | Path, old_text: str, new_text: str) -> None:
+def _replace_text_in_file(file_path: str | Path, old_text: str, new_text: str) -> bool:
     """
     Find and replace a string in a text file.
 
@@ -177,17 +177,26 @@ def _replace_text_in_file(file_path: str | Path, old_text: str, new_text: str) -
         The text to be replaced
     new_text: str
         The text that will replace `old_text`
+
+    Returns:
+    --------
+    text_replaced: bool
+       True if text was found and replaced, False if not found
     """
+    text_replaced = False
     file_path = Path(file_path).resolve()
     temp_file_path = Path(str(file_path) + ".tmp")
 
     with open(file_path, "r") as read_file, open(temp_file_path, "w") as write_file:
         for line in read_file:
+            if old_text in line:
+                text_replaced = True
             new_line = line.replace(old_text, new_text)
             write_file.write(new_line)
 
-    file_path.unlink()
     temp_file_path.rename(file_path)
+
+    return text_replaced
 
 
 def _list_to_concise_str(

--- a/cstar/case.py
+++ b/cstar/case.py
@@ -20,6 +20,7 @@ from cstar.roms.input_dataset import (
 )
 from cstar.roms.component import ROMSComponent, ROMSDiscretization
 
+
 if TYPE_CHECKING:
     from cstar.base import BaseModel
 
@@ -746,7 +747,6 @@ class Case:
         # Assuming for now that ROMS presence implies it is the master program
         # TODO add more advanced logic for this
         # 20240807 - TN - set first component as main?
-
         for component in self.components:
             if isinstance(component, ROMSComponent):
                 # Calculate number of time steps:

--- a/cstar/roms/component.py
+++ b/cstar/roms/component.py
@@ -281,10 +281,52 @@ class ROMSComponent(Component):
                 mod_namelist, "__FORCING_FILES_PLACEHOLDER__", namelist_forcing_str
             )
 
-            _replace_text_in_file(
+            marbl_settings_path = (
+                self.additional_code.working_path / "namelists/marbl_in"
+            )
+            marbl_placeholder_in_namelist = _replace_text_in_file(
                 mod_namelist,
-                "MARBL_NAMELIST_DIR",
-                str(self.additional_code.working_path / "namelists"),
+                "__MARBL_SETTINGS_FILE_PLACEHOLDER__",
+                str(marbl_settings_path),
+            )
+            if (marbl_placeholder_in_namelist) and (not marbl_settings_path.exists()):
+                raise FileNotFoundError(
+                    "Placeholder string for marbl_in file "
+                    + "found in ROMS namelist, but 'marbl_in' not found "
+                    + f"at {marbl_settings_path.parent}."
+                )
+
+            marbl_tracer_list_path = (
+                self.additional_code.working_path / "namelists/marbl_tracer_output_list"
+            )
+            marbl_placeholder_in_namelist = _replace_text_in_file(
+                mod_namelist,
+                "__MARBL_TRACER_LIST_FILE_PLACEHOLDER__",
+                str(
+                    self.additional_code.working_path
+                    / "namelists/marbl_tracer_output_list"
+                ),
+            )
+            if (marbl_placeholder_in_namelist) and (
+                not marbl_tracer_list_path.exists()
+            ):
+                raise FileNotFoundError(f"{marbl_tracer_list_path} not found.")
+
+            marbl_diag_list_path = (
+                self.additional_code.working_path
+                / "namelists/marbl_diagnostics_output_list"
+            )
+            if (marbl_placeholder_in_namelist) and (
+                not marbl_tracer_list_path.exists()
+            ):
+                raise FileNotFoundError(f"{marbl_diag_list_path} not found.")
+            marbl_placeholder_in_namelist = _replace_text_in_file(
+                mod_namelist,
+                "__MARBL_DIAG_LIST_FILE_PLACEHOLDER__",
+                str(
+                    self.additional_code.working_path
+                    / "namelists/marbl_diagnostics_output_list"
+                ),
             )
 
     def run(

--- a/cstar/roms/component.py
+++ b/cstar/roms/component.py
@@ -122,7 +122,18 @@ class ROMSComponent(Component):
             )
         builddir = working_path / "source_mods"
         if (builddir / "Compile").is_dir():
-            subprocess.run("make compile_clean", cwd=builddir, shell=True)
+            make_clean_result = subprocess.run(
+                "make compile_clean",
+                cwd=builddir,
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            if make_clean_result.returncode != 0:
+                raise RuntimeError(
+                    f"Error {make_clean_result.returncode} when compiling ROMS. STDERR stream: "
+                    + f"\n {make_clean_result.stderr}"
+                )
 
         print("Compiling UCLA-ROMS configuration...")
         make_roms_result = subprocess.run(
@@ -137,6 +148,7 @@ class ROMSComponent(Component):
                 f"Error {make_roms_result.returncode} when compiling ROMS. STDERR stream: "
                 + f"\n {make_roms_result.stderr}"
             )
+
         print(f"UCLA-ROMS compiled at {builddir}")
 
         self.exe_path = builddir / "roms"
@@ -204,7 +216,7 @@ class ROMSComponent(Component):
                     raise ValueError(f"InputDataset has no working path: {f}")
                 elif isinstance(f.working_path, list):
                     # if single InputDataset corresponds to many files, check they're colocated
-                    if all(
+                    if not all(
                         [d.parent == f.working_path[0].parent for d in f.working_path]
                     ):
                         raise ValueError(
@@ -451,7 +463,6 @@ class ROMSComponent(Component):
                 "Unable to calculate node distribution for this Component. "
                 + "Component.n_procs_tot is not set"
             )
-
         match _CSTAR_SCHEDULER:
             case "pbs":
                 if account_key is None:
@@ -529,32 +540,45 @@ class ROMSComponent(Component):
                 T0 = time.time()
                 if romsprocess.stdout is None:
                     raise RuntimeError("ROMS is not producing stdout")
-                for line in romsprocess.stdout:
-                    # Split the line by whitespace
-                    parts = line.split()
 
-                    # Check if there are exactly 9 parts and the first one is an integer
-                    if len(parts) == 9:
-                        try:
-                            # Try to convert the first part to an integer
-                            tstep = int(parts[0])
-                            if tstep0 == 0:
-                                tstep0 = tstep
-                            # Capture the first integer and print it
-                            ETA = (n_time_steps - (tstep - tstep0)) * (
-                                (tstep - tstep0) / (time.time() - T0)
-                            )
-                            print(
-                                f"Running ROMS: time-step {tstep-tstep0} of {n_time_steps} ({time.time()-T0:.1f}s elapsed; ETA {ETA:.1f}s)"
-                            )
-                        except ValueError:
-                            pass
-                    elif tstep0 == 0 and len(roms_init_string) == 0:
-                        roms_init_string = "Running ROMS: Initializing run..."
-                        print(roms_init_string)
+                # 2024-09-21 : the following is included as in some instances ROMS
+                # will exit with code 0 even if a fatal error occurs, see:
+                # https://github.com/CESR-lab/ucla-roms/issues/42
+
+                debugging = False  # Print raw output if true
+                if debugging:
+                    while True:
+                        output = romsprocess.stdout.readline()
+                        if output == "" and romsprocess.poll() is not None:
+                            break
+                        if output:
+                            print(output.strip())
+                else:
+                    for line in romsprocess.stdout:
+                        # Split the line by whitespace
+                        parts = line.split()
+
+                        # Check if there are exactly 9 parts and the first one is an integer
+                        if len(parts) == 9:
+                            try:
+                                # Try to convert the first part to an integer
+                                tstep = int(parts[0])
+                                if tstep0 == 0:
+                                    tstep0 = tstep
+                                    # Capture the first integer and print it
+                                ETA = (n_time_steps - (tstep - tstep0)) * (
+                                    (tstep - tstep0) / (time.time() - T0)
+                                )
+                                print(
+                                    f"Running ROMS: time-step {tstep-tstep0} of {n_time_steps} ({time.time()-T0:.1f}s elapsed; ETA {ETA:.1f}s)"
+                                )
+                            except ValueError:
+                                pass
+                        elif tstep0 == 0 and len(roms_init_string) == 0:
+                            roms_init_string = "Running ROMS: Initializing run..."
+                            print(roms_init_string)
 
                 romsprocess.wait()
-
                 if romsprocess.returncode != 0:
                     import datetime as dt
 

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -139,7 +139,16 @@ class ROMSInputDataset(InputDataset, ABC):
         import roms_tools
 
         roms_tools_class = getattr(roms_tools, roms_tools_class_name)
-        roms_tools_class_instance = roms_tools_class.from_yaml(yaml_file)
+
+        # roms-tools currently requires dask for every class except Grid
+        # in order to use wildcards in filepaths (known xarray issue):
+
+        if roms_tools_class_name == "Grid":
+            roms_tools_class_instance = roms_tools_class.from_yaml(yaml_file)
+        else:
+            roms_tools_class_instance = roms_tools_class.from_yaml(
+                yaml_file, use_dask=True
+            )
 
         # ... and save:
         print(f"Saving roms-tools dataset created from {yaml_file}...")

--- a/cstar/tests_old/test_roms_marbl_example.py
+++ b/cstar/tests_old/test_roms_marbl_example.py
@@ -37,11 +37,12 @@ roms_marbl_remote_case = cstar.Case.from_blueprint(
 # patch will automatically respond "y" to any call for input
 with patch("builtins.input", return_value="y"):
     roms_marbl_remote_case.setup()
-    roms_marbl_remote_case.persist("test_blueprint.yaml")
-    roms_marbl_remote_case.build()
-    roms_marbl_remote_case.pre_run()
-    roms_marbl_remote_case.run()
-    roms_marbl_remote_case.post_run()
+
+roms_marbl_remote_case.persist("test_blueprint.yaml")
+roms_marbl_remote_case.build()
+roms_marbl_remote_case.pre_run()
+roms_marbl_remote_case.run()
+roms_marbl_remote_case.post_run()
 
 print("Test complete with remote input dataset files")
 

--- a/cstar/tests_old/test_roms_tools_integration.py
+++ b/cstar/tests_old/test_roms_tools_integration.py
@@ -31,7 +31,7 @@ for oldfiles in [
 
 roms_marbl_remote_case = cstar.Case.from_blueprint(
     blueprint=(cstar.base.environment._CSTAR_ROOT)
-    + "/../tests/cstar_blueprint_roms_tools_example.yaml",
+    + "/tests_old/cstar_blueprint_roms_tools_example.yaml",
     caseroot="roms_tools_remote_case/",
     start_date="20120101 12:00:00",
     end_date="20120101 12:30:00",

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -33,7 +33,6 @@ components:
           - "source_mods/param.opt"
           - "source_mods/tracers.opt"
           - "source_mods/Makefile"
-          - "source_mods/get_makefile"
           - "source_mods/Make.depend"
         namelists:
           - "namelists/roms.in_TEMPLATE"

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -21,8 +21,8 @@ components:
         n_procs_y: 3
         time_step: 360
       additional_code:
-        location: 'https://github.com/dafyddstephenson/cstar_blueprint_roms_marbl_example.git'
-        checkout_target: 'dab634b0a6bd1049814b82b5f13db28e07292e5f'
+        location: 'https://github.com/dafyddstephenson/roms_marbl_example.git'
+        checkout_target: '6ac50e2193dea8cae9cf921fdf889b71f9cb8bf1'
         subdir: 'additional_code/ROMS'
         source_mods:
           - "source_mods/bgc.opt"

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -21,8 +21,8 @@ components:
         n_procs_y: 3
         time_step: 360
       additional_code:
-        location: 'https://github.com/CWorthy-Ocean/cstar_blueprint_roms_marbl_example.git'
-        checkout_target: 'a07ba58168fdc7c1e7f8f8b0cda191e80f507541'
+        location: 'https://github.com/dafyddstephenson/cstar_blueprint_roms_marbl_example.git'
+        checkout_target: 'dab634b0a6bd1049814b82b5f13db28e07292e5f'
         subdir: 'additional_code/ROMS'
         source_mods:
           - "source_mods/bgc.opt"

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -21,8 +21,8 @@ components:
         n_procs_y: 3
         time_step: 360
       additional_code:
-        location: 'https://github.com/dafyddstephenson/roms_marbl_example.git'
-        checkout_target: 'f6496b5ae968ccad9d5df0ed76acef749172dcc3'
+        location: 'https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git'
+        checkout_target: 'a9762a46a36c09225423305a1aaa59bdeb984074'
         subdir: 'additional_code/ROMS'
         source_mods:
           - "source_mods/bgc.opt"

--- a/examples/cstar_blueprint_roms_marbl_example.yaml
+++ b/examples/cstar_blueprint_roms_marbl_example.yaml
@@ -22,7 +22,7 @@ components:
         time_step: 360
       additional_code:
         location: 'https://github.com/dafyddstephenson/roms_marbl_example.git'
-        checkout_target: '6ac50e2193dea8cae9cf921fdf889b71f9cb8bf1'
+        checkout_target: 'f6496b5ae968ccad9d5df0ed76acef749172dcc3'
         subdir: 'additional_code/ROMS'
         source_mods:
           - "source_mods/bgc.opt"


### PR DESCRIPTION
This PR:
- Renames the placeholder strings concerning MARBL namelists in `roms.in` to be more consistent with other placeholder strings elsewhere
- Adds a T/F output to `utils.py`'s `_replace_text_in_file` to indicate whether the text to be replaced was found
- Uses this to determine whether the namelist being modified in `ROMSComponent.pre_run()` contains placeholder strings related to MARBL
- Raises an error if the placeholder is present but has been replaced with a filepath e.g. `Case.caseroot/"additional_code/namelists/ROMS/marbl_in"` that does not exist
- updates the example blueprint to point to my fork of the blueprint repo which has been modified in line with these changes (so as not to immediately break anybody else's work when this goes in)