### PR TITLE
Parameterize interactive mode

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -239,7 +239,6 @@ class ExternalCodeBase(ABC, LoggingMixin):
                 return
             case 1:
                 env_var_repo_remote = _get_repo_remote(local_root)
-                # if not env_var_repo_remote.strip():
 
                 raise EnvironmentError(
                     (

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -54,7 +54,10 @@ class ExternalCodeBase(ABC, LoggingMixin):
     """
 
     def __init__(
-        self, source_repo: Optional[str] = None, checkout_target: Optional[str] = None
+        self,
+        source_repo: Optional[str] = None,
+        checkout_target: Optional[str] = None,
+        interactive: bool = True,
     ):
         """Initialize a ExternalCodeBase object manually from a source repository and
         checkout target.
@@ -75,6 +78,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
         # TODO: Type check here
         self._source_repo = source_repo
         self._checkout_target = checkout_target
+        self.interactive = interactive
 
     def __str__(self) -> str:
         base_str = f"{self.__class__.__name__}"
@@ -235,28 +239,37 @@ class ExternalCodeBase(ABC, LoggingMixin):
                 return
             case 1:
                 env_var_repo_remote = _get_repo_remote(local_root)
+                # if not env_var_repo_remote.strip():
+
                 raise EnvironmentError(
-                    "System environment variable "
-                    + f"'{self.expected_env_var}' points to "
-                    + "a github repository whose "
-                    + f"remote: \n '{env_var_repo_remote}' \n"
-                    + "does not match that expected by C-Star: \n"
-                    + f"{self.source_repo}."
-                    + "Your environment may be misconfigured."
+                    (
+                        "System environment variable "
+                        f"'{self.expected_env_var}' points to "
+                        "a github repository whose "
+                        f"remote: \n '{env_var_repo_remote}' \n"
+                        "does not match that expected by C-Star: \n"
+                        f"{self.source_repo}."
+                        "Your environment may be misconfigured."
+                    )
                 )
             case 2:
                 head_hash = _get_repo_head_hash(local_root)
                 print(
-                    "############################################################\n"
-                    + f"C-STAR: {self.expected_env_var} points to the correct repo "
-                    + f"{self.source_repo} but HEAD is at: \n"
-                    + f"{head_hash}, rather than the hash associated with "
-                    + f"checkout_target {self.checkout_target}:\n"
-                    + f"{self.checkout_hash}"
-                    + "\n############################################################"
+                    (
+                        "############################################################\n"
+                        f"C-STAR: {self.expected_env_var} points to the correct repo "
+                        f"{self.source_repo} but HEAD is at: \n"
+                        f"{head_hash}, rather than the hash associated with "
+                        f"checkout_target {self.checkout_target}:\n"
+                        f"{self.checkout_hash}"
+                        "\n############################################################"
+                    )
                 )
                 while True:
-                    yn = input("Would you like to checkout this target now?")
+                    yn = "y"
+                    if self.interactive:
+                        yn = input("Would you like to checkout this target now?")
+
                     if yn.casefold() in ["y", "yes"]:
                         try:
                             _checkout(
@@ -277,22 +290,31 @@ class ExternalCodeBase(ABC, LoggingMixin):
                     / f"externals/{self.repo_basename}"
                 )
                 print(
-                    "#######################################################\n"
-                    + f"C-STAR: {self.expected_env_var}"
-                    + " not found in current cstar_sysmgr.environment. \n"
-                    + "if this is your first time running C-Star with "
-                    + f"an instance of {self.__class__.__name__}, "
-                    + "you will need to set it up.\n"
-                    + "It is recommended that you install this external codebase in \n"
-                    + f"{ext_dir}"
-                    + "\nThis will also modify your `~/.cstar.env` file."
-                    + "\n#######################################################"
+                    (
+                        "#######################################################\n"
+                        f"C-STAR: {self.expected_env_var}"
+                        " not found in current cstar_sysmgr.environment. \n"
+                        "if this is your first time running C-Star with "
+                        f"an instance of {self.__class__.__name__}, "
+                        "you will need to set it up.\n"
+                        "It is recommended that you install this external codebase in \n"
+                        f"{ext_dir}"
+                        f"\nThis will also modify your `~/.cstar.env` file."
+                        "\n#######################################################"
+                    )
                 )
                 while True:
-                    yn = input(
-                        "Would you like to do this now? "
-                        + "('y', 'n', or 'custom' to install at a custom path)\n"
-                    )
+                    if not ext_dir.exists():
+                        ext_dir.mkdir(parents=True)
+
+                    yn = "y"
+                    if self.interactive:
+                        yn = input(
+                            (
+                                "Would you like to do this now? "
+                                "('y', 'n', or 'custom' to install at a custom path)\n"
+                            )
+                        )
                     if yn.casefold() in ["y", "yes", "ok"]:
                         self.get(ext_dir)
                         break

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -55,9 +55,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
     """
 
     def __init__(
-        self,
-        source_repo: Optional[str] = None,
-        checkout_target: Optional[str] = None,
+        self, source_repo: Optional[str] = None, checkout_target: Optional[str] = None
     ):
         """Initialize a ExternalCodeBase object manually from a source repository and
         checkout target.

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
@@ -57,7 +58,6 @@ class ExternalCodeBase(ABC, LoggingMixin):
         self,
         source_repo: Optional[str] = None,
         checkout_target: Optional[str] = None,
-        interactive: bool = True,
     ):
         """Initialize a ExternalCodeBase object manually from a source repository and
         checkout target.
@@ -78,7 +78,6 @@ class ExternalCodeBase(ABC, LoggingMixin):
         # TODO: Type check here
         self._source_repo = source_repo
         self._checkout_target = checkout_target
-        self.interactive = interactive
 
     def __str__(self) -> str:
         base_str = f"{self.__class__.__name__}"
@@ -231,6 +230,8 @@ class ExternalCodeBase(ABC, LoggingMixin):
             )
         )
 
+        interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
+
         match self.local_config_status:
             case 0:
                 self.log.info(
@@ -266,7 +267,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                 )
                 while True:
                     yn = "y"
-                    if self.interactive:
+                    if interactive:
                         yn = input("Would you like to checkout this target now?")
 
                     if yn.casefold() in ["y", "yes"]:
@@ -307,7 +308,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                         ext_dir.mkdir(parents=True)
 
                     yn = "y"
-                    if self.interactive:
+                    if interactive:
                         yn = input(
                             (
                                 "Would you like to do this now? "

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -100,7 +100,11 @@ class ExecutionHandler(ABC, LoggingMixin):
 
         pass
 
-    def updates(self, seconds: float = 10, confirm_indefinite: bool = True):
+    def updates(
+        self,
+        seconds: float = 10,
+        interactive: bool = True,
+    ):
         """Stream live updates from the task's output file.
 
         This method streams updates from the task's output file for the
@@ -115,10 +119,10 @@ class ExecutionHandler(ABC, LoggingMixin):
             The duration (in seconds) for which updates should be streamed.
             If set to 0, updates will be streamed indefinitely until
             interrupted by the user.
-        confirm_indefinite: bool, optional, default = True
+        interactive: bool, optional, default = True
             If 'seconds' is set to 0, the user will be prompted to confirm
             whether they want to continue with an indefinite update stream
-            if confirm_indefinite is set to True
+            if interactive is set to True
         Notes
         -----
         - This method moves to the end of the output file and streams only
@@ -143,7 +147,7 @@ class ExecutionHandler(ABC, LoggingMixin):
             self.log.warning(error_msg)
             return
 
-        if (seconds == 0) and (confirm_indefinite):
+        if interactive and seconds == 0:
             # Confirm indefinite tailing
             confirmation = (
                 input(

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -1,3 +1,4 @@
+import os
 import time
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -103,7 +104,6 @@ class ExecutionHandler(ABC, LoggingMixin):
     def updates(
         self,
         seconds: float = 10,
-        interactive: bool = True,
     ):
         """Stream live updates from the task's output file.
 
@@ -119,10 +119,6 @@ class ExecutionHandler(ABC, LoggingMixin):
             The duration (in seconds) for which updates should be streamed.
             If set to 0, updates will be streamed indefinitely until
             interrupted by the user.
-        interactive: bool, optional, default = True
-            If 'seconds' is set to 0, the user will be prompted to confirm
-            whether they want to continue with an indefinite update stream
-            if interactive is set to True
         Notes
         -----
         - This method moves to the end of the output file and streams only
@@ -147,6 +143,7 @@ class ExecutionHandler(ABC, LoggingMixin):
             self.log.warning(error_msg)
             return
 
+        interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
         if interactive and seconds == 0:
             # Confirm indefinite tailing
             confirmation = (

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -101,10 +101,7 @@ class ExecutionHandler(ABC, LoggingMixin):
 
         pass
 
-    def updates(
-        self,
-        seconds: float = 10,
-    ):
+    def updates(self, seconds: float = 10):
         """Stream live updates from the task's output file.
 
         This method streams updates from the task's output file for the

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -101,7 +101,7 @@ class ExecutionHandler(ABC, LoggingMixin):
 
         pass
 
-    def updates(self, seconds: float = 10):
+    def updates(self, seconds: float = 10, confirm_indefinite: bool = True):
         """Stream live updates from the task's output file.
 
         This method streams updates from the task's output file for the
@@ -116,6 +116,11 @@ class ExecutionHandler(ABC, LoggingMixin):
             The duration (in seconds) for which updates should be streamed.
             If set to 0, updates will be streamed indefinitely until
             interrupted by the user.
+        confirm_indefinite: bool, optional, default = True
+            If 'seconds' is set to 0, the user will be prompted to confirm
+            whether they want to continue with an indefinite update stream
+            if confirm_indefinite is set to True
+
         Notes
         -----
         - This method moves to the end of the output file and streams only
@@ -141,7 +146,7 @@ class ExecutionHandler(ABC, LoggingMixin):
             return
 
         interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
-        if interactive and seconds == 0:
+        if seconds == 0 and confirm_indefinite and interactive:
             # Confirm indefinite tailing
             confirmation = (
                 input(

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1103,11 +1103,10 @@ class ROMSSimulation(Simulation):
         runtime_code_dir = self.directory / "ROMS/runtime_code"
         input_datasets_dir = self.directory / "ROMS/input_datasets"
 
-        self.log.info(f"🛠️  Configuring {self.__class__.__name__}")
+        self.log.info(f"🛠️ Configuring {self.__class__.__name__}")
 
         for codebase in self.codebases:
             self.log.info(f"🔧 Setting up {codebase.__class__.__name__}...")
-            codebase.interactive = self.interactive
             codebase.handle_config_status()
 
         # Compile-time code

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -10,6 +10,7 @@ import yaml
 from cstar import Simulation
 from cstar.base.additional_code import AdditionalCode
 from cstar.base.datasource import DataSource
+from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.utils import (
     _dict_to_tree,
     _get_sha256_hash,
@@ -423,7 +424,7 @@ class ROMSSimulation(Simulation):
         return ROMSExternalCodeBase()
 
     @property
-    def codebases(self) -> list:
+    def codebases(self) -> list[ExternalCodeBase]:
         """Returns a list of external codebases associated with this ROMS simulation.
 
         This property includes both the primary ROMS external codebase and the
@@ -1105,7 +1106,7 @@ class ROMSSimulation(Simulation):
 
         self.log.info(f"🛠️ Configuring {self.__class__.__name__}")
 
-        for codebase in self.codebases:
+        for codebase in filter(lambda x: x is not None, self.codebases):
             self.log.info(f"🔧 Setting up {codebase.__class__.__name__}...")
             codebase.handle_config_status()
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1104,14 +1104,11 @@ class ROMSSimulation(Simulation):
         input_datasets_dir = self.directory / "ROMS/input_datasets"
 
         self.log.info(f"🛠️  Configuring {self.__class__.__name__}")
-        self.log.info(f"🔧 Setting up {self.codebase.__class__.__name__}...")
 
-        # Setup ExternalCodeBase
-        self.codebase.handle_config_status()
-
-        if self.marbl_codebase is not None:
-            self.log.info(f"🔧 Setting up {self.marbl_codebase.__class__.__name__}...")
-            self.marbl_codebase.handle_config_status()
+        for codebase in self.codebases:
+            self.log.info(f"🔧 Setting up {codebase.__class__.__name__}...")
+            codebase.interactive = self.interactive
+            codebase.handle_config_status()
 
         # Compile-time code
         self.log.info("📦 Fetching compile-time code...")

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -79,6 +79,7 @@ class Simulation(ABC, LoggingMixin):
         end_date: Optional[str | datetime] = None,
         valid_start_date: Optional[str | datetime] = None,
         valid_end_date: Optional[str | datetime] = None,
+        interactive: bool = True,
     ):
         """Initialize a Simulation object with a given name, directory, codebase, and
         configuration parameters.
@@ -137,9 +138,9 @@ class Simulation(ABC, LoggingMixin):
             self.codebase = self.default_codebase
             self.log.warning(
                 f"Creating {self.__class__.__name__} instance without a specified "
-                + "ExternalCodeBase, default codebase will be used:\n"
-                + f"          • Source location: {self.codebase.source_repo}\n"
-                + f"          • Checkout target: {self.codebase.checkout_target}\n"
+                "ExternalCodeBase, default codebase will be used:\n"
+                f"          • Source location: {self.codebase.source_repo}\n"
+                f"          • Checkout target: {self.codebase.checkout_target}\n"
             )
         else:
             self.codebase = codebase
@@ -147,6 +148,7 @@ class Simulation(ABC, LoggingMixin):
         self.runtime_code = runtime_code or None
         self.compile_time_code = compile_time_code or None
         self.discretization = discretization
+        self.interactive = interactive
 
     def _validate_simulation_directory(self, directory: str | Path) -> Path:
         """Validates and resolves the simulation directory.

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -1,5 +1,4 @@
 import copy
-import os
 import pickle
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -148,7 +147,6 @@ class Simulation(ABC, LoggingMixin):
         self.runtime_code = runtime_code or None
         self.compile_time_code = compile_time_code or None
         self.discretization = discretization
-        self.interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
 
     def _validate_simulation_directory(self, directory: str | Path) -> Path:
         """Validates and resolves the simulation directory.

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import pickle
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -79,7 +80,6 @@ class Simulation(ABC, LoggingMixin):
         end_date: Optional[str | datetime] = None,
         valid_start_date: Optional[str | datetime] = None,
         valid_end_date: Optional[str | datetime] = None,
-        interactive: bool = True,
     ):
         """Initialize a Simulation object with a given name, directory, codebase, and
         configuration parameters.
@@ -148,7 +148,7 @@ class Simulation(ABC, LoggingMixin):
         self.runtime_code = runtime_code or None
         self.compile_time_code = compile_time_code or None
         self.discretization = discretization
-        self.interactive = interactive
+        self.interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
 
     def _validate_simulation_directory(self, directory: str | Path) -> Path:
         """Validates and resolves the simulation directory.

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -20,7 +21,7 @@ class TestCStar:
     )
     def test_cstar(
         self,
-        tmpdir,
+        tmp_path: Path,
         mock_user_input,
         modify_template_blueprint,
         fetch_roms_tools_source_data,
@@ -32,7 +33,7 @@ class TestCStar:
 
         Parameters:
         -----------
-        tmpdir:
+        tmp_path:
            Built-in pytest fixture to create temporary directories
         mock_user_input:
            Fixture to simulate user-supplied input
@@ -57,8 +58,8 @@ class TestCStar:
             Logger instance for logging messages during test execution.
         """
 
-        dotenv_path = tmpdir / ".cstar.env"
-        ext_root = tmpdir / "externals"
+        dotenv_path = tmp_path / ".cstar.env"
+        ext_root = tmp_path / "externals"
 
         with (
             mock.patch(
@@ -85,14 +86,14 @@ class TestCStar:
             template_blueprint = config.get("template_blueprint_path")
             strs_to_replace = config.get("strs_to_replace")
 
-            log.info(f"Creating ROMSSimulation in {tmpdir / 'cstar_test_simulation'}")
+            log.info(f"Creating ROMSSimulation in {tmp_path / 'cstar_test_simulation'}")
             modified_blueprint = modify_template_blueprint(
                 template_blueprint_path=template_blueprint,
                 strs_to_replace=strs_to_replace,
             )
             cstar_test_case = ROMSSimulation.from_blueprint(
                 modified_blueprint,
-                directory=tmpdir / "cstar_test_simulation",
+                directory=tmp_path / "cstar_test_simulation",
                 start_date="20120101 12:00:00",
                 end_date="20120101 12:10:00",
             )
@@ -100,9 +101,10 @@ class TestCStar:
             with mock_user_input("y"):
                 cstar_test_case.setup()
 
-            cstar_test_case.to_blueprint(tmpdir / "test_blueprint_export.yaml")
+            cstar_test_case.to_blueprint(tmp_path / "test_blueprint_export.yaml")
             cstar_test_case.build()
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()
-            test_process.updates(seconds=0, confirm_indefinite=False)
+            with mock_user_input("y"):
+                test_process.updates(seconds=0, interactive=True)
             cstar_test_case.post_run()

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -106,5 +106,5 @@ class TestCStar:
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()
             with mock_user_input("y"):
-                test_process.updates(seconds=0, interactive=True)
+                test_process.updates(seconds=0)
             cstar_test_case.post_run()

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -285,7 +285,6 @@ class TestExternalCodeBaseConfigHandling:
         self.patch_local_config_status.stop()
         self.patch_get_repo_head_hash.stop()
         self.patch_get_repo_remote.stop()
-        self.patch_environment.stop()
 
     def test_handle_config_status_valid(
         self, generic_codebase, caplog: pytest.LogCaptureFixture

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -14,9 +14,10 @@ class MockExternalCodeBase(ExternalCodeBase):
     """A mock subclass of the `ExternalCodeBase` abstract base class used for testing
     purposes."""
 
-    def __init__(self, log: logging.Logger):
+    def __init__(self, log: logging.Logger, interactive: bool = True):
         super().__init__(None, None)
         self._log = log
+        self._interactive = interactive
 
     @property
     def expected_env_var(self):
@@ -441,7 +442,10 @@ class TestExternalCodeBaseConfigHandling:
 
     @mock.patch("builtins.input", side_effect=["not y or n"])  # mock_input
     def test_handle_config_status_no_env_var_user_invalid(
-        self, mock_input, generic_codebase, capsys: pytest.CaptureFixture
+        self,
+        mock_input,
+        generic_codebase,
+        capsys: pytest.CaptureFixture,
     ):
         self.mock_local_config_status.return_value = 3
 

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -443,7 +443,7 @@ class TestExternalCodeBaseConfigHandling:
     def test_handle_config_status_no_env_var_user_invalid(
         self,
         mock_input,
-        generic_codebase,
+        generic_codebase: ExternalCodeBase,
         capsys: pytest.CaptureFixture,
     ):
         self.mock_local_config_status.return_value = 3

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -285,7 +285,7 @@ class TestExternalCodeBaseConfigHandling:
             new_callable=mock.PropertyMock,
             return_value=mock.Mock(
                 environment_variables={"TEST_ROOT": "/path/to/repo"},
-                package_root=Path("/mock/package/root"),
+                package_root=Path("./mock/package/root"),
             ),
         )
         self.mock_environment = self.patch_environment.start()

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -14,10 +14,9 @@ class MockExternalCodeBase(ExternalCodeBase):
     """A mock subclass of the `ExternalCodeBase` abstract base class used for testing
     purposes."""
 
-    def __init__(self, log: logging.Logger, interactive: bool = True):
+    def __init__(self, log: logging.Logger):
         super().__init__(None, None)
         self._log = log
-        self._interactive = interactive
 
     @property
     def expected_env_var(self):

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -269,7 +269,7 @@ class TestExecutionHandlerUpdates:
         updater_thread.start()
 
         # Run the `updates` method
-        handler.updates(seconds=0, confirm_indefinite=False)
+        handler.updates(seconds=0, interactive=False)
 
         # Verify that only lines from `running_updates` were printed
         printed_calls = caplog.text

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -1,7 +1,9 @@
 import logging
+import os
 import threading
 import time
 from pathlib import Path
+from unittest import mock
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -269,7 +271,8 @@ class TestExecutionHandlerUpdates:
         updater_thread.start()
 
         # Run the `updates` method
-        handler.updates(seconds=0, interactive=False)
+        with mock.patch.dict(os.environ, {"CSTAR_INTERACTIVE": "0"}):
+            handler.updates(seconds=0)
 
         # Verify that only lines from `running_updates` were printed
         printed_calls = caplog.text


### PR DESCRIPTION
## Description

Enable a non-interactive UX by parameterizing the simulation and external codebase classes. Client applications can now avoid user interaction by supplying the `CSTAR_INTERACTIVE` environment variable:

- `"0"` for disabled
- `"1"` for enabled
- default: `"1"` - matches prior behavior

### Additional Tweaks:

- automatic formatting
- avoids repeated string concatenations

### checklist

- [x] Closes #CW-802
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
