### PR TITLE
Add PyCharm and C-star externals to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,7 @@ dask-worker-space/
 # Vscode
 .vscode/
 
-#PyCharm
+# PyCharm
 .idea/
 
 # C-Star specific

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ dask-worker-space/
 
 # Vscode
 .vscode/
+
+#PyCharm
+.idea/
+
+# C-Star specific
+cstar/externals/


### PR DESCRIPTION
no-op change to gitignore files related to the PyCharm IDE, as well as any external code repos that have been cloned into the C-Star directory structure (I'm surprised these weren't already ignored, or curious how others have been avoiding them).