### PR TITLE
Forcing correction

### DIFF
--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -75,6 +75,12 @@ class InputDataset(ABC):
         self._local_file_hash_cache: Optional[Dict] = None
         self._local_file_stat_cache: Optional[Dict] = None
 
+        # Subclass-specific  confirmation that everything is set up correctly:
+        self.validate()
+
+    def validate(self):
+        pass
+
     @property
     def exists_locally(self) -> bool:
         """Check if this InputDataset exists on the local filesystem.

--- a/cstar/roms/__init__.py
+++ b/cstar/roms/__init__.py
@@ -23,4 +23,5 @@ __all__ = [
     "ROMSBoundaryForcing",
     "ROMSSurfaceForcing",
     "ROMSRiverForcing",
+    "ROMSForcingCorrections",
 ]

--- a/cstar/roms/__init__.py
+++ b/cstar/roms/__init__.py
@@ -9,6 +9,7 @@ from cstar.roms.input_dataset import (
     ROMSBoundaryForcing,
     ROMSSurfaceForcing,
     ROMSRiverForcing,
+    ROMSForcingCorrections,
 )
 
 __all__ = [

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -275,3 +275,20 @@ class ROMSRiverForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for river forcing files."""
 
     pass
+
+
+class ROMSForcingCorrections(ROMSInputDataset):
+    """ROMS forcing correction file (e.g., climatology or bias-correction).
+
+    This file must not be generated from a roms-tools YAML. It should point directly to
+    a NetCDF or similar file.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.source.source_type == "yaml":
+            raise ValueError(
+                "Hey, you! we said no funny business! "
+                f"{self.__class__.__name__} cannot be initialized with a source YAML file. "
+                "Please provide a direct path or URL to a dataset (e.g., NetCDF)."
+            )

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -278,7 +278,9 @@ class ROMSRiverForcing(ROMSInputDataset):
 
 
 class ROMSForcingCorrections(ROMSInputDataset):
-    """ROMS forcing correction file (e.g., climatology or bias-correction).
+    """ROMS forcing correction file, such as SW correction or restoring fields.
+
+    These are used by older ROMS configurations, and included in C-Star to support them.
 
     This file must not be generated from a roms-tools YAML. It should point directly to
     a NetCDF or similar file.
@@ -288,7 +290,7 @@ class ROMSForcingCorrections(ROMSInputDataset):
         super().__init__(*args, **kwargs)
         if self.source.source_type == "yaml":
             raise ValueError(
-                "Hey, you! we said no funny business! "
+                "Hey, you! we said no funny business! -Scotty E."
                 f"{self.__class__.__name__} cannot be initialized with a source YAML file. "
                 "Please provide a direct path or URL to a dataset (e.g., NetCDF)."
             )

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -288,7 +288,7 @@ class ROMSForcingCorrections(ROMSInputDataset):
 
     def validate(self):
         if self.source.source_type == "yaml":
-            raise ValueError(
+            raise TypeError(
                 "Hey, you! we said no funny business! -Scotty E."
                 f"{self.__class__.__name__} cannot be initialized with a source YAML file. "
                 "Please provide a direct path or URL to a dataset (e.g., NetCDF)."

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -286,8 +286,7 @@ class ROMSForcingCorrections(ROMSInputDataset):
     a NetCDF or similar file.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def validate(self):
         if self.source.source_type == "yaml":
             raise ValueError(
                 "Hey, you! we said no funny business! -Scotty E."

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -214,26 +214,16 @@ class ROMSSimulation(Simulation):
         self.tidal_forcing = tidal_forcing
         self.river_forcing = river_forcing
         self.surface_forcing = [] if surface_forcing is None else surface_forcing
-        if not all([isinstance(sf, ROMSSurfaceForcing) for sf in self.surface_forcing]):
-            raise TypeError(
-                "ROMSSimulation.surface_forcing must be a list of ROMSSurfaceForcing instances"
-            )
+        self._check_forcing_collection_types(self.surface_forcing, ROMSSurfaceForcing)
+
         self.boundary_forcing = [] if boundary_forcing is None else boundary_forcing
-        if not all(
-            [isinstance(bf, ROMSBoundaryForcing) for bf in self.boundary_forcing]
-        ):
-            raise TypeError(
-                "ROMSSimulation.boundary_forcing must be a list of ROMSBoundaryForcing instances"
-            )
+        self._check_forcing_collection_types(self.boundary_forcing, ROMSBoundaryForcing)
         self.forcing_corrections = (
             [] if forcing_corrections is None else forcing_corrections
         )
-        if not all(
-            [isinstance(bf, ROMSForcingCorrections) for bf in self.forcing_corrections]
-        ):
-            raise TypeError(
-                "ROMSSimulation.forcing_corrections must be a list of ROMSForcingCorrections instances"
-            )
+        self._check_forcing_collection_types(
+            self.forcing_corrections, ROMSForcingCorrections
+        )
 
         self._check_inputdataset_dates()
 
@@ -254,6 +244,12 @@ class ROMSSimulation(Simulation):
         self.partitioned_files: List[Path] | None = None
 
         self._execution_handler: Optional["ExecutionHandler"] = None
+
+    def _check_forcing_collection_types(self, collection, expected_class):
+        if not all([isinstance(ind, expected_class) for ind in collection]):
+            raise TypeError(
+                f"ROMSSimulation.{collection} must be a list of {expected_class} instances"
+            )
 
     def _check_inputdataset_dates(self) -> None:
         """For ROMSInputDatasets whose source type is `yaml`, ensure that any set

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -333,7 +333,7 @@ class ROMSSimulation(Simulation):
         if len(self.boundary_forcing) > 0:
             base_str += (
                 f"\nBoundary forcing: <list of {len(self.boundary_forcing)} "
-                + f"{self.boundary_forcing[0].__class__.__name__} instances>\n"
+                + f"{self.boundary_forcing[0].__class__.__name__} instances>"
             )
         if len(self.forcing_corrections) > 0:
             base_str += (
@@ -378,7 +378,7 @@ class ROMSSimulation(Simulation):
         if hasattr(self, "boundary_forcing") and len(self.boundary_forcing) > 0:
             repr_str += (
                 f"\nboundary_forcing = <list of {len(self.boundary_forcing)} "
-                + f"{self.boundary_forcing[0].__class__.__name__} instances>"
+                + f"{self.boundary_forcing[0].__class__.__name__} instances>,"
             )
         if hasattr(self, "forcing_corrections") and len(self.forcing_corrections) > 0:
             repr_str += (

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -169,7 +169,7 @@ class ROMSSimulation(Simulation):
             List of datasets specifying boundary conditions for ROMS.
         surface_forcing : list[ROMSBoundaryForcing]
             List of surface forcing datasets (e.g., wind stress, heat flux).
-        forcing_corrections : list[ROMSForcingCorrections]
+        forcing_corrections : list[ROMSForcingCorrections], optional
             List of surface forcing correction datasets.
 
         Raises
@@ -246,6 +246,9 @@ class ROMSSimulation(Simulation):
         self._execution_handler: Optional["ExecutionHandler"] = None
 
     def _check_forcing_collection_types(self, collection, expected_class):
+        """For forcing types that may correspond to multiple InputDataset instances
+        (ROMSSurfaceForcing, ROMSBoundaryForcing, ROMSForcingCorrections), ensure that
+        the corresponding attribute is a list of instances of the correct type."""
         if not all([isinstance(ind, expected_class) for ind in collection]):
             raise TypeError(
                 f"ROMSSimulation.{collection} must be a list of {expected_class} instances"

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -3,7 +3,7 @@ import datetime as dt
 from unittest import mock
 from pathlib import Path
 from textwrap import dedent
-from cstar.roms import ROMSInputDataset
+from cstar.roms import ROMSInputDataset, ROMSForcingCorrections
 from cstar.base.datasource import DataSource
 
 
@@ -128,6 +128,20 @@ def remote_roms_yaml_dataset():
 
 
 ################################################################################
+
+
+class TestROMSInputDatasetInit:
+    """Test class for initializing ROMSInputDataset subclasses."""
+
+    def test_correction_cannot_be_yaml(self):
+        with pytest.raises(ValueError) as exception_info:
+            ROMSForcingCorrections(
+                location="https://www.totallylegityamlfiles.pk/downloadme.yaml"
+            )
+            expected_message = (
+                "ROMSForcingCorrections cannot be initialized with a source YAML file."
+            )
+            assert expected_message in str(exception_info.value)
 
 
 class TestStrAndRepr:

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -130,20 +130,6 @@ def remote_roms_yaml_dataset():
 ################################################################################
 
 
-class TestROMSInputDatasetInit:
-    """Test class for initializing ROMSInputDataset subclasses."""
-
-    def test_correction_cannot_be_yaml(self):
-        with pytest.raises(ValueError) as exception_info:
-            ROMSForcingCorrections(
-                location="https://www.totallylegityamlfiles.pk/downloadme.yaml"
-            )
-            expected_message = (
-                "ROMSForcingCorrections cannot be initialized with a source YAML file."
-            )
-            assert expected_message in str(exception_info.value)
-
-
 class TestStrAndRepr:
     """Test class for verifying the string and repr outputs of ROMSInputDataset.
 
@@ -1135,3 +1121,17 @@ class TestROMSInputDatasetPartition:
                 f"{local_roms_netcdf_dataset.working_path}."
             )
             assert str(exception_info.value) == expected_message
+
+
+def test_correction_cannot_be_yaml(self):
+    """Checks that the `validate()` method correctly raises a TypeError if
+    `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)"""
+
+    with pytest.raises(ValueError) as exception_info:
+        ROMSForcingCorrections(
+            location="https://www.totallylegityamlfiles.pk/downloadme.yaml"
+        )
+        expected_msg = (
+            "ROMSForcingCorrections cannot be initialized with a source YAML file."
+        )
+        assert expected_msg in str(exception_info.value)

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -1123,11 +1123,11 @@ class TestROMSInputDatasetPartition:
             assert str(exception_info.value) == expected_message
 
 
-def test_correction_cannot_be_yaml(self):
+def test_correction_cannot_be_yaml():
     """Checks that the `validate()` method correctly raises a TypeError if
     `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)"""
 
-    with pytest.raises(ValueError) as exception_info:
+    with pytest.raises(TypeError) as exception_info:
         ROMSForcingCorrections(
             location="https://www.totallylegityamlfiles.pk/downloadme.yaml"
         )

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -373,9 +373,7 @@ class TestROMSSimulationInitialization:
             ("forcing_corrections", "ROMSForcingCorrections"),
         ],
     )
-    def test_lists_of_input_datasets_raise_if_invalid(
-        self, tmp_path, argname, expected_type_name
-    ):
+    def test_check_forcing_collection(self, tmp_path, argname, expected_type_name):
         """Ensure a TypeError is raised when entries that should be lists of
         ROMSInputDatasets (ROMSSurfaceForcing, ROMSBoundaryForcing,
         ROMSForcingCorrections) are not.
@@ -406,8 +404,10 @@ class TestROMSSimulationInitialization:
 
         expected_msg = f"must be a list of {expected_type_name} instances"
 
-        with pytest.raises(TypeError, match=expected_msg):
+        with pytest.raises(TypeError) as exception_info:
             ROMSSimulation(**kwargs)
+
+            assert expected_msg in str(exception_info.value)
 
     def test_codebases(self, example_roms_simulation):
         """Test that the `codebases` property correctly lists the `ExternalCodeBase`

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -17,6 +17,7 @@ from cstar.roms.input_dataset import (
     ROMSBoundaryForcing,
     ROMSSurfaceForcing,
     ROMSRiverForcing,
+    ROMSForcingCorrections,
 )
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.base.additional_code import AdditionalCode
@@ -91,6 +92,11 @@ def example_roms_simulation(tmp_path):
         ],
         surface_forcing=[
             ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567"),
+        ],
+        forcing_corrections=[
+            ROMSForcingCorrections(
+                location="http://my.files/sw_corr.nc", file_hash="890"
+            ),
         ],
     )
 
@@ -359,62 +365,24 @@ class TestROMSSimulationInitialization:
         )
         assert sim.marbl_codebase.checkout_target == "marbl0.45.0"
 
-    def test_invalid_surface_forcing_type(self, tmp_path):
-        """Ensure a `TypeError` is raised when `surface_forcing` is not a list of
-        `ROMSSurfaceForcing` instances.
-
-        This test verifies that the `ROMSSimulation` constructor enforces type safety
-        by checking that `surface_forcing` is a list containing only `ROMSSurfaceForcing`
-        objects. Passing an invalid list should result in a `TypeError`.
-
-        Assertions
-        ----------
-        - A `TypeError` is raised when `surface_forcing` contains elements that are
-          not `ROMSSurfaceForcing` instances, including an expected message substring.
-
-        Mocks & Fixtures
-        ----------------
-        - `tmp_path` : A temporary directory fixture provided by `pytest` for
-          safely testing file system interactions.
-        """
-
-        with pytest.raises(
-            TypeError, match="must be a list of ROMSSurfaceForcing instances"
-        ):
-            ROMSSimulation(
-                name="test",
-                directory=tmp_path,
-                discretization=ROMSDiscretization(time_step=60),
-                codebase=ROMSExternalCodeBase(),
-                runtime_code=AdditionalCode(location="some/dir"),
-                compile_time_code=AdditionalCode(location="some/dir"),
-                start_date="2012-01-01",
-                end_date="2012-01-02",
-                valid_start_date="2012-01-01",
-                valid_end_date="2012-01-02",
-                surface_forcing=[
-                    "list",
-                    "of",
-                    "strings",
-                    "instead",
-                    "of",
-                    "ROMSSurfaceForcing",
-                    "instances",
-                ],
-            )
-
-    def test_invalid_boundary_forcing_type(self, tmp_path):
-        """Ensure a `TypeError` is raised when `boundary_forcing` is not a list of
-        `ROMSBoundaryForcing` instances.
-
-        This test verifies that the `ROMSSimulation` constructor enforces type safety
-        by ensuring that `boundary_forcing` is a list containing only `ROMSBoundaryForcing`
-        objects. Passing an invalid list should result in a `TypeError`.
+    @pytest.mark.parametrize(
+        "argname, expected_type_name",
+        [
+            ("surface_forcing", "ROMSSurfaceForcing"),
+            ("boundary_forcing", "ROMSBoundaryForcing"),
+            ("forcing_corrections", "ROMSForcingCorrections"),
+        ],
+    )
+    def test_lists_of_input_datasets_raise_if_invalid(
+        self, tmp_path, argname, expected_type_name
+    ):
+        """Ensure a TypeError is raised when entries that should be lists of
+        ROMSInputDatasets (ROMSSurfaceForcing, ROMSBoundaryForcing,
+        ROMSForcingCorrections) are not.
 
         Assertions
         ----------
-        - A `TypeError` is raised when `boundary_forcing` contains elements that are
-          not `ROMSBoundaryForcing` instances with an expected message substring
+        - A `TypeError` is raised when entries that should be lists of ROMSInputDatasets are not
 
         Mocks & Fixtures
         ----------------
@@ -422,30 +390,24 @@ class TestROMSSimulationInitialization:
           testing file system interactions.
         """
 
-        with pytest.raises(
-            TypeError, match="must be a list of ROMSBoundaryForcing instances"
-        ):
-            ROMSSimulation(
-                name="test",
-                directory=tmp_path,
-                discretization=ROMSDiscretization(time_step=60),
-                codebase=ROMSExternalCodeBase(),
-                runtime_code=AdditionalCode("some/dir"),
-                compile_time_code=AdditionalCode("some/dir"),
-                start_date="2012-01-01",
-                end_date="2012-01-02",
-                valid_start_date="2012-01-01",
-                valid_end_date="2012-01-02",
-                boundary_forcing=[
-                    "list",
-                    "of",
-                    "strings",
-                    "instead",
-                    "of",
-                    "ROMSBoundaryForcing",
-                    "instances",
-                ],
-            )
+        kwargs = {
+            "name": "test",
+            "directory": tmp_path,
+            "discretization": ROMSDiscretization(time_step=60),
+            "codebase": ROMSExternalCodeBase(),
+            "runtime_code": AdditionalCode(location="some/dir"),
+            "compile_time_code": AdditionalCode(location="some/dir"),
+            "start_date": "2012-01-01",
+            "end_date": "2012-01-02",
+            "valid_start_date": "2012-01-01",
+            "valid_end_date": "2012-01-02",
+            argname: ["this", "is", "not", "valid"],
+        }
+
+        expected_msg = f"must be a list of {expected_type_name} instances"
+
+        with pytest.raises(TypeError, match=expected_msg):
+            ROMSSimulation(**kwargs)
 
     def test_codebases(self, example_roms_simulation):
         """Test that the `codebases` property correctly lists the `ExternalCodeBase`
@@ -634,8 +596,85 @@ class TestROMSSimulationInitialization:
         rf = sim.river_forcing
         bc = sim.boundary_forcing[0]
         sf = sim.surface_forcing[0]
+        fc = sim.forcing_corrections[0]
 
-        assert sim.input_datasets == [mg, ic, td, rf, bc, sf]
+        assert sim.input_datasets == [mg, ic, td, rf, bc, sf, fc]
+
+    @pytest.mark.parametrize(
+        "start_date, valid_start_date, end_date, valid_end_date, substring",
+        [
+            (
+                "1992-02-11",
+                "1993-05-15",
+                "2000-01-01",
+                "2000-01-01",
+                "before the earliest",
+            ),
+            (
+                "1992-02-11",
+                "1992-02-11",
+                "2001-01-01",
+                "2000-01-01",
+                "after the latest",
+            ),
+            ("1993-05-15", "1900-01-01", "1992-02-11", "2000-01-01", "after end_date"),
+        ],
+    )
+    def test_validate_date_range(
+        self,
+        tmp_path,
+        start_date,
+        valid_start_date,
+        end_date,
+        valid_end_date,
+        substring,
+    ):
+        """Test the _validate_date_range function.
+
+        This test ensures the _validate_date_range function correctly raises
+        a ValueError in each of the following cases:
+        - The start date is before the valid_start_date
+        - The end date is after the valid_end_date
+        - The start date is after the end date
+
+
+        Parameters
+        ----------
+        start_date : str
+           The requested simulation start date.
+        valid_start_date : str
+           The earliest valid start date for the simulation.
+        end_date : str
+           The requested simulation end date.
+        valid_end_date : str
+           The latest valid end date for the simulation.
+        substring : str
+           A substring expected to be found in the raised error message.
+
+        Mocks & Fixtures
+        ----------------
+        - `tmp_path` : A pytest fixture providing a temporary directory for filesystem-safe tests.
+
+        Assertions
+        ----------
+        - Checks that `ROMSSimulation` raises a `ValueError` when the provided dates are invalid.
+        - Asserts that the error message contains a specific substring identifying the issue.
+        """
+
+        with pytest.raises(ValueError) as exception_info:
+            ROMSSimulation(
+                name="test",
+                directory=tmp_path,
+                runtime_code=[],
+                compile_time_code=[],
+                discretization=ROMSDiscretization(time_step=1),
+                start_date=start_date,
+                end_date=end_date,
+                valid_start_date=valid_start_date,
+                valid_end_date=valid_end_date,
+            )
+
+            assert substring in str(exception_info.value)
 
     def test_check_inputdataset_dates_warns_and_sets_start_date(
         self, example_roms_simulation
@@ -770,6 +809,7 @@ Tidal forcing: <ROMSTidalForcing instance>
 River forcing: <ROMSRiverForcing instance>
 Surface forcing: <list of 1 ROMSSurfaceForcing instances>
 Boundary forcing: <list of 1 ROMSBoundaryForcing instances>
+Forcing corrections: <list of 1 ROMSForcingCorrections instances>
 
 Is setup: False"""
         assert sim.__str__() == expected_str
@@ -812,7 +852,8 @@ initial_conditions = <ROMSInitialConditions instance>,
 tidal_forcing = <ROMSTidalForcing instance>,
 river_forcing = <ROMSRiverForcing instance>,
 surface_forcing = <list of 1 ROMSSurfaceForcing instances>,
-boundary_forcing = <list of 1 ROMSBoundaryForcing instances>
+boundary_forcing = <list of 1 ROMSBoundaryForcing instances>,
+forcing_corrections = <list of 1 ROMSForcingCorrections instances>
 )"""
         assert expected_repr == sim.__repr__()
 
@@ -843,7 +884,8 @@ boundary_forcing = <list of 1 ROMSBoundaryForcing instances>
     │   ├── tidal.nc
     │   ├── river.nc
     │   ├── boundary.nc
-    │   └── surface.nc
+    │   ├── surface.nc
+    │   └── sw_corr.nc
     ├── runtime_code
     │   ├── file1
     │   ├── file2.in_TEMPLATE
@@ -949,7 +991,10 @@ class TestToAndFromDictAndBlueprint:
                 {"location": "http://my.files/surface.nc", "file_hash": "567"}
             ],
             "boundary_forcing": [
-                {"location": "http://my.files/boundary.nc", "file_hash": "456"}
+                {"location": "http://my.files/boundary.nc", "file_hash": "456"},
+            ],
+            "forcing_corrections": [
+                {"location": "http://my.files/sw_corr.nc", "file_hash": "890"}
             ],
         }
 
@@ -1409,6 +1454,7 @@ class TestProcessingAndExecution:
             + f"\n     {partitioned_directory/'boundary.nc'}"
             + f"\n     {partitioned_directory/'tidal.nc'}"
             + f"\n     {partitioned_directory/'river.nc'}"
+            + f"\n     {partitioned_directory/'sw_corr.nc'}"
         )
 
         assert rtcm_dict["__MARBL_SETTINGS_FILE_PLACEHOLDER__"] == str(
@@ -1628,7 +1674,7 @@ class TestProcessingAndExecution:
         sim.setup()
         assert mock_handle_config_status.call_count == 2
         assert mock_additionalcode_get.call_count == 2
-        assert mock_inputdataset_get.call_count == 6
+        assert mock_inputdataset_get.call_count == 7
 
     @pytest.mark.parametrize(
         "codebase_status, marbl_status, expected",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,6 +42,7 @@ Input Datasets
    cstar.roms.ROMSRiverForcing
    cstar.roms.ROMSBoundaryForcing
    cstar.roms.ROMSSurfaceForcing
+   cstar.roms.ROMSForcingCorrections
 
 Discretization
 ----------------

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -7,6 +7,7 @@ v1.0.0
 New features:
 ~~~~~~~~~~~~~
 - Add support for river forcing
+- Add support for forcing corrections (used in legacy ROMS configurations)
 
 Breaking Changes:
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR introduces a `ROMSForcingCorrections` subclass to `ROMSInputDataset`, included to cover older ROMS configurations which may rely on datasets containing corrections to other forcings.

- [x] Closes #237 
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [x] New functions/methods are listed in `api.rst`
- [x] New functionality has documentation