### PR TITLE
De-duplicate error message

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1270,7 +1270,7 @@ class ROMSSimulation(Simulation):
             _run_cmd(
                 "make compile_clean",
                 cwd=build_dir,
-                msg_err="Error when cleaning ROMS compilation.",
+                msg_err="Error when cleaning existing ROMS compilation.",
                 raise_on_error=True,
             )
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1270,7 +1270,7 @@ class ROMSSimulation(Simulation):
             _run_cmd(
                 "make compile_clean",
                 cwd=build_dir,
-                msg_err="Error when compiling ROMS.",
+                msg_err="Error when cleaning ROMS compilation.",
                 raise_on_error=True,
             )
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -2061,7 +2061,7 @@ class TestProcessingAndExecution:
         mock_subprocess.return_value = MagicMock(returncode=1, stderr="")
         mock_get_hash.return_value = "mockhash123"
 
-        with pytest.raises(RuntimeError, match="Error when compiling ROMS"):
+        with pytest.raises(RuntimeError, match="Error when cleaning ROMS compilation."):
             sim.build()
         assert mock_subprocess.call_count == 1
         mock_subprocess.assert_any_call(

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -2061,7 +2061,7 @@ class TestProcessingAndExecution:
         mock_subprocess.return_value = MagicMock(returncode=1, stderr="")
         mock_get_hash.return_value = "mockhash123"
 
-        with pytest.raises(RuntimeError, match="Error when cleaning ROMS compilation."):
+        with pytest.raises(RuntimeError, match="Error when cleaning existing ROMS compilation."):
             sim.build()
         assert mock_subprocess.call_count == 1
         mock_subprocess.assert_any_call(

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -2061,7 +2061,9 @@ class TestProcessingAndExecution:
         mock_subprocess.return_value = MagicMock(returncode=1, stderr="")
         mock_get_hash.return_value = "mockhash123"
 
-        with pytest.raises(RuntimeError, match="Error when cleaning existing ROMS compilation."):
+        with pytest.raises(
+            RuntimeError, match="Error when cleaning existing ROMS compilation."
+        ):
             sim.build()
         assert mock_subprocess.call_count == 1
         mock_subprocess.assert_any_call(


### PR DESCRIPTION
This PR contains a minor adjustment to the error messaging during ROMS build to uniquely identify the source of an error.

`Simulation.build` currently raises two exceptions with identical error messages:

```py
        if (build_dir / "Compile").is_dir():
            _run_cmd(
                "make compile_clean",
                cwd=build_dir,
                msg_err="Error when compiling ROMS.",
                raise_on_error=True,
            )
```

and 

```py
        _run_cmd(
            f"make COMPILER={cstar_sysmgr.environment.compiler}",
            cwd=build_dir,
            msg_pre="Compiling UCLA-ROMS configuration...",
            msg_post=f"UCLA-ROMS compiled at {build_dir}",
            msg_err="Error when compiling ROMS.",
            raise_on_error=True,
        )
```

This change updates the error message when calling `compile_clean` to disambiguate the error source.

```py
        if (build_dir / "Compile").is_dir():
            _run_cmd(
                "make compile_clean",
                cwd=build_dir,
                msg_err="Error when cleaning ROMS compilation.",
                raise_on_error=True,
            )
```

- [X] Tests passing
- [X] Closes CW-825