### PR TITLE
Read blueprint from URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [
+        "types-requests",
         "types-python-dateutil",
         "types-PyYAML",
         "types-pytz"

--- a/cstar/case.py
+++ b/cstar/case.py
@@ -377,8 +377,8 @@ class Case:
 
         Parameters:
         -----------
-        blueprint: str | Path
-            Path to a yaml file containing the blueprint for the case
+        blueprint: str
+            Location of a yaml file (either a path or URL) containing the blueprint for the case
         caseroot: str | Path
             Path to the local directory where the case will be curated and run
         start_date: str or datetime, Optional, default=valid_start_date

--- a/cstar/case.py
+++ b/cstar/case.py
@@ -1,6 +1,7 @@
 import yaml
 import pickle
 import warnings
+import requests
 
 import dateutil.parser
 from pathlib import Path
@@ -11,6 +12,7 @@ from cstar.base.component import Component
 
 from cstar.system.manager import cstar_sysmgr
 from cstar.base.utils import _dict_to_tree
+from cstar.base.datasource import DataSource
 from cstar.roms.component import ROMSComponent
 from cstar.marbl.component import MARBLComponent
 
@@ -390,8 +392,16 @@ class Case:
             An initalized Case object based on the provided blueprint
         """
 
-        with open(blueprint, "r") as file:
-            bp_dict = yaml.safe_load(file)
+        source = DataSource(location=blueprint)
+        if source.source_type != "yaml":
+            raise ValueError(
+                f"C-Star expects blueprint in '.yaml' format, but got {blueprint}"
+            )
+        if source.location_type == "path":
+            with open(blueprint, "r") as file:
+                bp_dict = yaml.safe_load(file)
+        elif source.location_type == "url":
+            bp_dict = yaml.safe_load(requests.get(source.location).text)
 
         # Top-level metadata
         registry_attrs = bp_dict.get("registry_attrs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ dependencies = [
     "python-dotenv",
     "PyYAML==6.0.2",
     "pooch>=1.8.1",
-    "roms_tools[dask]>=2.0.0"
+    "roms_tools[dask]>=2.2.0"
 ]
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 
 [project.optional-dependencies]
 test = [
      "pytest>=7.0",
-     "roms_tools[dask]==2.0.0"
+     "roms_tools[dask]==2.2.0"
      ]
 dev =[]
 


### PR DESCRIPTION
Closes #217 
Following this PR :
-  `Case.from_blueprint` accepts a URL as the `blueprint` parameter.
- `Case.from_blueprint` creates a `DataSource` instance for the blueprint
- A check as to whether the blueprint (from any source) is a `yaml` file.

The `.pre-commit-config.yaml` file is updated to include additional `mypy` dependencies for the `requests` package.