### PR TITLE
Add configuration for skipping rebuild of pre-built external codebase

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -10,7 +10,6 @@ from cstar.base.gitutils import (
     _get_repo_remote,
 )
 from cstar.base.log import LoggingMixin
-from cstar.system.environment import CSTAR_USER_ENV_PATH
 from cstar.system.manager import cstar_sysmgr
 
 
@@ -175,9 +174,8 @@ class ExternalCodeBase(ABC, LoggingMixin):
         """
 
         # check 1: X_ROOT variable is in user's env
-        env_var_exists = (
-            self.expected_env_var
-            in cstar_sysmgr.environment.environment_variables.keys()
+        env_var_exists = cstar_sysmgr.environment.environment_variables.get(
+            self.expected_env_var, None
         )
 
         # check 2: X_ROOT points to the correct repository
@@ -223,11 +221,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
            - 3: The expected environment variable is not present and it is assumed the external codebase is not installed locally
                -> prompt installation of the external codebase
         """
-        local_root = Path(
-            cstar_sysmgr.environment.environment_variables.get(
-                self.expected_env_var, ""
-            )
-        )
+        local_root = Path(os.environ.get(self.expected_env_var, ""))
 
         interactive = bool(int(os.environ.get("CSTAR_INTERACTIVE", "1")))
 
@@ -288,6 +282,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                     cstar_sysmgr.environment.package_root
                     / f"externals/{self.repo_basename}"
                 )
+                user_env_path = cstar_sysmgr.environment.user_env_path
                 print(
                     (
                         "#######################################################\n"
@@ -298,7 +293,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                         "you will need to set it up.\n"
                         "It is recommended that you install this external codebase in \n"
                         f"{ext_dir}\n"
-                        f"This will also modify your `{CSTAR_USER_ENV_PATH}` file.\n"
+                        f"This will also modify your `{user_env_path}` file.\n"
                         "#######################################################"
                     )
                 )

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 
@@ -39,9 +40,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         versions, allowing C-Star to be used with ROMS across multiple different
         computing systems.
         """
-        roms_root = Path(
-            cstar_sysmgr.environment.environment_variables[self.expected_env_var]
-        )
+        roms_root = Path(os.environ[self.expected_env_var])
         shutil.copytree(
             roms_root / "ci/ci_makefiles/",
             roms_root,

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -3,11 +3,9 @@ import os
 import platform
 from pathlib import Path
 
-from dotenv import dotenv_values, load_dotenv, set_key
+from dotenv import dotenv_values, set_key
 
 from cstar.base.utils import _run_cmd
-
-CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
 
 
 class CStarEnvironment:
@@ -65,12 +63,12 @@ class CStarEnvironment:
         self._system_name = system_name
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
+        self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
+        self._env_vars: dict[str, str] = {}
 
         if self.uses_lmod:
-            self.load_lmod_modules(
-                lmod_file=f"{self.package_root}/additional_files/lmod_lists/{self._system_name}.lmod"
-            )
-        os.environ.update(self.environment_variables)
+            self.load_lmod_modules(lmod_file=self.lmod_path)
+        self._load_environment()
 
     @property
     def mpi_exec_prefix(self):
@@ -95,7 +93,7 @@ class CStarEnvironment:
         base_str += f"\nMPI Exec Prefix: {self.mpi_exec_prefix}"
         base_str += f"\nUses Lmod: {True if self.uses_lmod else False}"
         base_str += "\nEnvironment Variables:"
-        for key, value in self.environment_variables.items():
+        for key, value in self._env_vars.items():
             base_str += f"\n    {key}: {value}"
         return base_str
 
@@ -117,14 +115,32 @@ class CStarEnvironment:
             ">"
         )
 
+    def _load_environment(self) -> None:
+        """Loads the environment variables from the user and system .env files,
+        populates the local copy of the variables, and publishes them to the system
+        environment."""
+        sys_vars = dotenv_values(self.system_env_path)
+        usr_vars = dotenv_values(self.user_env_path)
+
+        # track all the platform- and user-specific environment variables
+        all_vars = {**sys_vars, **usr_vars}
+        self._env_vars = {k: v for k, v in all_vars.items() if v is not None}
+
+        # Use os.environ as "system of record" - only track changes in `_env_vars`
+        os.environ.update(self._env_vars)
+
     @property
-    def environment_variables(self) -> dict:
-        env_vars = dotenv_values(
-            self.package_root / f"additional_files/env_files/{self._system_name}.env"
-        )
-        user_env_vars = dotenv_values(CSTAR_USER_ENV_PATH)
-        env_vars.update(user_env_vars)
-        return env_vars
+    def environment_variables(self) -> dict[str, str]:
+        """Return the user and system environment variables that have been loaded.
+
+        Returns
+        -------
+        dict[str, str]
+            A dictionary containing the combined set of user and system
+            level environment variables.
+        """
+
+        return self._env_vars.copy()
 
     @property
     def package_root(self) -> Path:
@@ -164,6 +180,41 @@ class CStarEnvironment:
         """
 
         return (platform.system() == "Linux") and ("LMOD_CMD" in list(os.environ))
+
+    @property
+    def lmod_path(self) -> Path:
+        """Identify the expected path to a .lmod file for the current system.
+
+        Returns
+        -------
+        Path
+            The path to the `.lmod` file.
+        """
+        pkg_relative_path = f"additional_files/lmod_lists/{self._system_name}.lmod"
+        return self.package_root / pkg_relative_path
+
+    @property
+    def user_env_path(self) -> Path:
+        """Identify the expected path to a .env file for the current user.
+
+        Returns
+        -------
+        Path
+            The path to the `.env` file.
+        """
+        return self._CSTAR_USER_ENV_PATH
+
+    @property
+    def system_env_path(self) -> Path:
+        """Identify the expected path to a .env file for the current system.
+
+        Returns
+        -------
+        Path
+            The path to the `.env` file.
+        """
+        pkg_relative_path = f"additional_files/env_files/{self._system_name}.env"
+        return self.package_root / pkg_relative_path
 
     def _call_lmod(self, *args) -> None:
         """Calls Linux Environment Modules with specified arguments in python mode.
@@ -236,12 +287,10 @@ class CStarEnvironment:
                 "Your system does not appear to use Linux Environment Modules"
             )
         self._call_lmod("reset")
-        with open(
-            f"{self.package_root}/additional_files/lmod_lists/{self._system_name}.lmod"
-        ) as F:
-            lmod_list = F.readlines()
-            for mod in lmod_list:
-                self._call_lmod(f"load {mod}")
+        with open(self.lmod_path) as fp:
+            lmod_list = fp.readlines()
+        for mod in lmod_list:
+            self._call_lmod(f"load {mod}")
 
     def set_env_var(self, key: str, value: str) -> None:
         """Set value of an environment variable and store it in the user environment
@@ -254,5 +303,5 @@ class CStarEnvironment:
         value : str
             The value to set for the environment variable.
         """
-        set_key(CSTAR_USER_ENV_PATH, key, value)
-        load_dotenv(CSTAR_USER_ENV_PATH, override=True)
+        set_key(self.user_env_path, key, value)
+        self._load_environment()

--- a/cstar/tests/integration_tests/conftest.py
+++ b/cstar/tests/integration_tests/conftest.py
@@ -1,6 +1,7 @@
 import builtins
 import logging
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
@@ -45,4 +46,19 @@ def mock_user_input():
 
 @pytest.fixture
 def log() -> logging.Logger:
+    """Fixture to provide a logger for the integration tests."""
     return get_logger("cstar.tests.integration_tests")
+
+
+@pytest.fixture
+def mock_lmod_filename() -> str:
+    """Fixture to provide a default .lmod filename for tests."""
+    return "mock.lmod"
+
+
+@pytest.fixture
+def mock_lmod_path(tmp_path: Path, mock_lmod_filename: str) -> Path:
+    """Fixture to mock the existence of an Lmod configuration file."""
+    path = tmp_path / mock_lmod_filename
+    path.touch()  # CStarEnvironment expects the file to exist & opens it
+    return path

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -23,6 +23,7 @@ class TestCStar:
         self,
         tmp_path: Path,
         mock_user_input,
+        mock_lmod_path: Path,
         modify_template_blueprint,
         fetch_roms_tools_source_data,
         fetch_remote_test_case_data,
@@ -60,11 +61,16 @@ class TestCStar:
 
         dotenv_path = tmp_path / ".cstar.env"
         ext_root = tmp_path / "externals"
+        blueprint_path = tmp_path / "test_blueprint_export.yaml"
 
         with (
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
+            ),
+            mock.patch(
+                "cstar.system.environment.CStarEnvironment.lmod_path", mock_lmod_path
             ),
             mock.patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=ext_root
@@ -101,7 +107,7 @@ class TestCStar:
             with mock_user_input("y"):
                 cstar_test_case.setup()
 
-            cstar_test_case.to_blueprint(tmp_path / "test_blueprint_export.yaml")
+            cstar_test_case.to_blueprint(str(blueprint_path))
             cstar_test_case.build()
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -619,7 +619,7 @@ class TestAdditionalCodeGet:
         # Ensure the repository is cloned and checked out
         self.mock_clone.assert_called_once_with(
             source_repo=remote_additional_code.source.location,
-            local_path="/mock/tmp/dir",
+            local_path=Path("/mock/tmp/dir"),
             checkout_target=remote_additional_code.checkout_target,
         )
 
@@ -642,7 +642,7 @@ class TestAdditionalCodeGet:
             )
 
         # Ensure the temporary directory is cleaned up after use
-        self.mock_rmtree.assert_called_once_with("/mock/tmp/dir")
+        self.mock_rmtree.assert_called_once_with(Path("/mock/tmp/dir"))
 
         # Ensure that the working_path is set correctly
         assert remote_additional_code.working_path == Path("/mock/local/dir")
@@ -830,7 +830,7 @@ class TestAdditionalCodeGet:
         self.mock_resolve.return_value = Path("/mock/local/dir")
 
         # Call get method
-        remote_additional_code.get("/mock/local/dir")
+        remote_additional_code.get(Path("/mock/local/dir"))
 
         # Ensure the temporary directory is cleaned up after use
-        self.mock_rmtree.assert_called_once_with("/mock/tmp/dir")
+        self.mock_rmtree.assert_called_once_with(Path("/mock/tmp/dir"))

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -162,15 +163,6 @@ class TestExternalCodeBaseConfig:
     """
 
     def setup_method(self):
-        self.patch_environment = mock.patch(
-            "cstar.system.manager.CStarSystemManager.environment",
-            new_callable=mock.PropertyMock,
-            return_value=mock.Mock(
-                environment_variables={"TEST_ROOT": "/path/to/repo"}
-            ),
-        )
-        self.mock_environment = self.patch_environment.start()
-
         self.patch_get_repo_remote = mock.patch(
             "cstar.base.external_codebase._get_repo_remote"
         )
@@ -182,12 +174,17 @@ class TestExternalCodeBaseConfig:
         self.mock_get_repo_head_hash = self.patch_get_repo_head_hash.start()
 
     def teardown_method(self):
-        self.patch_environment.stop()
         self.patch_get_repo_remote.stop()
         self.patch_get_repo_head_hash.stop()
 
-    def test_local_config_status_valid(self, generic_codebase):
-        # Set return values for other mocks
+    def test_local_config_status_valid(
+        self,
+        generic_codebase: ExternalCodeBase,
+        default_user_env: Any,
+    ):
+        """Verify that local_config_status is 0 when the codebase has a valid repo url
+        and hash."""
+
         self.mock_get_repo_remote.return_value = "https://github.com/test/repo.git"
         self.mock_get_repo_head_hash.return_value = "test123"
 
@@ -195,21 +192,38 @@ class TestExternalCodeBaseConfig:
         assert generic_codebase.local_config_status == 0
         assert generic_codebase.is_setup
 
-    def test_local_config_status_wrong_remote(self, generic_codebase):
+    def test_local_config_status_wrong_remote(
+        self,
+        generic_codebase: ExternalCodeBase,
+        default_user_env: Any,
+    ):
+        """Verify the local_config_status is 1 when the codebase has a mismatch between
+        the repo URL and the directory on disk."""
         self.mock_get_repo_remote.return_value = (
             "https://github.com/test/wrong_repo.git"
         )
 
         assert generic_codebase.local_config_status == 1
 
-    def test_local_config_status_wrong_checkout(self, generic_codebase):
+    def test_local_config_status_wrong_checkout(
+        self,
+        generic_codebase: ExternalCodeBase,
+        default_user_env: Any,
+    ):
+        """Verify that local_config_status is 2 when the codebase has a valid repo URL
+        but the checkout hash does not match the desired hash."""
         self.mock_get_repo_remote.return_value = "https://github.com/test/repo.git"
         self.mock_get_repo_head_hash.return_value = "wrong123"
 
         assert generic_codebase.local_config_status == 2
 
-    def test_local_config_status_no_env_var(self, generic_codebase):
-        self.mock_environment.return_value.environment_variables = {}
+    def test_local_config_status_no_env_var(
+        self,
+        generic_codebase: ExternalCodeBase,
+        empty_user_env: Any,
+    ):
+        """Verify that local_config_status is 3 when no XXX_ROOT environment variable is
+        set."""
         assert generic_codebase.local_config_status == 3
 
 
@@ -368,6 +382,7 @@ class TestExternalCodeBaseConfigHandling:
         generic_codebase,
         capsys: pytest.CaptureFixture,
         tmp_path: Path,
+        default_user_env: Any,
     ):
         """Test handling when local_config_status == 2 (right remote, wrong hash) and
         user agrees to checkout."""

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,9 +1,12 @@
 import logging
 import pathlib
+from typing import Callable, Generator
+from unittest import mock
 
 import pytest
 
 from cstar.base.log import get_logger
+from cstar.system.manager import cstar_sysmgr
 
 
 @pytest.fixture
@@ -43,6 +46,18 @@ def mock_system_name() -> str:
 
 
 @pytest.fixture
+def default_xxx_root_var() -> str:
+    """Fixture to create the default key for the TEST_ROOT environment variable."""
+    return "TEST_ROOT"
+
+
+@pytest.fixture
+def default_xxx_root_value() -> str:
+    """Fixture to create the default value for the TEST_ROOT environment variable."""
+    return "/path/to/repo"
+
+
+@pytest.fixture
 def system_dotenv_path(
     mock_system_name: str, system_dotenv_dir: pathlib.Path
 ) -> pathlib.Path:
@@ -51,3 +66,91 @@ def system_dotenv_path(
         system_dotenv_dir.mkdir(parents=True)
 
     return system_dotenv_dir / f"{mock_system_name}.env"
+
+
+@pytest.fixture
+def mock_lmod_filename() -> str:
+    """Fixture to provide a default .lmod filename for tests."""
+    return "mock.lmod"
+
+
+@pytest.fixture
+def mock_lmod_path(tmp_path: pathlib.Path, mock_lmod_filename: str) -> pathlib.Path:
+    """Fixture to mock the existence of an Lmod configuration file."""
+    path = tmp_path / mock_lmod_filename
+    path.touch()  # CStarEnvironment expects the file to exist & opens it
+    return path
+
+
+@pytest.fixture
+def default_user_env_vars(
+    default_xxx_root_var: str, default_xxx_root_value: str
+) -> dict[str, str]:
+    """Fixture to create the default, minimum set of env vars for the user's .cstar.env
+    file, which includes an XXX_ROOT variable and its value."""
+    return {
+        default_xxx_root_var: default_xxx_root_value,
+    }
+
+
+@pytest.fixture
+def default_user_env(
+    default_user_env_vars: dict[str, str],
+) -> Generator[mock.Mock, None, None]:
+    """Fixture to create and populate the mock user environment file without additional
+    action in a test case."""
+    # Write default environment variables so the test can add this fixture
+    # parameter and do nothing else to the user environment file.
+    with mock.patch.dict("os.environ", {}) as mock_def_user_env:
+        for key, value in default_user_env_vars.items():
+            cstar_sysmgr.environment.set_env_var(key, value)
+        yield mock_def_user_env
+
+
+@pytest.fixture
+def custom_system_env(
+    system_dotenv_path: pathlib.Path,
+) -> Generator[Callable[[dict[str, str]], None], None, None]:
+    def _inner(
+        variables: dict[str, str],
+    ) -> None:
+        """Callback to parameterize the fixture and set custom system env vars."""
+        for key, value in variables.items():
+            cstar_sysmgr.environment.set_env_var(key, value)
+
+    with mock.patch(
+        "cstar.system.environment.CStarEnvironment.system_env_path",
+        new_callable=mock.PropertyMock,
+        return_value=system_dotenv_path,
+    ):
+        yield _inner
+
+
+@pytest.fixture
+def custom_user_env(
+    dotenv_path: pathlib.Path,
+) -> Generator[Callable[[dict[str, str]], None], None, None]:
+    def _inner(
+        variables: dict[str, str],
+    ) -> None:
+        """Callback to parameterize the fixture and set custom user env vars."""
+        for key, value in variables.items():
+            cstar_sysmgr.environment.set_env_var(key, value)
+
+    with mock.patch(
+        "cstar.system.environment.CStarEnvironment.user_env_path",
+        new_callable=mock.PropertyMock,
+        return_value=dotenv_path,
+    ):
+        yield _inner
+
+
+@pytest.fixture
+def empty_user_env() -> Generator[mock.Mock, None, None]:
+    """Fixture to create and populate the mock user environment file without additional
+    action in a test case."""
+    # Write default environment variables so the test can add as a parameter
+    # and do nothing else to the user environment file.
+
+    with mock.patch.dict("os.environ", {}) as mock_empty_env:
+        yield mock_empty_env

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -108,8 +108,9 @@ class TestMARBLExternalCodeBaseGet:
         value = str(marbl_path)
 
         with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
+            "cstar.system.environment.CStarEnvironment.user_env_path",
+            new_callable=mock.PropertyMock,
+            return_value=dotenv_path,
         ):
             # Test
             ## Call the get method
@@ -158,8 +159,9 @@ class TestMARBLExternalCodeBaseGet:
                 ),
             ),
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
             ),
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -116,8 +116,9 @@ class TestROMSExternalCodeBaseGet:
         """Test that the get method succeeds when subprocess calls succeed."""
         # Setup:
         with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
+            "cstar.system.environment.CStarEnvironment.user_env_path",
+            new_callable=mock.PropertyMock,
+            return_value=dotenv_path,
         ):
             ## Mock success of calls to subprocess.run:
             self.mock_subprocess_run.return_value.returncode = 0
@@ -190,8 +191,9 @@ class TestROMSExternalCodeBaseGet:
                 match="Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\nCompiling NHMG library failed successfully",
             ),
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
             ),
         ):
             roms_codebase.get(target=tmp_path)

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -22,6 +22,7 @@ Internal Changes:
 - Update calls to `roms-tools` to reflect latest changes in API
 - Update internal/test blueprints to reflect new structure
 - Save partitioned `ROMSInputDatasets` in the same directory as their un-partitioned versions, rather than a subdirectory "PARTITIONED"
+- Enable using pre-built `ROMS` and `MARBL` binaries in `XxxExternalCodeBase`
 
 Documentation:
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

This PR adds the capability to execute a simulation with pre-built ROMS and MARBL codebases.

## Critical Changes

