### PR TITLE
Fix use of deprecated ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ exclude = "properties|asv_bench|docs"
 # Configuration for ruff linter and formatter
 [tool.ruff]
 fix = true
+
+[tool.ruff.lint]
 extend-select = ["I"]
 
 [tool.pre-commit]


### PR DESCRIPTION
## Description

This PR makes a small modification to the `pyproject.toml` file to avoid the linter issuing a warning due to use of a deprecated configuration format.

- [X] Closes #CW-815
- [X] Tests passing
