### PR TITLE
Unify calls to subprocess.run

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -13,6 +13,10 @@ jobs:
   test:
     name: integration-${{ matrix.python-version }}
     runs-on: ubuntu-latest
+
+    # temporarily disable breaking integration tests from blocking a build
+    continue-on-error: true
+
     strategy:
       matrix:
         python-version: ["3.12",]

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -14,9 +14,6 @@ jobs:
     name: integration-${{ matrix.python-version }}
     runs-on: ubuntu-latest
 
-    # temporarily disable breaking integration tests from blocking a build
-    continue-on-error: true
-
     strategy:
       matrix:
         python-version: ["3.12",]

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -13,7 +13,6 @@ jobs:
   test:
     name: integration-${{ matrix.python-version }}
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         python-version: ["3.12",]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,11 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [
-        "types-requests",
-        "types-python-dateutil",
-        "types-PyYAML",
-        "types-pytz"
-      ]        
+          "types-requests",
+          "types-python-dateutil",
+          "types-PyYAML",
+          "types-pytz",
+        ]        
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -378,17 +378,17 @@ def _run_cmd(
 
     Examples:
     --------
-    In: _run_cmd("python foo.py", "Running script", "Script completed")
+    In: _run_cmd("python foo.py", msg_pre="Running script", msg_post="Script completed")
     Out: Running script
          Script completed
 
     In: _run_cmd("python foo.py")
     Out: Running command: python foo.py
-         Command completed successfully. STDOUT: <output of foo.py>
+         Command completed successfully.
 
     In: _run_cmd("python return_nonzero.py")
     Out: Running command: python return_nonzero.py
-         Command python return_nonzero.py failed: <stderror of foo.py>
+         Command `python return_nonzero.py` failed. STDERR: <stderror of foo.py>
     """
     print(msg_pre or f"Running command: {cmd}")
     stdout: str = ""
@@ -421,5 +421,5 @@ def _run_cmd(
 
         print(msg)
 
-    print(msg_post or f"Command completed successfully. STDOUT: {result.stdout}")
+    print(msg_post or "Command completed successfully.")
     return stdout

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -367,8 +367,7 @@ def _run_cmd(
         An overridden message logged after the command is successfully executed.
     msg_err (str | None), default = None):
         An overridden message logged when a command returns a non-zero code. Logs
-        will be supplied with the subprocess output using the name `result`,
-        e.g. `msg_err.format(result=result)`.
+        will automatically append the stderr output of the command.
     raise_on_error (bool, default = False):
         If True, raises a RuntimeError if the command returns a non-zero code.
 
@@ -413,9 +412,9 @@ def _run_cmd(
 
     if result.returncode != 0:
         if msg_err:
-            msg = msg_err.format(result=result)
+            msg = f"{msg_err} STDERR: {result.stderr.strip()}"
         else:
-            msg = f"Command `{cmd}` failed: {result.stderr.strip()}"
+            msg = f"Command `{cmd}` failed. STDERR: {result.stderr.strip()}"
 
         if raise_on_error:
             raise RuntimeError(msg)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -344,7 +344,7 @@ def _dict_to_tree(input_dict: dict, prefix: str = "") -> str:
 
 def _run_cmd(
     cmd: str,
-    cwd: PathLike | None = None,
+    cwd: Path | None = None,
     env: dict[str, str] | None = None,
     msg_pre: str | None = None,
     msg_post: str | None = None,
@@ -357,7 +357,7 @@ def _run_cmd(
     -----------
     cmd (str):
        The command to be executed as a separate process.
-    cwd (PathLike, default = None):
+    cwd (Path, default = None):
        The working directory for the command. If None, use current working directory.
     env (Dict[str, str], default = None):
        A dictionary of environment variables to be passed to the command.

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -1,7 +1,9 @@
 import re
+import functools
 import hashlib
 import warnings
 import subprocess
+from os import PathLike
 from pathlib import Path
 
 
@@ -338,3 +340,85 @@ def _dict_to_tree(input_dict: dict, prefix: str = "") -> str:
                 tree_str += f"{prefix}{sub_prefix}{item_branch}{item}\n"
 
     return tree_str
+
+
+def _run_cmd(
+    cmd: str,
+    cwd: PathLike | None = None,
+    env: dict[str, str] | None = None,
+    msg_pre: str | None = None,
+    msg_post: str | None = None,
+    msg_err: str | None = None,
+    raise_on_error: bool = False,
+) -> str:
+    """Execute a subprocess using default configuration, blocking until it completes.
+
+    Parameters:
+    -----------
+    cmd (str):
+       The command to be executed as a separate process.
+    cwd (PathLike, default = None):
+       The working directory for the command. If None, use current working directory.
+    env (Dict[str, str], default = None):
+       A dictionary of environment variables to be passed to the command.
+    msg_pre (str  | None), default = None):
+       An overridden message logged before the command is executed.
+    msg_post (str | None), default = None):
+        An overridden message logged after the command is successfully executed.
+    msg_err (str | None), default = None):
+        An overridden message logged when a command returns a non-zero code.
+    raise_on_error (bool, default = False):
+        If True, raises a RuntimeError if the command returns a non-zero code.
+
+    Returns:
+    -------
+    stdout: str
+       The captured standard output of the process.
+
+    Examples:
+    --------
+    In: _execute_cmd("python foo.py", "Running script", "Script completed")
+    Out: Running script
+         Script completed
+
+    In: _execute_cmd("python foo.py")
+    Out: Running command: python foo.py
+         Command completed successfully. STDOUT: <output of foo.py>
+
+    In: _execute_cmd("python return_nonzero.py")
+    Out: Running command: python return_nonzero.py
+         Command python return_nonzero.py failed: <stderror of foo.py>
+    """
+    print(msg_pre or f"Running command: {cmd}")
+    stdout: str = ""
+
+    fn = functools.partial(
+        subprocess.run,
+        cmd,
+        shell=True,
+        text=True,
+        capture_output=True,
+    )
+
+    kwargs: dict[str, str | PathLike | dict[str, str]] = {}
+    if cwd:
+        kwargs["cwd"] = cwd
+    if env:
+        kwargs["env"] = env
+
+    result: subprocess.CompletedProcess[str] = fn(**kwargs)
+    stdout = str(result.stdout).strip() if result.stdout is not None else ""
+
+    if result.returncode != 0:
+        if msg_err:
+            msg = msg_err.format(result=result)
+        else:
+            msg = f"Command `{cmd}` failed: {result.stderr.strip()}"
+
+        if raise_on_error:
+            raise RuntimeError(msg)
+
+        print(msg)
+
+    print(msg_post or f"Command completed successfully. STDOUT: {result.stdout}")
+    return stdout

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -412,9 +412,9 @@ def _run_cmd(
 
     if result.returncode != 0:
         if msg_err:
-            msg = f"{msg_err} STDERR: {result.stderr.strip()}"
+            msg = f"{msg_err} STDERR:\n{result.stderr.strip()}"
         else:
-            msg = f"Command `{cmd}` failed. STDERR: {result.stderr.strip()}"
+            msg = f"Command `{cmd}` failed. STDERR:\n{result.stderr.strip()}"
 
         if raise_on_error:
             raise RuntimeError(msg)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -379,15 +379,15 @@ def _run_cmd(
 
     Examples:
     --------
-    In: _execute_cmd("python foo.py", "Running script", "Script completed")
+    In: _run_cmd("python foo.py", "Running script", "Script completed")
     Out: Running script
          Script completed
 
-    In: _execute_cmd("python foo.py")
+    In: _run_cmd("python foo.py")
     Out: Running command: python foo.py
          Command completed successfully. STDOUT: <output of foo.py>
 
-    In: _execute_cmd("python return_nonzero.py")
+    In: _run_cmd("python return_nonzero.py")
     Out: Running command: python return_nonzero.py
          Command python return_nonzero.py failed: <stderror of foo.py>
     """

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -411,10 +411,13 @@ def _run_cmd(
     stdout = str(result.stdout).strip() if result.stdout is not None else ""
 
     if result.returncode != 0:
-        if msg_err:
-            msg = f"{msg_err} STDERR:\n{result.stderr.strip()}"
-        else:
-            msg = f"Command `{cmd}` failed. STDERR:\n{result.stderr.strip()}"
+        rc_out = f"Return Code: `{result.returncode}`."
+        stderr_out = f"STDERR:\n{result.stderr.strip()}"
+
+        if not msg_err:
+            msg_err = f"Command `{cmd}` failed."
+
+        msg = f"{msg_err} {rc_out} {stderr_out}"
 
         if raise_on_error:
             raise RuntimeError(msg)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -366,7 +366,9 @@ def _run_cmd(
     msg_post (str | None), default = None):
         An overridden message logged after the command is successfully executed.
     msg_err (str | None), default = None):
-        An overridden message logged when a command returns a non-zero code.
+        An overridden message logged when a command returns a non-zero code. Logs
+        will be supplied with the subprocess output using the name `result`,
+        e.g. `msg_err.format(result=result)`.
     raise_on_error (bool, default = False):
         If True, raises a RuntimeError if the command returns a non-zero code.
 

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -594,10 +594,7 @@ class SlurmJob(SchedulerJob):
             return ExecutionStatus.UNSUBMITTED
         else:
             sacct_cmd = f"sacct -j {self.id} --format=State%20 --noheader"
-            msg_err = (
-                f"Failed to retrieve job status using {sacct_cmd}."
-                "STDOUT: {result.stdout}, STDERR: {result.stderr}"
-            )
+            msg_err = f"Failed to retrieve job status using {sacct_cmd}."
             stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
 
         # Map sacct states to ExecutionStatus enum
@@ -687,7 +684,7 @@ class SlurmJob(SchedulerJob):
             f"sbatch {self.script_path}",
             cwd=self.run_path,
             env=slurm_env,
-            msg_err="Non-zero exit code when submitting job. STDERR: \n{result.stderr}",
+            msg_err="Non-zero exit code when submitting job.",
             raise_on_error=True,
         )
 
@@ -722,7 +719,7 @@ class SlurmJob(SchedulerJob):
             cwd=self.run_path,
             raise_on_error=True,
             msg_post=f"Job {self.id} cancelled",
