### PR TITLE
Enable and run import sorting

### DIFF
--- a/cstar/base/__init__.py
+++ b/cstar/base/__init__.py
@@ -1,7 +1,7 @@
-from cstar.base.input_dataset import InputDataset
-from cstar.base.discretization import Discretization
 from cstar.base.additional_code import AdditionalCode
+from cstar.base.discretization import Discretization
 from cstar.base.external_codebase import ExternalCodeBase
+from cstar.base.input_dataset import InputDataset
 
 __all__ = [
     "Component",

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -1,10 +1,11 @@
 import shutil
 import tempfile
-from typing import Optional, Dict
 from pathlib import Path
+from typing import Dict, Optional
+
 from cstar.base.datasource import DataSource
 from cstar.base.gitutils import _clone_and_checkout
-from cstar.base.utils import _list_to_concise_str, _get_sha256_hash
+from cstar.base.utils import _get_sha256_hash, _list_to_concise_str
 
 
 class AdditionalCode:

--- a/cstar/base/datasource.py
+++ b/cstar/base/datasource.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
-from pathlib import Path
 
 
 class DataSource:

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -1,14 +1,13 @@
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
-from abc import ABC, abstractmethod
 
 from cstar.base.gitutils import (
     _checkout,
     _get_hash_from_checkout_target,
-    _get_repo_remote,
     _get_repo_head_hash,
+    _get_repo_remote,
 )
-
 from cstar.system.manager import cstar_sysmgr
 
 

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -1,12 +1,14 @@
-import pooch
-from abc import ABC
 import datetime as dt
-import dateutil.parser
+from abc import ABC
 from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional
 from urllib.parse import urljoin
+
+import dateutil.parser
+import pooch
+
 from cstar.base.datasource import DataSource
 from cstar.base.utils import _get_sha256_hash
-from typing import Optional, List, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     pass

--- a/cstar/execution/local_process.py
+++ b/cstar/execution/local_process.py
@@ -1,7 +1,8 @@
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from datetime import datetime
+
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 
 

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -1,22 +1,23 @@
+import json
 import os
 import re
-import json
 import warnings
-from math import ceil
 from abc import ABC, abstractmethod
-from pathlib import Path
 from datetime import datetime, timedelta
+from math import ceil
+from pathlib import Path
 from typing import Optional, Tuple
+
 from cstar.base.utils import _run_cmd
-from cstar.execution.handler import ExecutionStatus, ExecutionHandler
+from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.system.manager import cstar_sysmgr
 from cstar.system.scheduler import (
-    Queue,
-    SlurmScheduler,
     PBSScheduler,
+    Queue,
     Scheduler,
-    SlurmQOS,
     SlurmPartition,
+    SlurmQOS,
+    SlurmScheduler,
 )
 
 

--- a/cstar/marbl/external_codebase.py
+++ b/cstar/marbl/external_codebase.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
+
 from cstar.base import ExternalCodeBase
 from cstar.base.gitutils import _clone_and_checkout
-from cstar.base.utils import _update_user_dotenv, _run_cmd
+from cstar.base.utils import _run_cmd, _update_user_dotenv
 from cstar.system.manager import cstar_sysmgr
 
 

--- a/cstar/roms/__init__.py
+++ b/cstar/roms/__init__.py
@@ -1,16 +1,16 @@
-from cstar.roms.external_codebase import ROMSExternalCodeBase
-from cstar.roms.simulation import ROMSSimulation
 from cstar.roms.discretization import ROMSDiscretization
+from cstar.roms.external_codebase import ROMSExternalCodeBase
 from cstar.roms.input_dataset import (
+    ROMSBoundaryForcing,
+    ROMSForcingCorrections,
+    ROMSInitialConditions,
     ROMSInputDataset,
     ROMSModelGrid,
-    ROMSInitialConditions,
-    ROMSTidalForcing,
-    ROMSBoundaryForcing,
-    ROMSSurfaceForcing,
     ROMSRiverForcing,
-    ROMSForcingCorrections,
+    ROMSSurfaceForcing,
+    ROMSTidalForcing,
 )
+from cstar.roms.simulation import ROMSSimulation
 
 __all__ = [
     "ROMSExternalCodeBase",

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+
 from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.gitutils import _clone_and_checkout
 from cstar.base.utils import _run_cmd, _update_user_dotenv

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -1,13 +1,14 @@
-import yaml
 import tempfile
-import requests
-import roms_tools
-
 from abc import ABC
 from pathlib import Path
-from typing import Optional, List, Any
+from typing import Any, List, Optional
+
+import requests
+import roms_tools
+import yaml
+
 from cstar.base.input_dataset import InputDataset
-from cstar.base.utils import _list_to_concise_str, _get_sha256_hash
+from cstar.base.utils import _get_sha256_hash, _list_to_concise_str
 
 
 class ROMSInputDataset(InputDataset, ABC):

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1,40 +1,38 @@
-import yaml
 import shutil
 import warnings
-import requests
-from pathlib import Path
 from datetime import datetime
-from cstar.roms.external_codebase import ROMSExternalCodeBase
-from cstar.roms.discretization import ROMSDiscretization
-from cstar.roms.input_dataset import (
-    ROMSModelGrid,
-    ROMSInitialConditions,
-    ROMSTidalForcing,
-    ROMSRiverForcing,
-    ROMSBoundaryForcing,
-    ROMSSurfaceForcing,
-    ROMSInputDataset,
-    ROMSForcingCorrections,
-)
-from cstar.marbl.external_codebase import MARBLExternalCodeBase
+from pathlib import Path
+from typing import Any, List, Optional, cast
 
-from cstar.base.datasource import DataSource
-from cstar.base.additional_code import AdditionalCode
-from cstar.base.utils import (
-    _get_sha256_hash,
-    _replace_text_in_file,
-    _dict_to_tree,
-    _run_cmd,
-)
-
-from cstar.execution.handler import ExecutionHandler
-from cstar.execution.scheduler_job import create_scheduler_job
-from cstar.execution.local_process import LocalProcess
-from cstar.execution.handler import ExecutionStatus
+import requests
+import yaml
 
 from cstar import Simulation
+from cstar.base.additional_code import AdditionalCode
+from cstar.base.datasource import DataSource
+from cstar.base.utils import (
+    _dict_to_tree,
+    _get_sha256_hash,
+    _replace_text_in_file,
+    _run_cmd,
+)
+from cstar.execution.handler import ExecutionHandler, ExecutionStatus
+from cstar.execution.local_process import LocalProcess
+from cstar.execution.scheduler_job import create_scheduler_job
+from cstar.marbl.external_codebase import MARBLExternalCodeBase
+from cstar.roms.discretization import ROMSDiscretization
+from cstar.roms.external_codebase import ROMSExternalCodeBase
+from cstar.roms.input_dataset import (
+    ROMSBoundaryForcing,
+    ROMSForcingCorrections,
+    ROMSInitialConditions,
+    ROMSInputDataset,
+    ROMSModelGrid,
+    ROMSRiverForcing,
+    ROMSSurfaceForcing,
+    ROMSTidalForcing,
+)
 from cstar.system.manager import cstar_sysmgr
-from typing import Optional, List, cast, Any
 
 
 class ROMSSimulation(Simulation):

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -1,15 +1,15 @@
 import copy
 import pickle
 import warnings
+from abc import ABC, abstractmethod
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
 import dateutil
 
-from abc import ABC, abstractmethod
-from typing import Optional, Any
-from pathlib import Path
-from datetime import datetime
-
-from cstar.base import ExternalCodeBase, AdditionalCode, Discretization
-from cstar.execution.handler import ExecutionStatus, ExecutionHandler
+from cstar.base import AdditionalCode, Discretization, ExternalCodeBase
+from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.execution.local_process import LocalProcess
 
 

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -1,7 +1,8 @@
+import importlib.util
 import os
 import platform
-import importlib.util
 from pathlib import Path
+
 from dotenv import dotenv_values
 
 from cstar.base.utils import _run_cmd

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -2,14 +2,15 @@ import os
 import platform
 from enum import Enum
 from typing import Optional
+
 from cstar.system.environment import CStarEnvironment
 from cstar.system.scheduler import (
-    Scheduler,
-    SlurmScheduler,
-    SlurmQOS,
-    SlurmPartition,
     PBSQueue,
     PBSScheduler,
+    Scheduler,
+    SlurmPartition,
+    SlurmQOS,
+    SlurmScheduler,
 )
 
 

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 from cstar.base.utils import _run_cmd
 

--- a/cstar/tests/integration_tests/blueprints/fixtures.py
+++ b/cstar/tests/integration_tests/blueprints/fixtures.py
@@ -1,6 +1,7 @@
-import pytest
 from pathlib import Path
 from typing import Callable
+
+import pytest
 
 
 @pytest.fixture

--- a/cstar/tests/integration_tests/config.py
+++ b/cstar/tests/integration_tests/config.py
@@ -10,6 +10,7 @@ from which the test case is constructed.
 """
 
 from pathlib import Path
+
 from pooch import os_cache
 
 ## Common paths used in tests

--- a/cstar/tests/integration_tests/conftest.py
+++ b/cstar/tests/integration_tests/conftest.py
@@ -1,10 +1,15 @@
-from cstar.tests.integration_tests.fixtures import fetch_roms_tools_source_data  # noqa: F401
-from cstar.tests.integration_tests.fixtures import fetch_remote_test_case_data  # noqa: F401
-from cstar.tests.integration_tests.blueprints.fixtures import modify_template_blueprint  # noqa : F401
-
 import builtins
 from contextlib import contextmanager
+
 import pytest
+
+from cstar.tests.integration_tests.blueprints.fixtures import (
+    modify_template_blueprint,  # noqa : F401
+)
+from cstar.tests.integration_tests.fixtures import (
+    fetch_remote_test_case_data,  # noqa: F401
+    fetch_roms_tools_source_data,  # noqa: F401
+)
 
 
 @pytest.fixture

--- a/cstar/tests/integration_tests/fixtures.py
+++ b/cstar/tests/integration_tests/fixtures.py
@@ -1,13 +1,14 @@
-import pooch
-import pytest
 import shutil
 import zipfile
-from typing import Callable
 from pathlib import Path
+from typing import Callable
+
+import pooch
+import pytest
 
 from cstar.tests.integration_tests.config import (
-    ROMS_TOOLS_DATA_DIRECTORY,
     CSTAR_TEST_DATA_DIRECTORY,
+    ROMS_TOOLS_DATA_DIRECTORY,
 )
 
 

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cstar.roms.simulation import ROMSSimulation
 from cstar.tests.integration_tests.config import TEST_CONFIG
 

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -1,11 +1,13 @@
 """Test suite to test fixtures defined in conftest.py and fixtures.py files."""
 
-import yaml
 from pathlib import Path
+
+import yaml
 from _pytest._py.path import LocalPath
+
 from cstar.tests.integration_tests.config import (
-    ROMS_TOOLS_DATA_DIRECTORY,
     CSTAR_TEST_DATA_DIRECTORY,
+    ROMS_TOOLS_DATA_DIRECTORY,
     TEST_DIRECTORY,
 )
 

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -1,8 +1,8 @@
-import pytest
-
 from pathlib import Path
-from unittest import mock
 from textwrap import dedent
+from unittest import mock
+
+import pytest
 
 from cstar.base import AdditionalCode
 from cstar.base.datasource import DataSource

--- a/cstar/tests/unit_tests/base/test_datasource.py
+++ b/cstar/tests/unit_tests/base/test_datasource.py
@@ -1,5 +1,7 @@
-import pytest
 from pathlib import Path
+
+import pytest
+
 from cstar.base.datasource import DataSource
 
 

--- a/cstar/tests/unit_tests/base/test_discretization.py
+++ b/cstar/tests/unit_tests/base/test_discretization.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cstar.base.discretization import Discretization
 
 

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -1,8 +1,10 @@
-import pytest
 from pathlib import Path
 from unittest import mock
-from cstar.system.manager import cstar_sysmgr
+
+import pytest
+
 from cstar.base.external_codebase import ExternalCodeBase
+from cstar.system.manager import cstar_sysmgr
 
 ################################################################################
 

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -1,8 +1,10 @@
 import stat
-import pytest
-from unittest import mock
 from pathlib import Path
 from textwrap import dedent
+from unittest import mock
+
+import pytest
+
 from cstar.base import InputDataset
 from cstar.base.datasource import DataSource
 

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -1,19 +1,21 @@
-import pytest
 import hashlib
 import warnings
 from unittest import mock
+
+import pytest
+
 from cstar.base.gitutils import (
     _clone_and_checkout,
+    _get_hash_from_checkout_target,
     _get_repo_head_hash,
     _get_repo_remote,
-    _get_hash_from_checkout_target,
 )
 from cstar.base.utils import (
-    _get_sha256_hash,
-    _update_user_dotenv,
-    _replace_text_in_file,
-    _list_to_concise_str,
     _dict_to_tree,
+    _get_sha256_hash,
+    _list_to_concise_str,
+    _replace_text_in_file,
+    _update_user_dotenv,
 )
 
 

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -1,7 +1,8 @@
-import time
 import threading
-from unittest.mock import patch, PropertyMock
+import time
 from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 
 

--- a/cstar/tests/unit_tests/execution/test_local_process.py
+++ b/cstar/tests/unit_tests/execution/test_local_process.py
@@ -1,11 +1,11 @@
-import pytest
 import subprocess
-
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import MagicMock, patch
 
-from cstar.execution.local_process import LocalProcess, ExecutionStatus
+import pytest
+
+from cstar.execution.local_process import ExecutionStatus, LocalProcess
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/execution/test_pbs_job.py
+++ b/cstar/tests/unit_tests/execution/test_pbs_job.py
@@ -1,11 +1,13 @@
 import json
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
-from cstar.system.scheduler import PBSScheduler, PBSQueue
+
 from cstar.execution.scheduler_job import (
     ExecutionStatus,
     PBSJob,
 )
+from cstar.system.scheduler import PBSQueue, PBSScheduler
 
 
 class TestPBSJob:

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -1,17 +1,19 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
-from cstar.system.scheduler import (
-    Scheduler,
-    PBSScheduler,
-    PBSQueue,
-    SlurmScheduler,
-    SlurmQOS,
-)
+
 from cstar.execution.scheduler_job import (
-    SchedulerJob,
     PBSJob,
+    SchedulerJob,
     SlurmJob,
     create_scheduler_job,
+)
+from cstar.system.scheduler import (
+    PBSQueue,
+    PBSScheduler,
+    Scheduler,
+    SlurmQOS,
+    SlurmScheduler,
 )
 
 

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -1,7 +1,9 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
-from cstar.system.scheduler import SlurmScheduler, SlurmQOS, SlurmPartition
-from cstar.execution.scheduler_job import SlurmJob, ExecutionStatus
+
+from cstar.execution.scheduler_job import ExecutionStatus, SlurmJob
+from cstar.system.scheduler import SlurmPartition, SlurmQOS, SlurmScheduler
 
 
 class TestSlurmJob:

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 from unittest import mock
+
+import pytest
+
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 

--- a/cstar/tests/unit_tests/roms/test_roms_discretization.py
+++ b/cstar/tests/unit_tests/roms/test_roms_discretization.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cstar.roms.discretization import ROMSDiscretization
 
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 from unittest import mock
+
+import pytest
+
 from cstar.roms.external_codebase import ROMSExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -1,10 +1,12 @@
-import pytest
 import datetime as dt
-from unittest import mock
 from pathlib import Path
 from textwrap import dedent
-from cstar.roms import ROMSInputDataset, ROMSForcingCorrections
+from unittest import mock
+
+import pytest
+
 from cstar.base.datasource import DataSource
+from cstar.roms import ROMSForcingCorrections, ROMSInputDataset
 
 
 class MockROMSInputDataset(ROMSInputDataset):

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1,28 +1,30 @@
+import pickle
 import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
+
 import pytest
 import yaml
-import pickle
-from typing import cast, Any
-from pathlib import Path
-from datetime import datetime
-from unittest.mock import patch, mock_open, MagicMock, PropertyMock
+
+from cstar.base.additional_code import AdditionalCode
 from cstar.base.external_codebase import ExternalCodeBase
-from cstar.roms.simulation import ROMSSimulation
-from cstar.roms.external_codebase import ROMSExternalCodeBase
+from cstar.execution.handler import ExecutionStatus
+from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.roms.discretization import ROMSDiscretization
+from cstar.roms.external_codebase import ROMSExternalCodeBase
 from cstar.roms.input_dataset import (
+    ROMSBoundaryForcing,
+    ROMSForcingCorrections,
+    ROMSInitialConditions,
     ROMSInputDataset,
     ROMSModelGrid,
-    ROMSInitialConditions,
-    ROMSTidalForcing,
-    ROMSBoundaryForcing,
-    ROMSSurfaceForcing,
     ROMSRiverForcing,
-    ROMSForcingCorrections,
+    ROMSSurfaceForcing,
+    ROMSTidalForcing,
 )
-from cstar.marbl.external_codebase import MARBLExternalCodeBase
-from cstar.base.additional_code import AdditionalCode
-from cstar.execution.handler import ExecutionStatus
+from cstar.roms.simulation import ROMSSimulation
 from cstar.system.manager import cstar_sysmgr
 
 

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -1,7 +1,9 @@
-import pytest
-from unittest.mock import patch, call, PropertyMock, mock_open
-import cstar
 import subprocess
+from unittest.mock import PropertyMock, call, mock_open, patch
+
+import pytest
+
+import cstar
 
 
 class MockEnvironment(cstar.system.environment.CStarEnvironment):

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -1,9 +1,11 @@
-import pytest
 import os
-from unittest.mock import patch, PropertyMock
-from cstar.system.manager import CStarSystemManager
-from cstar.system.scheduler import SlurmScheduler, PBSScheduler
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
 from cstar.system.environment import CStarEnvironment
+from cstar.system.manager import CStarSystemManager
+from cstar.system.scheduler import PBSScheduler, SlurmScheduler
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -1,12 +1,14 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock, PropertyMock
+
 from cstar.system.scheduler import (
-    Queue,
-    SlurmQOS,
-    SlurmPartition,
     PBSQueue,
-    SlurmScheduler,
     PBSScheduler,
+    Queue,
+    SlurmPartition,
+    SlurmQOS,
+    SlurmScheduler,
 )
 
 ################################################################################

--- a/cstar/tests/unit_tests/test_simulation.py
+++ b/cstar/tests/unit_tests/test_simulation.py
@@ -1,12 +1,14 @@
 import pickle
-import pytest
-from pathlib import Path
 from datetime import datetime
-from unittest.mock import patch, MagicMock
-from cstar.base import ExternalCodeBase, AdditionalCode, Discretization
-from cstar.simulation import Simulation
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cstar.base import AdditionalCode, Discretization, ExternalCodeBase
 from cstar.execution.handler import ExecutionStatus
 from cstar.execution.local_process import LocalProcess
+from cstar.simulation import Simulation
 
 
 # Minimal concrete subclass for testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ exclude = "properties|asv_bench|docs"
 # Configuration for ruff linter and formatter
 [tool.ruff]
 fix = true
+extend-select = ["I"]
 
 [tool.pre-commit]
 config = ".pre-commit-config.yaml"


### PR DESCRIPTION
Enable import sorting with the Ruff linter and execute against all files.

- [X] Closes CW-804