### PR TITLE
include file hash checks for local input datasets

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -1,8 +1,38 @@
 import re
+import hashlib
 import subprocess
 from math import ceil
 from typing import Tuple
 from pathlib import Path
+
+
+def _get_sha256_hash(file_path: str | Path) -> str:
+    """Calculate the 256-bit SHA checksum of a file.
+
+    Parameters
+    ----------
+    file_path: Path
+       Path to the file whose checksum is to be calculated
+
+    Returns
+    -------
+    file_hash: str
+       The SHA-256 checksum of the file at file_path
+    """
+
+    file_path = Path(file_path)
+    if not file_path.is_file():
+        raise FileNotFoundError(
+            f"Error when calculating file hash: {file_path} is not a valid file"
+        )
+
+    sha256_hash = hashlib.sha256()
+    with file_path.open("rb") as file:
+        for chunk in iter(lambda: file.read(4096), b""):
+            sha256_hash.update(chunk)
+
+    file_hash = sha256_hash.hexdigest()
+    return file_hash
 
 
 def _update_user_dotenv(env_file_str) -> None:

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -1,4 +1,5 @@
 import pytest
+import hashlib
 from unittest import mock
 from pathlib import Path
 from cstar.base import InputDataset
@@ -371,6 +372,24 @@ def test_to_dict(remote_input_dataset):
     }
 
 
+def test_get_hash(local_input_dataset, tmp_path):
+    """Test the _get_hash method for correctness."""
+    file_path = tmp_path / "test_file.txt"
+    file_path.write_text("Test data for hash")
+
+    # Compute the expected hash manually
+    expected_hash = hashlib.sha256("Test data for hash".encode()).hexdigest()
+
+    # Call _get_hash and verify
+    calculated_hash = local_input_dataset._get_hash(file_path)
+    assert calculated_hash == expected_hash, "Hash mismatch"
+
+    # Test FileNotFoundError
+    non_existent_path = tmp_path / "non_existent_file.txt"
+    with pytest.raises(FileNotFoundError):
+        local_input_dataset._get_hash(non_existent_path)
+
+
 class TestInputDatasetGet:
     """Test class for the InputDataset.get method.
 
@@ -493,6 +512,27 @@ class TestInputDatasetGet:
         assert (
             local_input_dataset.working_path == self.target_filepath_local
         ), f"Expected working_filepath to be {self.target_filepath_local}, but got {local_input_dataset.working_path}"
+
+    def test_get_local_wrong_hash(self, local_input_dataset):
+        """Test the `get` method with a bogus file_hash for local sources."""
+        # Assign a bogus file hash
+        local_input_dataset.file_hash = "bogus_hash"
+
+        source_filepath_local = Path(
+            local_input_dataset.source.location
+        )  # Source file in the local system
+
+        self.mock_exists.return_value = False
+        self.mock_resolve.side_effect = [self.target_dir, source_filepath_local]
+
+        # Patch `_get_hash` to return a different, valid hash
+        with mock.patch.object(
+            local_input_dataset, "_get_hash", return_value="valid_hash"
+        ):
+            with pytest.raises(
+                ValueError, match="The provided file hash.*does not match.*"
+            ):
+                local_input_dataset.get(self.target_dir)
 
     def test_get_with_remote_source(self, remote_input_dataset):
         """Test the InputDataset.get method with a remote source file.

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -1,5 +1,4 @@
 import pytest
-import hashlib
 from unittest import mock
 from pathlib import Path
 from cstar.base import InputDataset
@@ -372,24 +371,6 @@ def test_to_dict(remote_input_dataset):
     }
 
 
-def test_get_hash(local_input_dataset, tmp_path):
-    """Test the _get_hash method for correctness."""
-    file_path = tmp_path / "test_file.txt"
-    file_path.write_text("Test data for hash")
-
-    # Compute the expected hash manually
-    expected_hash = hashlib.sha256("Test data for hash".encode()).hexdigest()
-
-    # Call _get_hash and verify
-    calculated_hash = local_input_dataset._get_hash(file_path)
-    assert calculated_hash == expected_hash, "Hash mismatch"
-
-    # Test FileNotFoundError
-    non_existent_path = tmp_path / "non_existent_file.txt"
-    with pytest.raises(FileNotFoundError):
-        local_input_dataset._get_hash(non_existent_path)
-
-
 class TestInputDatasetGet:
     """Test class for the InputDataset.get method.
 
@@ -526,8 +507,8 @@ class TestInputDatasetGet:
         self.mock_resolve.side_effect = [self.target_dir, source_filepath_local]
 
         # Patch `_get_hash` to return a different, valid hash
-        with mock.patch.object(
-            local_input_dataset, "_get_hash", return_value="valid_hash"
+        with mock.patch(
+            "cstar.base.input_dataset._get_sha256_hash", return_value="valid_hash"
         ):
             with pytest.raises(
                 ValueError, match="The provided file hash.*does not match.*"

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
+import hashlib
 from unittest import mock
 from cstar.base.utils import (
+    _get_sha256_hash,
     _update_user_dotenv,
     _clone_and_checkout,
     _get_repo_head_hash,
@@ -11,6 +13,36 @@ from cstar.base.utils import (
     _list_to_concise_str,
     _dict_to_tree,
 )
+
+
+def test_get_sha256_hash(tmp_path):
+    """Test the get_sha256_hash method using the known hash of a temporary file.
+
+    Fixtures
+    ----------
+    tmp_path : Path
+        Pytest fixture providing a temporary directory for isolated filesystem operations.
+
+    Asserts
+    -------
+    - The calculated hash matches the expected hash
+    - A FileNotFoundError is raised if the file does not exist
+    """
+
+    file_path = tmp_path / "test_file.txt"
+    file_path.write_text("Test data for hash")
+
+    # Compute the expected hash manually
+    expected_hash = hashlib.sha256("Test data for hash".encode()).hexdigest()
+
+    # Call _get_sha256_hash and verify
+    calculated_hash = _get_sha256_hash(file_path)
+    assert calculated_hash == expected_hash, "Hash mismatch"
+
+    # Test FileNotFoundError
+    non_existent_path = tmp_path / "non_existent_file.txt"
+    with pytest.raises(FileNotFoundError):
+        _get_sha256_hash(non_existent_path)
 
 
 def test_update_user_dotenv(tmp_path):


### PR DESCRIPTION
- [x] Closes #164 
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage

This PR handles the situation uncovered in testing where a user could provide an incorrect `file_hash` attribute for a local `InputDataset` and C-Star would simply ignore the hash (as it is only used for remote downloads). There is now a `_get_sha256_hash` method  in `utils.py` and `InputDataset.get()` checks whether the provided hash of a local file matches the sha256 checksum of the file itself. If it doesn't, an error is raised and the user is told that they should either update or delete the incorrect hash (as it isn't strictly required by C-Star in their context).