-            msg_err="Non-zero exit code when cancelling job. STDERR: \n{result.stderr}",
+            msg_err="Non-zero exit code when cancelling job.",
         )
 
 
@@ -840,10 +837,7 @@ class PBSJob(SchedulerJob):
             return ExecutionStatus.UNSUBMITTED
 
         qstat_cmd = f"qstat -x -f -F json {self.id}"
-        msg_err = (
-            f"Failed to retrieve job status using {qstat_cmd}."
-            "STDOUT: {result.stdout}, STDERR: {result.stderr}"
-        )
+        msg_err = f"Failed to retrieve job status using {qstat_cmd}."
         stdout = _run_cmd(qstat_cmd, raise_on_error=True, msg_err=msg_err)
 
         # Parse the JSON output
@@ -905,7 +899,7 @@ class PBSJob(SchedulerJob):
             f"qsub {self.script_path}",
             cwd=self.run_path,
             raise_on_error=True,
-            msg_err="Non-zero exit code when submitting job. STDERR: \n{result.stderr}",
+            msg_err="Non-zero exit code when submitting job.",
         )
 
         # Validate the format of the job ID (e.g., "<int>.<str>")
@@ -940,9 +934,7 @@ class PBSJob(SchedulerJob):
         _run_cmd(
             f"qdel {self.id}",
             cwd=self.run_path,
-            msg_err=(
-                "Non-zero exit code when cancelling job. STDERR: \n{result.stderr}"
-            ),
+            msg_err="Non-zero exit code when cancelling job.",
             msg_post=f"Job {self.id} cancelled",
             raise_on_error=True,
         )

--- a/cstar/marbl/external_codebase.py
+++ b/cstar/marbl/external_codebase.py
@@ -1,8 +1,7 @@
 import os
-import subprocess
 from pathlib import Path
 from cstar.base import ExternalCodeBase
-from cstar.base.utils import _clone_and_checkout, _update_user_dotenv
+from cstar.base.utils import _clone_and_checkout, _update_user_dotenv, _run_cmd
 from cstar.system.manager import cstar_sysmgr
 
 
