### PR TITLE
Fix defect in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 exclude: '^(?!cstar/).*'
 ci:
   autoupdate_schedule: monthly
-
+files: '^cstar/'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
-    files: '^cstar/'
+    
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
Minor fix to move the `files` key in `pre-commit-config.yaml`.

Running `pre-commit install` results in a warning message Being displayed:

```log
[WARNING] Unexpected key(s) present on https://github.com/pre-commit/pre-commit-hooks: files
```

This fixes the warning and ensures that pre-commit runs against the correct subdirectory.
- files is not a valid option at the current level. see [here](https://pre-commit.com/#pre-commit-configyaml---repos).
- files is valid at [root](https://pre-commit.com/#pre-commit-configyaml---top-level) or [hook](https://pre-commit.com/#pre-commit-configyaml---hooks) level
