### PR TITLE
Blank releases notes page with template

### DIFF
--- a/.github/PULL_RELEASE_TEMPLATE.md
+++ b/.github/PULL_RELEASE_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Feel free to remove check-list items aren't relevant to your change -->
+
+- [ ] Closes #xxxx
+- [ ] Tests added
+- [ ] Tests passing
+- [ ] Full type hint coverage
+- [ ] Changes are documented in `docs/releases.rst`
+- [ ] New functions/methods are listed in `api.rst`
+- [ ] New functionality has documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,14 +43,13 @@ A key strength of C-Star lies in its ability to run regional simulations using a
 
 .. toctree::
    :maxdepth: 1
-   :caption: How To Contribute
-
-   contributing
-
-.. toctree::
-   :maxdepth: 1
    :caption: References
 
    api
 
+.. toctree::
+   :maxdepth: 1
+   :caption: For Developers
 
+   contributing
+   releases

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,0 +1,27 @@
+Release notes
+=============
+
+.. _v0.0.1:
+
+v0.0.1 (unreleased)
+-------------------
+
+First release of C-Star!
+
+New Features
+~~~~~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Internal Changes
+~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Closes part of #178.

We can populate this more when we actually do the release.