@@ -47,7 +46,7 @@ class MARBLExternalCodeBase(ExternalCodeBase):
         """
         _clone_and_checkout(
             source_repo=self.source_repo,
-            local_path=target,
+            local_path=Path(target),
             checkout_target=self.checkout_target,
         )
         # Set environment variables for this session:
@@ -59,17 +58,14 @@ class MARBLExternalCodeBase(ExternalCodeBase):
         _update_user_dotenv(env_file_str)
 
         # Make things
-        print("Compiling MARBL...")
-        make_marbl_result = subprocess.run(
+        _run_cmd(
             f"make {cstar_sysmgr.environment.compiler} USEMPI=TRUE",
-            cwd=f"{target}/src",
-            shell=True,
-            text=True,
-            capture_output=True,
+            cwd=Path(target) / "src",
+            msg_pre="Compiling MARBL...",
+            msg_post=f"MARBL successfully installed at {target}",
+            msg_err=(
+                "Error {result.returncode} when compiling MARBL. STDERR stream: "
+                "\n {result.stderr}"
+            ),
+            raise_on_error=True,
         )
-        if make_marbl_result.returncode != 0:
-            raise RuntimeError(
-                f"Error {make_marbl_result.returncode} when compiling MARBL. STDERR stream: "
-                + f"\n {make_marbl_result.stderr}"
-            )
-        print(f"MARBL successfully installed at {target}")

--- a/cstar/marbl/external_codebase.py
+++ b/cstar/marbl/external_codebase.py
@@ -63,9 +63,6 @@ class MARBLExternalCodeBase(ExternalCodeBase):
             cwd=Path(target) / "src",
             msg_pre="Compiling MARBL...",
             msg_post=f"MARBL successfully installed at {target}",
-            msg_err=(
-                "Error {result.returncode} when compiling MARBL. STDERR stream: "
-                "\n {result.stderr}"
-            ),
+            msg_err="Error when compiling MARBL.",
             raise_on_error=True,
         )

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -90,10 +90,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
             f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=target / "Work",
             msg_pre="Compiling NHMG library...",
-            msg_err=(
-                "Error {result.returncode} when compiling ROMS' NHMG library. STDERR stream: "
-                "\n {result.stderr}"
-            ),
+            msg_err="Error when compiling ROMS' NHMG library.",
             raise_on_error=True,
         )
         _run_cmd(
@@ -101,9 +98,6 @@ class ROMSExternalCodeBase(ExternalCodeBase):
             cwd=target / "Tools-Roms",
             msg_pre="Compiling Tools-Roms package for UCLA ROMS...",
             msg_post=f"UCLA-ROMS is installed at {target}",
-            msg_err=(
-                "Error {result.returncode} when compiling Tools-Roms. STDERR stream: "
-                "\n {result.stderr}"
-            ),
+            msg_err="Error when compiling Tools-Roms.",
             raise_on_error=True,
         )

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -1,9 +1,8 @@
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from cstar.base.external_codebase import ExternalCodeBase
-from cstar.base.utils import _clone_and_checkout, _update_user_dotenv
+from cstar.base.utils import _clone_and_checkout, _run_cmd, _update_user_dotenv
 from cstar.system.manager import cstar_sysmgr
 
 
@@ -87,30 +86,24 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         self._codebase_adjustments()
 
         # Make things
-        print("Compiling UCLA ROMS' NHMG library...")
-        make_nhmg_result = subprocess.run(
+        _run_cmd(
             f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=str(target) + "/Work",
-            capture_output=True,
-            text=True,
-            shell=True,
+            cwd=target / "Work",
+            msg_pre="Compiling NHMG library...",
+            msg_err=(
+                "Error {result.returncode} when compiling ROMS' NHMG library. STDERR stream: "
+                "\n {result.stderr}"
+            ),
+            raise_on_error=True,
         )
-        if make_nhmg_result.returncode != 0:
-            raise RuntimeError(
-                f"Error {make_nhmg_result.returncode} when compiling ROMS' NHMG library. STDERR stream: "
-                + f"\n {make_nhmg_result.stderr}"
-            )
-        print("Compiling Tools-Roms package for UCLA ROMS...")
-        make_tools_roms_result = subprocess.run(
+        _run_cmd(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=str(target) + "/Tools-Roms",
-            shell=True,
-            capture_output=True,
-            text=True,
+            cwd=target / "Tools-Roms",
+            msg_pre="Compiling Tools-Roms package for UCLA ROMS...",
+            msg_post=f"UCLA-ROMS is installed at {target}",
+            msg_err=(
+                "Error {result.returncode} when compiling Tools-Roms. STDERR stream: "
+                "\n {result.stderr}"
+            ),
+            raise_on_error=True,
         )
-        if make_tools_roms_result.returncode != 0:
-            raise RuntimeError(
-                f"Error {make_tools_roms_result.returncode} when compiling Tools-Roms. STDERR stream: "
-                + f"\n {make_tools_roms_result.stderr}"
-            )
-        print(f"UCLA-ROMS is installed at {target}")

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1177,10 +1177,7 @@ class ROMSSimulation(Simulation):
             _run_cmd(
                 "make compile_clean",
                 cwd=build_dir,
-                msg_err=(
-                    "Error {result.returncode} when compiling ROMS. STDERR stream: "
-                    "\n {result.stderr}"
-                ),
+                msg_err="Error when compiling ROMS.",
                 raise_on_error=True,
             )
 
@@ -1189,10 +1186,7 @@ class ROMSSimulation(Simulation):
             cwd=build_dir,
             msg_pre="Compiling UCLA-ROMS configuration...",
             msg_post=f"UCLA-ROMS compiled at {build_dir}",
-            msg_err=(
-                "Error {result.returncode} when compiling ROMS. STDERR stream: "
-                "\n {result.stderr}"
-            ),
+            msg_err="Error when compiling ROMS.",
             raise_on_error=True,
         )
 
@@ -1445,10 +1439,7 @@ class ROMSSimulation(Simulation):
                     f"ncjoin {wildcard_pattern}",
                     cwd=output_dir,
                     msg_pre=f"Joining netCDF files {wildcard_pattern}...",
-                    msg_err=(
-                        "Error {result.returncode} while joining ROMS output. "
-                        "STDERR stream:\n {result.stderr}"
-                    ),
+                    msg_err="Error while joining ROMS output.",
                     raise_on_error=True,
                 )
 

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -205,12 +205,7 @@ class CStarEnvironment:
         command = f"{lmod_path} python {' '.join(list(args))}"
         stdout = _run_cmd(
             command,
-            msg_err=(
-                "Linux Environment Modules command "
-                f"\n{command} "
-                "\n failed with code {result.returncode}. STDERR: "
-                "{result.stderr}"
-            ),
+            msg_err=f"Linux Environment Modules command `{command}` failed.",
             raise_on_error=True,
         )
 

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -205,7 +205,7 @@ class CStarEnvironment:
         command = f"{lmod_path} python {' '.join(list(args))}"
         stdout = _run_cmd(
             command,
-            msg_err=f"Linux Environment Modules command `{command}` failed.",
+            msg_err=f"Linux Environment Modules command `{command.strip()}` failed.",
             raise_on_error=True,
         )
 

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -1,9 +1,10 @@
 import os
 import platform
-import subprocess
 import importlib.util
 from pathlib import Path
 from dotenv import dotenv_values
+
+from cstar.base.utils import _run_cmd
 
 
 class CStarEnvironment:
@@ -202,18 +203,18 @@ class CStarEnvironment:
 
         lmod_path = Path(os.environ.get("LMOD_CMD", ""))
         command = f"{lmod_path} python {' '.join(list(args))}"
-        lmod_result = subprocess.run(
-            command, shell=True, text=True, capture_output=True
-        )
-        if lmod_result.returncode != 0:
-            raise RuntimeError(
+        stdout = _run_cmd(
+            command,
+            msg_err=(
                 "Linux Environment Modules command "
-                + f"\n{command} "
-                + f"\n failed with code {lmod_result.returncode}. STDERR: "
-                + f"{lmod_result.stderr}"
-            )
-        else:
-            exec(lmod_result.stdout)
+                f"\n{command} "
+                "\n failed with code {result.returncode}. STDERR: "
+                "{result.stderr}"
+            ),
+            raise_on_error=True,
+        )
+
+        exec(stdout)
 
     def load_lmod_modules(self, lmod_file) -> None:
         """Loads necessary modules for this machine using Linux Environment Modules.

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -437,7 +437,7 @@ class SlurmScheduler(Scheduler):
         """
         if stdout := _run_cmd(
             'scontrol show nodes | grep -o "cpu=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
-            msg_err="Error querying node property. STDERR: {result.stderr}",
+            msg_err="Error querying node property.",
         ):
             return int(stdout)
 
@@ -464,7 +464,7 @@ class SlurmScheduler(Scheduler):
 
         if stdout := _run_cmd(
             'scontrol show nodes | grep -o "RealMemory=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
-            msg_err="Error querying node property. STDERR: {result.stderr}",
+            msg_err="Error querying node property.",
         ):
             return float(stdout) / (1024)
 
@@ -521,7 +521,7 @@ class PBSScheduler(Scheduler):
 
         if stdout := _run_cmd(
             'pbsnodes -a | grep "resources_available.ncpus" | cut -d= -f2 | sort -nr | head -1',
-            msg_err="Error querying node property. STDERR: {result.stderr}",
+            msg_err="Error querying node property.",
         ):
             return int(stdout)
 
@@ -548,7 +548,7 @@ class PBSScheduler(Scheduler):
 
         stdout = _run_cmd(
             'pbsnodes -a | grep "resources_available.mem" | cut -d== -f2 | sort -nr | head -1',
-            msg_err="Error querying node property. STDERR: {result.stderr}",
+            msg_err="Error querying node property.",
         )
         if stdout.endswith("kb"):
             return float(stdout[:-2]) / (1024**2)  # Convert kilobytes to gigabytes

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -435,11 +435,11 @@ class SlurmScheduler(Scheduler):
         RuntimeError
             If the command to query the SLURM scheduler fails.
         """
