### PR TITLE
Environment bugfixes + re-add Expanse

### DIFF
--- a/cstar/base/base_model.py
+++ b/cstar/base/base_model.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Optional
 from abc import ABC, abstractmethod
@@ -165,11 +164,17 @@ class BaseModel(ABC):
         """
 
         # check 1: X_ROOT variable is in user's env
-        env_var_exists = self.expected_env_var in os.environ
+
+        env_var_exists = (
+            self.expected_env_var
+            in cstar_system.environment.environment_variables.keys()
+        )
 
         # check 2: X_ROOT points to the correct repository
         if env_var_exists:
-            local_root = Path(os.environ[self.expected_env_var])
+            local_root = Path(
+                cstar_system.environment.environment_variables[self.expected_env_var]
+            )
             env_var_repo_remote = _get_repo_remote(local_root)
             env_var_matches_repo = self.source_repo == env_var_repo_remote
             if not env_var_matches_repo:
@@ -208,7 +213,11 @@ class BaseModel(ABC):
               -> prompt installation of the base model
         """
 
-        local_root = Path(os.environ.get(self.expected_env_var, ""))
+        local_root = Path(
+            cstar_system.environment.environment_variables.get(
+                self.expected_env_var, ""
+            )
+        )
 
         match self.local_config_status:
             case 0:

--- a/cstar/roms/component.py
+++ b/cstar/roms/component.py
@@ -991,7 +991,7 @@ class ROMSComponent(Component):
                 scheduler_script += f"\n#SBATCH --nodes={nnodes}"
                 scheduler_script += f"\n#SBATCH --ntasks-per-node={ncores}"
                 scheduler_script += f"\n#SBATCH --account={account_key}"
