### PR TITLE
update integration tests to use roms-tools v2.00

### DIFF
--- a/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml
@@ -44,24 +44,20 @@ components:
           - "Makefile"
       model_grid:
         location: '<input_datasets_location>/roms_grd.nc'
-        file_hash: '893aff53b3c1d08c9bb381244f4fecbf9782403ba7cde82200ccb9d0f328745d'
+        file_hash: '4fe2beba68c16a7c4bccaad5d424c66255314543bc128faa527229e6e04f9e5d'
       initial_conditions:
         location: '<input_datasets_location>/roms_ini.nc'
-        file_hash: '20c2e62fcffe614e36f5948a16b2d941d85995a31cebbeecc5a3d6b8bf750907'
+        file_hash: '55168d62d9206e03433f44c3fcd06830fbd322c9b543cc9813b747dbe24dd403'
       tidal_forcing:
         location: '<input_datasets_location>/roms_tides.nc'
-        file_hash: '63e47c25604d9acf45439c7a555941c5a4b2ea84dd957f6ec23f68a6f429d47c'
+        file_hash: '4fe2beba68c16a7c4bccaad5d424c66255314543bc128faa527229e6e04f9e5d'
       boundary_forcing:
-        - location: '<input_datasets_location>/roms_bry_2012.nc'
-          file_hash: 'c501802a892320e5c915f6718da69ed6d1fbfa88106ce08a78a8661e0b2069a5'
-        - location: '<input_datasets_location>/roms_bry_bgc_2012.nc'
-          file_hash: '0fa5707547283cad4c0b0dd5cea4d4ec5be4b8451683430c4c89806ae9c4a0c8'
+        - location: '<input_datasets_location>/roms_bry.nc'
+          file_hash: '694fd224f93bfbae5022bf38d6e81c5663112151d7a9875d9ea6d917adb09e85'
+        - location: '<input_datasets_location>/roms_bry_bgc.nc'
+          file_hash: 'b286fe317a8b4a64f25971ccd0ad03abcfde9aa0ab27a439013a99126453960d'
       surface_forcing:
-        - location: '<input_datasets_location>/roms_frc_2012.nc'
-          file_hash: '02c817af1221657ad5a4a512e8c8151b110ea5b370599fc8a574017cfcd31bee'
-        - location: '<input_datasets_location>/roms_frc_2013.nc'
-          file_hash: '8fad7df6093643019e618f060056bbd97c1707ca08386a2494c9b098492d5efb'
-        - location: '<input_datasets_location>/roms_frc_bgc_2012.nc'
-          file_hash: '9f94cac6d689150bfeae6365af30a162eca9001fe649bc9562514dc99bb2ef3b'
-        - location: '<input_datasets_location>/roms_frc_bgc_2013.nc'
-          file_hash: 'd912f5700876e9126eabf4f5ebb2ddefcc34be143cb6d0f98e9a05f951947b4b'
+        - location: '<input_datasets_location>/roms_frc.nc'
+          file_hash: '43c1e15e5a4ae0718f87eb10367b1f54262a251f8bc7f9b791880efb7843f41c'
+        - location: '<input_datasets_location>/roms_frc_bgc.nc'
+          file_hash: '754421b2d99a51d3bab6086f96f78b59d3a2b5cfcf0bd582449e1f310da1378d'

--- a/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml
@@ -44,20 +44,20 @@ components:
           - "Makefile"
       model_grid:
         location: '<input_datasets_location>/roms_grd.yaml'
-        file_hash: '22d9d65c1ce25152f5181ccefdf97ac1a15a7b87fbf090b45b3c15b44fad65aa'
+        file_hash: 'c71a0fb19b1694bab3f465e849d3c897aa4be177414f4821d446aa312d02b463'
       initial_conditions:
         location: '<input_datasets_location>/roms_ini.yaml'
-        file_hash: '849577dad30e55ee4308bdfbef2e9d947b7182c920894a03787f34970b934949'
+        file_hash: '22a666a5402748de77e36c66bc16da073eb04aec4e7c7384ef314b5a275c7db8'
       tidal_forcing:
         location: '<input_datasets_location>/roms_tides.yaml'