-        if so := _run_cmd(
+        if stdout := _run_cmd(
             'scontrol show nodes | grep -o "cpu=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
             msg_err="Error querying node property. STDERR: {result.stderr}",
         ):
-            return int(so)
+            return int(stdout)
 
         return None
 
@@ -462,11 +462,11 @@ class SlurmScheduler(Scheduler):
             If the command to query the SLURM scheduler fails.
         """
 
-        if so := _run_cmd(
+        if stdout := _run_cmd(
             'scontrol show nodes | grep -o "RealMemory=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
             msg_err="Error querying node property. STDERR: {result.stderr}",
         ):
-            return float(so) / (1024)
+            return float(stdout) / (1024)
 
         return None
 
@@ -519,11 +519,11 @@ class PBSScheduler(Scheduler):
             If the command to query the PBS scheduler fails.
         """
 
-        if so := _run_cmd(
+        if stdout := _run_cmd(
             'pbsnodes -a | grep "resources_available.ncpus" | cut -d= -f2 | sort -nr | head -1',
             msg_err="Error querying node property. STDERR: {result.stderr}",
         ):
-            return int(so)
+            return int(stdout)
 
         return None
 

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -274,7 +274,11 @@ class TestSlurmJob:
         "subprocess_stdout, subprocess_returncode, expected_exception_message",
         [
             # Case 1: Non-zero return code from subprocess.run
-            ("", 1, "Non-zero exit code when submitting job. STDERR:"),
+            (
+                "",
+                1,
+                "Non-zero exit code when submitting job. Return Code: `1`. STDERR:",
+            ),
             # Case 2: Missing job ID in subprocess stdout
             (
                 "Submitted job without ID",

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -141,6 +141,6 @@ class TestMARBLExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error when compiling MARBL. STDERR:\nMocked MARBL Compilation Failure",
+            match="Error when compiling MARBL. Return Code: `1`. STDERR:\nMocked MARBL Compilation Failure",
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -141,6 +141,6 @@ class TestMARBLExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error when compiling MARBL. STDERR: Mocked MARBL Compilation Failure",
+            match="Error when compiling MARBL. STDERR:\nMocked MARBL Compilation Failure",
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -124,7 +124,7 @@ class TestMARBLExternalCodeBaseGet:
 
         self.mock_subprocess_run.assert_called_once_with(
             f"make {cstar_sysmgr.environment.compiler} USEMPI=TRUE",
-            cwd=f"{marbl_dir}/src",
+            cwd=marbl_dir / "src",
             capture_output=True,
             text=True,
             shell=True,
@@ -135,12 +135,12 @@ class TestMARBLExternalCodeBaseGet:
 
         ## There are two subprocess calls, we'd like one fail, one pass:
         self.mock_subprocess_run.side_effect = [
-            mock.Mock(returncode=1, stderr="Compiling MARBL failed successfully"),
+            mock.Mock(returncode=1, stderr="Mocked MARBL Compilation Failure"),
         ]
 
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error 1 when compiling MARBL. STDERR stream: \n Compiling MARBL failed successfully",
+            match="Error 1 when compiling MARBL. STDERR stream: \n Mocked MARBL Compilation Failure",
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -141,6 +141,6 @@ class TestMARBLExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error 1 when compiling MARBL. STDERR stream: \n Mocked MARBL Compilation Failure",
+            match="Error when compiling MARBL. STDERR: Mocked MARBL Compilation Failure",
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -173,7 +173,7 @@ class TestROMSExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error 1 when compiling ROMS' NHMG library. STDERR stream: \n Compiling NHMG library failed successfully",
+            match="Error when compiling ROMS' NHMG library. STDERR: Compiling NHMG library failed successfully",
         ):
             roms_codebase.get(target=tmp_path)
 
@@ -189,7 +189,7 @@ class TestROMSExternalCodeBaseGet:
             mock.Mock(returncode=0),  # Success for nhmg
             mock.Mock(
                 returncode=1,
-                stderr="Error 1 when compiling Tools-Roms. STDERR stream: \n Compiling Tools-Roms failed successfully",
+                stderr="Error when compiling Tools-Roms. STDERR: Compiling Tools-Roms failed successfully",
             ),  # Fail Tools-Roms
         ]
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -173,7 +173,7 @@ class TestROMSExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error when compiling ROMS' NHMG library. STDERR: Compiling NHMG library failed successfully",
+            match="Error when compiling ROMS' NHMG library. STDERR:\nCompiling NHMG library failed successfully",
         ):
             roms_codebase.get(target=tmp_path)
 
@@ -189,12 +189,12 @@ class TestROMSExternalCodeBaseGet:
             mock.Mock(returncode=0),  # Success for nhmg
             mock.Mock(
                 returncode=1,
-                stderr="Error when compiling Tools-Roms. STDERR: Compiling Tools-Roms failed successfully",
+                stderr="Error when compiling Tools-Roms. STDERR:\nCompiling Tools-Roms failed successfully",
             ),  # Fail Tools-Roms
         ]
 
         with pytest.raises(
-            RuntimeError, match=" Compiling Tools-Roms failed successfully"
+            RuntimeError, match="Compiling Tools-Roms failed successfully"
         ):
             roms_codebase.get(target=tmp_path)
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -145,7 +145,7 @@ class TestROMSExternalCodeBaseGet:
 
         self.mock_subprocess_run.assert_any_call(
             f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=f"{roms_dir}/Work",
+            cwd=roms_dir / "Work",
             capture_output=True,
             text=True,
             shell=True,
@@ -153,7 +153,7 @@ class TestROMSExternalCodeBaseGet:
 
         self.mock_subprocess_run.assert_any_call(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=f"{roms_dir}/Tools-Roms",
+            cwd=roms_dir / "Tools-Roms",
             capture_output=True,
             text=True,
             shell=True,

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -173,7 +173,7 @@ class TestROMSExternalCodeBaseGet:
         # Test
         with pytest.raises(
             RuntimeError,
-            match="Error when compiling ROMS' NHMG library. STDERR:\nCompiling NHMG library failed successfully",
+            match="Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\nCompiling NHMG library failed successfully",
         ):
             roms_codebase.get(target=tmp_path)
 
@@ -189,7 +189,7 @@ class TestROMSExternalCodeBaseGet:
             mock.Mock(returncode=0),  # Success for nhmg
             mock.Mock(
                 returncode=1,
-                stderr="Error when compiling Tools-Roms. STDERR:\nCompiling Tools-Roms failed successfully",
+                stderr="Error when compiling Tools-Roms. Return Code: `1`. STDERR:\nCompiling Tools-Roms failed successfully",
             ),  # Fail Tools-Roms
         ]
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1897,7 +1897,7 @@ class TestProcessingAndExecution:
         mock_subprocess.return_value = MagicMock(returncode=1, stderr="")
         mock_get_hash.return_value = "mockhash123"
 
-        with pytest.raises(RuntimeError, match="Error 1 when compiling ROMS"):
+        with pytest.raises(RuntimeError, match="Error when compiling ROMS"):
             sim.build()
         assert mock_subprocess.call_count == 1
         mock_subprocess.assert_any_call(
@@ -1937,7 +1937,7 @@ class TestProcessingAndExecution:
         mock_subprocess.return_value = MagicMock(returncode=1, stderr="")
         mock_get_hash.return_value = "mockhash123"
 
-        with pytest.raises(RuntimeError, match="Error 1 when compiling ROMS"):
+        with pytest.raises(RuntimeError, match="Error when compiling ROMS"):
             sim.build()
         assert mock_subprocess.call_count == 1
 
@@ -2439,7 +2439,7 @@ class TestProcessingAndExecution:
         )  # Ensure run is complete
 
         # Call post_run and expect error
-        with pytest.raises(RuntimeError, match="Error 1 while joining ROMS output"):
+        with pytest.raises(RuntimeError, match="Error while joining ROMS output"):
             sim.post_run()
 
         mock_subprocess.assert_called_once_with(

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -368,7 +368,7 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match="Linux Environment Modules command \n/mock/lmod python reset \n failed with code 1. STDERR: Module reset error",
+            match="Linux Environment Modules command `/mock/lmod python reset` failed. STDERR: Module reset error",
         ):
             MockEnvironment()
 
@@ -414,6 +414,6 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match=r"Linux Environment Modules command\s+\n/mock/lmod python load module1\s+\n failed with code 1\. STDERR: Module load error",
+            match=r"Linux Environment Modules command\s+`/mock/lmod python load module1\s` failed. STDERR: Module load error",
         ):
             MockEnvironment()

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -368,7 +368,10 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match="Linux Environment Modules command `/mock/lmod python reset` failed. STDERR:\nModule reset error",
+            match=(
+                "Linux Environment Modules command `/mock/lmod python reset` failed. "
+                "Return Code: `1`. STDERR:\nModule reset error"
+            ),
         ):
             MockEnvironment()
 
