### PR TITLE
codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+   require_ci_to_pass: no
+   max_report_age: off
+
+ coverage:
+   precision: 2
+   round: down
+   status:
+     project:
+       default:
+         target: 95
+         informational: true
+     patch: off
+     changes: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,19 @@ codecov:
    require_ci_to_pass: no
    max_report_age: off
 
- coverage:
-   precision: 2
-   round: down
-   status:
-     project:
-       default:
-         target: 95
-         informational: true
-     patch: off
-     changes: off
+coverage:
+  status:
+    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+      default:
+        # basic
+        target: auto #default
+        threshold: 0%
+        base: auto 
+
+comment:
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]


### PR DESCRIPTION
This PR adds a `codecov.yml`, which will hopefully force CodeCov to comment on every PR with the change of code coverage implied by that PR. 