-        file_hash: '15342ffc02a7dc7a5fcced2ba3b28736032fa586e2b0d96cd81414f589aeffb4'
+        file_hash: 'c71a0fb19b1694bab3f465e849d3c897aa4be177414f4821d446aa312d02b463'
       boundary_forcing:
         - location: '<input_datasets_location>/roms_bry.yaml'
-          file_hash: 'ee2ba557bd45645a8ddd5da464a88b382a078265d15106ca4b4cf7e55f182a44'
+          file_hash: '9446dfb3e9304723dae92e35a51172c11e2412e086a29eed573b3f6c1c1e0d16'
         - location: '<input_datasets_location>/roms_bry_bgc.yaml'
-          file_hash: '9d9e1e0129eb4f7a2cade1c36e0f5cce868e52f69b180fdc98901e7d20cdf736'
+          file_hash: '6d600be6794fd197d72e30cb4aca96b96a4d80912b9581a763041a99a48784cf'
       surface_forcing:
         - location: '<input_datasets_location>/roms_frc.yaml'
-          file_hash: '13238c6671683690f56e85674b3d7d5a8a3c6a9ae10cca96ba3a4e2fce112948'
+          file_hash: '3183bf45d6d827dbdde3133c680a77a3f8e6e2d9f5577716ced9ff06de6c4a4c'
         - location: '<input_datasets_location>/roms_frc_bgc.yaml'
-          file_hash: 'f9953ca6c675f196e11036f24896ab40df3156207e3f870cc1f7de2b252fdf34'
+          file_hash: '528a112e18d30f41ec7154a84316772ffcaae92d4931bae3c36eee147e0a236e'

--- a/cstar/tests/integration_tests/fixtures.py
+++ b/cstar/tests/integration_tests/fixtures.py
@@ -126,7 +126,7 @@ def fetch_remote_test_case_data() -> Callable[[], None]:
         test_case_repo_url = (
             "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/"
         )
-        checkout_target = "d7996aea8d4fd4ca4148b34d2d898f019c90a8ff"
+        checkout_target = "935b5d4f6012b2863c2db103596f8f173a024d1c"
 
         # Construct the URL of this commit as a zip archive:
         archive_url = f"{test_case_repo_url.rstrip('/')}/archive/{checkout_target}.zip"
@@ -134,7 +134,7 @@ def fetch_remote_test_case_data() -> Callable[[], None]:
         # Download the zip with pooch
         zip_path = pooch.retrieve(
             url=archive_url,
-            known_hash="e291bc79dd5f0ab88f486974075f3defe2076ff3706787131dae7fd0f01358b5",
+            known_hash="c9847301c308044f98731fc70864018a65c82df0981bea7c4e47d5b8e3b41b03",
             fname=f"{checkout_target}.zip",  # Name of the cached file
             path=CSTAR_TEST_DATA_DIRECTORY,  # Set the cache directory (customize as needed)
         )

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -130,8 +130,8 @@ class TestFetchData:
         expected_files = [
             "additional_code/ROMS/namelists/roms.in",
             "additional_code/ROMS/source_mods/Makefile",
-            "input_datasets/ROMS/roms_bry_2012.nc",
-            "input_datasets/ROMS/roms_frc_2012.nc",
+            "input_datasets/ROMS/roms_bry.nc",
+            "input_datasets/ROMS/roms_frc.nc",
             "roms_tools_yaml_files/roms_bry.yaml",
             "roms_tools_yaml_files/roms_ini.yaml",
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "python-dotenv",
     "PyYAML==6.0.2",
     "pooch>=1.8.1",
-    "roms_tools[dask]>=1.4.2"
+    "roms_tools[dask]>=2.0.0"
 ]
 
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
@@ -36,7 +36,7 @@ keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 [project.optional-dependencies]
 test = [
      "pytest>=7.0",
-     "roms_tools[dask]==1.4.2"
+     "roms_tools[dask]==2.0.0"
      ]
 dev =[]
 


### PR DESCRIPTION
The latest [roms-tools update](https://github.com/CWorthy-ocean/roms-tools/releases/tag/v2.0.0) breaks backwards compatibility, so this PR (and [935b5d4](https://github.com/CWorthy-ocean/cstar_blueprint_test_case/commit/935b5d4f6012b2863c2db103596f8f173a024d1c) on the test case blueprint repo) update the C-Star integration tests to bring it back in line with roms-tools.