@@ -414,6 +417,9 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match=r"Linux Environment Modules command\s+`/mock/lmod python load module1\s` failed. STDERR:\nModule load error",
+            match=(
+                "Linux Environment Modules command `/mock/lmod python load module1` "
+                "failed. Return Code: `1`. STDERR:\nModule load error"
+            ),
         ):
             MockEnvironment()

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -32,7 +32,7 @@ class TestSetupEnvironmentFromFiles:
     """
 
     @pytest.mark.parametrize("lmod_syshost", ["perlmutter", "derecho", "expanse"])
-    @patch("cstar.system.environment.subprocess.run")
+    @patch("cstar.base.utils.subprocess.run")
     @patch.object(
         cstar.system.environment.CStarEnvironment,
         "uses_lmod",
@@ -283,7 +283,7 @@ class TestExceptions:
         """
 
         self.subprocess_patcher = patch(
-            "cstar.system.environment.subprocess.run",
+            "cstar.base.utils.subprocess.run",
             return_value=subprocess.CompletedProcess(args="module reset", returncode=0),
         )
         self.mock_subprocess = self.subprocess_patcher.start()
@@ -346,7 +346,7 @@ class TestExceptions:
     @patch.dict(
         "cstar.system.environment.os.environ", {"LMOD_CMD": "/mock/lmod"}, clear=True
     )
