### PR TITLE
Add MVP for an interactive slurm job 

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -157,19 +157,15 @@ def retrieve_status(
         raise_on_error=True,
     )
 
-    status_lines: list[tuple[str, str, str]] = []
-    for line in stdout.split("\n"):
-        split_line = line.strip().split(",", 2)
-        if len(split_line) < 3:
-            log.warning(f"Unknown output format encountered: {line}")
-            continue
+    # remove empties and filter to lines containing job-id, status, job-name triplet
+    status_lines = (x.strip().split(",") for x in stdout.split("\n") if x.strip())
+    status_data = filter(lambda x: len(x) == 3, status_lines)
+    status_tuples = list(map(lambda x: (x[0], x[1], x[2]), status_data))
 
-        status_lines.append((split_line[0], split_line[1], split_line[2]))
-
-    if not status_lines:
+    if not status_tuples:
         log.debug(f"No status results for job {slurm_job_id} found")
 
-    return status_lines
+    return status_tuples
 
 
 def query_status(

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -1,11 +1,16 @@
+import abc
+import dataclasses
 import json
+import logging
 import os
 import re
+import uuid
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from datetime import datetime, timedelta
 from math import ceil
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, override
 
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
@@ -18,6 +23,200 @@ from cstar.system.scheduler import (
     SlurmQOS,
     SlurmScheduler,
 )
+
+
+@dataclasses.dataclass
+class JobStatus(abc.ABC):
+    state: ExecutionStatus
+
+    @property
+    @abstractmethod
+    def is_terminated(self) -> bool: ...
+
+    @property
+    @abstractmethod
+    def is_running(self) -> bool: ...
+
+    @staticmethod
+    @abstractmethod
+    def map_status(state: str) -> ExecutionStatus: ...
+
+    @staticmethod
+    @abstractmethod
+    def from_raw(state: str) -> "JobStatus": ...
+
+
+@dataclasses.dataclass
+class SlurmJobStatus(JobStatus):
+    state: ExecutionStatus
+
+    @override
+    @property
+    def is_terminated(self) -> bool:
+        """Returns `True` if the job has completed."""
+        return self.state in {
+            ExecutionStatus.COMPLETED,
+            ExecutionStatus.CANCELLED,
+            ExecutionStatus.FAILED,
+        }
+
+    @override
+    @property
+    def is_running(self) -> bool:
+        """Returns `True` if the job has not yet completed."""
+        return self.state in {
+            ExecutionStatus.PENDING,
+            ExecutionStatus.RUNNING,
+        }
+
+    @override
+    @staticmethod
+    def map_status(raw_status: str) -> ExecutionStatus:
+        """Map raw output from sacct to the ExecutionStatus enum.
+
+        Return ExecutionStatus.UNKNOWN if state cannot be mapped.
+
+        Raises
+        ------
+        ValueError
+            If an empty `raw_state` is provided
+        """
+        if not raw_status or not raw_status.strip():
+            raise ValueError("Unable to map an empty raw status")
+
+        sacct_status_map: dict[str, ExecutionStatus] = defaultdict(
+            lambda: ExecutionStatus.UNKNOWN
+        )
+        sacct_status_map.update(
+            {
+                "PENDING": ExecutionStatus.PENDING,
+                "RUNNING": ExecutionStatus.RUNNING,
+                "COMPLETED": ExecutionStatus.COMPLETED,
+                "CANCELLED": ExecutionStatus.CANCELLED,
+                "FAILED": ExecutionStatus.FAILED,
+            }
+        )
+        key = raw_status.upper()
+        return sacct_status_map[key]
+
+    @override
+    @staticmethod
+    def from_raw(raw_state: str) -> "SlurmJobStatus":
+        """Convert the raw output of a call to `sacct` into a `SlurmJobStatus` instance.
+
+        Raises
+        ------
+        ValueError
+            If an empty `raw_state` is provided
+        """
+        if not raw_state or not raw_state.strip():
+            raise ValueError("Unable to convert empty raw state")
+
+        status = SlurmJobStatus.map_status(raw_state)
+        return SlurmJobStatus(status)
+
+
+def retrieve_status(
+    slurm_job_id: str,
+    *,
+    log: logging.Logger,
+    task_id: Optional[str] = None,
+    task_name: Optional[str] = None,
+) -> list[tuple[str, str, str]]:
+    """Query SLURM for the status of a job or task.
+
+    Parameters
+    ----------
+    slurm_job_id : str
+        The ID of the main job
+
+    Returns
+    -------
+    status_lines: list[tuple[str, str, str]]
+        Output of the query; tuples containing [job-id, job-status, job-name]
+
+    Raises
+    ------
+    ValueError
+        If an invalid `slurm_job_id` is provided
+    """
+    if not slurm_job_id or not slurm_job_id.strip():
+        raise ValueError("Invalid slurm_job_id provided")
+
+    slurm_job_id = slurm_job_id.strip() if slurm_job_id else ""
+    task_id = task_id.strip() if task_id else ""
+    task_name = task_name.strip() if task_name else ""
+
+    sacct_cmd = (
+        f"sacct -j {slurm_job_id} "
+        "--format=JobID,State,JobName --noheader -P --delimiter=,"
+    )
+    stdout = _run_cmd(
+        sacct_cmd,
+        msg_err=f"Failed to retrieve job status using {sacct_cmd}.",
+        raise_on_error=True,
+    )
+
+    status_lines: list[tuple[str, str, str]] = []
+    for line in stdout.split("\n"):
+        split_line = line.strip().split(",", 2)
+        if len(split_line) < 3:
+            log.warning(f"Unknown output format encountered: {line}")
+            continue
+
+        status_lines.append((split_line[0], split_line[1], split_line[2]))
+
+    if not status_lines:
+        log.debug(f"No status results for job {slurm_job_id} found")
+
+    return status_lines
+
+
+def query_status(
+    slurm_job_id: str,
+    *,
+    log: logging.Logger,
+    task_id: Optional[str] = None,
+    task_name: Optional[str] = None,
+) -> tuple[str, str, str]:
+    """Parse output from SLURM for the status of a job or task, looking for a specific
+    job or task.
+
+    Parameters
+    ----------
+    stdout : str
+        The raw output of the call to `sacct` by `SLURM`
+
+    Returns
+    -------
+    details: tuple[str, str, str]
+        A tuple containing the job id, job status, and job name
+    """
+
+    status_lines = retrieve_status(
+        slurm_job_id, log=log, task_id=task_id, task_name=task_name
+    )
+
+    result: Optional[tuple[str, str, str]] = None
+    if status_lines:
+        # Batch job will have JobID == slurm_job_id, srun has slurm_job_id.<StepID>
+        if task_id:
+            result = next(
+                (atom for atom in status_lines if atom[0] == str(task_id)), None
+            )
+        elif task_name:
+            result = next(
+                (atom for atom in status_lines if atom[2] == str(task_name)), None
+            )
+        else:
+            result = next(
+                (atom for atom in status_lines if atom[0] == str(slurm_job_id)), None
+            )
+
+    if not result:
+        return "", str(ExecutionStatus.UNSUBMITTED).lower(), ""
+
+    return result
 
 
 def create_scheduler_job(
@@ -81,10 +280,13 @@ def create_scheduler_job(
     """
 
     # mypy assigns type based on first condition, assigning explicitly:
-    job_type: type[SlurmJob] | type[PBSJob]
+    job_type: type[SlurmJob] | type[PBSJob] | type[SlurmInteractiveJob]
 
     if isinstance(cstar_sysmgr.scheduler, SlurmScheduler):
-        job_type = SlurmJob
+        if not os.environ.get("SLURM_JOB_ID", None):
+            job_type = SlurmJob
+        else:
+            job_type = SlurmInteractiveJob
     elif isinstance(cstar_sysmgr.scheduler, PBSScheduler):
         job_type = PBSJob
     else:
@@ -338,7 +540,8 @@ class SchedulerJob(ExecutionHandler, ABC):
             self._nodes = nodes
 
         self._account_key = account_key
-        self._id: Optional[int] = None
+        self._id: Optional[str] = None
+        self._job_status: Optional[JobStatus] = None
 
     @property
     def output_file(self) -> Path:
@@ -404,7 +607,7 @@ class SchedulerJob(ExecutionHandler, ABC):
         return self._commands
 
     @property
-    def id(self) -> Optional[int]:
+    def id(self) -> Optional[str]:
         """Retrieve the unique job ID assigned by the scheduler.
 
         The job ID is assigned when the job is successfully submitted to the scheduler.
@@ -413,7 +616,7 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         Returns
         -------
-        id: int or None
+        id: str or None
             The unique job ID assigned by the scheduler, or `None` if the job has not
             been submitted.
         """
@@ -589,28 +792,21 @@ class SlurmJob(SchedulerJob):
         RuntimeError
             If the command to retrieve the job status fails or returns an unexpected result.
         """
+        if self._job_status is not None:
+            return self._job_status.state
 
         if self.id is None:
             return ExecutionStatus.UNSUBMITTED
-        else:
-            sacct_cmd = f"sacct -j {self.id} --format=State%20 --noheader"
-            msg_err = f"Failed to retrieve job status using {sacct_cmd}."
-            stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
 
-        # Map sacct states to ExecutionStatus enum
-        sacct_status_map = {
-            "PENDING": ExecutionStatus.PENDING,
-            "RUNNING": ExecutionStatus.RUNNING,
-            "COMPLETED": ExecutionStatus.COMPLETED,
-            "CANCELLED": ExecutionStatus.CANCELLED,
-            "FAILED": ExecutionStatus.FAILED,
-        }
-        for state, status in sacct_status_map.items():
-            if state in stdout:
-                return status
+        job_id, job_status, job_name = query_status(self.id, log=self.log)
+        self.log.debug(f"Retrieved status {job_status} for job: {self.id}")
 
-        # Fallback if no known state is found
-        return ExecutionStatus.UNKNOWN
+        result = SlurmJobStatus.from_raw(job_status)
+        if result.is_terminated:
+            # cache the result to avoid additional, unnecessary status retrievals.
+            self._job_status: SlurmJobStatus = result
+
+        return result.state
 
     @property
     def script(self) -> str:
@@ -650,7 +846,7 @@ class SlurmJob(SchedulerJob):
         scheduler_script += f"\n\n{self.commands}"
         return scheduler_script
 
-    def submit(self) -> Optional[int]:
+    def submit(self) -> Optional[str]:
         """Submit the job to the SLURM scheduler.
 
         This method saves the job script to the specified `script_path` and submits it
@@ -659,7 +855,7 @@ class SlurmJob(SchedulerJob):
 
         Returns
         -------
-        job_id : int
+        job_id : str
             The unique job ID assigned by the SLURM scheduler.
 
         Raises
@@ -691,7 +887,7 @@ class SlurmJob(SchedulerJob):
         # Extract the job ID from the output
         matches = re.search(r"Submitted batch job (\d+)", stdout)
         if matches:
-            self._id = int(matches.group(1))
+            self._id = matches.group(1)
             return self._id
         else:
             raise RuntimeError(f"Failed to parse job ID from sbatch output: {stdout}")
@@ -711,6 +907,183 @@ class SlurmJob(SchedulerJob):
         """
 
         if self.status not in {ExecutionStatus.RUNNING, ExecutionStatus.PENDING}:
+            self.log.info(f"Cannot cancel job with status '{self.status}'")
+            return
+
+        _run_cmd(
+            f"scancel {self.id}",
+            cwd=self.run_path,
+            raise_on_error=True,
+            msg_post=f"Job {self.id} cancelled",
+            msg_err="Non-zero exit code when cancelling job.",
+        )
+
+
+class SlurmInteractiveJob(SchedulerJob):
+    """Represents a job submitted to the SLURM scheduler.
+
+    This class extends `SchedulerJob` to handle SLURM-specific functionality for
+    job submission, status retrieval, and script generation.
+
+    Attributes
+    ----------
+    scheduler : SlurmScheduler
+        The SLURM scheduler managing this job.
+    commands : str
+        The commands to execute within the job script.
+    account_key : str
+        The account key associated with the job for resource tracking.
+    cpus : int
+        The total number of CPUs required for the job.
+    nodes : int or None
+        The number of nodes to request.
+        If not provided and a specific nodes x CPUs distribution is required,
+        C-Star will attempt to calculate an appropriate number of nodes.
+    cpus_per_node : int or None
+        The number of CPUs per node to request.
+        If not provided and a specific nodes x CPUs distribution is required,
+        C-Star will attempt to calculate an appropriate number of CPUs per node.
+    script_path : Path
+        The file path where the job script will be saved.
+    run_path : Path
+        The directory where the job will be executed.
+    job_name : str
+        The name of the job.
+    output_file : Path
+        The file path for job output.
+    queue_name : str
+        The name of the SLURM queue (partition or QOS) to which the job will be submitted.
+    walltime : str
+        The maximum walltime for the job, in the format "HH:MM:SS".
+    id : int or None
+        The unique job ID assigned by the SLURM scheduler. None if the job has not been submitted.
+    status : ExecutionStatus
+        The current status of the job, retrieved from SLURM.
+    script : str
+        The SLURM-specific job script, including directives and commands.
+
+    Methods
+    -------
+    submit()
+        Submit the job to the SLURM scheduler.
+    cancel()
+        Cancel the job using the SLURM `scancel` command.
+    """
+
+    @property
+    def status(self) -> ExecutionStatus:
+        """Retrieve the current status of the job from the SLURM scheduler.
+
+        This property queries SLURM using the `sacct` command to determine the job's
+        state and maps it to a corresponding `ExecutionStatus` enumeration.
+
+        Returns
+        -------
+        status: ExecutionStatus
+            The current status of the job. Possible values include:
+            - `ExecutionStatus.PENDING`: The job has been submitted but is waiting to start.
+            - `ExecutionStatus.RUNNING`: The job is currently executing.
+            - `ExecutionStatus.COMPLETED`: The job finished successfully.
+            - `ExecutionStatus.CANCELLED`: The job was cancelled before completion.
+            - `ExecutionStatus.FAILED`: The job finished unsuccessfully.
+            - `ExecutionStatus.UNKNOWN`: The job state could not be determined.
+
+        Raises
+        ------
+        RuntimeError
+            If the command to retrieve the job status fails or returns an unexpected result.
+        """
+
+        if self._job_status is not None:
+            return self._job_status.state  # type: ignore
+
+        _, job_status, _ = query_status(
+            self._slurm_job_id, log=self.log, task_id=self._id
+        )
+        self.log.debug(f"Retrieved status {job_status} for job: {self.id}")
+
+        result = SlurmJobStatus.from_raw(job_status)
+        if result.is_terminated:
+            # cache the result to avoid additional, unnecessary status retrievals.
+            self._job_status = result
+
+        return result.state
+
+    @property
+    def script(self) -> str:
+        """Generate the SLURM-specific job script to be submitted to the scheduler.
+        Includes standard Slurm scheduler directives as well as scheduler-specific
+        directives specified by the scheduler.other_scheduler_directives attribute.
+
+        Returns
+        -------
+        scheduler_script: str
+            The complete SLURM job script as a string, ready for submission.
+        """
+
+        scheduler_script = "#!/bin/bash"
+
+        # Add roms command to scheduler script
+        scheduler_script += f"\n\n{self.commands}"
+        return scheduler_script
+
+    def submit(self) -> Optional[str]:
+        """Submit the job to the SLURM scheduler.
+
+        This method saves the job script to the specified `script_path` and submits it
+        to the SLURM scheduler using the `sbatch` command. It extracts and stores the
+        job ID assigned by SLURM to the 'id' attribute.
+
+        Returns
+        -------
+        job_id : str
+            The unique job ID assigned by the SLURM scheduler.
+
+        Raises
+        ------
+        RuntimeError
+            If the `srun` command fails or if the job ID cannot be extracted from the
+            submission output.
+        """
+
+        if slurm_job_id := os.environ.get("SLURM_JOB_ID", None):
+            # generate a unique identifier for this task
+            self._id = str(uuid.uuid4()).split("-")[0]
+            self._slurm_job_id = slurm_job_id
+            self._commands = self._commands.replace("srun", f"srun -J {self._id}")
+
+        self.save_script()
+
+        # Execute the step immediately in a blocking manner
+        stdout = _run_cmd(
+            self.commands,
+            cwd=self.run_path,
+            msg_err="Non-zero exit code when submitting job.",
+            raise_on_error=True,
+        )
+
+        print(stdout)
+
+        _, job_status, _ = query_status(
+            self._slurm_job_id, log=self.log, task_id=self.id
+        )
+
+        return self.id
+
+    def cancel(self):
+        """Cancel the job in the SLURM scheduler.
+
+        This method cancels the job using the SLURM `scancel` command and provides
+        feedback about the cancellation process.
+
+        It can only be used on jobs with RUNNING or PENDING status.
+
+        Raises
+        ------
+        RuntimeError
+            If the `scancel` command fails or returns a non-zero exit code.
+        """
+        if self.status.is_running:
             self.log.info(f"Cannot cancel job with status '{self.status}'")
             return
 
@@ -759,7 +1132,7 @@ class PBSJob(SchedulerJob):
         The name of the PBS queue to which the job will be submitted.
     walltime : str
         The maximum walltime for the job, in the format "HH:MM:SS".
-    id : int or None
+    id : str or None
         The unique job ID assigned by the PBS scheduler. None if the job has not been submitted.
     status : ExecutionStatus
         The current status of the job, retrieved from PBS.
@@ -873,7 +1246,7 @@ class PBSJob(SchedulerJob):
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Failed to parse JSON from qstat output: {e}")
 
-    def submit(self) -> Optional[int]:
+    def submit(self) -> Optional[str]:
         """Submit the job to the PBS scheduler.
 
         This method saves the job script to the specified `script_path` and submits it
@@ -882,7 +1255,7 @@ class PBSJob(SchedulerJob):
 
         Returns
         -------
-        job_id : int
+        job_id : str
             The unique job ID assigned by the PBS scheduler.
 
         Raises
@@ -907,7 +1280,7 @@ class PBSJob(SchedulerJob):
             raise RuntimeError(f"Unexpected job ID format from qsub: {job_id_full}")
 
         # Extract the job ID from the output
-        self._id = int(job_id_full.split(".")[0])
+        self._id = job_id_full.split(".")[0]
         return self._id
 
     def cancel(self):

--- a/cstar/tests/unit_tests/execution/test_pbs_job.py
+++ b/cstar/tests/unit_tests/execution/test_pbs_job.py
@@ -249,7 +249,7 @@ class TestPBSJob:
             **self.common_job_params,
             run_path=tmp_path,
         )
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Cancel the job
         job.cancel()
@@ -302,7 +302,7 @@ class TestPBSJob:
             **self.common_job_params,
             run_path=tmp_path,
         )
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Get the logger from the job instance
         caplog.set_level(logging.INFO, logger=job.log.name)
@@ -353,7 +353,7 @@ class TestPBSJob:
             **self.common_job_params,
             run_path=tmp_path,
         )
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Expect an error when qdel fails
         with pytest.raises(
@@ -507,7 +507,7 @@ class TestPBSJob:
 
         # Create a PBSJob with a set job ID
         job = PBSJob(**self.common_job_params)
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Check the expected outcome
         if should_raise:
@@ -547,7 +547,7 @@ class TestPBSJob:
 
         # Create a PBSJob with a set job ID
         job = PBSJob(**self.common_job_params)
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Check for JSONDecodeError handling
         with pytest.raises(

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -271,7 +271,7 @@ class TestSlurmJob:
         )
 
         # Check that the job ID was set
-        assert job.id == 12345
+        assert job.id == "12345"
 
     @pytest.mark.parametrize(
         "subprocess_stdout, subprocess_returncode, expected_exception_message",
@@ -382,7 +382,7 @@ class TestSlurmJob:
             **self.common_job_params,
             run_path=run_path,
         )
-        job._id = 12345  # Manually set the job ID
+        job._id = "12345"  # Manually set the job ID
 
         # Call cancel
         job.cancel()
@@ -464,24 +464,42 @@ class TestSlurmJob:
         "job_id, sacct_output, return_code, expected_status, should_raise",
         [
             (None, "", 0, ExecutionStatus.UNSUBMITTED, False),  # Unsubmitted job
-            (12345, "PENDING\n", 0, ExecutionStatus.PENDING, False),  # Pending job
-            (12345, "RUNNING\n", 0, ExecutionStatus.RUNNING, False),  # Running job
             (
-                12345,
-                "COMPLETED\n",
+                "12345",
+                "12345,PENDING,TheJobName\n",
+                0,
+                ExecutionStatus.PENDING,
+                False,
+            ),  # Pending job
+            (
+                "12345",
+                "12345,RUNNING,TheJobName\n",
+                0,
+                ExecutionStatus.RUNNING,
+                False,
+            ),  # Running job
+            (
+                "12345",
+                "12345,COMPLETED,TheJobName\n",
                 0,
                 ExecutionStatus.COMPLETED,
                 False,
             ),  # Completed job
             (
-                12345,
-                "CANCELLED\n",
+                "12345",
+                "12345,CANCELLED,TheJobName\n",
                 0,
                 ExecutionStatus.CANCELLED,
                 False,
             ),  # Cancelled job
-            (12345, "FAILED\n", 0, ExecutionStatus.FAILED, False),  # Failed job
-            (12345, "", 1, None, True),  # sacct command failure
+            (
+                "12345",
+                "12345,FAILED,TheJobName\n",
+                0,
+                ExecutionStatus.FAILED,
+                False,
+            ),  # Failed job
+            ("12345", "", 1, None, True),  # sacct command failure
         ],
     )
     def test_status(

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -1,8 +1,13 @@
 import logging
+import textwrap
+import unittest
+from typing import Optional
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
+from cstar.execution.handler import ExecutionStatus
+from cstar.execution.scheduler_job import SlurmJobStatus, query_status
 from cstar.system.scheduler import (
     PBSQueue,
     PBSScheduler,
@@ -423,6 +428,692 @@ class TestScheduler:
                 text=True,
                 capture_output=True,
             )
+
+
+class TestJobStatus:
+    """Unit tests for SlurmJobStatus class.
+
+    Tests
+    -----
+    test_is_terminated
+        Verify that the class correctly identifies states that indicate a
+        job has completed processing.
+    test_is_running
+        Verify that the class correctly identifies states that indicate a
+        job has not completed processing.
+    test_invalid_mapping
+        Verify that an invalid source causes an appropriate exception to occur.
+    test_mapping
+        Verify that mapping of a source state str to an ExecutionStatus
+        correctly converts known inputs.
+
+    Fixtures
+    --------
+    n/a
+    """
+
+    @pytest.mark.parametrize(
+        "input_state,expected_result",
+        [
+            ("completed", True),
+            ("cancelled", True),
+            ("failed", True),
+            ("pending", False),
+            ("running", False),
+            ("COMPLETED", True),
+            ("CANCELLED", True),
+            ("FAILED", True),
+            ("PENDING", False),
+            ("RUNNING", False),
+        ],
+    )
+    def test_is_terminated(self, input_state: str, expected_result: bool) -> None:
+        """Verify that the class correctly identifies states that indicate a job has
+        completed processing."""
+        job_status = SlurmJobStatus.from_raw(input_state)
+        assert job_status.is_terminated == expected_result
+
+    @pytest.mark.parametrize(
+        "input_state,expected_result",
+        [
+            ("completed", False),
+            ("cancelled", False),
+            ("failed", False),
+            ("pending", True),
+            ("running", True),
+            ("COMPLETED", False),
+            ("CANCELLED", False),
+            ("FAILED", False),
+            ("PENDING", True),
+            ("RUNNING", True),
+        ],
+    )
+    def test_is_running(self, input_state: str, expected_result: bool) -> None:
+        """Verify that the class correctly identifies states that indicate a job has not
+        completed processing."""
+        job_status = SlurmJobStatus.from_raw(input_state)
+        assert job_status.is_running == expected_result
+
+    @pytest.mark.parametrize("input_state", [" ", "", None])
+    def test_invalid_mapping(self, input_state: Optional[str]) -> None:
+        """Verify that an invalid source causes an appropriate exception to occur."""
+        with pytest.raises(ValueError):
+            SlurmJobStatus.from_raw(input_state)  # type: ignore
+
+    @pytest.mark.parametrize(
+        "input_state,expected_state",
+        [
+            ("pending", ExecutionStatus.PENDING),
+            ("running", ExecutionStatus.RUNNING),
+            ("completed", ExecutionStatus.COMPLETED),
+            ("cancelled", ExecutionStatus.CANCELLED),
+            ("failed", ExecutionStatus.FAILED),
+            ("xyz", ExecutionStatus.UNKNOWN),
+            ("PENDING", ExecutionStatus.PENDING),
+            ("RUNNING", ExecutionStatus.RUNNING),
+            ("COMPLETED", ExecutionStatus.COMPLETED),
+            ("CANCELLED", ExecutionStatus.CANCELLED),
+            ("FAILED", ExecutionStatus.FAILED),
+            ("XYZ", ExecutionStatus.UNKNOWN),
+        ],
+    )
+    def test_mapping(self, input_state: Optional[str], expected_state) -> None:
+        """Verify that mapping of a source state str to an ExecutionStatus correctly
+        converts known inputs."""
+        job_status = SlurmJobStatus.from_raw(input_state)  # type: ignore
+        assert job_status.state == expected_state
+
+
+class TestQueryStatus:
+    """Unit tests for `query_status` method.
+
+    Tests
+    -----
+    test_invalid_job_id
+        Verify that query_status fails as expected when a job ID
+        is not provided.
+    test_job_not_found
+        Verify that an unsubmitted job is properly handled when slurm
+        returns no results.
+    test_job_unsubmitted
+        Verify that an unsubmitted job is properly handled when
+        slurm returns existing results for the parent job.
+    test_job_found
+        Verify that the correct output is returned for a known Job ID.
+    test_task_found
+       Verify that the correct output is returned for a known task ID.
+    test_task_name_found
+        Verify that the correct output is returned for a known task name.
+    test_task_not_found
+        Verify that a valid job ID with unknown task ID returns
+        the correct result.
+
+    Fixtures
+    --------
+    mock_subprocess_run : MagicMock
+        Mocks `subprocess.run` to simulate `make` commands and other shell operations.
+    mock_query_output: str
+        A mock query result containing multiple tasks with a parent task and two
+        subtasks. 1 subtask is pending and another has failed.
+    """
+
+    @pytest.fixture
+    def mock_subprocess_run(self):
+        """Mock subprocess.run for testing system command execution.
+
+        This fixture ensures that subprocess.run calls are intercepted,
+        allowing tests to simulate their outputs or errors without running
+        actual commands.
+
+        Yields
+        ------
+        mock_run : unittest.mock.MagicMock
+            A mock object for subprocess.run.
+        """
+        with patch("subprocess.run") as mock_run:
+            yield mock_run
+
+    @pytest.fixture
+    def mock_job_id(self) -> str:
+        """Return a known job ID included in mock query output."""
+        return "12345"
+
+    @pytest.fixture
+    def mock_job_name(self) -> str:
+        """Return a known job name included in mock query output."""
+        return "TheMockJob"
+
+    @pytest.fixture
+    def mock_task_id(self, mock_job_id: str) -> str:
+        """Return a known task ID included in mock query output."""
+        return f"{mock_job_id}.1"
+
+    @pytest.fixture
+    def mock_task_name(self) -> str:
+        """Return a known task name included in mock query output."""
+        return "MockTaskInJob"
+
+    @pytest.fixture
+    def mock_task_status(self) -> str:
+        """Return a known task status included in mock query output."""
+        return "pending"
+
+    @pytest.fixture
+    def mock_failed_task_id(self, mock_job_id: str) -> str:
+        """Return a known task ID included in mock query output."""
+        return f"{mock_job_id}.2"
+
+    @pytest.fixture
+    def mock_failed_task_name(self) -> str:
+        """Return a known task name included in mock query output."""
+        return "FailingTask!"
+
+    @pytest.fixture
+    def mock_job_status(self) -> str:
+        """Return the status of the job returned in the `mock_query_output`"""
+        return "running"
+
+    @pytest.fixture
+    def mock_query_output(
+        self,
+        mock_job_id: str,
+        mock_job_name: str,
+        mock_task_name: str,
+        mock_task_id: str,
+        mock_task_status: str,
+        mock_job_status: str,
+        mock_failed_task_id: str,
+        mock_failed_task_name: str,
+    ) -> str:
+        """Return a well-formatted query result containing a parent task and 2
+        subtasks."""
+        return textwrap.dedent(
+            f"""
+                {mock_job_id},{mock_job_status},{mock_job_name}
+                {mock_task_id},{mock_task_status},{mock_task_name}
+                {mock_failed_task_id},failed,{mock_failed_task_name}
+            """
+        )
+
+    @pytest.mark.parametrize(
+        "slurm_job_id",
+        [
+            None,
+            "",
+            " ",
+        ],
+    )
+    def test_invalid_job_id(
+        self, slurm_job_id: Optional[str], log: logging.Logger
+    ) -> None:
+        """Verify that query_status fails as expected when a job ID is not provided."""
+
+        with pytest.raises(ValueError) as ex:
+            query_status(slurm_job_id, log=log)  # type: ignore
+
+        ex_args = "".join(str(arg) for arg in ex.value.args)
+        assert "slurm_job_id" in ex_args
+
+    def test_job_not_found(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+    ) -> None:
+        """Verify that an unsubmitted job is properly handled when slurm returns no
+        results."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout="",  # returns an empty string (no query results for job id)
+        )
+
+        job_id, job_status, job_name = query_status(
+            "not-submitted",
+            log=log,
+        )
+
+        assert job_status == "unsubmitted"
+        assert job_id == ""
+        assert job_name == ""
+
+    def test_job_unsubmitted(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+        mock_query_output: str,
+    ) -> None:
+        """Verify that an unsubmitted job is properly handled when slurm returns
+        existing results for the parent job."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout=mock_query_output,
+        )
+
+        job_id, job_status, job_name = query_status(
+            "not-submitted",
+            log=log,
+        )
+
+        assert job_status == "unsubmitted"
+        assert job_id == ""
+        assert job_name == ""
+
+    def test_job_found(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+        mock_query_output: str,
+        mock_job_id: str,
+        mock_job_status: str,
+        mock_job_name: str,
+    ) -> None:
+        """Verify that the correct output is returned for a known Job ID."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout=mock_query_output,
+        )
+
+        job_id, job_status, job_name = query_status(
+            mock_job_id,
+            log=log,
+        )
+
+        assert job_status == mock_job_status
+        assert job_id == mock_job_id
+        assert job_name == mock_job_name
+
+    def test_task_found(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+        mock_query_output: str,
+        mock_job_id: str,
+        mock_job_status: str,
+        mock_task_id: str,
+        mock_task_status: str,
+        mock_task_name: str,
+    ) -> None:
+        """Verify that the correct output is returned for a known task ID."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout=mock_query_output,
+        )
+
+        job_id, job_status, job_name = query_status(
+            mock_job_id,
+            log=log,
+            # include task id in query
+            task_id=mock_task_id,
+        )
+
+        assert job_id == mock_task_id
+        assert job_status == mock_task_status
+        assert job_name == mock_task_name
+
+        # confirm we didn't grab the job instead of the task
+        assert job_status != mock_job_status
+
+    def test_task_name_found(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+        mock_query_output: str,
+        mock_job_id: str,
+        mock_job_status: str,
+        mock_task_id: str,
+        mock_task_name: str,
+        mock_task_status: str,
+    ) -> None:
+        """Verify that the correct output is returned for a known task name."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout=mock_query_output,
+        )
+
+        job_id, job_status, job_name = query_status(
+            mock_job_id,
+            log=log,
+            # include task name in query
+            task_name=mock_task_name,
+        )
+
+        assert job_id == mock_task_id
+        assert job_status == mock_task_status
+        assert job_name == mock_task_name
+
+        # status shouldn't match the parent job
+        assert job_status != mock_job_status
+
+    def test_task_not_found(
+        self,
+        log: logging.Logger,
+        mock_subprocess_run: unittest.mock.MagicMock,
+        mock_query_output: str,
+        mock_job_id: str,
+        mock_task_id: str,
+    ) -> None:
+        """Verify that a valid job ID with unknown task ID returns the correct
+        result."""
+
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=0,
+            stdout=mock_query_output,
+        )
+
+        job_id, job_status, job_name = query_status(
+            mock_job_id,
+            log=log,
+            # include unknown task id in query
+            task_id=mock_task_id + "000",
+        )
+
+        assert job_status == "unsubmitted"
+        assert job_id == ""
+        assert job_name == ""
+
+
+class TestSlurmInteractiveScheduler:
+    """Unit tests for SlurmInteractiveJob class.
+
+    Tests
+    -----
+    test_scheduler_initialization
+        Verify initialization of a Scheduler instance from a list of queues
+    test_scheduler_get_queue
+        Ensure that queues can be retrieved by name, and missing queues raise a ValueError.
+    test_slurmscheduler_global_max_cpus_per_node_success
+        Confirm SlurmScheduler queries and sets the maximum CPUs per node successfully.
+    test_slurmscheduler_global_max_cpus_per_node_failure
+        Validate SlurmScheduler handles subprocess failures when querying CPUs.
+    test_slurmscheduler_global_max_mem_per_node_gb_success
+        Confirm SlurmScheduler queries and sets maximum memory per node in GB successfully.
+    test_slurmscheduler_global_max_mem_per_node_gb_failure
+        Validate SlurmScheduler handles subprocess failures when querying memory.
+    test_pbsscheduler_global_max_cpus_per_node_success
+        Confirm PBSScheduler rqueries and sets the maximum CPUs per node successfully.
+    test_pbsscheduler_global_max_cpus_per_node_failure
+        Validate PBSScheduler handles subprocess failures when querying CPUs.
+    test_pbsscheduler_global_max_mem_per_node_gb
+        Parameterized test for PBSScheduler.global_max_mem_per_node_gb, covering
+        various memory formats (kb, mb, gb) and invalid cases.
+    test_pbsscheduler_global_max_mem_per_node_gb_failure
+        Validate PBSScheduler handles subprocess failures when querying memory.
+
+    Fixtures
+    --------
+    mock_subprocess_run
+        Mocks subprocess.run to simulate system commands without actual execution.
+    """
+
+    @pytest.fixture
+    def mock_subprocess_run(self):
+        """Mock subprocess.run for testing system command execution.
+
+        This fixture ensures that subprocess.run calls are intercepted,
+        allowing tests to simulate their outputs or errors without running
+        actual commands.
+
+        Yields
+        ------
+        mock_run : unittest.mock.MagicMock
+            A mock object for subprocess.run.
+        """
+        with patch("subprocess.run") as mock_run:
+            yield mock_run
+
+    # def test_scheduler_initialization(self):
+    #     """Verify initialization of a Scheduler instance from a list of queues."""
+    #     queue1 = MockQueue(name="general")
+    #     queue2 = MockQueue(name="batch")
+    #     scheduler = SlurmScheduler(
+    #         queues=[queue1, queue2], primary_queue_name="general"
+    #     )
+
+    #     assert scheduler.queues == [queue1, queue2]
+    #     assert scheduler.primary_queue_name == "general"
+    #     assert scheduler.queue_names == ["general", "batch"]
+    #     assert scheduler.other_scheduler_directives == {}
+
+    # def test_scheduler_get_queue(self):
+    #     """Ensure that queues can be retrieved by name, and missing queues raise a
+    #     ValueError."""
+    #     queue1 = MockQueue(name="general")
+    #     queue2 = MockQueue(name="batch")
+    #     scheduler = SlurmScheduler(
+    #         queues=[queue1, queue2], primary_queue_name="general"
+    #     )
+
+    #     result = scheduler.get_queue("batch")
+    #     assert result == queue2
+
+    #     with pytest.raises(ValueError, match="not found in list of queues"):
+    #         scheduler.get_queue("nonexistent")
+
+    # def test_slurmscheduler_global_max_cpus_per_node_success(self, mock_subprocess_run):
+    #     """Confirm SlurmScheduler queries and sets the maximum CPUs per node
+    #     successfully.
+
+    #     Uses mock_subprocess_run to simulate a successful system command output.
+    #     """
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=0, stdout="128", stderr=""
+    #     )
+    #     scheduler = SlurmScheduler(queues=[], primary_queue_name="general")
+
+    #     result = scheduler.global_max_cpus_per_node
+    #     assert result == 128
+
+    #     mock_subprocess_run.assert_called_once_with(
+    #         'scontrol show nodes | grep -o "cpu=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
+    #         shell=True,
+    #         text=True,
+    #         capture_output=True,
+    #     )
+
+    # def test_slurmscheduler_global_max_cpus_per_node_failure(
+    #     self, mock_subprocess_run, caplog: pytest.CaptureFixture
+    # ):
+    #     """Validate SlurmScheduler handles subprocess failures when querying CPUs.
+
+    #     Captures printed error messages to ensure the failure is logged correctly.
+
+    #     Mocks and Fixtures
+    #     ------------------
+    #     caplog (pytest.LogCaptureFixture)
+    #         Builtin fixture to capture log messages
+
+    #     Asserts
+    #     -------
+    #     - Appropriate error messages are logged
+    #     """
+    #     caplog.set_level(logging.INFO, logger="cstar.utils.log")
+
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=2, stdout="", stderr="Error querying CPUs"
+    #     )
+    #     scheduler = SlurmScheduler(queues=[], primary_queue_name="general")
+
+    #     result = scheduler.global_max_cpus_per_node
+    #     assert result is None
+
+    #     captured = caplog.text
+    #     assert "Error querying node property." in captured
+    #     assert "STDERR:\nError querying CPUs" in captured
+
+    # def test_slurmscheduler_global_max_mem_per_node_gb_success(
+    #     self, mock_subprocess_run
+    # ):
+    #     """Confirm SlurmScheduler queries and sets maximum memory per node in GB
+    #     successfully.
+
+    #     Uses mock_subprocess_run to simulate a successful system command output.
+    #     """
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=0, stdout="131072", stderr=""
+    #     )
+    #     scheduler = SlurmScheduler(queues=[], primary_queue_name="general")
+
+    #     result = scheduler.global_max_mem_per_node_gb
+    #     assert result == 128.0  # 131072 MB -> 128 GB
+
+    #     mock_subprocess_run.assert_called_once_with(
+    #         'scontrol show nodes | grep -o "RealMemory=[0-9]*" | cut -d= -f2 | sort -nr | head -1',
+    #         shell=True,
+    #         text=True,
+    #         capture_output=True,
+    #     )
+
+    # def test_slurmscheduler_global_max_mem_per_node_gb_failure(
+    #     self, mock_subprocess_run, caplog: pytest.CaptureFixture
+    # ):
+    #     """Validate SlurmScheduler handles subprocess failures when querying memory.
+
+    #     Captures printed error messages to ensure the failure is logged correctly.
+
+    #     Mocks and Fixtures
+    #     ------------------
+    #     caplog (pytest.LogCaptureFixture)
+    #         captures log messages
+
+    #     Asserts
+    #     -------
+    #     - Appropriate error messages are logged
+    #     """
+    #     caplog.set_level(logging.DEBUG, logger="cstar.base.utils.log")
+
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=1, stdout="", stderr="Error querying memory"
+    #     )
+    #     scheduler = SlurmScheduler(queues=[], primary_queue_name="general")
+
+    #     result = scheduler.global_max_mem_per_node_gb
+    #     assert result is None
+
+    #     captured = caplog.text
+    #     assert "Error querying node property." in captured
+    #     assert "STDERR:\nError querying memory" in captured
+
+    # def test_pbsscheduler_global_max_cpus_per_node_success(self, mock_subprocess_run):
+    #     """Confirm PBSScheduler queries and sets the maximum CPUs per node successfully.
+
+    #     Uses mock_subprocess_run to simulate a successful system command output.
+    #     """
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=0, stdout="128", stderr=""
+    #     )
+    #     scheduler = PBSScheduler(queues=[], primary_queue_name="batch")
+
+    #     result = scheduler.global_max_cpus_per_node
+    #     assert result == 128
+
+    #     mock_subprocess_run.assert_called_once_with(
+    #         'pbsnodes -a | grep "resources_available.ncpus" | cut -d= -f2 | sort -nr | head -1',
+    #         shell=True,
+    #         text=True,
+    #         capture_output=True,
+    #     )
+
+    # def test_pbsscheduler_global_max_cpus_per_node_failure(
+    #     self, mock_subprocess_run, caplog: pytest.CaptureFixture
+    # ):
+    #     """Validate PBSScheduler handles subprocess failures when querying CPUs.
+
+    #     Captures printed error messages to ensure the failure is logged correctly.
+
+    #     Mocks and Fixtures
+    #     ------------------
+    #     caplog (pytest.LogCaptureFixture)
+    #         captures log messages
+    #     mock_subprocess_run (unittest.mock.MagicMock)
+    #         Mocks the subprocess.run method
+
+    #     Asserts
+    #     -------
+    #     - An appropriate error message is logged
+    #     """
+
+    #     caplog.set_level(logging.DEBUG, logger="cstar.base.utils.log")
+
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=1, stdout="", stderr="Error querying CPUs"
+    #     )
+    #     scheduler = PBSScheduler(queues=[], primary_queue_name="batch")
+
+    #     result = scheduler.global_max_cpus_per_node
+    #     assert result is None
+
+    #     captured = caplog.text
+    #     assert "Error querying node property." in captured
+    #     assert "STDERR:\nError querying CPUs" in captured
+
+    # def test_pbsscheduler_global_max_mem_per_node_gb_failure(
+    #     self, mock_subprocess_run, caplog: pytest.CaptureFixture
+    # ):
+    #     """Validate PBSScheduler handles subprocess failures when querying memory.
+
+    #     Captures printed error messages to ensure the failure is logged correctly.
+
+    #     Mocks and Fixtures
+    #     ------------------
+    #     caplog (pytest.LogCaptureFixture)
+    #         captures log messages
+    #     mock_subprocess_run (unittest.mock.MagicMock)
+    #         Mocks the subprocess.run method
+
+    #     Asserts
+    #     -------
+    #     - An appropriate error message is logged
+    #     """
+
+    #     caplog.set_level(logging.DEBUG, logger="cstar.base.utils.log")
+
+    #     mock_subprocess_run.return_value = MagicMock(
+    #         returncode=1, stdout="", stderr="Error querying memory"
+    #     )
+    #     scheduler = PBSScheduler(queues=[], primary_queue_name="batch")
+
+    #     result = scheduler.global_max_mem_per_node_gb
+    #     assert result is None
+
+    #     captured = caplog.text
+    #     assert "Error querying node property." in captured
+    #     assert "STDERR:\nError querying memory" in captured
+
+    # @pytest.mark.parametrize(
+    #     "stdout,expected",
+    #     [
+    #         ("1048576kb", 1.0),  # Kilobytes to gigabytes
+    #         ("1024mb", 1.0),  # Megabytes to gigabytes
+    #         ("2gb", 2.0),  # Already in gigabytes
+    #         ("1234tb", None),  # Invalid format
+    #         ("", None),  # Empty output
+    #     ],
+    # )
+    # def test_pbsscheduler_global_max_mem_per_node_gb(self, stdout, expected):
+    #     """Parameterized test for PBSScheduler.global_max_mem_per_node_gb.
+
+    #     Tests various memory formats (kb, mb, gb) and ensures correct conversions or
+    #     handling of invalid formats.
+    #     """
+    #     with patch("subprocess.run") as mock_subprocess_run:
+    #         mock_subprocess_run.return_value = MagicMock(
+    #             returncode=0, stdout=stdout, stderr=""
+    #         )
+    #         scheduler = PBSScheduler(queues=[], primary_queue_name="batch")
+
+    #         result = scheduler.global_max_mem_per_node_gb
+    #         assert result == expected
+
+    #         mock_subprocess_run.assert_called_once_with(
+    #             'pbsnodes -a | grep "resources_available.mem" | cut -d== -f2 | sort -nr | head -1',
+    #             shell=True,
+    #             text=True,
+    #             capture_output=True,
+    #         )
 
 
 class TestStrAndRepr:


### PR DESCRIPTION
Add minimum viable version of a job that executes within an existing allocation.

- [ ] Closes #CW-816
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation