### PR TITLE
Fix bug where errors may not be displayed to user

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -264,6 +264,7 @@ def _run_cmd(
         if raise_on_error:
             raise RuntimeError(msg)
 
+        print(result.stderr)
         log.error(msg)
 
     log.debug(msg_post or "Command completed successfully.")

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -590,12 +590,12 @@ def test_run_cmd_error_reporting(
 def test_run_cmd_error_reporting_on_raise(
     mock_run: mock.MagicMock, capsys: pytest.CaptureFixture
 ):
-    """Verify that any errors encountered while running an external process are
-    displayed directly to the user when `_run_cmd` throws an exception.
+    """Verify that any errors encountered while running an external process are not
+    displayed repeatedly to the user when `_run_cmd` throws an exception.
 
     Asserts
     -------
-    - Ensure errors will not be written twice when an exception is thrown.
+    - Ensure error is not written to stdout when an exception is thrown
     """
 
     mock_output = "mock stdout"


### PR DESCRIPTION
### Description

The `_run_cmd` utility method introduced a defect where only successful execution outputs are displayed directly to the user. 

See `cstar/base/utils.py`

```
        if raise_on_error:
            raise RuntimeError(msg)
```

This results in the stdout being written to a log but may not be displayed to the user if raise_on_error is False, resulting in a silent failure.

### Request

Update the above code to include a print to `stdout` including the error.

```
        if raise_on_error:
            raise RuntimeError(msg)

        # Exception was not thrown. Report error
        print(stderr)
```

### Acceptance Criteria

- The user is informed of a failure in _run_cmd without looking at logs
- All existing tests must pass

### Checklist

- [X] Closes #CW-821
- [X] Tests passing
- [X] Tests added