-    @patch("cstar.system.environment.subprocess.run")
+    @patch("cstar.base.utils.subprocess.run")
     def test_load_lmod_modules_raises_runtime_error_on_module_reset_failure(
         self, mock_subprocess
     ):

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -368,7 +368,7 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match="Linux Environment Modules command `/mock/lmod python reset` failed. STDERR: Module reset error",
+            match="Linux Environment Modules command `/mock/lmod python reset` failed. STDERR:\nModule reset error",
         ):
             MockEnvironment()
 
@@ -414,6 +414,6 @@ class TestExceptions:
 
         with pytest.raises(
             RuntimeError,
-            match=r"Linux Environment Modules command\s+`/mock/lmod python load module1\s` failed. STDERR: Module load error",
+            match=r"Linux Environment Modules command\s+`/mock/lmod python load module1\s` failed. STDERR:\nModule load error",
         ):
             MockEnvironment()

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -228,7 +228,7 @@ class TestScheduler:
         Captures printed error messages to ensure the failure is logged correctly.
         """
         mock_subprocess_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="Error querying CPUs"
+            returncode=2, stdout="", stderr="Error querying CPUs"
         )
         scheduler = SlurmScheduler(queues=[], primary_queue_name="general")
 
@@ -237,7 +237,8 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR:\nError querying CPUs" in captured.out
+            "Error querying node property. Return Code: `2`. STDERR:\nError querying CPUs"
+            in captured.out
         )
 
     def test_slurmscheduler_global_max_mem_per_node_gb_success(
@@ -280,7 +281,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR:\nError querying memory"
+            "Error querying node property. Return Code: `1`. STDERR:\nError querying memory"
             in captured.out
         )
 
@@ -321,7 +322,8 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR:\nError querying CPUs" in captured.out
+            "Error querying node property. Return Code: `1`. STDERR:\nError querying CPUs"
+            in captured.out
         )
 
     def test_pbsscheduler_global_max_mem_per_node_gb_failure(
@@ -341,7 +343,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR:\nError querying memory"
+            "Error querying node property. Return Code: `1`. STDERR:\nError querying memory"
             in captured.out
         )
 

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -237,7 +237,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR: Error querying CPUs" in captured.out
+            "Error querying node property. STDERR:\nError querying CPUs" in captured.out
         )
 
     def test_slurmscheduler_global_max_mem_per_node_gb_success(
@@ -280,7 +280,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR: Error querying memory"
+            "Error querying node property. STDERR:\nError querying memory"
             in captured.out
         )
 
@@ -321,7 +321,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR: Error querying CPUs" in captured.out
+            "Error querying node property. STDERR:\nError querying CPUs" in captured.out
         )
 
     def test_pbsscheduler_global_max_mem_per_node_gb_failure(
@@ -341,7 +341,7 @@ class TestScheduler:
 
         captured = capsys.readouterr()
         assert (
-            "Error querying node property. STDERR: Error querying memory"
+            "Error querying node property. STDERR:\nError querying memory"
             in captured.out
         )
 

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -311,6 +311,7 @@ class TestScheduler:
 
         Captures printed error messages to ensure the failure is logged correctly.
         """
+        capsys.readouterr()  # Clear previous output
         mock_subprocess_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="Error querying CPUs"
         )

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -311,7 +311,6 @@ class TestScheduler:
 
         Captures printed error messages to ensure the failure is logged correctly.
         """
-        capsys.readouterr()  # Clear previous output
         mock_subprocess_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="Error querying CPUs"
         )


### PR DESCRIPTION
This PR wraps up the common pattern of calling `subprocess.run` with a utility method. The new method includes:

- always-on logging before start w/message customization
- always-on logging after process term w/message customization
- always-on logging on a non-zero return code w/message customization

> [!NOTE] 
> Out-of-Scope
> Calls to `subprocess.run` related to git repository manipulation are not replaced here. They will be completed in [another ticket](https://github.com/CWorthy-ocean/C-Star/issues/6).


- [x] Closes #204
- [x] Tests updated
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst` - `n/a`
- [ ] New functionality has documentation - `n/a`