-                scheduler_script += "\n#SBATCH --export=NONE"
+                scheduler_script += "\n#SBATCH --export=ALL"
                 scheduler_script += "\n#SBATCH --mail-type=ALL"
                 scheduler_script += f"\n#SBATCH --time={walltime}"
                 for (
@@ -1026,9 +1026,16 @@ class ROMSComponent(Component):
                     f.write(scheduler_script)
 
                 # remove any slurm variables in case submitting from inside another slurm job
+                env_vars_to_exclude = []
+                for k in os.environ.keys():
+                    if k.startswith("SLURM_"):
+                        if k not in {"SLURM_CONF", "SLURM_VERSION"}:
+                            env_vars_to_exclude.append(k)
+
                 slurm_env = {
-                    k: v for k, v in os.environ.items() if not k.startswith("SLURM_")
+                    k: v for k, v in os.environ.items() if k not in env_vars_to_exclude
                 }
+
                 subprocess.run(
                     f"sbatch {script_fname}", shell=True, cwd=run_path, env=slurm_env
                 )

--- a/cstar/tests/unit_tests/base/test_base_model.py
+++ b/cstar/tests/unit_tests/base/test_base_model.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from pathlib import Path
 from unittest import mock
@@ -150,11 +149,20 @@ class TestBaseModelConfig:
         Mocks `cstar.utils._get_repo_remote` function to simulate different repository remotes.
     patch_get_repo_head_hash : MagicMock
         Mocks `cstar.utils._get_repo_head_hash` function to simulate different repository head hashes.
-    patch_os_environ : MagicMock
-        Mocks `os.environ` to control the environment variable `TEST_ROOT`.
+    patch_environment_variables : MagicMock
+        Mocks `cstar_system.environment.environment_variables` to control the environment variables.
     """
 
     def setup_method(self):
+        self.patch_environment = mock.patch(
+            "cstar.base.system.CStarSystem.environment",
+            new_callable=mock.PropertyMock,
+            return_value=mock.Mock(
+                environment_variables={"TEST_ROOT": "/path/to/repo"}
+            ),
+        )
+        self.mock_environment = self.patch_environment.start()
+
         self.patch_get_repo_remote = mock.patch(
             "cstar.base.base_model._get_repo_remote"
         )
@@ -165,20 +173,17 @@ class TestBaseModelConfig:
         )
         self.mock_get_repo_head_hash = self.patch_get_repo_head_hash.start()
 
-        self.patch_os_environ = mock.patch.dict(
-            os.environ, {"TEST_ROOT": "/path/to/repo"}, clear=True
-        )
-        self.patch_os_environ.start()
-
     def teardown_method(self):
+        self.patch_environment.stop()
         self.patch_get_repo_remote.stop()
         self.patch_get_repo_head_hash.stop()
-        self.patch_os_environ.stop()
 
     def test_local_config_status_valid(self, generic_base_model):
+        # Set return values for other mocks
         self.mock_get_repo_remote.return_value = "https://github.com/test/repo.git"
         self.mock_get_repo_head_hash.return_value = "test123"
 
+        # Assert local_config_status logic
         assert generic_base_model.local_config_status == 0
         assert generic_base_model.is_setup
 
@@ -195,8 +200,8 @@ class TestBaseModelConfig:
 
         assert generic_base_model.local_config_status == 2
 
-    @mock.patch.dict(os.environ, {}, clear=True)
     def test_local_config_status_no_env_var(self, generic_base_model):
+        self.mock_environment.return_value.environment_variables = {}
         assert generic_base_model.local_config_status == 3
 
 
@@ -266,10 +271,20 @@ class TestBaseModelConfigHandling:
         self.patch_subprocess_run = mock.patch("subprocess.run")
         self.mock_subprocess_run = self.patch_subprocess_run.start()
 
-        self.patch_os_environ = mock.patch.dict(
-            os.environ, {"TEST_ROOT": "/path/to/repo"}, clear=True
+        # self.patch_os_environ = mock.patch.dict(
+        #     os.environ, {"TEST_ROOT": "/path/to/repo"}, clear=True
+        # )
+        # self.patch_os_environ.start()  # Apply the patch
+
+        self.patch_environment = mock.patch(
+            "cstar.base.system.CStarSystem.environment",
+            new_callable=mock.PropertyMock,
+            return_value=mock.Mock(
+                environment_variables={"TEST_ROOT": "/path/to/repo"},
+                package_root=Path("/mock/package/root"),
+            ),
         )
-        self.patch_os_environ.start()  # Apply the patch
+        self.mock_environment = self.patch_environment.start()
 
     def teardown_method(self):
         self.patch_local_config_status.stop()
@@ -277,7 +292,8 @@ class TestBaseModelConfigHandling:
         self.patch_local_config_status.stop()
         self.patch_get_repo_head_hash.stop()
         self.patch_get_repo_remote.stop()
-        self.patch_os_environ.stop()
+        # self.patch_os_environ.stop()
+        self.patch_environment.stop()
 
     def test_handle_config_status_valid(self, generic_base_model, capsys):
         """Test when local_config_status == 0 (correct configuration)"""

--- a/cstar/tests/unit_tests/base/test_base_model.py
+++ b/cstar/tests/unit_tests/base/test_base_model.py
@@ -248,8 +248,8 @@ class TestBaseModelConfigHandling:
         Mocks `BaseModel.local_config_status` to simulate different configuration states.
     patch_subprocess_run : MagicMock
         Mocks `subprocess.run` to simulate command-line actions for `git checkout`.
-    patch_os_environ : MagicMock
-        Mocks `os.environ` to control environment variable presence and paths.
+    patch_environment : MagicMock
+        Mocks `cstar_system.environment.environment_variables` to control the environment variables.
     """
 
     def setup_method(self):
@@ -271,11 +271,6 @@ class TestBaseModelConfigHandling:
         self.patch_subprocess_run = mock.patch("subprocess.run")
         self.mock_subprocess_run = self.patch_subprocess_run.start()
 
-        # self.patch_os_environ = mock.patch.dict(
-        #     os.environ, {"TEST_ROOT": "/path/to/repo"}, clear=True
-        # )
-        # self.patch_os_environ.start()  # Apply the patch
-
         self.patch_environment = mock.patch(
             "cstar.base.system.CStarSystem.environment",
             new_callable=mock.PropertyMock,
@@ -292,7 +287,6 @@ class TestBaseModelConfigHandling:
         self.patch_local_config_status.stop()
         self.patch_get_repo_head_hash.stop()
         self.patch_get_repo_remote.stop()
-        # self.patch_os_environ.stop()
         self.patch_environment.stop()
 
     def test_handle_config_status_valid(self, generic_base_model, capsys):

--- a/docs/machines.md
+++ b/docs/machines.md
@@ -10,3 +10,4 @@ C-Star aims to be deployable on a wide range of HPC systems, but so far it has b
 | MacOS ARM64 (Apple Silicon) | Tested         |       |
 | [NERSC Perlmutter](https://docs.nersc.gov/systems/perlmutter/architecture/)            | Tested         |       |
 | [NCAR Derecho](https://ncar-hpc-docs.readthedocs.io/en/latest/compute-systems/derecho/)                | Tested         |       |
+| [SDSC Expanse](https://www.sdsc.edu/support/user_guides/expanse.html)					 | Tested	  |	  |

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -14,3 +14,16 @@ There is support for using existing model input data in netCDF format, or creati
 Note that the python API is not yet stable, and some aspects of the schema for the blueprint will likely evolve. 
 Therefore whilst you are welcome to try out using the package, we cannot yet guarantee backwards compatibility. 
 We expect to reach a more stable version in Q1 2025.
+
+.. _v0.0.3-alpha:
+
+v0.0.3-alpha (9th Dec 2024)
+---------------------------
+
+New features:
+~~~~~~~~~~~~~
+- Add support for SDSC Expanse HPC
+
+Bugfixes:
+~~~~~~~~~
+- Fix bug where in certain circumstances environment variables were checked for before being set, prompting user to install already installed externals


### PR DESCRIPTION
This PR fixes two separate issues that I uncovered while working on Expanse after being locked out of it for a while:

## Slurm environment management
### Problem:
using the `export=NONE` Slurm directive along with using `sbatch` in a subprocess that explicitly removed any environment variables prefixed with `SLURM_` was motivated by the need to submit jobs from inside an existing job when running notebooks on Perlmutter, but quietly broke Expanse compatibility. 
### Solution: 
Reverted to `export=ALL`, now removing all `SLURM_` prefixed environment variables EXCEPT `SLURM_CONF`, and `SLURM_VERSION`, which are system-related globals that should be present even when not in the context of a Slurm job.
This simplifies submission script generation and is tested and working on both machines.

## ROMS/MARBL existing install checks
### Problem:
The `BaseModel.local_config_status` property was searching `os.environ` for BaseModel related environment variables like `MARBL_ROOT`. However, following the environment refactor PR (#168), these aren't actually added to `os.environ` until `cstar_system.environment` is first accessed, so attempting to set up the example case on a system where MARBL and ROMS were already installed prompted the user to install them "for the first time" (then errored out because it couldn't, as they were already installed). Going through this process triggered the `os.environ` update somewhere, so attempting the set up call again worked fine.

### Solution:
`base/base_model.py` now no longer checks `os.environ` for C-Star related environment variables, but instead `cstar_system.environment.environment_variables` (which is safer and automatically updates `os.environ` to include them)

@TomNicholas @NoraLoose 
Is the process of updating the release to include these fixes straightforward?
