### PR TITLE
Add mocking to fix tests that fail when run on Perlmutter

### DIFF
--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -27,6 +27,7 @@ from cstar.roms.input_dataset import (
     ROMSTidalForcing,
 )
 from cstar.roms.simulation import ROMSSimulation
+from cstar.system.environment import CStarEnvironment
 from cstar.system.manager import cstar_sysmgr
 
 
@@ -1477,11 +1478,11 @@ class TestProcessingAndExecution:
             partitioned_directory / "initial.nc"
         )
         assert rtcm_dict["__FORCING_FILES_PLACEHOLDER__"] == (
-            f"{partitioned_directory/'surface.nc'}"
-            + f"\n     {partitioned_directory/'boundary.nc'}"
-            + f"\n     {partitioned_directory/'tidal.nc'}"
-            + f"\n     {partitioned_directory/'river.nc'}"
-            + f"\n     {partitioned_directory/'sw_corr.nc'}"
+            f"{partitioned_directory / 'surface.nc'}"
+            + f"\n     {partitioned_directory / 'boundary.nc'}"
+            + f"\n     {partitioned_directory / 'tidal.nc'}"
+            + f"\n     {partitioned_directory / 'river.nc'}"
+            + f"\n     {partitioned_directory / 'sw_corr.nc'}"
         )
 
         assert rtcm_dict["__MARBL_SETTINGS_FILE_PLACEHOLDER__"] == str(
@@ -2019,7 +2020,7 @@ class TestProcessingAndExecution:
 
             # Ensure early exit exception was triggered
             expected_msg = (
-                f"ROMS has already been built at {build_dir/"roms"}, and "
+                f"ROMS has already been built at {build_dir / 'roms'}, and "
                 "the source code appears not to have changed. "
                 "If you would like to recompile, call "
                 "ROMSSimulation.build(rebuild = True)"
@@ -2275,10 +2276,24 @@ class TestProcessingAndExecution:
             # Ensure execution handler was set correctly
             assert execution_handler == mock_process_instance
 
+    @pytest.mark.parametrize(
+        "mock_system_name,exp_mpi_prefix",
+        [
+            ["darwin_arm64", "mpirun"],
+            ["derecho", "mpirun"],
+            ["expanse", "srun --mpi=pmi2"],
+            ["perlmutter", "srun"],
+        ],
+    )
     @patch("cstar.roms.simulation._replace_text_in_file")  # Mock text replacement
     @patch.object(ROMSSimulation, "update_runtime_code")  # Mock updating runtime code
     def test_run_with_scheduler(
-        self, mock_update_runtime_code, mock_replace_text, example_roms_simulation
+        self,
+        mock_update_runtime_code,
+        mock_replace_text,
+        example_roms_simulation,
+        mock_system_name: str,
+        exp_mpi_prefix: str,
     ):
         """Tests that `run` correctly submits a job to a scheduler when available.
 
@@ -2311,6 +2326,24 @@ class TestProcessingAndExecution:
         with (
             patch("cstar.roms.simulation.create_scheduler_job") as mock_create_job,
             patch(
+                "cstar.system.environment.CStarEnvironment.uses_lmod",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch(
+                "cstar.system.manager.CStarSystemManager.name",
+                new_callable=PropertyMock,
+                return_value=mock_system_name,
+            ),
+            patch(
+                "cstar.system.manager.CStarSystemManager.environment",
+                CStarEnvironment(
+                    system_name=mock_system_name,
+                    mpi_exec_prefix=exp_mpi_prefix,
+                    compiler="mock-compiler",
+                ),
+            ),
+            patch(
                 "cstar.system.manager.CStarSystemManager.scheduler",
                 new_callable=PropertyMock,
                 return_value=mock_scheduler,
@@ -2324,7 +2357,7 @@ class TestProcessingAndExecution:
             execution_handler = sim.run(account_key="some_key")
 
             mock_create_job.assert_called_once_with(
-                commands=f'mpirun -n 6 {build_dir/"roms"} file2.in',
+                commands=f"{exp_mpi_prefix} -n 6 {build_dir / 'roms'} file2.in",
                 job_name=None,
                 cpus=6,
                 account_key="some_key",
@@ -2723,7 +2756,7 @@ class TestROMSSimulationRestart:
 
         # Call method
         with pytest.raises(
-            FileNotFoundError, match=f"No files in {directory/'output'} match"
+            FileNotFoundError, match=f"No files in {directory / 'output'} match"
         ):
             sim.restart(new_end_date=new_end_date)
 

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -281,7 +281,12 @@ class TestStrAndReprMethods:
     - test_repr_method: Confirms accurate representation of state in __repr__.
     """
 
-    def test_str_method(self):
+    @patch.object(
+        cstar.system.environment.CStarEnvironment,
+        "uses_lmod",
+        new_callable=PropertyMock(return_value=False),
+    )
+    def test_str_method(self, _mock_uses_lmod):
         """Tests that __str__ produces a formatted, readable summary.
 
         Mocks
@@ -316,7 +321,12 @@ class TestStrAndReprMethods:
 
             assert str(env) == expected_str
 
-    def test_repr_method(self):
+    @patch.object(
+        cstar.system.environment.CStarEnvironment,
+        "uses_lmod",
+        new_callable=PropertyMock(return_value=False),
+    )
+    def test_repr_method(self, _mock_uses_lmod):
         """Tests that __repr__ produces a detailed, state-reflective representation.
 
         Mocks


### PR DESCRIPTION
## Description

This PR fixes a set of unit tests that fail when executed on Perlmutter.

### Additional Changes

- Some minor automatic formatting changes

### Checklist

- [X] Closes #CW-813
- [X] Tests passing