1. Make use of an environment variable to modify loading behavior of `ExternalCodeBase` 
    - Expose value via `ExternalCodeBase.prebuilt_env_var`
    - variable names: `CSTAR_ROMS_PREBUILT`, `CSTAR_MARBL_PREBUILT`
    - See [cstar.marbl.MARBLExternalCodeBase.prebuilt_env_var](https://github.com/ankona/C-Star/pull/3/files#diff-993854d42e51ac86cabec96ffaf1da152a9825aafe9a8b503577a0b8c4b98891)
    - See [cstar.roms.ROMSExternalCodeBase.prebuilt_env_var](https://github.com/ankona/C-Star/pull/3/files#diff-3f26891eb34e2f7ef4c5b9e65c2257570f73d841e1142dfb70e6fa13ee3dbedb)
    - See [cstar.base.ExternalCodeBase](https://github.com/ankona/C-Star/pull/3/files#diff-902e474e3191cc18135e9612ba4b4fe02e1446163598dff47a6195f902cd60b4R156-R166)
    - See (consuming env var) [cstar.base.ExternalCodeBase](https://github.com/ankona/C-Star/pull/3/files#diff-902e474e3191cc18135e9612ba4b4fe02e1446163598dff47a6195f902cd60b4R197-R203)
2. Add `Preparable` protocol to enable consistent API for verifying availability of resource locally.
    - See [cstar.base.contracts.Preparable](https://github.com/ankona/C-Star/pull/3/files#diff-6293580d24104468e93374afabb7cff75933787db273dc825322e5506ef4f505)
    - See [ROMSSimulation](https://github.com/ankona/C-Star/pull/3/files#diff-e6d685e87d5614e7407420e263eb25cfbade43441d1cc72f2629f1b000d2de2cR1175-R1187)
    - See [AdditionalCode](https://github.com/ankona/C-Star/pull/3/files#diff-daf5473fe240407781507ddb4aa1f8006e77b326597c2ca12d3503f5f3452f17R235-R244)
3. Avoid having two ways to access environment variables; modify env via `cstar.system.base.environment` but never use it for retrieving values.
    - See [_load_environment](https://github.com/ankona/C-Star/pull/3/files#diff-fd30250cc8918a860498b743daa5d4007a758676186f4061eb684161ae099b30R118-R130)


### Secondary Changes

1. Minor formatting/naming changes in affected files (ruff).
2. Minor type checker mitigations for unchecked nullable fields.
    - See [cstar.base.AdditionalCode](https://github.com/ankona/C-Star/pull/3/files#diff-daf5473fe240407781507ddb4aa1f8006e77b326597c2ca12d3503f5f3452f17R135-R187)
3. Minor refactor of `lmod path` in CStarEnvironment to simplify mocking (fixes test failures on `Perlmutter`)
    - See [cstar.system.environment.CStarEnvironment](https://github.com/ankona/C-Star/pull/3/files#diff-fd30250cc8918a860498b743daa5d4007a758676186f4061eb684161ae099b30R165)
5. Move global `CSTAR_USER_ENV_PATH` to property on `CStarEnvironment` for consistency w/`lmod_path` and `system_env_path`
    - See [cstar.system.environment.CStarEnvironment](https://github.com/ankona/C-Star/pull/3/files#diff-fd30250cc8918a860498b743daa5d4007a758676186f4061eb684161ae099b30R177-R197)
6. Fix docstring issues (renamed method)
    - See [cstar.base.ExternalCodeBase](https://github.com/ankona/C-Star/pull/3/files#diff-902e474e3191cc18135e9612ba4b4fe02e1446163598dff47a6195f902cd60b4R47)
    - Add [missing docstrings](https://github.com/ankona/C-Star/pull/3/files#diff-255ee099734acb405b1af1dbd0d78c73481899d43ba316c6894e439b122d79f8R41)



## Checklist

- [x] Closes #CW-819
- [x] Tests added
- [x] Tests passing (must fix `test_tree`?)
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [ ] New classes are listed in `api.rst` - `N/A`
- [x] New functionality has documentation