### PR TITLE
Add optional ability to log to file in `get_logger`

### DIFF
--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -70,7 +70,8 @@ def get_logger(
         existing_fh = [
             h
             for h in logger.handlers
-            if isinstance(h, logging.FileHandler) and Path(h.baseFilename).resolve() == Path(filename).resolve()
+            if isinstance(h, logging.FileHandler)
+            and Path(h.baseFilename).resolve() == Path(filename).resolve()
         ]
         if not existing_fh:
             file_handler = logging.FileHandler(filename)

--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -1,23 +1,29 @@
 import logging
 import sys
+from pathlib import Path
 
 DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_LOG_FORMAT = "[%(levelname)s] %(message)s"
 
 
 def get_logger(
-    name: str | None = None, level: int = DEFAULT_LOG_LEVEL, fmt: str | None = None
+    name: str | None = None,
+    level: int = DEFAULT_LOG_LEVEL,
+    fmt: str | None = None,
+    filename: str | None | Path = None,
 ) -> logging.Logger:
     """Get a logger instance with the specified name.
 
     Parameters
     ----------
-    name : str
+    name: str
         The name of the logger.
     level: int
         The minimum log level to write.
-    fmt : str
+    fmt: str
         The log format string.
+    filename: str | None
+        A file path where logs will be written.
 
     Returns
     -------
@@ -56,6 +62,21 @@ def get_logger(
         stdout_handler.setFormatter(formatter)
 
         logger.addHandler(stdout_handler)
+
+    if filename:
+        if isinstance(filename, Path):
+            filename = str(filename)
+
+        existing_fh = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.FileHandler) and h.baseFilename == filename
+        ]
+        if not existing_fh:
+            file_handler = logging.FileHandler(filename)
+            file_handler.setLevel(level)
+            file_handler.setFormatter(logging.Formatter(fmt=fmt))
+            logger.addHandler(file_handler)
 
     # Re-enable propagation on final logger
     logger.propagate = True

--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -70,7 +70,7 @@ def get_logger(
         existing_fh = [
             h
             for h in logger.handlers
-            if isinstance(h, logging.FileHandler) and h.baseFilename == filename
+            if isinstance(h, logging.FileHandler) and Path(h.baseFilename).resolve() == Path(filename).resolve()
         ]
         if not existing_fh:
             file_handler = logging.FileHandler(filename)

--- a/cstar/tests/unit_tests/base/test_log.py
+++ b/cstar/tests/unit_tests/base/test_log.py
@@ -1,0 +1,132 @@
+import logging
+import logging.handlers
+import pathlib
+import typing as t
+import uuid
+
+import pytest
+
+from cstar.base.log import get_logger
+
+
+@pytest.fixture
+def all_levels() -> list[int]:
+    return [
+        logging.DEBUG,
+        logging.INFO,
+        logging.WARNING,
+        logging.ERROR,
+        logging.CRITICAL,
+    ]
+
+
+@pytest.fixture
+def levels_fn(
+    all_levels: list[int],
+) -> t.Callable[[int], t.Tuple[list[int], list[int]]]:
+    """Return a function that returns a tuple of lists containing all log levels below
+    and above the specified log level.
+
+    Returns:
+        t.Callable[list[int], list[int]]: the function
+    """
+
+    def _inner(level: int) -> t.Tuple[list[int], list[int]]:
+        """Return a tuple containing:
+        1. list of levels less than the supplied level
+        2. list of levels greater than or equal to the supplied level
+
+        Args:
+            level (int): the target log level
+
+        Returns:
+            tuple[list[int], list[int]]: the lists of log levels
+        """
+        lt, gte = [], []
+
+        for level_ in all_levels:
+            if level_ < level:
+                lt.append(level_)
+            elif level_ >= level:
+                gte.append(level_)
+
+        return lt, gte
+
+    return _inner
+
+
+@pytest.mark.parametrize(
+    "level",
+    [
+        logging.DEBUG,
+        logging.INFO,
+        logging.WARNING,
+        logging.ERROR,
+        logging.CRITICAL,
+    ],
+)
+def test_loglevel_fh(
+    request: pytest.FixtureRequest,
+    level: int,
+    levels_fn: t.Callable[[int], tuple[list[int], list[int]]],
+    all_levels: list[int],
+    tmp_path: pathlib.Path,
+) -> None:
+    """Verify the loggers are configured properly to output the desired log levels when
+    the optional file handler is requested."""
+
+    for level in all_levels:
+        logger_name = f"{request.function.__name__}-{level}"
+        filename = tmp_path / f"{logger_name}.log"
+
+        log = get_logger(logger_name, level, filename=str(filename))
+
+        lt_levels, gt_eq_levels = levels_fn(level)
+
+        msg = str(uuid.uuid4())
+        funcs = [log.debug, log.info, log.warning, log.error, log.critical]
+
+        for msg_level, log_fn in zip(all_levels, funcs):
+            log_fn(msg)
+            log_content = filename.read_text()
+
+            # confirm all messages < level aren't in file
+            if msg_level in list(gt_eq_levels):
+                expected_log_entry = f"[{logging._levelToName[msg_level]}] {msg}"
+                assert expected_log_entry in log_content
+
+            # confirm messages >= level are in file
+            if msg_level in list(lt_levels):
+                assert msg not in log_content
+
+
+def test_filehandler_no_dupes(
+    request: pytest.FixtureRequest,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Verify the loggers are configured properly to output the desired log levels when
+    the optional file handler is requested."""
+
+    level = logging.INFO
+    logger_name = f"{request.function.__name__}-{level}"
+    filename = tmp_path / f"{logger_name}.log"
+
+    # ask for log repeatedly, fh should only be added once.
+    log = get_logger(logger_name, level, filename=filename)
+    log = get_logger(logger_name, level, filename=filename)
+    log = get_logger(logger_name, level, filename=filename)
+    log = get_logger(logger_name, level, filename=filename)
+
+    msg = str(uuid.uuid4())
+    log.info(msg)
+
+    log_content = filename.read_text()
+    expected_log_entry = f"[{logging._levelToName[level]}] {msg}"
+
+    # confirm entry is found...
+    found_at = log_content.find(expected_log_entry)
+    assert found_at > -1
+
+    # ... and isn't written more than once
+    found_at = log_content.find(expected_log_entry, len(expected_log_entry))
+    assert found_at == -1

--- a/cstar/tests/unit_tests/base/test_log.py
+++ b/cstar/tests/unit_tests/base/test_log.py
@@ -92,7 +92,7 @@ def test_loglevel_fh(
 
             # confirm all messages >= level are in the file
             if msg_level in list(gt_eq_levels):
-                expected_log_entry = f"[{logging._levelToName[msg_level]}] {msg}"
+                expected_log_entry = f"[{logging.getLevelName(msg_level)}] {msg}"
                 assert expected_log_entry in log_content
 
             # confirm messages < level are not in file

--- a/cstar/tests/unit_tests/base/test_log.py
+++ b/cstar/tests/unit_tests/base/test_log.py
@@ -90,12 +90,12 @@ def test_loglevel_fh(
             log_fn(msg)
             log_content = filename.read_text()
 
-            # confirm all messages < level aren't in file
+            # confirm all messages >= level are in the file
             if msg_level in list(gt_eq_levels):
                 expected_log_entry = f"[{logging._levelToName[msg_level]}] {msg}"
                 assert expected_log_entry in log_content
 
-            # confirm messages >= level are in file
+            # confirm messages < level are not in file
             if msg_level in list(lt_levels):
                 assert msg not in log_content
 


### PR DESCRIPTION
Add a parameter to `get_logger` to enable logging to a file in addition to the existing stream handlers.

- [X] Closes #CW-822
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
