### PR TITLE
Formatting run through all docstrings, add typehints to test suite

### DIFF
--- a/cstar/__init__.py
+++ b/cstar/__init__.py
@@ -4,17 +4,14 @@
 
 from importlib.metadata import version as _version
 
-# from cstar.case import Case
 from cstar.simulation import Simulation
 
-__all__ = [
-    "Simulation",
-]
+__all__ = ["Simulation"]
 
 
 try:
     __version__ = _version("cstar-ocean")
-except Exception:
+except Exception:  # noqa: BLE001
     # Local copy or not installed with setuptools.
     # Disable minimum version checks on downstream libraries.
     __version__ = "9999"

--- a/cstar/base/__init__.py
+++ b/cstar/base/__init__.py
@@ -4,9 +4,9 @@ from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.input_dataset import InputDataset
 
 __all__ = [
-    "Component",
-    "ExternalCodeBase",
     "AdditionalCode",
-    "InputDataset",
+    "Component",
     "Discretization",
+    "ExternalCodeBase",
+    "InputDataset",
 ]

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -16,7 +16,7 @@ class AdditionalCode(LoggingMixin):
 
     Attributes
     ----------
-    source  DataSource
+    source : DataSource
         Describes the location and type of source data (e.g. repository,directory)
     subdir : str
         Subdirectory of source.location in which the additional code is kept

--- a/cstar/base/discretization.py
+++ b/cstar/base/discretization.py
@@ -1,36 +1,29 @@
-from abc import ABC
-
-
-class Discretization(ABC):
+class Discretization:
     """Holds discretization information about a Component.
 
-    Attributes:
-    -----------
-
+    Attributes
+    ----------
     time_step: int
         The time step with which to run the Component
     """
 
-    def __init__(
-        self,
-        time_step: int,
-    ):
+    def __init__(self, time_step: int) -> None:
         """Initialize a Discretization object from basic discretization parameters.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         time_step: int
             The time step with which to run the Component
 
-        Returns:
-        --------
+        Returns
+        -------
         Discretization:
             An initialized Discretization object
         """
-
         self.time_step: int = time_step
 
     def __str__(self) -> str:
+        """Return a human-readable string representation."""
         # Discretisation
         disc_str = ""
 
@@ -44,6 +37,7 @@ class Discretization(ABC):
         return disc_str
 
     def __repr__(self) -> str:
+        """Return a constructor-style string representation."""
         repr_str = ""
         repr_str = f"{self.__class__.__name__}("
         if hasattr(self, "time_step") and self.time_step is not None:

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -248,7 +248,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
             case 1:
                 env_var_repo_remote = _get_repo_remote(local_root)
 
-                raise OSError(
+                raise EnvironmentError(  # noqa: UP024
                     f"System environment variable '{self.expected_env_var}' points to "
                     f"a github repository whose remote: \n '{env_var_repo_remote}' \n"
                     f"does not match that expected by C-Star: \n{self.source_repo}."
@@ -282,7 +282,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                         return
 
                     if yn.casefold() in ["n", "no"]:
-                        raise OSError
+                        raise EnvironmentError  # noqa: UP024
 
                     print("invalid selection; enter 'y' or 'n'")
             case 3:
@@ -317,7 +317,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                         break
 
                     if yn.casefold() in ["n", "no"]:
-                        raise OSError
+                        raise EnvironmentError  # noqa: UP024
 
                     if yn.casefold() == "custom":
                         custom_path = input("Enter custom path for install:\n")

--- a/cstar/base/gitutils.py
+++ b/cstar/base/gitutils.py
@@ -6,7 +6,7 @@ from cstar.base.utils import _run_cmd
 
 
 def _clone(source_repo: str, local_path: str | Path) -> None:
-    """Clone `source_repo` to `local_path`"""
+    """Clone `source_repo` to `local_path`."""
     _run_cmd(
         f"git clone {source_repo} {local_path}",
         msg_pre=f"Cloning `{source_repo}`",
@@ -36,8 +36,13 @@ def _clone_and_checkout(
 
 
 def _get_repo_remote(local_path: str | Path) -> str:
-    """Take a local repository path string (local_path) and return as a string the
-    remote URL."""
+    """Return the remote repository for the code located in the supplied path.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        The local path containing a git repository.
+    """
     return _run_cmd(
         f"git -C {local_path} remote get-url origin",
         msg_pre=f"Retrieving URL for remote in repository `{local_path}`.",
@@ -47,8 +52,13 @@ def _get_repo_remote(local_path: str | Path) -> str:
 
 
 def _get_repo_head_hash(local_path: str | Path) -> str:
-    """Take a local repository path string (local_path) and return as a string the
-    commit hash of HEAD."""
+    """Return the commit hash of HEAD for the code located in the supplied path.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        The local path containing a git repository.
+    """
     return _run_cmd(
         f"git -C {local_path} rev-parse HEAD",
         msg_pre=f"Retrieving commit hash for repository `{local_path}`.",
@@ -58,26 +68,27 @@ def _get_repo_head_hash(local_path: str | Path) -> str:
 
 
 def _get_hash_from_checkout_target(repo_url: str, checkout_target: str) -> str:
-    """Take a git checkout target (any `arg` accepted by `git checkout arg`) and return
+    """Return the commit hash for the supplied repository and checkout target.
+
+    Take a git checkout target (any `arg` accepted by `git checkout arg`) and return
     a commit hash.
 
     This method parses the output of `git ls-remote {repo_url}` to create a dictionary
     of refs and hashes, returning the hash corresponding to `checkout_target` or
     raising an error listing available branches and tags if the target is not found.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     repo_url: str
         URL pointing to a git-controlled repository
     checkout_target: str
         Any valid argument that can be supplied to `git checkout`
 
-    Returns:
-    --------
+    Returns
+    -------
     git_hash: str
         A git commit hash associated with the checkout target
     """
-
     # Get list of targets from git ls-remote
     ls_remote = _run_cmd(
         f"git ls-remote {repo_url}",
@@ -97,10 +108,7 @@ def _get_hash_from_checkout_target(repo_url: str, checkout_target: str) -> str:
 
     # Otherwise, see if it is listed as a branch or tag
     for ref, has in ref_dict.items():
-        if (
-            ref == f"refs/heads/{checkout_target}"
-            or ref == f"refs/tags/{checkout_target}"
-        ):
+        if ref in {f"refs/heads/{checkout_target}", f"refs/tags/{checkout_target}"}:
             return has
 
     # Lastly, if NOTA worked, see if the checkout target is a 7 or 40 digit hexadecimal string
@@ -110,7 +118,9 @@ def _get_hash_from_checkout_target(repo_url: str, checkout_target: str) -> str:
     if is_potential_hash:
         warnings.warn(
             f"C-STAR: The checkout target {checkout_target} appears to be a commit hash, "
-            f"but it is not possible to verify that this hash is a valid checkout target of {repo_url}"
+            "but it is not possible to verify that this hash is a valid checkout target "
+            f"of {repo_url}",
+            stacklevel=2,
         )
 
         return checkout_target

--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -16,13 +16,13 @@ def get_logger(
 
     Parameters
     ----------
-    name: str
+    name : str
         The name of the logger.
-    level: int
+    level : int
         The minimum log level to write.
-    fmt: str
+    fmt : str
         The log format string.
-    filename: str | None
+    filename : str | None
         A file path where logs will be written.
 
     Returns
@@ -30,7 +30,6 @@ def get_logger(
     logging.Logger
         A logger instance with the specified name.
     """
-
     fmt = fmt or DEFAULT_LOG_FORMAT
 
     logger = logging.getLogger(name)
@@ -89,6 +88,7 @@ class LoggingMixin:
 
     @property
     def log(self) -> logging.Logger:
+        """Return a logger instance."""
         if not hasattr(self, "_log"):
             name = f"{self.__class__.__module__}.{self.__class__.__name__}"
             self._log = get_logger(name)

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -43,6 +43,7 @@ class ExecutionStatus(Enum):
     UNKNOWN = auto()
 
     def __str__(self) -> str:
+        """Return a human-readable string representation."""
         return self.name.lower()  # Convert enum name to lowercase for display
 
 
@@ -86,8 +87,6 @@ class ExecutionHandler(ABC, LoggingMixin):
         system to determine the task's status.
         """
 
-        pass
-
     @property
     @abstractmethod
     def output_file(self) -> Path:
@@ -99,9 +98,7 @@ class ExecutionHandler(ABC, LoggingMixin):
             Path to the file in which stdout and stderr will be written.
         """
 
-        pass
-
-    def updates(self, seconds: float = 10, confirm_indefinite: bool = True):
+    def updates(self, seconds: float = 10, confirm_indefinite: bool = True) -> None:
         """Stream live updates from the task's output file.
 
         This method streams updates from the task's output file for the
@@ -116,7 +113,7 @@ class ExecutionHandler(ABC, LoggingMixin):
             The duration (in seconds) for which updates should be streamed.
             If set to 0, updates will be streamed indefinitely until
             interrupted by the user.
-        confirm_indefinite: bool, optional, default = True
+        confirm_indefinite : bool, optional, default = True
             If 'seconds' is set to 0, the user will be prompted to confirm
             whether they want to continue with an indefinite update stream
             if confirm_indefinite is set to True
@@ -128,7 +125,6 @@ class ExecutionHandler(ABC, LoggingMixin):
         - When streaming indefinitely (`seconds=0`), user confirmation is
           required before proceeding.
         """
-
         if self.status != ExecutionStatus.RUNNING:
             error_msg = f"This job is currently not running ({self.status}). Live updates cannot be provided."
             is_complete = self.status in {
@@ -160,14 +156,15 @@ class ExecutionHandler(ABC, LoggingMixin):
                 return
 
         try:
-            with open(self.output_file, "r") as f:
+            with open(self.output_file) as f:  # noqa: PTH123
                 f.seek(0, 2)  # Move to the end of the file
                 start_time = time.time()
                 while seconds == 0 or (time.time() - start_time < seconds):
                     line = f.readline()
                     if self.status != ExecutionStatus.RUNNING:
                         return
-                    elif line:
+
+                    if line:
                         self.log.info(line)
                     else:
                         time.sleep(0.1)  # 100ms delay between updates

--- a/cstar/execution/local_process.py
+++ b/cstar/execution/local_process.py
@@ -62,8 +62,9 @@ class LocalProcess(ExecutionHandler):
         """
         self.commands = commands
         self.run_path = Path(run_path) if run_path is not None else Path.cwd()
-        dt_string = datetime.strftime(datetime.now(), "%Y%m%d_%H%M%S")
-        self._default_name = f"cstar_process_{dt_string}"
+        self._default_name = (
+            f"cstar_process_{datetime.strftime(datetime.now(), "%Y%m%d_%H%M%S")}"
+        )
         self._output_file = (
             Path(output_file) if output_file is not None else output_file
         )

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from math import ceil
 from pathlib import Path
-from typing import Optional, Tuple
 
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
@@ -24,18 +23,17 @@ def create_scheduler_job(
     commands: str,
     account_key: str,
     cpus: int,
-    nodes: Optional[int] = None,
-    cpus_per_node: Optional[int] = None,
-    script_path: Optional[str | Path] = None,
-    run_path: Optional[str | Path] = None,
-    job_name: Optional[str] = None,
-    output_file: Optional[str | Path] = None,
-    queue_name: Optional[str] = None,
-    send_email: Optional[bool] = True,
-    walltime: Optional[str] = None,
+    nodes: int | None = None,
+    cpus_per_node: int | None = None,
+    script_path: str | Path | None = None,
+    run_path: str | Path | None = None,
+    job_name: str | None = None,
+    output_file: str | Path | None = None,
+    queue_name: str | None = None,
+    send_email: bool | None = True,
+    walltime: str | None = None,
 ) -> "SchedulerJob":
-    """Create a scheduler job for either SLURM or PBS based on the system's active
-    scheduler.
+    """Create the appropriate scheduler job based on the system's active scheduler.
 
     Parameters
     ----------
@@ -71,7 +69,7 @@ def create_scheduler_job(
 
     Returns
     -------
-    job: SchedulerJob
+    job : SchedulerJob
         An instance of `SlurmJob` or `PBSJob`, depending on the active scheduler.
 
     Raises
@@ -79,9 +77,8 @@ def create_scheduler_job(
     TypeError
         If the active scheduler is not SLURM or PBS.
     """
-
     # mypy assigns type based on first condition, assigning explicitly:
-    job_type: type[SlurmJob] | type[PBSJob]
+    job_type: type[SlurmJob | PBSJob]
 
     if isinstance(cstar_sysmgr.scheduler, SlurmScheduler):
         job_type = SlurmJob
@@ -150,9 +147,9 @@ class SchedulerJob(ExecutionHandler, ABC):
         The maximum walltime for the job, in the format "HH:MM:SS".
     id : int or None
         The unique job ID assigned by the scheduler. None if the job has not been submitted.
-    status: ExecutionStatus
+    status : ExecutionStatus
         A representation of the current status of the job, e.g. RUNNING or CANCELLED
-    script: str
+    script : str
         The job script to be submitted to the scheduler.
 
     Methods
@@ -171,16 +168,16 @@ class SchedulerJob(ExecutionHandler, ABC):
         commands: str,
         account_key: str,
         cpus: int,
-        nodes: Optional[int] = None,
-        cpus_per_node: Optional[int] = None,
-        script_path: Optional[str | Path] = None,
-        run_path: Optional[str | Path] = None,
-        job_name: Optional[str] = None,
-        output_file: Optional[str | Path] = None,
-        queue_name: Optional[str] = None,
-        send_email: Optional[bool] = True,
-        walltime: Optional[str] = None,
-    ):
+        nodes: int | None = None,
+        cpus_per_node: int | None = None,
+        script_path: str | Path | None = None,
+        run_path: str | Path | None = None,
+        job_name: str | None = None,
+        output_file: str | Path | None = None,
+        queue_name: str | None = None,
+        send_email: bool | None = True,  # noqa: ARG002
+        walltime: str | None = None,
+    ) -> None:
         """Initialize a SchedulerJob instance.
 
         Parameters
@@ -229,7 +226,6 @@ class SchedulerJob(ExecutionHandler, ABC):
             If neither `nodes` nor `cpus_per_node` are provided and the scheduler cannot
             determine the system's CPUs per node automatically.
         """
-
         self._scheduler = scheduler
         self._commands = commands
         self._cpus = cpus
@@ -256,19 +252,20 @@ class SchedulerJob(ExecutionHandler, ABC):
         if (walltime is None) and (self.queue.max_walltime is None):
             raise ValueError(
                 "Cannot create scheduler job: walltime parameter not provided "
-                + f"and C-Star cannot default to the max walltime for the queue {queue_name} "
-                + " as it cannot be determined"
+                f"and C-Star cannot default to the max walltime for the queue {queue_name} "
+                " as it cannot be determined"
             )
-        elif self.queue.max_walltime is None:
+
+        if self.queue.max_walltime is None:
             self.log.warning(
                 f"Unable to determine the maximum allowed walltime for chosen queue {queue_name}. "
-                + f"If your chosen walltime {walltime} exceeds the (unknown) limit, this job may be "
-                + "rejected by your system's job scheduler.",
+                f"If your chosen walltime {walltime} exceeds the (unknown) limit, this job may be "
+                "rejected by your system's job scheduler."
             )
         elif walltime is None:
             self.log.warning(
                 "Walltime parameter unspecified. Creating scheduler job with maximum walltime "
-                + f"for queue {queue_name}, {self.queue.max_walltime}"
+                f"for queue {queue_name}, {self.queue.max_walltime}"
             )
             self._walltime = self.queue.max_walltime
         else:
@@ -282,13 +279,13 @@ class SchedulerJob(ExecutionHandler, ABC):
             if walltime_delta > max_walltime_delta:
                 raise ValueError(
                     f"Selected walltime {walltime} exceeds maximum "
-                    + f"walltime for selected queue {queue_name}: "
-                    + f"{self.queue.max_walltime}"
+                    f"walltime for selected queue {queue_name}: "
+                    f"{self.queue.max_walltime}"
                 )
 
         # Explicitly typing to avoid mypy confusion in conditional pathways below
-        self._cpus_per_node: Optional[int]
-        self._nodes: Optional[int]
+        self._cpus_per_node: int | None
+        self._nodes: int | None
 
         if (
             (nodes is None)
@@ -310,26 +307,24 @@ class SchedulerJob(ExecutionHandler, ABC):
             and (scheduler.requires_task_distribution)
         ):
             if scheduler.global_max_cpus_per_node is None:
-                raise EnvironmentError(
+                raise OSError(
                     "You attempted to create a scheduler job without 'nodes', and "
-                    + "'cpus_per_node' parameters, but your scheduler explicitly "
-                    + "requires a task distribution. C-Star is unable to determine "
-                    + "your system's CPUs per node automatically and cannot continue"
+                    "'cpus_per_node' parameters, but your scheduler explicitly "
+                    "requires a task distribution. C-Star is unable to determine "
+                    "your system's CPUs per node automatically and cannot continue"
                 )
 
             nnodes, ncpus = self._calculate_node_distribution(
                 cpus, scheduler.global_max_cpus_per_node
             )
             self.log.warning(
-                (
-                    "Attempting to create scheduler job without 'nodes' and 'cpus_per_node' "
-                    + "parameters, but your system requires an explicitly specified task distribution."
-                    + "\n C-Star will attempt "
-                    + f"\nto use a distribution of {nnodes} nodes with {ncpus} CPUs each, "
-                    + "\nbased on your system maximum of "
-                    + f"{scheduler.global_max_cpus_per_node} CPUS per node "
-                    + f"\nand your job requirement of {cpus} CPUS."
-                ),
+                "Attempting to create scheduler job without 'nodes' and 'cpus_per_node' "
+                "parameters, but your system requires an explicitly specified task distribution."
+                "\n C-Star will attempt "
+                f"\nto use a distribution of {nnodes} nodes with {ncpus} CPUs each, "
+                "\nbased on your system maximum of "
+                f"{scheduler.global_max_cpus_per_node} CPUS per node "
+                f"\nand your job requirement of {cpus} CPUS."
             )
             self._cpus_per_node = ncpus
             self._nodes = nnodes
@@ -338,7 +333,7 @@ class SchedulerJob(ExecutionHandler, ABC):
             self._nodes = nodes
 
         self._account_key = account_key
-        self._id: Optional[int] = None
+        self._id: int | None = None
 
     @property
     def output_file(self) -> Path:
@@ -355,12 +350,12 @@ class SchedulerJob(ExecutionHandler, ABC):
         return self._account_key
 
     @property
-    def nodes(self) -> Optional[int]:
+    def nodes(self) -> int | None:
         """The number of nodes to request."""
         return self._nodes
 
     @property
-    def cpus_per_node(self) -> Optional[int]:
+    def cpus_per_node(self) -> int | None:
         """The number of CPUs per node to request."""
         return self._cpus_per_node
 
@@ -378,7 +373,7 @@ class SchedulerJob(ExecutionHandler, ABC):
         return self._job_name
 
     @property
-    def walltime(self) -> Optional[str]:
+    def walltime(self) -> str | None:
         """The maximum walltime for the job, in the format "HH:MM:SS"."""
         return self._walltime
 
@@ -394,8 +389,12 @@ class SchedulerJob(ExecutionHandler, ABC):
 
     @property
     def scheduler(self) -> Scheduler:
-        """The scheduler managing this job (e.g., a SlurmScheduler or PBSScheduler
-        instance)"""
+        """The scheduler managing this job.
+
+        Supported schedulers include:
+        - SlurmScheduler
+        - PBSScheduler
+        """
         return self._scheduler
 
     @property
@@ -404,7 +403,7 @@ class SchedulerJob(ExecutionHandler, ABC):
         return self._commands
 
     @property
-    def id(self) -> Optional[int]:
+    def id(self) -> int | None:
         """Retrieve the unique job ID assigned by the scheduler.
 
         The job ID is assigned when the job is successfully submitted to the scheduler.
@@ -413,11 +412,10 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         Returns
         -------
-        id: int or None
+        id : int or None
             The unique job ID assigned by the scheduler, or `None` if the job has not
             been submitted.
         """
-
         if self._id is None:
             self.log.warning(
                 "No Job ID found. Submit this job with SchedulerJob.submit()"
@@ -427,7 +425,7 @@ class SchedulerJob(ExecutionHandler, ABC):
     @property
     @abstractmethod
     def script(self) -> str:
-        """Generate the job script to be submitted to the scheduler.
+        """Generate the job script to be submitted to the SLURM scheduler.
 
         This property constructs the job script as a string, incorporating scheduler-specific
         directives (e.g., SLURM or PBS) and the commands provided during initialization. The
@@ -436,22 +434,21 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         Returns
         -------
-        script: str
+        script : str
             The complete job script as a string, ready for submission.
         """
-        pass
 
-    def save_script(self):
+    def save_script(self) -> None:
         """Save the job script to a file.
 
         Writes the generated job script to the file specified by the `script_path` attribute.
         The file can then be used to submit the job to the scheduler.
         """
-        with open(self.script_path, "w") as f:
+        with open(self.script_path, "w") as f:  # noqa: PTH123
             f.write(self.script)
 
     @abstractmethod
-    def submit(self):
+    def submit(self) -> None:
         """Submit the job to the scheduler.
 
         This method is responsible for submitting the generated job script to the
@@ -460,7 +457,6 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         This method updates the 'id' attribute
         """
-        pass
 
     @property
     @abstractmethod
@@ -477,34 +473,32 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         Returns
         -------
-        status: ExecutionStatus
+        status : ExecutionStatus
             An enumeration value representing the current status of the job.
         """
-        pass
 
     def _calculate_node_distribution(
         self, n_cores_required: int, tot_cores_per_node: int
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Determine how many nodes and cores per node to request from a job scheduler.
 
         For example, if requiring 192 cores for a job on a system with 128 cores per node,
         this method advises requesting 2 nodes with 96 cores each.
 
-        Parameters:
-        -----------
-        n_cores_required: int
+        Parameters
+        ----------
+        n_cores_required : int
             The number of cores required for the job
-        tot_cores_per_node: int
+        tot_cores_per_node : int
             The number of cores per node on the target system
 
-        Returns:
-        --------
-        n_nodes_to_request: int
-            The number of nodes to request from the scheduler
-        cores_to_request_per_node: int
-            The number of cores per node to request from the scheduler
+        Returns
+        -------
+            n_nodes_to_request : int
+                The number of nodes to request from the scheduler
+            cores_to_request_per_node : int
+                The number of cores per node to request from the scheduler
         """
-
         n_nodes_to_request = ceil(n_cores_required / tot_cores_per_node)
         cores_to_request_per_node = ceil(
             tot_cores_per_node
@@ -575,7 +569,7 @@ class SlurmJob(SchedulerJob):
 
         Returns
         -------
-        status: ExecutionStatus
+        ExecutionStatus
             The current status of the job. Possible values include:
             - `ExecutionStatus.PENDING`: The job has been submitted but is waiting to start.
             - `ExecutionStatus.RUNNING`: The job is currently executing.
@@ -589,13 +583,12 @@ class SlurmJob(SchedulerJob):
         RuntimeError
             If the command to retrieve the job status fails or returns an unexpected result.
         """
-
         if self.id is None:
             return ExecutionStatus.UNSUBMITTED
-        else:
-            sacct_cmd = f"sacct -j {self.id} --format=State%20 --noheader"
-            msg_err = f"Failed to retrieve job status using {sacct_cmd}."
-            stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
+
+        sacct_cmd = f"sacct -j {self.id} --format=State%20 --noheader"
+        msg_err = f"Failed to retrieve job status using {sacct_cmd}."
+        stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
 
         # Map sacct states to ExecutionStatus enum
         sacct_status_map = {
@@ -614,16 +607,16 @@ class SlurmJob(SchedulerJob):
 
     @property
     def script(self) -> str:
-        """Generate the SLURM-specific job script to be submitted to the scheduler.
+        """Generate the job script to be submitted to the scheduler.
+
         Includes standard Slurm scheduler directives as well as scheduler-specific
         directives specified by the scheduler.other_scheduler_directives attribute.
 
         Returns
         -------
-        scheduler_script: str
+        str
             The complete SLURM job script as a string, ready for submission.
         """
-
         scheduler_script = "#!/bin/bash"
         scheduler_script += f"\n#SBATCH --job-name={self.job_name}"
         scheduler_script += f"\n#SBATCH --output={self.output_file}"
@@ -640,17 +633,14 @@ class SlurmJob(SchedulerJob):
         scheduler_script += "\n#SBATCH --export=ALL"
         scheduler_script += "\n#SBATCH --mail-type=ALL"
         scheduler_script += f"\n#SBATCH --time={self.walltime}"
-        for (
-            key,
-            value,
-        ) in self.scheduler.other_scheduler_directives.items():
+        for key, value in self.scheduler.other_scheduler_directives.items():
             scheduler_script += f"\n#SBATCH {key} {value}"
 
         # Add roms command to scheduler script
         scheduler_script += f"\n\n{self.commands}"
         return scheduler_script
 
-    def submit(self) -> Optional[int]:
+    def submit(self) -> int | None:  # type: ignore[override]
         """Submit the job to the SLURM scheduler.
 
         This method saves the job script to the specified `script_path` and submits it
@@ -670,11 +660,11 @@ class SlurmJob(SchedulerJob):
         """
         self.save_script()
         # remove any slurm variables in case submitting from inside another slurm job
-        env_vars_to_exclude = []
-        for k in os.environ.keys():
-            if k.startswith("SLURM_"):
-                if k not in {"SLURM_CONF", "SLURM_VERSION"}:
-                    env_vars_to_exclude.append(k)
+        env_vars_to_exclude = [
+            k
+            for k in os.environ
+            if k.startswith("SLURM_") and k not in {"SLURM_CONF", "SLURM_VERSION"}
+        ]
 
         slurm_env = {
             k: v for k, v in os.environ.items() if k not in env_vars_to_exclude
@@ -693,10 +683,10 @@ class SlurmJob(SchedulerJob):
         if matches:
             self._id = int(matches.group(1))
             return self._id
-        else:
-            raise RuntimeError(f"Failed to parse job ID from sbatch output: {stdout}")
 
-    def cancel(self):
+        raise RuntimeError(f"Failed to parse job ID from sbatch output: {stdout}")
+
+    def cancel(self) -> None:
         """Cancel the job in the SLURM scheduler.
 
         This method cancels the job using the SLURM `scancel` command and provides
@@ -709,7 +699,6 @@ class SlurmJob(SchedulerJob):
         RuntimeError
             If the `scancel` command fails or returns a non-zero exit code.
         """
-
         if self.status not in {ExecutionStatus.RUNNING, ExecutionStatus.PENDING}:
             self.log.info(f"Cannot cancel job with status '{self.status}'")
             return
@@ -776,18 +765,16 @@ class PBSJob(SchedulerJob):
 
     @property
     def script(self) -> str:
-        """Generate the PBS-specific job script to be submitted to the scheduler.
+        """Generate the job script to be submitted to the PBS scheduler.
+
         Includes standard Slurm scheduler directives as well as scheduler-specific
         directives specified by the scheduler.other_scheduler_directives attribute.
 
-        Generate the PBS-specific job script to be submitted to the scheduler.
-
         Returns
         -------
-        scheduler_script : str
+        str
             The complete PBS job script as a string, ready for submission.
         """
-
         scheduler_script = "#PBS -S /bin/bash"
         scheduler_script += f"\n#PBS -N {self.job_name}"
         scheduler_script += f"\n#PBS -o {self.output_file}"
@@ -797,10 +784,7 @@ class PBSJob(SchedulerJob):
         scheduler_script += "\n#PBS -j oe"
         scheduler_script += "\n#PBS -k eod"
         scheduler_script += "\n#PBS -V"
-        for (
-            key,
-            value,
-        ) in self.scheduler.other_scheduler_directives.items():
+        for key, value in self.scheduler.other_scheduler_directives.items():
             scheduler_script += f"\n#PBS {key} {value}"
         scheduler_script += "\ncd ${PBS_O_WORKDIR}"
 
@@ -832,7 +816,6 @@ class PBSJob(SchedulerJob):
         RuntimeError
             If the `qstat` command fails or the job cannot be found in the scheduler's records.
         """
-
         if self.id is None:
             return ExecutionStatus.UNSUBMITTED
 
@@ -845,8 +828,10 @@ class PBSJob(SchedulerJob):
             job_data = json.loads(stdout)
             try:
                 job_info = next(iter(job_data["Jobs"].values()))
-            except StopIteration:
-                raise RuntimeError(f"Job ID {self.id} not found in qstat output.")
+            except StopIteration as ex:
+                raise RuntimeError(
+                    f"Job ID {self.id} not found in qstat output."
+                ) from ex
 
             # Extract the job state
             job_state = job_info["job_state"]
@@ -866,14 +851,13 @@ class PBSJob(SchedulerJob):
                     if exit_status == 0
                     else ExecutionStatus.FAILED
                 )
-            else:
-                # Default to UNKNOWN for unmapped states
-                return pbs_status_map.get(job_state, ExecutionStatus.UNKNOWN)
+            # Default to UNKNOWN for unmapped states
+            return pbs_status_map.get(job_state, ExecutionStatus.UNKNOWN)
 
         except json.JSONDecodeError as e:
-            raise RuntimeError(f"Failed to parse JSON from qstat output: {e}")
+            raise RuntimeError(f"Failed to parse JSON from qstat output: {e}") from e
 
-    def submit(self) -> Optional[int]:
+    def submit(self) -> int | None:  # type: ignore[override]
         """Submit the job to the PBS scheduler.
 
         This method saves the job script to the specified `script_path` and submits it
@@ -891,7 +875,6 @@ class PBSJob(SchedulerJob):
             If the `qsub` command fails or if the job ID cannot be parsed from the
             submission output.
         """
-
         self.save_script()
 
         # job_id_full will contain full job ID (e.g., "7063621.desched1")
@@ -910,7 +893,7 @@ class PBSJob(SchedulerJob):
         self._id = int(job_id_full.split(".")[0])
         return self._id
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Cancel the job in the PBS scheduler.
 
         This method cancels the job using the PBS `qdel` command and provides feedback
@@ -922,7 +905,6 @@ class PBSJob(SchedulerJob):
         RuntimeError
             If the `qdel` command fails or returns a non-zero exit code.
         """
-
         if self.status not in {
             ExecutionStatus.RUNNING,
             ExecutionStatus.PENDING,

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -307,7 +307,7 @@ class SchedulerJob(ExecutionHandler, ABC):
             and (scheduler.requires_task_distribution)
         ):
             if scheduler.global_max_cpus_per_node is None:
-                raise OSError(
+                raise EnvironmentError(  # noqa: UP024
                     "You attempted to create a scheduler job without 'nodes', and "
                     "'cpus_per_node' parameters, but your scheduler explicitly "
                     "requires a task distribution. C-Star is unable to determine "
@@ -494,10 +494,10 @@ class SchedulerJob(ExecutionHandler, ABC):
 
         Returns
         -------
-            n_nodes_to_request : int
-                The number of nodes to request from the scheduler
-            cores_to_request_per_node : int
-                The number of cores per node to request from the scheduler
+        n_nodes_to_request : int
+            The number of nodes to request from the scheduler
+        cores_to_request_per_node : int
+            The number of cores per node to request from the scheduler
         """
         n_nodes_to_request = ceil(n_cores_required / tot_cores_per_node)
         cores_to_request_per_node = ceil(
@@ -614,7 +614,7 @@ class SlurmJob(SchedulerJob):
 
         Returns
         -------
-        str
+        scheduler_script : str
             The complete SLURM job script as a string, ready for submission.
         """
         scheduler_script = "#!/bin/bash"
@@ -772,7 +772,7 @@ class PBSJob(SchedulerJob):
 
         Returns
         -------
-        str
+        scheduler_script : str
             The complete PBS job script as a string, ready for submission.
         """
         scheduler_script = "#PBS -S /bin/bash"

--- a/cstar/marbl/external_codebase.py
+++ b/cstar/marbl/external_codebase.py
@@ -7,28 +7,30 @@ from cstar.system.manager import cstar_sysmgr
 
 
 class MARBLExternalCodeBase(ExternalCodeBase):
-    """An implementation of the ExternalCodeBase class for the Marine Biogeochemistry
-    Library.
+    """An ExternalCodeBase using the Marine Biogeochemistry Library.
 
     This subclass sets unique values for ExternalCodeBase properties specific to MARBL, and overrides
     the get() method to compile MARBL.
 
-    Methods:
-    --------
+    Methods
+    -------
     get()
         overrides ExternalCodeBase.get() to clone the MARBL repository, set environment, and compile library.
     """
 
     @property
     def default_source_repo(self) -> str:
+        """Return the default source repository for this codebase."""
         return "https://github.com/marbl-ecosys/MARBL.git"
 
     @property
     def default_checkout_target(self) -> str:
+        """Return the default checkout target for this codebase."""
         return "marbl0.45.0"
 
     @property
     def expected_env_var(self) -> str:
+        """Return the environment variable name specifying the codebase location."""
         return "MARBL_ROOT"
 
     def get(self, target: str | Path) -> None:
@@ -40,8 +42,8 @@ class MARBLExternalCodeBase(ExternalCodeBase):
         3. Sets environment variable MARBL_ROOT
         4. Compiles MARBL
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         target: str
             The local path where MARBL will be cloned and compiled
         """

--- a/cstar/roms/__init__.py
+++ b/cstar/roms/__init__.py
@@ -14,17 +14,17 @@ from cstar.roms.input_dataset import (
 from cstar.roms.simulation import ROMSSimulation
 
 __all__ = [
-    "ROMSExternalCodeBase",
-    "ROMSComponent",
-    "ROMSSimulation",
-    "ROMSDiscretization",
-    "ROMSInputDataset",
-    "ROMSPartitioning",
-    "ROMSModelGrid",
-    "ROMSInitialConditions",
-    "ROMSTidalForcing",
     "ROMSBoundaryForcing",
-    "ROMSSurfaceForcing",
-    "ROMSRiverForcing",
+    "ROMSComponent",
+    "ROMSDiscretization",
+    "ROMSExternalCodeBase",
     "ROMSForcingCorrections",
+    "ROMSInitialConditions",
+    "ROMSInputDataset",
+    "ROMSModelGrid",
+    "ROMSPartitioning",
+    "ROMSRiverForcing",
+    "ROMSSimulation",
+    "ROMSSurfaceForcing",
+    "ROMSTidalForcing",
 ]

--- a/cstar/roms/discretization.py
+++ b/cstar/roms/discretization.py
@@ -6,41 +6,34 @@ class ROMSDiscretization(Discretization):
 
     Additional attributes:
     ----------------------
-    n_procs_x: int
+    n_procs_x : int
         The number of parallel processors over which to subdivide the x axis of the domain.
-    n_procs_y: int
+    n_procs_y : int
         The number of parallel processors over which to subdivide the y axis of the domain.
 
-    Properties:
-    -----------
-    n_procs_tot: int
+    Properties
+    ----------
+    n_procs_tot : int
         The value of n_procs_x * n_procs_y
     """
 
-    def __init__(
-        self,
-        time_step: int,
-        n_procs_x: int = 1,
-        n_procs_y: int = 1,
-    ):
+    def __init__(self, time_step: int, n_procs_x: int = 1, n_procs_y: int = 1) -> None:
         """Initialize a ROMSDiscretization object from basic discretization parameters.
 
-        Parameters:
-        -----------
-        time_step: int
+        Parameters
+        ----------
+        time_step : int
             The time step with which to run the Component
-        n_procs_x: int
+        n_procs_x : int
            The number of parallel processors over which to subdivide the x axis of the domain.
-        n_procs_y: int
+        n_procs_y : int
            The number of parallel processors over which to subdivide the y axis of the domain.
 
-
-        Returns:
-        --------
+        Returns
+        -------
         ROMSDiscretization:
             An initialized ROMSDiscretization object
         """
-
         super().__init__(time_step)
         self.n_procs_x = n_procs_x
         self.n_procs_y = n_procs_y
@@ -51,6 +44,7 @@ class ROMSDiscretization(Discretization):
         return self.n_procs_x * self.n_procs_y
 
     def __str__(self) -> str:
+        """Return a human-readable string representation."""
         disc_str = super().__str__()
 
         if hasattr(self, "n_procs_x") and self.n_procs_x is not None:
@@ -68,6 +62,7 @@ class ROMSDiscretization(Discretization):
         return disc_str
 
     def __repr__(self) -> str:
+        """Return a constructor-style string representation."""
         repr_str = super().__repr__().rstrip(")")
         if hasattr(self, "n_procs_x") and self.n_procs_x is not None:
             repr_str += f", n_procs_x = {self.n_procs_x}, "

--- a/cstar/roms/discretization.py
+++ b/cstar/roms/discretization.py
@@ -17,7 +17,12 @@ class ROMSDiscretization(Discretization):
         The value of n_procs_x * n_procs_y
     """
 
-    def __init__(self, time_step: int, n_procs_x: int = 1, n_procs_y: int = 1) -> None:
+    def __init__(
+        self,
+        time_step: int,
+        n_procs_x: int = 1,
+        n_procs_y: int = 1,
+    ) -> None:
         """Initialize a ROMSDiscretization object from basic discretization parameters.
 
         Parameters

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -8,28 +8,30 @@ from cstar.system.manager import cstar_sysmgr
 
 
 class ROMSExternalCodeBase(ExternalCodeBase):
-    """An implementation of the ExternalCodeBase class for the UCLA Regional Ocean
-    Modeling System.
+    """An ExternalCodeBase tied to the UCLA Regional Ocean Modeling System.
 
     This subclass sets unique values for ExternalCodeBase properties specific to ROMS, and overrides
     the get() method to compile ROMS-specific libraries.
 
-    Methods:
-    --------
+    Methods
+    -------
     get()
         overrides ExternalCodeBase.get() to clone the UCLA ROMS repository, set environment, and compile libraries
     """
 
     @property
     def default_source_repo(self) -> str:
+        """Return the default source code repository URL."""
         return "https://github.com/CESR-lab/ucla-roms.git"
 
     @property
     def default_checkout_target(self) -> str:
+        """Return the default checkout target."""
         return "main"
 
     @property
     def expected_env_var(self) -> str:
+        """Return the environment variable name containing the source directory."""
         return "ROMS_ROOT"
 
     def _codebase_adjustments(self) -> None:
@@ -42,11 +44,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         roms_root = Path(
             cstar_sysmgr.environment.environment_variables[self.expected_env_var]
         )
-        shutil.copytree(
-            roms_root / "ci/ci_makefiles/",
-            roms_root,
-            dirs_exist_ok=True,
-        )
+        shutil.copytree(roms_root / "ci/ci_makefiles/", roms_root, dirs_exist_ok=True)
 
     def get(self, target: str | Path) -> None:
         """Clone ROMS code to local machine, set environment, compile libraries.
@@ -59,13 +57,13 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         5. Compiles the NHMG library
         6. Compiles the Tools-Roms package
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         target: src
             the path where ROMS will be cloned and compiled
         """
         target = Path(target).expanduser()
-        # TODO: Situation where environment variables like ROMS_ROOT are not set...
+        # TODO(Tom Nichols): Situation where environment variables like ROMS_ROOT are not set...
         # ... but repo already exists at local_path results in an error rather than a prompt
         _clone_and_checkout(
             source_repo=self.source_repo,

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -44,7 +44,11 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         roms_root = Path(
             cstar_sysmgr.environment.environment_variables[self.expected_env_var]
         )
-        shutil.copytree(roms_root / "ci/ci_makefiles/", roms_root, dirs_exist_ok=True)
+        shutil.copytree(
+            roms_root / "ci/ci_makefiles/",
+            roms_root,
+            dirs_exist_ok=True,
+        )
 
     def get(self, target: str | Path) -> None:
         """Clone ROMS code to local machine, set environment, compile libraries.

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -264,7 +264,10 @@ class ROMSInputDataset(InputDataset, ABC):  # noqa: D101
             if tempdir_obj:
                 tempdir_obj.cleanup()
 
-    def get(self, local_dir: str | Path) -> None:
+    def get(
+        self,
+        local_dir: str | Path,
+    ) -> None:
         """Ensure this input dataset is available as a NetCDF file in `local_dir`.
 
         If the source is not a YAML file, this method delegates to the base class

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -217,7 +217,10 @@ class Simulation(ABC, LoggingMixin):
         return date if isinstance(date, datetime) else dateutil.parser.parse(date)
 
     def _get_date_or_fallback(
-        self, date: str | datetime | None, fallback: datetime | None, field_name: str
+        self,
+        date: str | datetime | None,
+        fallback: datetime | None,
+        field_name: str,
     ) -> datetime:
         """Ensure a date is set, using a fallback if needed.
 
@@ -486,7 +489,11 @@ class Simulation(ABC, LoggingMixin):
 
     @classmethod
     @abstractmethod
-    def from_blueprint(cls, blueprint: str, directory: str | Path) -> "Simulation":
+    def from_blueprint(
+        cls,
+        blueprint: str,
+        directory: str | Path,
+    ) -> "Simulation":
         """Abstract method to create a Simulation instance from a blueprint file.
 
         This method should be implemented in subclasses to read a YAML file containing
@@ -731,9 +738,8 @@ class Simulation(ABC, LoggingMixin):
         elif isinstance(new_end_date, datetime):
             new_sim.end_date = new_end_date
         else:
-            msg = (
+            raise ValueError(  # noqa: TRY004
                 f"Expected str or datetime for `new_end_date`, got {type(new_end_date)}"
             )
-            raise ValueError(msg)  # noqa: TRY004
 
         return new_sim

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -229,7 +229,7 @@ class CStarEnvironment:
             If any `module load <module_name>` command fails.
         """
         if not self.uses_lmod:
-            raise OSError(
+            raise EnvironmentError(  # noqa: UP024
                 "Your system does not appear to use Linux Environment Modules"
             )
         self._call_lmod("reset")

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -1,7 +1,6 @@
 import os
 import platform
 from enum import Enum
-from typing import Optional
 
 from cstar.system.environment import CStarEnvironment
 from cstar.system.scheduler import (
@@ -42,13 +41,14 @@ class SystemName(Enum):
 
 
 class CStarSystemManager:
-    _environment: Optional[CStarEnvironment] = None
-    _scheduler: Optional[Scheduler] = None
+    """Manages configuration related to the system executing a simulation."""
+
+    _environment: CStarEnvironment | None = None
+    _scheduler: Scheduler | None = None
 
     @property
     def name(self) -> str:
-        """Determines the system name based on environment variables or platform
-        details.
+        """Determine system name using environment variables or platform details.
 
         Checks for Lmod-specific variables (`LMOD_SYSHOST` or `LMOD_SYSTEM_NAME`).
         Otherwise, constructs a system name using `platform.system()` and
@@ -64,7 +64,6 @@ class CStarSystemManager:
         EnvironmentError
             If the system name cannot be determined from environment variables or platform information.
         """
-
         sysname = os.environ.get("LMOD_SYSHOST", default="") or os.environ.get(
             "LMOD_SYSTEM_NAME"
         )
@@ -73,24 +72,23 @@ class CStarSystemManager:
         elif (platform.system() is not None) and (platform.machine() is not None):
             sysname = platform.system() + "_" + platform.machine()
         else:
-            raise EnvironmentError(
+            raise OSError(
                 f"C-Star cannot determine your system name. Diagnostics: "
                 f"LMOD_SYSHOST={os.environ.get('LMOD_SYSHOST')}, "
                 f"LMOD_SYSTEM_NAME={os.environ.get('LMOD_SYSTEM_NAME')}, "
                 f"platform.system()={platform.system()}, "
                 f"platform.machine()={platform.machine()}"
             )
-            # raise EnvironmentError("C-Star cannot determine your system name")
 
         return sysname.casefold()
 
     def _system_name_enum(self) -> SystemName:
-        """Converts the system name string to a validated SystemName enum."""
+        """Convert the system name string to a validated SystemName enum."""
         return SystemName(self.name)
 
     @property
-    def scheduler(self) -> Optional[Scheduler]:
-        """Returns the Scheduler instance corresponding to the system.
+    def scheduler(self) -> Scheduler | None:
+        """Return the Scheduler instance for the system.
 
         The scheduler instance is created based on the detected system name
         and cached for future access.
@@ -101,7 +99,6 @@ class CStarSystemManager:
             A `Scheduler` instance configured for the detected system, or `None` if the
             system is not supported or does not use a job scheduler.
         """
-
         if self._scheduler is not None:
             return self._scheduler
 

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -72,7 +72,7 @@ class CStarSystemManager:
         elif (platform.system() is not None) and (platform.machine() is not None):
             sysname = platform.system() + "_" + platform.machine()
         else:
-            raise OSError(
+            raise EnvironmentError(  # noqa: UP024
                 f"C-Star cannot determine your system name. Diagnostics: "
                 f"LMOD_SYSHOST={os.environ.get('LMOD_SYSHOST')}, "
                 f"LMOD_SYSTEM_NAME={os.environ.get('LMOD_SYSTEM_NAME')}, "

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -550,7 +550,7 @@ class PBSScheduler(Scheduler):
             msg_err="Error querying node property.",
         )
         if stdout.endswith("kb"):
-            return int(float(stdout[:-2]) / (1024**2))  # Convert kilobytes to gigabytes
+            return float(stdout[:-2]) / (1024**2)  # Convert kilobytes to gigabytes
         if stdout.endswith("mb"):
             return float(stdout[:-2]) / 1024  # Convert megabytes to gigabytes
         if stdout.endswith("gb"):

--- a/cstar/tests/integration_tests/blueprints/fixtures.py
+++ b/cstar/tests/integration_tests/blueprints/fixtures.py
@@ -1,54 +1,64 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+from typing import Any
 
 import pytest
 
 
 @pytest.fixture
-def modify_template_blueprint(tmpdir) -> Callable[[Path | str, dict[str, str]], Path]:
+def modify_template_blueprint(
+    tmpdir: str,
+) -> Callable[[Path | str, dict[str, str]], str]:
     """Fixture that provides a factory function for modifying template blueprint files.
 
     This fixture returns a function that can returns a path to a modified a blueprint
     template file based on specified string replacements.
 
-    Parameters:
-    -----
+    Parameters
+    ----------
     tmpdir:
        Pytest fixture used to create a temporary directory in which to hold a modified version
        of the template file during the test.
 
-    Returns:
-    --------
+    Returns
+    -------
     _modify_template_blueprint, Callable[[Path | str, dict[str, str]], Path]:
        The factory function
+
+    Raises
+    ------
+    ValueError
     """
 
     def _modify_template_blueprint(
-        template_blueprint_path: Path | str, strs_to_replace: dict, **kwargs
-    ) -> Path:
-        """Creates a temporary, customized blueprint file from a template.
+        template_blueprint_path: Path | str,
+        strs_to_replace: dict,
+        **kwargs: dict[str, Any],  # noqa: ARG001
+    ) -> str:
+        """Create a temporary, customized blueprint file from a template.
 
-        This function reads a blueprint template file, performs string replacements as specified
-        by `strs_to_replace`, saves the modified content to a temporary file within the `tmpdir`
-        provided by pytest.
+        This function reads a blueprint template file, performs string replacements
+        as specified by `strs_to_replace`, saves the modified content to a temporary
+        file within the `tmpdir` provided by pytest.
 
-        Parameters:
-        -----------
-        template_blueprint_path (Path | str):
+        Parameters
+        ----------
+        template_blueprint_path : Path | str
            The path to the blueprint template file.
-        strs_to_replace (dict[str, str]):
+        strs_to_replace : dict[str, str]
            A dictionary where keys are substrings to find in the template,
            and values are the replacements.
+        kwargs : dict[str, Any]
+            keyword arguments used to modify the template
 
-        Returns:
-        --------
+        Returns
+        -------
         modified_blueprint_path:
            A temporary path to a modified version of the template blueprint file.
         """
-
         template_blueprint_path = Path(template_blueprint_path)
 
-        with open(template_blueprint_path, "r") as template_file:
+        with open(template_blueprint_path) as template_file:  # noqa: PTH123
             template_content = template_file.read()
 
         modified_template_content = template_content
@@ -57,7 +67,7 @@ def modify_template_blueprint(tmpdir) -> Callable[[Path | str, dict[str, str]], 
                 oldstr, newstr
             )
         temp_path = tmpdir.join(template_blueprint_path.name)
-        with open(temp_path, "w") as temp_file:
+        with open(temp_path, "w") as temp_file:  # noqa: PTH123
             temp_file.write(modified_template_content)
 
         return temp_path

--- a/cstar/tests/integration_tests/config.py
+++ b/cstar/tests/integration_tests/config.py
@@ -16,15 +16,14 @@ from pooch import os_cache
 ## Common paths used in tests
 
 
-def _get_test_directory():
+def _get_test_directory() -> Path:
     from importlib.util import find_spec
     from pathlib import Path
 
     spec = find_spec("cstar")
-    if spec is not None:
+    if spec is not None and spec.origin:
         return Path(spec.origin).parent / "tests"
-    else:
-        raise RuntimeError("Cannot determine the package location of cstar")
+    raise RuntimeError("Cannot determine the package location of cstar")
 
 
 TEST_DIRECTORY = _get_test_directory()

--- a/cstar/tests/integration_tests/conftest.py
+++ b/cstar/tests/integration_tests/conftest.py
@@ -1,21 +1,22 @@
-import builtins
 import logging
-from contextlib import contextmanager
+from collections.abc import Callable, Generator
+from contextlib import _GeneratorContextManager, contextmanager
+from unittest import mock
 
 import pytest
 
 from cstar.base.log import get_logger
 from cstar.tests.integration_tests.blueprints.fixtures import (
-    modify_template_blueprint,  # noqa : F401  # noqa : F401
+    modify_template_blueprint,  # noqa : F401
 )
 from cstar.tests.integration_tests.fixtures import (
-    fetch_remote_test_case_data,  # noqa: F401  # noqa: F401
-    fetch_roms_tools_source_data,  # noqa: F401  # noqa: F401
+    fetch_remote_test_case_data,  # noqa: F401
+    fetch_roms_tools_source_data,  # noqa: F401
 )
 
 
 @pytest.fixture
-def mock_user_input():
+def mock_user_input() -> Callable[[str], _GeneratorContextManager[Callable[..., str]]]:
     """Monkeypatch which will automatically respond to any call for input.
 
     Use it like this:
@@ -28,21 +29,16 @@ def mock_user_input():
     """
 
     @contextmanager
-    def _mock_input(input_string):
-        original_input = builtins.input
-
-        def mock_input_function(_):
-            return input_string
-
-        builtins.input = mock_input_function
-        try:
-            yield
-        finally:
-            builtins.input = original_input
+    def _mock_input(
+        input_string: str,
+    ) -> Generator[_GeneratorContextManager[Callable[..., str]], None, None]:
+        with mock.patch("builtins.input", return_value=input_string) as _:
+            yield _
 
     return _mock_input
 
 
 @pytest.fixture
 def log() -> logging.Logger:
+    """Retrieve a logger instance for logging during tests."""
     return get_logger("cstar.tests.integration_tests")

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -64,9 +64,14 @@ class TestCStar:
         ext_root = tmp_path / "externals"
 
         with (
-            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
+            mock.patch(
+                "cstar.system.environment.CSTAR_USER_ENV_PATH",
+                dotenv_path,
+            ),
             mock.patch.object(
-                cstar.system.environment.CStarEnvironment, "package_root", new=ext_root
+                cstar.system.environment.CStarEnvironment,
+                "package_root",
+                new=ext_root,
             ),
         ):
             # Regardless of remote or local, if yaml_datasets we need roms-tools support data

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from unittest import mock
 
@@ -10,6 +11,8 @@ from cstar.tests.integration_tests.config import TEST_CONFIG
 
 
 class TestCStar:
+    """Test harness for C-Star integration tests that execute a simulation."""
+
     @pytest.mark.parametrize(
         "test_config_key",
         [
@@ -22,18 +25,18 @@ class TestCStar:
     def test_cstar(
         self,
         tmp_path: Path,
-        mock_user_input,
-        modify_template_blueprint,
-        fetch_roms_tools_source_data,
-        fetch_remote_test_case_data,
-        test_config_key,
+        mock_user_input: mock.Mock,
+        modify_template_blueprint: mock.Mock,
+        fetch_roms_tools_source_data: mock.Mock,
+        fetch_remote_test_case_data: Callable[[], None],
+        test_config_key: str,
         log: logging.Logger,
-    ):
+    ) -> None:
         """Run the C-Star minimal test case from a selection of different blueprints.
 
-        Parameters:
-        -----------
-        tmp_path:
+        Parameters
+        ----------
+        tmp_path : Path
            Built-in pytest fixture to create temporary directories
         mock_user_input:
            Fixture to simulate user-supplied input
@@ -51,21 +54,17 @@ class TestCStar:
            code for compiling ROMS, yaml files to supply to roms-tools, etc.
            These are saved to a subdirectory of the system cache specified by
            CSTAR_TEST_DATA_DIRECTORY in the config.py module
-        test_config_key (str):
+        test_config_key : str
            Key determining the specific variation of the test case that is run, as
            defined in the dictionary TEST_CONFIG in the config.py module
-        log (logging.Logger):
+        log : logging.Logger
             Logger instance for logging messages during test execution.
         """
-
         dotenv_path = tmp_path / ".cstar.env"
         ext_root = tmp_path / "externals"
 
         with (
-            mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
-            ),
+            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
             mock.patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=ext_root
             ),
@@ -101,7 +100,7 @@ class TestCStar:
             with mock_user_input("y"):
                 cstar_test_case.setup()
 
-            cstar_test_case.to_blueprint(tmp_path / "test_blueprint_export.yaml")
+            cstar_test_case.to_blueprint(str(tmp_path / "test_blueprint_export.yaml"))
             cstar_test_case.build()
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -1,5 +1,6 @@
 """Test suite to test fixtures defined in conftest.py and fixtures.py files."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import yaml
@@ -12,23 +13,20 @@ from cstar.tests.integration_tests.config import (
 )
 
 
-def test_mock_input_fixture(mock_user_input):
-    # Mocked input behavior
-    with mock_user_input("yes"):
-        assert input("Enter your choice: ") == "yes"
+def test_modify_template_blueprint(
+    modify_template_blueprint: Callable[..., Path],
+) -> None:
+    """Ensure the modify_template_blueprint works as expected.
 
-
-def test_modify_template_blueprint(modify_template_blueprint, tmpdir):
-    """This test verifies that the modify_template_blueprint fixture correctly reads a
-    specified blueprint, performs string replacements, and returns a Simulation instance
-    with the correct parameters corresponding to the string replacements.
+    This test verifies that the modify_template_blueprint fixture correctly
+    reads a specified blueprint, performs string replacements, and returns a
+    Simulation instance with the correct parameters corresponding to the string
+    replacements.
 
     Parameters
     ----------
     modify_template_blueprint : Callable
         A fixture that modifies a template blueprint with specific string replacements.
-    tmpdir : Path
-        Built-in pytest fixture for creating a temporary directory during the test
 
     Asserts
     -------
@@ -46,7 +44,7 @@ def test_modify_template_blueprint(modify_template_blueprint, tmpdir):
     assert isinstance(
         test_blueprint, LocalPath
     ), f"Expected type LocalPath, but got {type(test_blueprint)}"
-    with open(test_blueprint, "r") as bpfile:
+    with open(test_blueprint) as bpfile:  # noqa: PTH123
         bpyaml = yaml.safe_load(bpfile)
 
     assert (
@@ -56,14 +54,12 @@ def test_modify_template_blueprint(modify_template_blueprint, tmpdir):
 
 
 class TestFetchData:
-    """Test class for testing data-fetching fixtures defined in the roms/fixtures.py
-    file."""
+    """Tests for data-fetching fixtures defined in the roms/fixtures.py file."""
 
     def test_fetch_roms_tools_source_data(
-        self, request, tmpdir, fetch_roms_tools_source_data
-    ):
-        """Test the fetch_roms_tools_source_data fixture by validating data fetching and
-        symlink creation.
+        self, tmpdir: Path, fetch_roms_tools_source_data: Callable[[str | Path], None]
+    ) -> None:
+        """Ensure the fetch_roms_tools_source_data fixture works as expected.
 
         This test checks that the fetch_roms_tools_source_data fixture correctly fetches the
         expected data files, creates a symlink to the data directory, and ensures all expected
@@ -84,7 +80,6 @@ class TestFetchData:
         - The symlink exists and is valid
         - All expected data files are present in the symlinked directory
         """
-
         test_data_directory = Path(tmpdir / "test_data_directory")
         fetch_roms_tools_source_data(test_data_directory)
 
@@ -107,7 +102,9 @@ class TestFetchData:
         missing_files = [f for f in expected_files if f not in file_list]
         assert not missing_files, f"missing expected files {missing_files}"
 
-    def test_fetch_remote_test_case_data(self, fetch_remote_test_case_data):
+    def test_fetch_remote_test_case_data(
+        self, fetch_remote_test_case_data: Callable[[], None]
+    ) -> None:
         """Test the fetch_remote_test_case_data fixture.
 
         This test verifies that the fetch_remote_test_case_data fixture correctly downloads

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
@@ -11,7 +10,7 @@ from cstar.base.datasource import DataSource
 
 # Set up fixtures
 @pytest.fixture
-def remote_additional_code():
+def remote_additional_code() -> AdditionalCode:
     """Pytest fixture that provides an instance of the AdditionalCode class representing
     a remote repository.
 
@@ -26,8 +25,8 @@ def remote_additional_code():
     This fixture can be used in tests that involve handling or manipulating code
     fetched from a remote Git repository.
 
-    Returns:
-        AdditionalCode: An instance of the AdditionalCode class with preset
+    Returns
+        AdditionalCode : An instance of the AdditionalCode class with preset
         remote repository details.
     """
     return AdditionalCode(
@@ -39,7 +38,7 @@ def remote_additional_code():
 
 
 @pytest.fixture
-def local_additional_code():
+def local_additional_code() -> AdditionalCode:
     """Pytest fixture that provides an instance of the AdditionalCode class representing
     code located on the local filesystem.
 
@@ -53,8 +52,8 @@ def local_additional_code():
     This fixture can be used in tests that involve handling or manipulating
     code that resides on the local filesystem.
 
-    Returns:
-        AdditionalCode: An instance of the AdditionalCode class with preset
+    Returns
+        AdditionalCode : An instance of the AdditionalCode class with preset
         local directory details.
     """
     return AdditionalCode(
@@ -80,7 +79,7 @@ class TestInit:
         when optional attributes are not provided.
     """
 
-    def test_init(self, remote_additional_code):
+    def test_init(self, remote_additional_code: AdditionalCode) -> None:
         """Test that an AdditionalCode object is initialized with the correct
         attributes."""
         assert (
@@ -94,7 +93,7 @@ class TestInit:
             "test_file_3.opt",
         ]
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         """Test that a minimal AdditionalCode object is initialized with correct default
         values."""
         additional_code = AdditionalCode(location="test/location")
@@ -132,10 +131,11 @@ class TestStrAndRepr:
         Patches the `exists_locally` property to simulate the existence or non-existence of files.
     """
 
-    def test_repr_remote(self, remote_additional_code):
+    def test_repr_remote(self, remote_additional_code: AdditionalCode) -> None:
         """Test that the __repr__ method returns the correct string for the example
         remote AdditionalCode instance defined in the above fixture."""
-        expected_repr = dedent("""\
+        expected_repr = dedent(
+            """\
         AdditionalCode(
         location = 'https://github.com/test/repo.git',
         subdir = 'test/subdir'
@@ -143,16 +143,17 @@ class TestStrAndRepr:
         files = ['test_file_1.F',
                  'test_file_2.py',
                  'test_file_3.opt']
-        )""")
+        )"""
+        )
         assert (
             repr(remote_additional_code) == expected_repr
-        ), f"expected \n{repr(remote_additional_code)}\n, got \n{expected_repr}"
+        ), f"expected \n{remote_additional_code!r}\n, got \n{expected_repr}"
 
-    def test_repr_local(self, local_additional_code):
+    def test_repr_local(self, local_additional_code: AdditionalCode) -> None:
         """Test that the __repr__ method returns the correct string for the example
         local AdditionalCode instance defined in the above fixture."""
-
-        expected_repr = dedent("""\
+        expected_repr = dedent(
+            """\
         AdditionalCode(
         location = '/some/local/directory',
         subdir = 'some/subdirectory'
@@ -160,7 +161,8 @@ class TestStrAndRepr:
         files = ['test_file_1.F',
                  'test_file_2.py',
                  'test_file_3.opt']
-        )""")
+        )"""
+        )
         assert repr(local_additional_code) == expected_repr
 
     @mock.patch(
@@ -168,7 +170,11 @@ class TestStrAndRepr:
         new_callable=mock.PropertyMock,
         return_value=True,
     )
-    def test_repr_with_working_path(self, mock_exists_locally, local_additional_code):
+    def test_repr_with_working_path(
+        self,
+        mock_exists_locally: mock.PropertyMock,  # noqa: ARG002
+        local_additional_code: AdditionalCode,
+    ) -> None:
         """Test that the __repr__ method contains the correct substring when
         working_path attr is defined.
 
@@ -177,17 +183,16 @@ class TestStrAndRepr:
         - mock_exists: Patches Path.exists() to ensure exists_locally property used in __repr__ returns True.
         - local_additional_code: An example AdditionalCode instance representing local code
         """
-
         local_additional_code.working_path = Path("/mock/local/dir")
         assert "State: <working_path = /mock/local/dir,exists_locally = True>" in repr(
             local_additional_code
         )
 
-    def test_str_remote(self, remote_additional_code):
+    def test_str_remote(self, remote_additional_code: AdditionalCode) -> None:
         """Test that the __str__ method returns the correct string for the example
         remote AdditionalCode instance defined in the above fixture."""
-
-        expected_str = dedent("""\
+        expected_str = dedent(
+            """\
         AdditionalCode
         --------------
         Location: https://github.com/test/repo.git
@@ -198,13 +203,16 @@ class TestStrAndRepr:
         Files:
             test_file_1.F
             test_file_2.py
-            test_file_3.opt""")
+            test_file_3.opt"""
+        )
 
         assert (
             str(remote_additional_code) == expected_str
-        ), f"expected \n{str(remote_additional_code)}\n, got \n{expected_str}"
+        ), f"expected \n{remote_additional_code!s}\n, got \n{expected_str}"
 
-    def test_str_with_template_file(self, local_additional_code):
+    def test_str_with_template_file(
+        self, local_additional_code: AdditionalCode
+    ) -> None:
         """Test that the __str__ method contains the correct substring when an
         additional code filename has the '_TEMPLATE' suffix."""
         # Simulate template files with "_TEMPLATE"
@@ -215,11 +223,11 @@ class TestStrAndRepr:
             local_additional_code
         )
 
-    def test_str_local(self, local_additional_code):
+    def test_str_local(self, local_additional_code: AdditionalCode) -> None:
         """Test that the __str__ method returns the correct string for the example local
         AdditionalCode instance defined in the above fixture."""
-
-        expected_str = dedent("""\
+        expected_str = dedent(
+            """\
         AdditionalCode
         --------------
         Location: /some/local/directory
@@ -229,11 +237,12 @@ class TestStrAndRepr:
         Files:
             test_file_1.F
             test_file_2.py
-            test_file_3.opt""")
+            test_file_3.opt"""
+        )
 
         assert (
             str(local_additional_code) == expected_str
-        ), f"expected \n{str(local_additional_code)}\n, got \n{expected_str}"
+        ), f"expected \n{local_additional_code!s}\n, got \n{expected_str}"
 
 
 class TestExistsLocally:
@@ -263,7 +272,7 @@ class TestExistsLocally:
         Patches the `Path.exists` property to handle a variety of situations regarding file existings
     """
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up common mocks before each test."""
         self.patch_get_sha256_hash = mock.patch(
             "cstar.base.additional_code._get_sha256_hash"
@@ -273,11 +282,11 @@ class TestExistsLocally:
         self.patch_exists = mock.patch("pathlib.Path.exists")
         self.mock_exists = self.patch_exists.start()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Stop all mocks after each test."""
         mock.patch.stopall()
 
-    def test_all_files_exist_and_hashes_match(self):
+    def test_all_files_exist_and_hashes_match(self) -> None:
         """Verifies that `exists_locally` returns True when all files exist and their
         hashes match the cache.
 
@@ -307,7 +316,7 @@ class TestExistsLocally:
         additional_code.working_path = Path("/mock/local/dir")
 
         # Simulate correct hash cache
-        additional_code._local_file_hash_cache = {
+        additional_code._local_file_hash_cache = {  # noqa: SLF001
             Path(f"/mock/local/dir/{file}"): f"mock_hash_{file}"
             for file in additional_code.files
         }
@@ -319,7 +328,7 @@ class TestExistsLocally:
         assert self.mock_exists.call_count == len(additional_code.files)
         assert self.mock_get_sha256_hash.call_count == len(additional_code.files)
 
-    def test_some_files_missing(self):
+    def test_some_files_missing(self) -> None:
         """Verifies that `exists_locally` returns False when some files are missing.
 
         This test ensures that the `exists_locally` property correctly identifies when
@@ -347,7 +356,7 @@ class TestExistsLocally:
         )
         additional_code.working_path = Path("/mock/local/dir")
 
-        additional_code._local_file_hash_cache = {
+        additional_code._local_file_hash_cache = {  # noqa: SLF001
             Path(f"/mock/local/dir/{file}"): f"mock_hash_{file}"
             for file in additional_code.files
         }
@@ -360,7 +369,7 @@ class TestExistsLocally:
             self.mock_get_sha256_hash.call_count == 2
         )  # Stops checking when a file is missing.
 
-    def test_hash_mismatch(self):
+    def test_hash_mismatch(self) -> None:
         """Verifies that `exists_locally` returns False when a file's hash does not
         match the cached value.
 
@@ -378,7 +387,6 @@ class TestExistsLocally:
         - `exists_locally` is False when a hash mismatch occurs for any file.
         - `Path.exists` and `_get_sha256_hash` are only called up to the first mismatch.
         """
-
         self.mock_exists.return_value = True
 
         additional_code = AdditionalCode(
@@ -389,7 +397,7 @@ class TestExistsLocally:
         additional_code.working_path = Path("/mock/local/dir")
 
         # Simulate incorrect hash cache
-        additional_code._local_file_hash_cache = {
+        additional_code._local_file_hash_cache = {  # noqa: SLF001
             Path(f"/mock/local/dir/{file}"): f"wrong_hash_{file}"
             for file in additional_code.files
         }
@@ -408,7 +416,7 @@ class TestExistsLocally:
         assert self.mock_exists.call_count == 1
         assert self.mock_get_sha256_hash.call_count == 1
 
-    def test_no_working_path(self):
+    def test_no_working_path(self) -> None:
         """Verifies that `exists_locally` returns False when the `working_path`
         attribute is None.
 
@@ -420,7 +428,6 @@ class TestExistsLocally:
         - `exists_locally` is False when `working_path` is None.
         - `_get_sha256_hash` is not called, as no files are checked.
         """
-
         additional_code = AdditionalCode(
             location="/mock/local",
             subdir="subdir",
@@ -431,7 +438,7 @@ class TestExistsLocally:
         assert additional_code.exists_locally is False
         self.mock_get_sha256_hash.assert_not_called()
 
-    def test_no_cached_hashes(self):
+    def test_no_cached_hashes(self) -> None:
         """Verifies that `exists_locally` returns False when the hash cache
         (`_local_file_hash_cache`) is None.
 
@@ -443,22 +450,23 @@ class TestExistsLocally:
         - `exists_locally` is False when `_local_file_hash_cache` is None.
         - `_get_sha256_hash` is not called, as no hashes are available for comparison.
         """
-
         additional_code = AdditionalCode(
             location="/mock/local",
             subdir="subdir",
             files=["file1.F", "file2.py", "file3.opt"],
         )
         additional_code.working_path = Path("/mock/local/dir")
-        additional_code._local_file_hash_cache = None
+        additional_code._local_file_hash_cache = {}  # noqa: SLF001
 
         assert additional_code.exists_locally is False
         self.mock_get_sha256_hash.assert_not_called()
 
 
 class TestAdditionalCodeGet:
-    """Test class for the `AdditionalCode.get()` method, which handles fetching and
-    copying code from both local directories and remote repositories.
+    """Test behavior of `AdditionalCode.get()`.
+
+    The method under test handles fetching and copying code from both local
+    directories and remote repositories.
 
     Tests:
     ------
@@ -472,7 +480,7 @@ class TestAdditionalCodeGet:
     - test_cleanup_temp_directory
     """
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up common mocks and start patching before each test case.
 
         Mocks initialized:
@@ -524,16 +532,17 @@ class TestAdditionalCodeGet:
         self.patch_hash = mock.patch("cstar.base.additional_code._get_sha256_hash")
         self.mock_hash = self.patch_hash.start()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Stop all the patches after each test to clean up the mock environment."""
         mock.patch.stopall()
 
-    def test_get_from_local_directory(self, local_additional_code):
-        """Test the `get` method when fetching additional code from elsewhere on the
-        current filesystem.
+    def test_get_from_local_directory(
+        self, local_additional_code: AdditionalCode
+    ) -> None:
+        """Test behavior of the `get` method when code is fetched from local files.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path"
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory"
@@ -541,8 +550,8 @@ class TestAdditionalCodeGet:
         - mock_mkdir: Mocks the creation of the target directory if it doesn’t exist.
         - mock_copy: Mocks the copying of files from the source to the target directory.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - The target directory is created (mock_mkdir is called once with correct parameters).
         - The correct number of files are copied (mock_copy is called for each file).
         - Each file is copied from the correct source path to the correct target path.
@@ -574,19 +583,23 @@ class TestAdditionalCodeGet:
         for f in local_additional_code.files:
             tgt_file_path = Path("/mock/local/dir") / Path(f).name
             assert (
-                local_additional_code._local_file_hash_cache[tgt_file_path]
+                local_additional_code._local_file_hash_cache[  # noqa: SLF001
+                    tgt_file_path
+                ]
                 == "mock_hash_value"
             )
 
         # Ensure that the working_path is set correctly
         assert local_additional_code.working_path == Path("/mock/local/dir")
 
-    def test_get_from_remote_repository(self, remote_additional_code):
+    def test_get_from_remote_repository(
+        self, remote_additional_code: AdditionalCode
+    ) -> None:
         """Test the `get` method when fetching additional code from a remote Git
         repository.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url"
         - mock_source_type: Mocks AdditionalCode.source.source_type  as "repository"
@@ -597,8 +610,8 @@ class TestAdditionalCodeGet:
         - mock_copy: Mocks the copying of files from the temporary clone to the target directory.
         - mock_rmtree: Mocks the cleanup (removal) of the temporary directory.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - The repository is cloned and checked out at the correct target.
         - The temporary directory is created (mock_mkdtemp is called once).
         - The target directory is created (mock_mkdir is called once with the correct parameters).
@@ -637,7 +650,9 @@ class TestAdditionalCodeGet:
         for f in remote_additional_code.files:
             tgt_file_path = Path("/mock/local/dir") / Path(f).name
             assert (
-                remote_additional_code._local_file_hash_cache[tgt_file_path]
+                remote_additional_code._local_file_hash_cache[  # noqa: SLF001
+                    tgt_file_path
+                ]
                 == "mock_hash_value"
             )
 
@@ -649,25 +664,28 @@ class TestAdditionalCodeGet:
 
     # Test failures:
 
-    def test_get_raises_if_checkout_target_none(self, remote_additional_code):
+    def test_get_raises_if_checkout_target_none(
+        self, remote_additional_code: AdditionalCode
+    ) -> None:
         """Test that `get` raises a `ValueError` when no checkout_target provided for a
         remote repo.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url"
         - mock_source_type: Mocks AdditionalCode.source.source_type as "repository"
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `ValueError` is raised with the correct message when `checkout_target` is `None`.
         - The repository is not cloned (mock_clone is not called).
         - No files are copied (mock_copy is not called).
         """
-
         # Simulate a remote repository source but without checkout_target
-        remote_additional_code._checkout_target = None  # This should raise a ValueError
+        remote_additional_code._checkout_target = (  # noqa: SLF001
+            None  # This should raise a ValueError
+        )
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "repository"
 
@@ -679,45 +697,48 @@ class TestAdditionalCodeGet:
         self.mock_clone.assert_not_called()
         self.mock_copy.assert_not_called()
 
-    def test_get_raises_if_source_incompatible(self, remote_additional_code):
+    def test_get_raises_if_source_incompatible(
+        self, remote_additional_code: AdditionalCode
+    ) -> None:
         """Test that `get` raises a `ValueError` when the source location and type are
         incompatible.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url"
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory"
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `ValueError` is raised with the correct message when AdditionalCode.source.source_type is "directory" and AdditionalCode.source.location_type is "url"
         - No files are copied (mock_copy is not called).
         """
-
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "directory"
 
-        with pytest.raises(ValueError) as exception_info:
+        with pytest.raises(ValueError) as exception_info:  # noqa: PT011
             remote_additional_code.get("/mock/local/dir")
 
         expected_message = (
             "Invalid source for AdditionalCode. "
-            + "AdditionalCode.source.location_type and "
-            + "AdditionalCode.source.source_type should be "
-            + "'url' and 'repository', or 'path' and 'repository', or"
-            + "'path' and 'directory', not"
-            + "'url' and 'directory'"
+            "AdditionalCode.source.location_type and "
+            "AdditionalCode.source.source_type should be "
+            "'url' and 'repository', or 'path' and 'repository', or"
+            "'path' and 'directory', not"
+            "'url' and 'directory'"
         )
 
         assert str(exception_info.value) == expected_message
 
-    def test_get_raises_if_missing_files(self, local_additional_code):
+    def test_get_raises_if_missing_files(
+        self, local_additional_code: AdditionalCode
+    ) -> None:
         """Test that `get` raises a `FileNotFoundError` when a file is missing in a
         local directory.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory".
@@ -725,8 +746,8 @@ class TestAdditionalCodeGet:
         - mock_exists: Mocks file existence checks, simulating the third file as missing.
         - mock_copy: Mocks the copying of files to the target directory.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `FileNotFoundError` is raised with the correct message when a file does not exist.
         - `mock_exists` is called for each file to check its existence (3 calls in this case).
         - Only existing files are copied (2 calls to `mock_copy` for the first two files).
@@ -746,19 +767,21 @@ class TestAdditionalCodeGet:
         assert self.mock_exists.call_count == 3
         assert self.mock_copy.call_count == 2  # Only the first two files were copied
 
-    def test_get_with_template_files(self, local_additional_code, log: logging.Logger):
+    def test_get_with_template_files(
+        self, local_additional_code: AdditionalCode
+    ) -> None:
         """Test that `get` correctly handles files with the '_TEMPLATE' filename suffix.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory".
         - mock_resolve: Mocks resolving the target directory.
         - mock_copy: Mocks the copying of template files and renaming them.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - `mock_copy` is called the correct number of times (2 original files + 2 renamed files).
         - Each template file is copied and renamed (from "fileX_TEMPLATE" to "fileX").
         - The `modified_files` attribute is correctly updated with the renamed files.
@@ -785,16 +808,18 @@ class TestAdditionalCodeGet:
         )
         assert local_additional_code.modified_files == ["file1", "file2"]
 
-    def test_get_with_empty_file_list(self, local_additional_code):
+    def test_get_with_empty_file_list(
+        self, local_additional_code: AdditionalCode
+    ) -> None:
         """Test that `get` raises a `ValueError` when the `files` attribute is empty in
         AdditionalCode.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_additional_code: An example AdditionalCode instance representing local code.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `ValueError` is raised with the correct message when `files` is an empty list.
         """
         expected_message = (
@@ -802,17 +827,19 @@ class TestAdditionalCodeGet:
         )
         local_additional_code.files = []
 
-        with pytest.raises(ValueError) as exception_info:
+        with pytest.raises(ValueError) as exception_info:  # noqa: PT011
             local_additional_code.get("/mock/local/dir")
 
         assert str(exception_info.value) == expected_message
 
-    def test_cleanup_temp_directory(self, remote_additional_code):
+    def test_cleanup_temp_directory(
+        self, remote_additional_code: AdditionalCode
+    ) -> None:
         """Test that the temporary directory is cleaned up (deleted) after fetching
         remote additional code.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "repository".
@@ -821,8 +848,8 @@ class TestAdditionalCodeGet:
         - mock_mkdtemp: Mocks the creation of a temporary directory for cloning the repo.
         - mock_rmtree: Mocks the cleanup (removal) of the temporary directory.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - The temporary directory is cleaned up (mock_rmtree is called once with the correct path).
         """
         self.mock_location_type.return_value = "url"

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -26,8 +26,8 @@ def remote_additional_code() -> AdditionalCode:
     fetched from a remote Git repository.
 
     Returns
-        AdditionalCode : An instance of the AdditionalCode class with preset
-        remote repository details.
+    -------
+    AdditionalCode : An AdditionalCode instance with pre-set remote repository details.
     """
     return AdditionalCode(
         location="https://github.com/test/repo.git",
@@ -53,8 +53,8 @@ def local_additional_code() -> AdditionalCode:
     code that resides on the local filesystem.
 
     Returns
-        AdditionalCode : An instance of the AdditionalCode class with preset
-        local directory details.
+    -------
+    AdditionalCode : An AdditionalCode instance with pre-set local directory details.
     """
     return AdditionalCode(
         location="/some/local/directory",

--- a/cstar/tests/unit_tests/base/test_datasource.py
+++ b/cstar/tests/unit_tests/base/test_datasource.py
@@ -7,7 +7,7 @@ from cstar.base.datasource import DataSource
 
 # Mock paths for local file tests
 @pytest.fixture
-def mock_netcdf_file_path(tmp_path):
+def mock_netcdf_file_path(tmp_path: Path) -> Path:
     """Fixture to return a temporary empty file with a .nc extension."""
     file_path = tmp_path / "testfile.nc"
     file_path.touch()  # create an empty file for testing
@@ -15,7 +15,7 @@ def mock_netcdf_file_path(tmp_path):
 
 
 @pytest.fixture
-def mock_yaml_file_path(tmp_path):
+def mock_yaml_file_path(tmp_path: Path) -> Path:
     """Fixture to return a temporary empty file with a .yaml extension."""
     file_path = tmp_path / "testfile.yaml"
     file_path.touch()  # create an empty file for testing
@@ -23,7 +23,7 @@ def mock_yaml_file_path(tmp_path):
 
 
 @pytest.fixture
-def mock_directory_path(tmp_path):
+def mock_directory_path(tmp_path: Path) -> Path:
     """Fixture to return a temporary empty directory."""
     dir_path = tmp_path / "test_dir"
     dir_path.mkdir()
@@ -31,7 +31,7 @@ def mock_directory_path(tmp_path):
 
 
 @pytest.fixture
-def mock_git_path(tmp_path):
+def mock_git_path(tmp_path: Path) -> Path:
     """Fixture to return a temporary mocked git repository."""
     git_dir = tmp_path / "test_repo.git"
     git_dir.mkdir()
@@ -40,84 +40,77 @@ def mock_git_path(tmp_path):
 
 
 # Tests for the `location_type` property
-def test_location_type_url():
+def test_location_type_url() -> None:
     """Check the DataSource.location_type property correctly returns 'url' for a remote
     data source."""
-
     data_source = DataSource("https://example.com/data.nc")
     assert data_source.location_type == "url"
 
 
-def test_location_type_path(mock_netcdf_file_path):
+def test_location_type_path(mock_netcdf_file_path: Path) -> None:
     """Check the DataSource.location_type property correctly returns 'path' for a local
     data file."""
-
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.location_type == "path"
 
 
-def test_location_type_invalid():
+def test_location_type_invalid() -> None:
     """Test the DataSource.location_type property raises a ValueError for an invalid
     location."""
+    data_source = DataSource("invalid_location")
 
-    with pytest.raises(ValueError):
-        data_source = DataSource("invalid_location")
-        data_source.location_type
+    with pytest.raises(ValueError):  # noqa: PT011
+        _ = data_source.location_type
 
 
 # Tests for the `source_type` property
-def test_source_type_netcdf(mock_netcdf_file_path):
+def test_source_type_netcdf(mock_netcdf_file_path: Path) -> None:
     """Test the DataSource.source_type property correctly returns 'netcdf' for a mock
     '.nc' file."""
-
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.source_type == "netcdf"
 
 
-def test_source_type_directory(mock_directory_path):
+def test_source_type_directory(mock_directory_path: Path) -> None:
     """Test the DataSource.source_type property correctly returns 'directory' for a
     temporary directory."""
-
     data_source = DataSource(mock_directory_path)
     assert data_source.source_type == "directory"
 
 
-def test_source_type_repository(mock_git_path):
+def test_source_type_repository(mock_git_path: Path) -> None:
     """Test the DataSource.source_type property correctly returns 'repository' for a
     mock git repository."""
-
     data_source = DataSource(mock_git_path)
     assert data_source.source_type == "repository"
 
 
-def test_source_type_yaml(mock_yaml_file_path):
+def test_source_type_yaml(mock_yaml_file_path: Path) -> None:
     """Test the DataSource.source_type property correctly returns 'yaml' for a mock
     '.yaml' file."""
     data_source = DataSource(mock_yaml_file_path)
     assert data_source.source_type == "yaml"
 
 
-def test_source_type_unsupported_extension(tmp_path):
+def test_source_type_unsupported_extension(tmp_path: Path) -> None:
     """Test the DataSource.source_type property raises a ValueError for an unsupported
     file."""
-
     unsupported_file = tmp_path / "data.unsupported"
     unsupported_file.touch()
     data_source = DataSource(unsupported_file)
-    with pytest.raises(ValueError):
-        data_source.source_type
+    with pytest.raises(ValueError):  # noqa: PT011
+        _ = data_source.source_type
 
 
-def test_basename(mock_netcdf_file_path):
+def test_basename(mock_netcdf_file_path: Path) -> None:
     """Test the DataSource.basename property correctly returns the filename and
     extension."""
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.basename == "testfile.nc"
 
 
-def test_str(mock_netcdf_file_path):
+def test_str(mock_netcdf_file_path: Path) -> None:
     """Test the string representation of DataSource."""
-
     expected_str = f"""DataSource
 ----------
  location: {mock_netcdf_file_path.resolve()}
@@ -129,14 +122,14 @@ def test_str(mock_netcdf_file_path):
     assert str(data_source) == expected_str
 
 
-def test_repr(mock_netcdf_file_path):
+def test_repr(mock_netcdf_file_path: Path) -> None:
     """Test the repr representation of DataSource."""
     data_source = DataSource(mock_netcdf_file_path)
     expected_repr = f"""DataSource(location={data_source.location!r})"""
     assert repr(data_source) == expected_repr
 
 
-def test_init_with_path_object(mock_netcdf_file_path):
+def test_init_with_path_object(mock_netcdf_file_path: Path) -> None:
     """Test the DataSource.location property when initialized with a Path object."""
     data_source = DataSource(Path(mock_netcdf_file_path))
     assert data_source.location == str(mock_netcdf_file_path)

--- a/cstar/tests/unit_tests/base/test_discretization.py
+++ b/cstar/tests/unit_tests/base/test_discretization.py
@@ -1,22 +1,20 @@
-import logging
-
 import pytest
 
 from cstar.base.discretization import Discretization
 
 
 @pytest.fixture
-def discretization():
+def discretization() -> Discretization:
     """Create a Discretization instance with fixed parameters for testing."""
     return Discretization(time_step=3)
 
 
-def test_init(discretization, log: logging.Logger):
+def test_init(discretization: Discretization) -> None:
     """Test the attributes were set correctly."""
     assert discretization.time_step == 3
 
 
-def test_str(discretization):
+def test_str(discretization: Discretization) -> None:
     """Test the string representation is correct."""
     expected_str = """Discretization
 --------------
@@ -24,7 +22,7 @@ time_step: 3s"""
     assert str(discretization) == expected_str
 
 
-def test_repr(discretization):
+def test_repr(discretization: Discretization) -> None:
     """Test the repr representation is correct."""
     expected_repr = "Discretization(time_step = 3)"
     assert repr(discretization) == expected_repr

--- a/cstar/tests/unit_tests/base/test_log.py
+++ b/cstar/tests/unit_tests/base/test_log.py
@@ -26,7 +26,9 @@ def levels_fn(all_levels: list[int]) -> t.Callable[[int], tuple[list[int], list[
     """Return a factory for creating a split of log levels above/below a fixed level.
 
     Returns
-        fn : t.Callable[list[int], list[int]]
+    -------
+    t.Callable[list[int], list[int]]
+        A function that will generate the list for the desired split
     """
 
     def _inner(level: int) -> tuple[list[int], list[int]]:
@@ -42,7 +44,8 @@ def levels_fn(all_levels: list[int]) -> t.Callable[[int], tuple[list[int], list[
 
         Returns
         -------
-            tuple[list[int], list[int]] : the lists of log levels
+        lt, gte : tuple[list[int], list[int]]
+            the of levels less than split, the levels greater  or equal to split
         """
         lt, gte = [], []
 

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -410,8 +410,8 @@ class TestReplaceTextInFile:
 
 
 class TestListToConciseStr:
-    """Tests for `_list_to_concise_str`, verifies correct behavior under different
-    list."""
+    """Tests for `_list_to_concise_str`, verifies correct behavior under different list
+    lengths and parameter configurations.."""
 
     def test_basic_case_no_truncation(self) -> None:
         """Test `_list_to_concise_str` with a short list that does not exceed

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,5 +1,8 @@
 import logging
 import pathlib
+from collections.abc import Generator
+from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -8,37 +11,37 @@ from cstar.base.log import get_logger
 
 @pytest.fixture
 def log() -> logging.Logger:
+    """Return the logger for logging during tests."""
     return get_logger("cstar.tests.unit_tests")
 
 
 @pytest.fixture
 def dotenv_path(tmp_path: pathlib.Path) -> pathlib.Path:
-    # A path to a temporary user environment configuration file
+    """Return a path to a temporary user environment configuration file."""
     return tmp_path / ".cstar.env"
 
 
 @pytest.fixture
 def marbl_path(tmp_path: pathlib.Path) -> pathlib.Path:
-    # A path to a temporary directory for writing the marbl code
+    """Return a path to a temporary directory for writing the marbl code."""
     return tmp_path / "marbl"
 
 
 @pytest.fixture
 def roms_path(tmp_path: pathlib.Path) -> pathlib.Path:
-    # A path to a temporary directory for writing the roms code
+    """Return a path to a temporary directory for writing the roms code."""
     return tmp_path / "roms"
 
 
 @pytest.fixture
 def system_dotenv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
-    # A path to a temporary directory for writing system-level
-    # environment configuration file
+    """Return a path for writing the system-level environment configuration file."""
     return tmp_path / "additional_files" / "env_files"
 
 
 @pytest.fixture
 def mock_system_name() -> str:
-    # A name for the mock system/platform executing the tests.
+    """Return a name for the mock system/platform executing the tests."""
     return "mock_system"
 
 
@@ -46,8 +49,36 @@ def mock_system_name() -> str:
 def system_dotenv_path(
     mock_system_name: str, system_dotenv_dir: pathlib.Path
 ) -> pathlib.Path:
-    # A path to a temporary, system-level environment configuration file
+    """Return a path to a temporary, system-level environment configuration file."""
     if not system_dotenv_dir.exists():
         system_dotenv_dir.mkdir(parents=True)
 
     return system_dotenv_dir / f"{mock_system_name}.env"
+
+
+@pytest.fixture
+def mock_input_y() -> Generator[Any, Any, Any]:
+    """Return a mock input that returns the value 'y'."""
+    with mock.patch("builtins.input", side_effect=["y"]):
+        yield
+
+
+@pytest.fixture
+def mock_input_n() -> Generator[Any, Any, Any]:
+    """Return a mock input that returns the value 'n'."""
+    with mock.patch("builtins.input", side_effect=["n"]):
+        yield
+
+
+@pytest.fixture
+def mock_input_invalid() -> Generator[Any, Any, Any]:
+    """Return a value that does not work as a valid confirm or deny."""
+    with mock.patch("builtins.input", side_effect=["not y or n"]):
+        yield
+
+
+@pytest.fixture
+def mock_input_with_custom_path() -> Generator[Any, Any, Any]:
+    """Return a mock input that returns a custom sub-path."""
+    with mock.patch("builtins.input", side_effect=["custom", "some/install/path"]):
+        yield

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -139,7 +139,8 @@ class TestSlurmJob:
         new_callable=PropertyMock,
     )
     def test_script_task_distribution_required(
-        self, mock_global_max_cpus: MagicMock
+        self,
+        mock_global_max_cpus: MagicMock,
     ) -> None:
         """Verifies the job script is correctly generated when the nodes x cpu
         distribution is required by the system.

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -5,14 +5,14 @@ from unittest import mock
 import dotenv
 import pytest
 
+from cstar.base.external_codebase import ExternalCodeBase
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 
 
 @pytest.fixture
-def marbl_codebase():
-    """Fixture providing a configured instance of `MARBLExternalCodeBase` for
-    testing."""
+def marbl_codebase() -> ExternalCodeBase:
+    """Retuns a configured instance of `MARBLExternalCodeBase` for testing."""
     source_repo = "https://github.com/marbl-ecosys/MARBL.git"
     checkout_target = "marbl0.45.0"
     return MARBLExternalCodeBase(
@@ -20,7 +20,7 @@ def marbl_codebase():
     )
 
 
-def test_default_source_repo(marbl_codebase):
+def test_default_source_repo(marbl_codebase: ExternalCodeBase) -> None:
     """Test if the default source repo is set correctly."""
     assert (
         marbl_codebase.default_source_repo
@@ -28,20 +28,19 @@ def test_default_source_repo(marbl_codebase):
     )
 
 
-def test_default_checkout_target(marbl_codebase):
+def test_default_checkout_target(marbl_codebase: ExternalCodeBase) -> None:
     """Test if the default checkout target is set correctly."""
     assert marbl_codebase.default_checkout_target == "marbl0.45.0"
 
 
-def test_expected_env_var(marbl_codebase):
+def test_expected_env_var(marbl_codebase: ExternalCodeBase) -> None:
     """Test if the expected environment variable is set correctly."""
     assert marbl_codebase.expected_env_var == "MARBL_ROOT"
 
 
-def test_defaults_are_set():
+def test_defaults_are_set() -> None:
     """Test that the defaults are set correctly if MARBLExternalCodeBase initialized
     without args."""
-
     marbl_codebase = MARBLExternalCodeBase()
     assert marbl_codebase.source_repo == "https://github.com/marbl-ecosys/MARBL.git"
     assert marbl_codebase.checkout_target == "marbl0.45.0"
@@ -77,8 +76,8 @@ class TestMARBLExternalCodeBaseGet:
         Mocks `os.environ` to control environment variables during tests.
     """
 
-    def setup_method(self):
-        """Common setup before each test method."""
+    def setup_method(self) -> None:
+        """Perform common setup before each test method."""
         # Mock subprocess and _clone_and_checkout
         self.mock_subprocess_run = mock.patch("subprocess.run").start()
         self.mock_clone_and_checkout = mock.patch(
@@ -89,8 +88,8 @@ class TestMARBLExternalCodeBaseGet:
         self.env_patch = mock.patch.dict(os.environ, {}, clear=True)
         self.env_patch.start()
 
-    def teardown_method(self):
-        """Common teardown after each test method."""
+    def teardown_method(self) -> None:
+        """Perform common teardown after each test method."""
         mock.patch.stopall()
 
     def test_get_success(
@@ -98,7 +97,7 @@ class TestMARBLExternalCodeBaseGet:
         dotenv_path: pathlib.Path,
         marbl_path: pathlib.Path,
         marbl_codebase: MARBLExternalCodeBase,
-    ):
+    ) -> None:
         """Test that the get method succeeds when subprocess calls succeed."""
         # Setup:
         ## Mock success of calls to subprocess.run:
@@ -107,10 +106,7 @@ class TestMARBLExternalCodeBaseGet:
         key = marbl_codebase.expected_env_var
         value = str(marbl_path)
 
-        with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
-        ):
+        with mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path):
             # Test
             ## Call the get method
             marbl_codebase.get(target=marbl_path)
@@ -138,14 +134,15 @@ class TestMARBLExternalCodeBaseGet:
                 shell=True,
             )
 
-    def test_make_failure(self, marbl_codebase, tmp_path):
+    def test_make_failure(
+        self, marbl_codebase: ExternalCodeBase, tmp_path: pathlib.Path
+    ) -> None:
         """Test that the get method raises an error when 'make' fails."""
-
         ## There are two subprocess calls, we'd like one fail, one pass:
         dotenv_path = tmp_path / ".cstar.env"
 
         self.mock_subprocess_run.side_effect = [
-            mock.Mock(returncode=1, stderr="Mocked MARBL Compilation Failure"),
+            mock.Mock(returncode=1, stderr="Mocked MARBL Compilation Failure")
         ]
 
         # Test
@@ -157,9 +154,6 @@ class TestMARBLExternalCodeBaseGet:
                     "Mocked MARBL Compilation Failure"
                 ),
             ),
-            mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
-            ),
+            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -106,7 +106,10 @@ class TestMARBLExternalCodeBaseGet:
         key = marbl_codebase.expected_env_var
         value = str(marbl_path)
 
-        with mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path):
+        with mock.patch(
+            "cstar.system.environment.CSTAR_USER_ENV_PATH",
+            dotenv_path,
+        ):
             # Test
             ## Call the get method
             marbl_codebase.get(target=marbl_path)
@@ -154,6 +157,9 @@ class TestMARBLExternalCodeBaseGet:
                     "Mocked MARBL Compilation Failure"
                 ),
             ),
-            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
+            mock.patch(
+                "cstar.system.environment.CSTAR_USER_ENV_PATH",
+                dotenv_path,
+            ),
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/roms/test_roms_discretization.py
+++ b/cstar/tests/unit_tests/roms/test_roms_discretization.py
@@ -4,37 +4,37 @@ from cstar.roms.discretization import ROMSDiscretization
 
 
 @pytest.fixture
-def roms_discretization():
+def roms_discretization() -> ROMSDiscretization:
     """Create a ROMSDiscretization instance with fixed parameters for testing."""
     return ROMSDiscretization(time_step=3, n_procs_x=2, n_procs_y=123)
 
 
-def test_init(roms_discretization):
+def test_init(roms_discretization: ROMSDiscretization) -> None:
     """Test the attributes were set correctly."""
     assert roms_discretization.time_step == 3
     assert roms_discretization.n_procs_x == 2
     assert roms_discretization.n_procs_y == 123
 
 
-def test_defaults():
+def test_defaults() -> None:
     """Test defaults are set correctly when not provided."""
     roms_discretization = ROMSDiscretization(time_step=3)
     assert roms_discretization.n_procs_x == 1
     assert roms_discretization.n_procs_y == 1
 
 
-def test_n_procs_tot(roms_discretization):
+def test_n_procs_tot(roms_discretization: ROMSDiscretization) -> None:
     """Test the n_procs_tot property correctly multiplies n_procs_x and n_procs_y."""
     assert roms_discretization.n_procs_tot == 2 * 123
 
 
-def test_repr(roms_discretization):
+def test_repr(roms_discretization: ROMSDiscretization) -> None:
     """Test the repr representation is correct."""
     expected_repr = "ROMSDiscretization(time_step = 3, n_procs_x = 2, n_procs_y = 123)"
     assert repr(roms_discretization) == expected_repr
 
 
-def test_str(roms_discretization):
+def test_str(roms_discretization: ROMSDiscretization) -> None:
     """Test the string representation is correct."""
     expected_str = """ROMSDiscretization
 ------------------

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -115,7 +115,10 @@ class TestROMSExternalCodeBaseGet:
     ) -> None:
         """Test that the get method succeeds when subprocess calls succeed."""
         # Setup:
-        with mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path):
+        with mock.patch(
+            "cstar.system.environment.CSTAR_USER_ENV_PATH",
+            dotenv_path,
+        ):
             ## Mock success of calls to subprocess.run:
             self.mock_subprocess_run.return_value.returncode = 0
 
@@ -187,7 +190,10 @@ class TestROMSExternalCodeBaseGet:
                 RuntimeError,
                 match="Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\nCompiling NHMG library failed successfully",
             ),
-            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
+            mock.patch(
+                "cstar.system.environment.CSTAR_USER_ENV_PATH",
+                dotenv_path,
+            ),
         ):
             roms_codebase.get(target=tmp_path)
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -5,12 +5,13 @@ from unittest import mock
 import dotenv
 import pytest
 
+from cstar.base.external_codebase import ExternalCodeBase
 from cstar.roms.external_codebase import ROMSExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 
 
 @pytest.fixture
-def roms_codebase():
+def roms_codebase() -> ExternalCodeBase:
     """Fixture providing a configured instance of `ROMSExternalCodeBase` for testing."""
     source_repo = "https://github.com/CESR-lab/ucla-roms.git"
     checkout_target = "246c11fa537145ba5868f2256dfb4964aeb09a25"
@@ -19,26 +20,25 @@ def roms_codebase():
     )
 
 
-def test_default_source_repo(roms_codebase):
+def test_default_source_repo(roms_codebase: ExternalCodeBase) -> None:
     """Test if the default source repo is set correctly."""
     assert (
         roms_codebase.default_source_repo == "https://github.com/CESR-lab/ucla-roms.git"
     )
 
 
-def test_default_checkout_target(roms_codebase):
+def test_default_checkout_target(roms_codebase: ExternalCodeBase) -> None:
     """Test if the default checkout target is set correctly."""
     assert roms_codebase.default_checkout_target == "main"
 
 
-def test_expected_env_var(roms_codebase):
+def test_expected_env_var(roms_codebase: ExternalCodeBase) -> None:
     """Test if the expected environment variable is set correctly."""
     assert roms_codebase.expected_env_var == "ROMS_ROOT"
 
 
-def test_defaults_are_set():
+def test_defaults_are_set() -> None:
     """Test that the defaults are set correctly."""
-
     roms_codebase = ROMSExternalCodeBase()
     assert roms_codebase.source_repo == "https://github.com/CESR-lab/ucla-roms.git"
     assert roms_codebase.checkout_target == "main"
@@ -89,8 +89,8 @@ class TestROMSExternalCodeBaseGet:
         Mocks `os.environ` to control and simulate environment variable modifications.
     """
 
-    def setup_method(self):
-        """Common setup before each test method."""
+    def setup_method(self) -> None:
+        """Perform common setup before each test method."""
         # Mock subprocess, _clone_and_checkout, and _write_to_config_file
         self.mock_subprocess_run = mock.patch("subprocess.run").start()
         self.mock_clone_and_checkout = mock.patch(
@@ -103,8 +103,8 @@ class TestROMSExternalCodeBaseGet:
         self.env_patch = mock.patch.dict(os.environ, {}, clear=True)
         self.env_patch.start()
 
-    def teardown_method(self):
-        """Common teardown after each test method."""
+    def teardown_method(self) -> None:
+        """Perform common teardown after each test method."""
         mock.patch.stopall()
 
     def test_get_success(
@@ -112,13 +112,10 @@ class TestROMSExternalCodeBaseGet:
         dotenv_path: pathlib.Path,
         roms_path: pathlib.Path,
         roms_codebase: ROMSExternalCodeBase,
-    ):
+    ) -> None:
         """Test that the get method succeeds when subprocess calls succeed."""
         # Setup:
-        with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
-        ):
+        with mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path):
             ## Mock success of calls to subprocess.run:
             self.mock_subprocess_run.return_value.returncode = 0
 
@@ -171,9 +168,10 @@ class TestROMSExternalCodeBaseGet:
                 shell=True,
             )
 
-    def test_make_nhmg_failure(self, roms_codebase, tmp_path):
+    def test_make_nhmg_failure(
+        self, roms_codebase: ExternalCodeBase, tmp_path: pathlib.Path
+    ) -> None:
         """Test that the get method raises an error when 'make nhmg' fails."""
-
         ## There are two subprocess calls, we'd like one fail, one pass:
         self.mock_subprocess_run.side_effect = [
             mock.Mock(
@@ -189,10 +187,7 @@ class TestROMSExternalCodeBaseGet:
                 RuntimeError,
                 match="Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\nCompiling NHMG library failed successfully",
             ),
-            mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
-            ),
+            mock.patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
         ):
             roms_codebase.get(target=tmp_path)
 
@@ -200,9 +195,10 @@ class TestROMSExternalCodeBaseGet:
         ## Check that subprocess.run was called only once due to failure
         assert self.mock_subprocess_run.call_count == 1
 
-    def test_make_tools_roms_failure(self, roms_codebase, tmp_path):
+    def test_make_tools_roms_failure(
+        self, roms_codebase: ExternalCodeBase, tmp_path: pathlib.Path
+    ) -> None:
         """Test that the get method raises an error when 'make Tools-Roms' fails."""
-
         # Simulate success for `make nhmg` and failure for `make Tools-Roms`
         self.mock_subprocess_run.side_effect = [
             mock.Mock(returncode=0),  # Success for nhmg

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -1,7 +1,9 @@
 import datetime as dt
 import logging
+from collections.abc import Generator
 from pathlib import Path
 from textwrap import dedent
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -13,11 +15,18 @@ from cstar.roms import ROMSForcingCorrections, ROMSInputDataset, ROMSPartitionin
 class MockROMSInputDataset(ROMSInputDataset):
     """A minimal example subclass of the ROMSInputDataset abstract base class."""
 
-    pass
+
+@pytest.fixture
+def mock_get_hash() -> Generator[Any, Any, Any]:
+    """Return a mock method that produces a good hash."""
+    with mock.patch(
+        "cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash"
+    ):
+        yield
 
 
 @pytest.fixture
-def local_roms_netcdf_dataset():
+def local_roms_netcdf_dataset() -> Generator[ROMSInputDataset, None, None]:
     """Fixture to provide a ROMSInputDataset with a local NetCDF source.
 
     Mocks:
@@ -26,8 +35,8 @@ def local_roms_netcdf_dataset():
     - DataSource.source_type: Property mocked as 'netcdf'
     - DataSource.basename: Property mocked as 'local_file.nc'
 
-    Yields:
-    -------
+    Yields
+    ------
         MockROMSInputDataset: A mock dataset pointing to a local NetCDF file.
     """
     with (
@@ -51,7 +60,7 @@ def local_roms_netcdf_dataset():
 
 
 @pytest.fixture
-def local_roms_yaml_dataset():
+def local_roms_yaml_dataset() -> Generator[ROMSInputDataset, None, None]:
     """Fixture to provide a ROMSInputDataset with a local YAML source.
 
     Mocks:
@@ -60,8 +69,8 @@ def local_roms_yaml_dataset():
     - DataSource.source_type: Property mocked as 'yaml'
     - DataSource.basename: Property mocked as 'local_file.yaml'
 
-    Yields:
-    -------
+    Yields
+    ------
         MockROMSInputDataset: A mock dataset pointing to a local YAML file.
     """
     with (
@@ -89,7 +98,7 @@ def local_roms_yaml_dataset():
 
 
 @pytest.fixture
-def remote_roms_yaml_dataset():
+def remote_roms_yaml_dataset() -> Generator[ROMSInputDataset, None, None]:
     """Fixture to provide a ROMSInputDataset with a remote YAML source.
 
     Mocks:
@@ -98,8 +107,8 @@ def remote_roms_yaml_dataset():
     - DataSource.source_type: Property mocked as 'yaml'
     - DataSource.basename: Property mocked as 'remote_file.yaml'
 
-    Yields:
-    -------
+    Yields
+    ------
         MockROMSInputDataset: A mock dataset pointing to a local YAML file.
     """
     with (
@@ -147,25 +156,28 @@ class TestStrAndRepr:
       correct format.
     """
 
-    def test_str_with_partitioned_files(self, local_roms_netcdf_dataset):
+    def test_str_with_partitioned_files(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Test the ROMSInputDataset string representation has correct substring for
         partitioned_files.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_netcdf_dataset: Provides a ROMSInputDataset with a local NetCDF source.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - String representation of the dataset includes the list of
           partitioned files in the correct format.
         """
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1,
             np_eta=2,
+            # files=[Path("local_file.001.nc"), Path("local_file.002.nc")],
             files=[
-                "local_file.001.nc",
-                "local_file.002.nc",
+                Path("local_file.001.nc"),
+                Path("local_file.002.nc"),
             ],
         )
         expected_str = (
@@ -179,29 +191,31 @@ class TestStrAndRepr:
             expected_str in actual_str
         ), f"Expected:\n{expected_str}\nBut got:\n{actual_str}"
 
-    def test_repr_with_partitioned_files(self, local_roms_netcdf_dataset):
+    def test_repr_with_partitioned_files(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Test the ROMSInputDataset repr includes `partitioned_files`.
 
         This test ensures that the `repr` output of a `ROMSInputDataset` object
         contains the `partitioned_files` attribute formatted as expected.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_netcdf_dataset`: Provides a mock ROMSInputDataset object
           with a local NetCDF source.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - The `partitioned_files` attribute is included in the repr output.
         - The format of the `partitioned_files` list matches the expected string output.
         """
-
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1,
             np_eta=2,
+            # files=[Path("local_file.001.nc"), Path("local_file.002.nc")],
             files=[
-                "local_file.001.nc",
-                "local_file.002.nc",
+                Path("local_file.001.nc"),
+                Path("local_file.002.nc"),
             ],
         )
         expected_repr = dedent(
@@ -220,8 +234,8 @@ class TestStrAndRepr:
         ), f"Expected:\n{expected_repr}\nBut got:\n{actual_repr}"
 
     def test_repr_with_partitioned_files_and_working_path(
-        self, local_roms_netcdf_dataset
-    ):
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Test the ROMSInputDataset repr includes `partitioned_files` and
         `working_path`.
 
@@ -229,27 +243,27 @@ class TestStrAndRepr:
         contains both the `partitioned_files` and `working_path` attributes formatted
         as expected.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_netcdf_dataset`: Provides a mock ROMSInputDataset object
           with a local NetCDF source.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - The `working_path` and `partitioned_files` attributes are included in the repr output.
         - The format of both attributes matches the expected string output.
         """
-
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1,
             np_eta=2,
+            # files=[Path("local_file.001.nc"), Path("local_file.002.nc")],
             files=[
-                "local_file.001.nc",
-                "local_file.002.nc",
+                Path("local_file.001.nc"),
+                Path("local_file.002.nc"),
             ],
         )
 
-        local_roms_netcdf_dataset.working_path = "/some/path/local_file.nc"
+        local_roms_netcdf_dataset.working_path = Path("/some/path/local_file.nc")
 
         expected_repr = dedent(
             """\
@@ -292,7 +306,7 @@ class TestROMSInputDatasetGet:
       Confirms that the method exits early for non-YAML input datasets.
     """
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up common patches and mocks for each test in TestROMSInputDatasetGet.
 
         This method initializes patches and mocks for methods and classes commonly
@@ -312,7 +326,6 @@ class TestROMSInputDatasetGet:
             - Mocks the `from_yaml` method for creating instances.
             - Mocks specific SurfaceForcing instances, including their `save` method.
         """
-
         # Mocking InputDataset.get()
         self.patch_get = mock.patch(
             "cstar.roms.input_dataset.InputDataset.get", autospec=True
@@ -363,16 +376,19 @@ class TestROMSInputDatasetGet:
         # Explicitly create a mock for the SurfaceForcing instance
         self.mock_rt_surface_forcing_instance = mock.Mock()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Stop all patches."""
         mock.patch.stopall()
 
-    @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
+    @pytest.mark.usefixtures("mock_get_hash")
     @mock.patch("pathlib.Path.stat", autospec=True)
     @mock.patch("requests.get", autospec=True)
     def test_get_grid_from_remote_yaml(
-        self, mock_request, mock_stat, mock_get_hash, remote_roms_yaml_dataset
-    ):
+        self,
+        mock_request: mock.Mock,
+        mock_stat: mock.Mock,
+        remote_roms_yaml_dataset: ROMSInputDataset,
+    ) -> None:
         """Test the `get` method for ROMS grid files from a remote YAML source.
 
         This test ensures the `get` method correctly processes a `roms-tools` YAML file to
@@ -380,8 +396,8 @@ class TestROMSInputDatasetGet:
         editing it in memory, creating a Grid object,
         and saving the Grid object.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `remote_roms_yaml_dataset`: Provides a ROMSInputDataset instance with a remote YAML source.
 
         Mocks:
@@ -392,15 +408,14 @@ class TestROMSInputDatasetGet:
         - `roms_tools.Grid.from_yaml`: Simulates creating a Grid object from the YAML file.
         - `roms_tools.Grid.save`: Simulates saving Grid data as a NetCDF file.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Confirms `resolve` is called for the directory, and saved file.
         - Ensures `yaml.safe_load` processes the YAML content as expected.
         - Validates `roms_tools.Grid.from_yaml` creates the Grid object from the YAML file.
         - Verifies `roms_tools.Grid.save` saves files with correct parameters.
         - Ensures metadata and checksums for saved file is cached via `stat` and `_get_sha256_hash`.
         """
-
         # Mock the stat result
         mock_stat_result = mock.Mock(
             st_size=12345, st_mtime=1678901234, st_mode=0o100644
@@ -418,7 +433,7 @@ class TestROMSInputDatasetGet:
 
         # Mock the list of paths returned by roms_tools.save
         self.mock_rt_grid_instance.save.return_value = [
-            Path("some/local/dir/remote_file.nc"),
+            Path("some/local/dir/remote_file.nc")
         ]
 
         # Mock yaml loading
@@ -460,16 +475,19 @@ class TestROMSInputDatasetGet:
     @mock.patch("pathlib.Path.stat", autospec=True)
     @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
     def test_get_surface_forcing_from_local_yaml(
-        self, mock_get_hash, mock_stat, local_roms_yaml_dataset
-    ):
+        self,
+        mock_get_hash: mock.Mock,  # noqa: ARG002
+        mock_stat: mock.Mock,
+        local_roms_yaml_dataset: ROMSInputDataset,
+    ) -> None:
         """Test the `get` method for creating SurfaceForcing from a local YAML source.
 
         This test verifies that the `get` method processes a `roms-tools` YAML file correctly to
         create a SurfaceForcing dataset. It ensures proper handling of YAML
         content and the creation of associated NetCDF files.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_yaml_dataset`: Provides a ROMSInputDataset instance with a local YAML source.
 
         Mocks:
@@ -480,8 +498,8 @@ class TestROMSInputDatasetGet:
         - `roms_tools.SurfaceForcing.from_yaml`: Simulates creating a SurfaceForcing object from the YAML file.
         - `roms_tools.SurfaceForcing.save`: Simulates saving SurfaceForcing data as a NetCDF file.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Ensures the start and end times in the YAML dictionary are updated correctly.
         - Validates that `get` is called on the YAML file with the correct arguments.
         - Verifies `yaml.safe_load` processes the YAML content correctly.
@@ -489,7 +507,6 @@ class TestROMSInputDatasetGet:
         - Ensures `roms_tools.SurfaceForcing.save` saves the file with the correct parameters.
         - Verifies file metadata and checksum caching via `stat` and `_get_sha256_hash`.
         """
-
         # Mock resolve to return a resolved path
         self.mock_resolve.side_effect = [
             Path("some/local/dir"),  # First resolve: local_dir
@@ -557,7 +574,9 @@ class TestROMSInputDatasetGet:
             mock_stat.call_count == 1
         ), f"Expected stat to be called 1 time, but got {mock_stat.call_count} calls."
 
-    def test_get_from_yaml_raises_if_not_yaml(self, local_roms_netcdf_dataset):
+    def test_get_from_yaml_raises_if_not_yaml(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Tests that the `ROMSInputDataset._get_from_yaml` method raises if called from
         a ROMSInputDataset whose source.source_type is not 'yaml'.
 
@@ -574,20 +593,22 @@ class TestROMSInputDatasetGet:
             ValueError,
             match="_get_from_yaml requires a ROMSInputDataset whose source_type is yaml",
         ):
-            local_roms_netcdf_dataset._get_from_yaml(local_dir="/some/dir")
+            local_roms_netcdf_dataset._get_from_yaml(  # noqa: SLF001
+                local_dir="/some/dir"
+            )
 
     @mock.patch("pathlib.Path.stat", autospec=True)
     def test_get_raises_with_wrong_number_of_keys(
-        self, mock_stat, local_roms_yaml_dataset
-    ):
+        self, mock_stat: mock.Mock, local_roms_yaml_dataset: ROMSInputDataset
+    ) -> None:
         """Test that the `get` method raises a ValueError when the YAML file contains
         more than two sections.
 
         This test ensures that the `get` method validates the structure of the YAML file
         and raises an error if the file contains more than two sections (e.g., `Grid` and one other).
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_yaml_dataset`: Provides a ROMSInputDataset with a local YAML source.
 
         Mocks:
@@ -595,14 +616,13 @@ class TestROMSInputDatasetGet:
         - `Path.resolve`: Simulates resolving the path to the source yaml file
         - `yaml.safe_load`: Simulates loading YAML content from a file with too many sections.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Ensures `resolve` is called to determine the actual path of the YAML file.
         - Ensures `yaml.safe_load` is invoked to parse the YAML content.
         - Confirms that a `ValueError` is raised when the YAML file contains more than two sections.
         - Validates that the exception message matches the expected error message.
         """
-
         # Mock resolve to return a resolved path
         resolved_path = Path("/resolved/path/to/local_file.yaml")
         self.mock_resolve.side_effect = [
@@ -627,13 +647,13 @@ class TestROMSInputDatasetGet:
         mock_stat.return_value = mock_stat_result
 
         # Call the method under test and expect a ValueError
-        with pytest.raises(ValueError) as exception_info:
+        with pytest.raises(ValueError) as exception_info:  # noqa: PT011
             local_roms_yaml_dataset.get(local_dir="some/local/dir")
 
         # Define the expected error message
         expected_message = (
             "roms tools yaml file has 3 sections. "
-            + "Expected 'Grid' and one other class"
+            "Expected 'Grid' and one other class"
         )
 
         # Assert the error message matches
@@ -649,10 +669,10 @@ class TestROMSInputDatasetGet:
     )
     def test_get_skips_if_working_path_in_same_parent_dir(
         self,
-        mock_exists_locally,
-        local_roms_yaml_dataset,
+        mock_exists_locally: mock.Mock,
+        local_roms_yaml_dataset: ROMSInputDataset,
         caplog: pytest.LogCaptureFixture,
-    ):
+    ) -> None:
         """Test that the `get` method skips execution when `working_path` is set and
         points to the same parent directory as `local_dir`.
 
@@ -660,23 +680,22 @@ class TestROMSInputDatasetGet:
         as the specified `local_dir`, the `get` method does not proceed with further
         file operations.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_yaml_dataset`: Provides a ROMSInputDataset with a mocked `source` attribute.
         - `caplog`: Captures log outputs to verify the correct skip message is displayed.
 
-        Mocks:
-        ------
+        Mocks
+        -----
         - `exists_locally`: Simulates the local existence check for `working_path`.
         - `Path.resolve`: Simulates resolving paths to their actual locations.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Ensures the skip message is printed when `working_path` exists in `local_dir`.
         - Confirms that no further operations (e.g., copying, YAML parsing) are performed.
         - An information message is logged
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_yaml_dataset.log.name)
 
         # Mock `working_path` to point to a file in `some/local/dir`
@@ -704,10 +723,10 @@ class TestROMSInputDatasetGet:
     )
     def test_get_skips_if_working_path_list_in_same_parent_dir(
         self,
-        mock_exists_locally,
-        local_roms_yaml_dataset,
+        mock_exists_locally: mock.Mock,
+        local_roms_yaml_dataset: ROMSInputDataset,
         caplog: pytest.LogCaptureFixture,
-    ):
+    ) -> None:
         """Test that the `get` method skips execution when `working_path` is a list and
         its first element points to the same parent directory as `local_dir`.
 
@@ -715,22 +734,21 @@ class TestROMSInputDatasetGet:
         its elements exists in the same parent directory as `local_dir`, the `get` method
         does not proceed with further file operations.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - `local_roms_yaml_dataset`: Provides a ROMSInputDataset with a mocked `source` attribute.
         - `caplog`: Captures log outputs to verify the correct skip message is displayed.
 
-        Mocks:
+        Mocks
         ------
         - `exists_locally`: Simulates the local existence check for `working_path`.
         - `Path.resolve`: Simulates resolving paths to their actual locations.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Ensures the skip message is printed when a `working_path` in the list exists in `local_dir`.
         - Confirms that no further operations (e.g., copying, YAML parsing) are performed.
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_yaml_dataset.log.name)
 
         # Mock `working_path` to be a list pointing to files in `some/local/dir`
@@ -758,29 +776,31 @@ class TestROMSInputDatasetGet:
         "cstar.base.input_dataset.InputDataset.exists_locally",
         new_callable=mock.PropertyMock,
     )
-    def test_get_exits_if_not_yaml(self, mock_exists_locally, local_roms_yaml_dataset):
+    def test_get_exits_if_not_yaml(
+        self, mock_exists_locally: mock.Mock, local_roms_yaml_dataset: ROMSInputDataset
+    ) -> None:
         """Test that the `get` method exits early if `self.source.source_type` is not
         'yaml'.
 
         This test ensures that the `get` method performs no further operations if the input dataset's
         source type is not 'yaml', ensuring that early returns function correctly.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_yaml_dataset: Provides a ROMSInputDataset with a mocked `source` attribute.
         - mock_exists_locally: Mocks the `exists_locally` property to simulate the file's existence.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - Ensures the parent class `get` method (`self.mock_get`) is called with the correct arguments.
         - Ensures no further actions (e.g., loading, modifying YAML, or saving files) occur.
         - Ensures no messages are printed during the method's execution.
         """
         # Mock the `source` attribute and its `source_type` property
         mock_source = mock.Mock()
-        type(mock_source).source_type = mock.PropertyMock(
-            return_value="netcdf"
-        )  # Non-yaml type
+
+        # set up the mock to return a non-yaml value
+        type(mock_source).source_type = mock.PropertyMock(return_value="netcdf")
 
         # Assign the mocked `source` to the dataset
         with mock.patch.object(local_roms_yaml_dataset, "source", mock_source):
@@ -809,8 +829,10 @@ class TestROMSInputDatasetGet:
         autospec=True,
     )
     def test_get_with_partitioned_source(
-        self, mock_get_from_partitioned_source, local_roms_netcdf_dataset
-    ):
+        self,
+        mock_get_from_partitioned_source: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Tests the 'get' method calls _get_from_partitioned_source when the
         ROMSInputDataset has a partitioned source.
 
@@ -825,11 +847,10 @@ class TestROMSInputDatasetGet:
         -------
         - _get_from_partitioned_source is called once with the expected arguments
         """
-
         self.mock_resolve.return_value = Path("/some/dir")
 
         # Set source partitioning attributes
-        local_roms_netcdf_dataset.source._location = (
+        local_roms_netcdf_dataset.source._location = (  # noqa: SLF001
             "some/local/source/path/local_file.00.nc"
         )
         local_roms_netcdf_dataset.source_np_xi = 4
@@ -852,11 +873,11 @@ class TestROMSInputDatasetGet:
     @mock.patch("cstar.roms.input_dataset.Path.stat")
     def test_get_from_partitioned_source(
         self,
-        mock_path_stat,
-        mock_get_hash,
-        mock_symlink_or_download,
-        local_roms_netcdf_dataset,
-    ):
+        mock_path_stat: mock.Mock,  # noqa: ARG002
+        mock_get_hash: mock.Mock,
+        mock_symlink_or_download: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Tests the _get_from_partitioned_source helper method.
 
         This test takes an example ROMSInputDataset whose source is partitioned into
@@ -880,18 +901,15 @@ class TestROMSInputDatasetGet:
         - Asserts the calls to _symlink_or_download_from_source have expected arguments
         - Asserts the `ROMSInputDataset.partitioning` attribute is set as expected
         """
-
         # Set source partitioning attributes
-        local_roms_netcdf_dataset.source._location = (
+        local_roms_netcdf_dataset.source._location = (  # noqa: SLF001
             "some/local/source/path/local_file.00.nc"
         )
         local_roms_netcdf_dataset.source_np_xi = 4
         local_roms_netcdf_dataset.source_np_eta = 3
 
-        local_roms_netcdf_dataset._get_from_partitioned_source(
-            local_dir=Path("/some/dir"),
-            source_np_xi=4,
-            source_np_eta=3,
+        local_roms_netcdf_dataset._get_from_partitioned_source(  # noqa: SLF001
+            local_dir=Path("/some/dir"), source_np_xi=4, source_np_eta=3
         )
 
         mock_get_hash.side_effect = [f"mock_hash_{i}" for i in range(12)]
@@ -903,7 +921,6 @@ class TestROMSInputDatasetGet:
                 location_type="path",
                 expected_file_hash=None,
                 target_path=mock.ANY,
-                logger=mock.ANY,
             )
             for i in range(12)
         ]
@@ -912,6 +929,7 @@ class TestROMSInputDatasetGet:
 
         expected_files = [Path(f"/some/dir/local_file.{i:02d}.nc") for i in range(12)]
 
+        assert local_roms_netcdf_dataset.partitioning is not None
         assert local_roms_netcdf_dataset.partitioning.np_xi == 4
         assert local_roms_netcdf_dataset.partitioning.np_eta == 3
         assert local_roms_netcdf_dataset.partitioning.files == expected_files
@@ -944,24 +962,28 @@ class TestROMSInputDatasetPartition:
         Validates that an error is raised if files span multiple directories.
     """
 
-    def setup_method(self):
+    def setup_method(self) -> None:
+        """Set up the common mocks."""
         self.patch_mkdir = mock.patch("pathlib.Path.mkdir", autospec=True)
         self.mock_mkdir = self.patch_mkdir.start()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Stop all patches."""
         mock.patch.stopall()
 
-    def test_source_partitioning(self, local_roms_netcdf_dataset):
+    def test_source_partitioning(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Test the ROMSInputDataset.source_partitioning property."""
         local_roms_netcdf_dataset.source_np_xi = 4
         local_roms_netcdf_dataset.source_np_eta = 3
 
         assert local_roms_netcdf_dataset.source_partitioning == (4, 3)
 
-    def test_to_dict_with_source_partitioning(self, local_roms_netcdf_dataset):
+    def test_to_dict_with_source_partitioning(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Test the ROMSInputDataset.to_dict() method with a partitioned source file."""
-
         local_roms_netcdf_dataset.source_np_xi = 4
         local_roms_netcdf_dataset.source_np_eta = 3
 
@@ -969,12 +991,15 @@ class TestROMSInputDatasetPartition:
         assert test_dict["source_np_xi"] == 4
         assert test_dict["source_np_eta"] == 3
 
-    @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
+    @pytest.mark.usefixtures("mock_get_hash")
     @mock.patch("pathlib.Path.stat", autospec=True)
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_single_file(
-        self, mock_partition_netcdf, mock_get_hash, mock_stat, local_roms_netcdf_dataset
-    ):
+        self,
+        mock_partition_netcdf: mock.Mock,
+        mock_stat: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Ensures that a single NetCDF file is partitioned and tracked correctly.
 
         Mocks:
@@ -984,17 +1009,16 @@ class TestROMSInputDatasetPartition:
         - _get_sha256_hash: Mocks file shasum calculation
         - Path.resolve: Mocks the resolution of the partitioned filepaths
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_netcdf_dataset: Provides a dataset with a single NetCDF file.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - `partition_netcdf` is called with the correct arguments.
         - `ROMSInputDataset.partitioning.files` is updated with the expected file paths.
         - `Path.stat` is called once for each partitioned file
         """
-
         np_xi, np_eta = 2, 3
         num_partitions = np_xi * np_eta
 
@@ -1037,6 +1061,7 @@ class TestROMSInputDatasetPartition:
                     local_roms_netcdf_dataset.working_path, np_xi=np_xi, np_eta=np_eta
                 )
 
+                assert local_roms_netcdf_dataset.partitioning is not None
                 assert (
                     local_roms_netcdf_dataset.partitioning.files
                     == expected_partitioned_files
@@ -1047,12 +1072,15 @@ class TestROMSInputDatasetPartition:
                     mock_stat.call_count == 6
                 ), f"Expected stat to be called 6 times, but got {mock_stat.call_count} calls."
 
-    @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
+    @pytest.mark.usefixtures("mock_get_hash")
     @mock.patch("pathlib.Path.stat", autospec=True)
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_multiple_files(
-        self, mock_partition_netcdf, mock_get_hash, mock_stat, local_roms_netcdf_dataset
-    ):
+        self,
+        mock_partition_netcdf: mock.Mock,
+        mock_stat: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Verifies partitioning behavior when multiple files are provided.
 
         Mocks:
@@ -1062,17 +1090,16 @@ class TestROMSInputDatasetPartition:
         - _get_sha256_hash: Mocks file shasum calculation
         - Path.resolve: Mocks the resolution of the partitioned filepaths
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_netcdf_dataset: Provides a dataset with multiple files.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - `partition_netcdf` is called the correct number of times.
         - `ROMSInputDataset.partitioning.files` is updated with the expected file paths.
         - `Path.stat` is called once for each partitioned file
         """
-
         np_xi, np_eta = 2, 2
         num_partitions = np_xi * np_eta
 
@@ -1116,6 +1143,7 @@ class TestROMSInputDatasetPartition:
                 local_roms_netcdf_dataset.partition(np_xi=np_xi, np_eta=np_eta)
 
                 # Assert partition_netcdf is called for each file
+                assert local_roms_netcdf_dataset.partitioning is not None
                 assert mock_partition_netcdf.call_count == len(
                     local_roms_netcdf_dataset.working_path
                 )
@@ -1132,10 +1160,10 @@ class TestROMSInputDatasetPartition:
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_skips_if_already_partitioned(
         self,
-        mock_partition_netcdf,
-        local_roms_netcdf_dataset,
+        mock_partition_netcdf: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
         caplog: pytest.LogCaptureFixture,
-    ):
+    ) -> None:
         """Tests that no action is taken if a ROMSInputDataset has already been
         partitioned.
 
@@ -1153,7 +1181,6 @@ class TestROMSInputDatasetPartition:
         - Confirms that an appropriate message is logged
         - Confirms that roms_tools.partition_netcdf is not called
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_netcdf_dataset.log.name)
 
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
@@ -1167,12 +1194,14 @@ class TestROMSInputDatasetPartition:
         local_roms_netcdf_dataset.partition(np_xi=1, np_eta=2)
 
         assert "MockROMSInputDataset already partitioned, skipping" in caplog.text
-        mock_partition_netcdf.assert_not_called
+        mock_partition_netcdf.assert_not_called()
 
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_raises_if_already_partitioned_differently(
-        self, mock_partition_netcdf, local_roms_netcdf_dataset
-    ):
+        self,
+        mock_partition_netcdf: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Test that a FileExistsError is raised if this ROMSInputDataset has been
         partitioned in a different arrangement to that requested.
 
@@ -1191,19 +1220,21 @@ class TestROMSInputDatasetPartition:
         - A FileExistsError is raised with an appropriate message
         - roms_tools.partition_netcdf is not called
         """
-
+        local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
+            np_xi=1,
+            np_eta=2,
+            files=[
+                Path("/some/dir/local_file.0.nc"),
+                Path("/some/dir/local_file.1.nc"),
+            ],
+        )
         with pytest.raises(
             FileExistsError,
             match="The file has already been partitioned into a different arrangement",
         ):
-            local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
-                np_xi=1,
-                np_eta=2,
-                files=["/some/dir/local_file.0.nc", "/some/dir/local_file.1.nc"],
-            )
             local_roms_netcdf_dataset.partition(np_xi=3, np_eta=4)
 
-        mock_partition_netcdf.assert_not_called
+        mock_partition_netcdf.assert_not_called()
 
     @mock.patch("cstar.roms.input_dataset.shutil.move")
     @mock.patch(
@@ -1212,8 +1243,12 @@ class TestROMSInputDatasetPartition:
     )
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_restores_existing_files_if_repeat_partitioning_fails(
-        self, mock_partition_netcdf, mock_exists, mock_move, local_roms_netcdf_dataset
-    ):
+        self,
+        mock_partition_netcdf: mock.Mock,
+        mock_exists: mock.Mock,
+        mock_move: mock.Mock,
+        local_roms_netcdf_dataset: ROMSInputDataset,
+    ) -> None:
         """Test that existing partitioned files are restored if _repeat_ partitioning
         fails.
 
@@ -1231,15 +1266,14 @@ class TestROMSInputDatasetPartition:
         - `shutil.move`: Tracks file move operations during backup and restore.
         - `Path.resolve`: Returns deterministic paths for assertions.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - `shutil.move` is called four times: twice to back up existing files,
           and twice to restore them after failure.
         - The first two calls move files into a temporary directory.
         - The last two calls restore files from the backup location.
         - The original exception (`RuntimeError`) is raised.
         """
-
         existing_files = [
             Path("/some/dir/local_file.0.nc"),
             Path("/some/dir/local_file.1.nc"),
@@ -1247,47 +1281,50 @@ class TestROMSInputDatasetPartition:
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1, np_eta=2, files=existing_files
         )
-        local_roms_netcdf_dataset.working_path = "/some/dir/local_file.nc"
+        local_roms_netcdf_dataset.working_path = Path("/some/dir/local_file.nc")
         mock_exists.return_value = True
         mock_partition_netcdf.side_effect = RuntimeError("simulated failure")
-        with mock.patch.object(
-            Path, "resolve", autospec=True, side_effect=existing_files * 2
+        with (
+            mock.patch.object(
+                Path, "resolve", autospec=True, side_effect=existing_files * 2
+            ),
+            pytest.raises(RuntimeError, match="simulated failure"),
         ):
-            with pytest.raises(RuntimeError, match="simulated failure"):
-                local_roms_netcdf_dataset.partition(
-                    np_xi=3, np_eta=3, overwrite_existing_files=True
-                )
+            local_roms_netcdf_dataset.partition(
+                np_xi=3, np_eta=3, overwrite_existing_files=True
+            )
 
         assert mock_move.call_count == 4
 
         backup_calls = mock_move.call_args_list[:2]
-        for call, original in zip(backup_calls, existing_files):
+        for call, original in zip(backup_calls, existing_files, strict=False):
             src, dst = call[0]
             assert src == original
             assert "tmp" in str(dst)  # destination should be in a temp dir
 
         restore_calls = mock_move.call_args_list[2:]
-        for call, original in zip(restore_calls, existing_files):
+        for call, original in zip(restore_calls, existing_files, strict=False):
             src, dst = call[0]
             assert dst == original
             assert "tmp" in str(src)
 
-    def test_partition_raises_when_not_local(self, local_roms_netcdf_dataset):
+    def test_partition_raises_when_not_local(
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Confirms an error is raised when `working_path` does not exist locally.
 
         Mocks:
         ------
         - exists_locally: Ensures the dataset is treated as non-existent.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_netcdf_dataset: Provides a dataset for testing.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `ValueError` is raised with the correct message.
         """
-
         # Simulate a dataset that does not exist locally
         with mock.patch.object(
             type(local_roms_netcdf_dataset),
@@ -1296,34 +1333,33 @@ class TestROMSInputDatasetPartition:
         ) as mock_exists_locally:
             mock_exists_locally.return_value = False
 
-            with pytest.raises(ValueError) as exception_info:
+            with pytest.raises(ValueError) as exception_info:  # noqa: PT011
                 local_roms_netcdf_dataset.partition(np_xi=2, np_eta=3)
 
         expected_message = (
             f"working_path of InputDataset \n {local_roms_netcdf_dataset.working_path}, "
-            + "refers to a non-existent file"
-            + "\n call InputDataset.get() and try again."
+            "refers to a non-existent file"
+            "\n call InputDataset.get() and try again."
         )
         assert str(exception_info.value) == expected_message
 
     def test_partition_raises_with_mismatched_directories(
-        self, local_roms_netcdf_dataset
-    ):
+        self, local_roms_netcdf_dataset: ROMSInputDataset
+    ) -> None:
         """Validates that an error is raised if files span multiple directories.
 
         Mocks:
         ------
         - exists_locally: Ensures the dataset is treated as existing.
 
-        Fixtures:
-        ---------
+        Fixtures
+        --------
         - local_roms_netcdf_dataset: Provides a dataset for testing.
 
-        Asserts:
-        --------
+        Asserts
+        -------
         - A `ValueError` is raised with the correct message.
         """
-
         # Set up the dataset with files in different directories
         local_roms_netcdf_dataset.working_path = [
             Path("some/local/source/path/file1.nc"),
@@ -1339,7 +1375,7 @@ class TestROMSInputDatasetPartition:
             mock_exists_locally.return_value = True
 
             # Expect a ValueError due to mismatched directories
-            with pytest.raises(ValueError) as exception_info:
+            with pytest.raises(ValueError) as exception_info:  # noqa: PT011
                 local_roms_netcdf_dataset.partition(np_xi=2, np_eta=3)
 
             expected_message = (
@@ -1349,15 +1385,15 @@ class TestROMSInputDatasetPartition:
             assert str(exception_info.value) == expected_message
 
 
-def test_correction_cannot_be_yaml():
+def test_correction_cannot_be_yaml() -> None:
     """Checks that the `validate()` method correctly raises a TypeError if
-    `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)"""
-
+    `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)."""
     with pytest.raises(TypeError) as exception_info:
         ROMSForcingCorrections(
             location="https://www.totallylegityamlfiles.pk/downloadme.yaml"
         )
-        expected_msg = (
-            "ROMSForcingCorrections cannot be initialized with a source YAML file."
-        )
-        assert expected_msg in str(exception_info.value)
+
+    expected_msg = (
+        "ROMSForcingCorrections cannot be initialized with a source YAML file."
+    )
+    assert expected_msg in str(exception_info.value)

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -92,15 +92,17 @@ def example_roms_simulation(tmp_path: Path) -> tuple[ROMSSimulation, Path]:
             location="http://my.files/river.nc", file_hash="543"
         ),
         boundary_forcing=[
-            ROMSBoundaryForcing(location="http://my.files/boundary.nc", file_hash="456")
+            ROMSBoundaryForcing(
+                location="http://my.files/boundary.nc", file_hash="456"
+            ),
         ],
         surface_forcing=[
-            ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567")
+            ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567"),
         ],
         forcing_corrections=[
             ROMSForcingCorrections(
                 location="http://my.files/sw_corr.nc", file_hash="890"
-            )
+            ),
         ],
     )
 
@@ -1580,8 +1582,7 @@ class TestProcessingAndExecution:
 
         Mocks & Fixtures
         ----------------
-        example_roms_simulation: tuple[ROMSSimulation, Path]
-            Provides a pre-configured `ROMSSimulation` instance.
+        - `example_roms_simulation`: Provides a pre-configured `ROMSSimulation` instance.
 
         Assertions
         ----------

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -97,7 +97,7 @@ class TestSetupEnvironmentFromFiles:
                     capture_output=True,
                     shell=True,
                     text=True,
-                )
+                ),
             ] + [
                 call(
                     f"/mock/lmod python load {mod}",

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import PropertyMock, call, mock_open, patch
+from unittest.mock import Mock, PropertyMock, call, mock_open, patch
 
 import pytest
 
@@ -10,16 +10,17 @@ from cstar.system.environment import CStarEnvironment
 
 
 class MockEnvironment(cstar.system.environment.CStarEnvironment):
+    """Mock environment for use in tests."""
+
     def __init__(
         self,
-        system_name="mock_system",
-        mpi_exec_prefix="mock_mpi_prefix",
-        compiler="mock_compiler",
-    ):
+        system_name: str = "mock_system",
+        mpi_exec_prefix: str = "mock_mpi_prefix",
+        compiler: str = "mock_compiler",
+    ) -> None:
+        """Initialize the instance."""
         super().__init__(
-            system_name=system_name,
-            mpi_exec_prefix=mpi_exec_prefix,
-            compiler=compiler,
+            system_name=system_name, mpi_exec_prefix=mpi_exec_prefix, compiler=compiler
         )
 
 
@@ -48,7 +49,12 @@ class TestSetupEnvironmentFromFiles:
     @patch.dict(
         "cstar.system.environment.os.environ", {"LMOD_CMD": "/mock/lmod"}, clear=True
     )
-    def test_load_lmod_modules(self, mock_uses_lmod, mock_run, lmod_syshost):
+    def test_load_lmod_modules(
+        self,
+        mock_uses_lmod: Mock,  # noqa: ARG002
+        mock_run: Mock,
+        lmod_syshost: PropertyMock,
+    ) -> None:
         """Tests that the load_lmod_modules function correctly interacts with Linux
         Envionment Modules.
 
@@ -67,7 +73,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms the correct sequence of subprocess calls for resetting and loading modules.
         """
-
         # Set up the LMOD_SYSHOST environment variable
         with patch.dict(
             "cstar.system.environment.os.environ", {"LMOD_SYSHOST": lmod_syshost}
@@ -92,7 +97,7 @@ class TestSetupEnvironmentFromFiles:
                     capture_output=True,
                     shell=True,
                     text=True,
-                ),
+                )
             ] + [
                 call(
                     f"/mock/lmod python load {mod}",
@@ -105,21 +110,19 @@ class TestSetupEnvironmentFromFiles:
 
             mock_run.assert_has_calls(expected_calls, any_order=False)
 
-    def get_expected_lmod_modules(self, env):
-        """Retrieves the expected list of Lmod modules for a given system from a .lmod
+    def get_expected_lmod_modules(self, env: CStarEnvironment) -> list[str]:
+        """Retrieve the expected list of Lmod modules for a given system from a .lmod
         file.
 
         Returns
         -------
         lmod_list: Module names to be loaded, based on the system's `.lmod` file.
         """
-
         lmod_file_path = (
-            f"{env.package_root}/additional_files/lmod_lists/{env._system_name}.lmod"
+            f"{env.package_root}/additional_files/lmod_lists/{env._system_name}.lmod"  # noqa: SLF001
         )
-        with open(lmod_file_path) as file:
-            lmod_list = file.readlines()
-            return lmod_list
+        with open(lmod_file_path) as file:  # noqa: PTH123
+            return file.readlines()
 
     @patch.dict(
         "os.environ",
@@ -132,11 +135,8 @@ class TestSetupEnvironmentFromFiles:
         clear=True,
     )
     def test_env_file_loading(
-        self,
-        tmp_path: Path,
-        dotenv_path: Path,
-        system_dotenv_path: Path,
-    ):
+        self, tmp_path: Path, dotenv_path: Path, system_dotenv_path: Path
+    ) -> None:
         """Tests that environment variables are loaded and expanded correctly from .env
         files.
 
@@ -149,7 +149,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms merged environment variables with expected values after expansion.
         """
-
         # Write simulated system .env content to the appropriate location
         system_dotenv_path.write_text(
             "NETCDFHOME=${NETCDF_FORTRANHOME}/\n"
@@ -197,7 +196,7 @@ class TestSetupEnvironmentFromFiles:
         mock_system_name: str,
         system_dotenv_path: Path,
         tmp_path: Path,
-    ):
+    ) -> None:
         """Tests that environment variables are updated correctly in the user .env file.
 
         Mocks
@@ -209,7 +208,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms merged environment variables with expected values after expansion.
         """
-
         # Write simulated system .env content to the appropriate location
         exp_system_env = {
             "NETCDFHOME": "${NETCDF_FORTRANHOME}/",
@@ -286,7 +284,7 @@ class TestStrAndReprMethods:
         "uses_lmod",
         new_callable=PropertyMock(return_value=False),
     )
-    def test_str_method(self, _mock_uses_lmod):
+    def test_str_method(self, _mock_uses_lmod: PropertyMock) -> None:  # noqa: PT019
         """Tests that __str__ produces a formatted, readable summary.
 
         Mocks
@@ -299,11 +297,9 @@ class TestStrAndReprMethods:
           like system name, scheduler, compiler, primary queue, and environment variables.
         """
         # Set up our mock environment with some sample properties
-        with (
-            patch.object(
-                MockEnvironment, "environment_variables", new_callable=PropertyMock
-            ) as mock_env_vars,
-        ):
+        with patch.object(
+            MockEnvironment, "environment_variables", new_callable=PropertyMock
+        ) as mock_env_vars:
             mock_env_vars.return_value = {"VAR1": "value1", "VAR2": "value2"}
 
             env = MockEnvironment()
@@ -326,7 +322,7 @@ class TestStrAndReprMethods:
         "uses_lmod",
         new_callable=PropertyMock(return_value=False),
     )
-    def test_repr_method(self, _mock_uses_lmod):
+    def test_repr_method(self, _mock_uses_lmod: PropertyMock) -> None:  # noqa: PT019
         """Tests that __repr__ produces a detailed, state-reflective representation.
 
         Mocks
@@ -364,8 +360,8 @@ class TestExceptions:
     - test_cores_per_node_raises_error_when_cpu_count_is_none: Confirms error when cpu_count is None.
     """
 
-    def setup_method(self):
-        """Sets up common patches for subprocess and environment variables.
+    def setup_method(self) -> None:
+        """Set up common patches for subprocess and environment variables.
 
         Mocks
         -----
@@ -373,7 +369,6 @@ class TestExceptions:
         - CStarEnvironment.uses_lmod: Patched to simulate environments that use or don’t use Lmod.
         - os.environ: Cleared and patched with specific values for test isolation.
         """
-
         self.subprocess_patcher = patch(
             "cstar.base.utils.subprocess.run",
             return_value=subprocess.CompletedProcess(args="module reset", returncode=0),
@@ -391,16 +386,17 @@ class TestExceptions:
         )
         self.os_environ_patcher.start()
 
-    def teardown_method(self):
-        """Stops all patches after each test."""
+    def teardown_method(self) -> None:
+        """Stop all patches after each test."""
         self.subprocess_patcher.stop()
         self.uses_lmod_patcher.stop()
         self.os_environ_patcher.stop()
 
     @patch("cstar.system.environment.importlib.util.find_spec", return_value=None)
     def test_package_root_raises_import_error_when_package_not_found(
-        self, mock_find_spec
-    ):
+        self,
+        mock_find_spec: Mock,  # noqa: ARG002
+    ) -> None:
         """Tests that missing package spec raises an ImportError in package_root
         property.
 
@@ -414,9 +410,11 @@ class TestExceptions:
         """
         self.mock_uses_lmod.return_value = False
         with pytest.raises(ImportError, match="Top-level package '.*' not found"):
-            MockEnvironment().package_root
+            _ = MockEnvironment().package_root
 
-    def test_load_lmod_modules_raises_environment_error_when_lmod_not_used(self):
+    def test_load_lmod_modules_raises_environment_error_when_lmod_not_used(
+        self,
+    ) -> None:
         """Tests that load_lmod_modules raises an EnvironmentError if Lmod is not used.
 
         Mocks
@@ -427,12 +425,12 @@ class TestExceptions:
         -------
         - Raises EnvironmentError with a message indicating Lmod modules are not supported on the system.
         """
-
         self.mock_uses_lmod.return_value = False
+        env = MockEnvironment()
+
         with pytest.raises(
             EnvironmentError, match="does not appear to use Linux Environment Modules"
         ):
-            env = MockEnvironment()
             env.load_lmod_modules(lmod_file="/some/file")
 
     @patch.dict(
@@ -440,8 +438,8 @@ class TestExceptions:
     )
     @patch("cstar.base.utils.subprocess.run")
     def test_load_lmod_modules_raises_runtime_error_on_module_reset_failure(
-        self, mock_subprocess
-    ):
+        self, mock_subprocess: Mock
+    ) -> None:
         """Tests that a RuntimeError is raised if `module reset` fails.
 
         Mocks
@@ -454,7 +452,6 @@ class TestExceptions:
         - Raises RuntimeError with a message indicating failure of the "module reset" command.
         - subprocess.run is called with the expected command for `module reset`.
         """
-
         mock_subprocess.return_value.returncode = 1  # Simulate failure
         mock_subprocess.return_value.stderr = "Module reset error"
 
@@ -477,8 +474,9 @@ class TestExceptions:
     )
     @patch("builtins.open", new_callable=mock_open, read_data="module1\nmodule2\n")
     def test_load_lmod_modules_raises_runtime_error_on_module_load_failure(
-        self, mock_open_file
-    ):
+        self,
+        mock_open: Mock,  # noqa: ARG002
+    ) -> None:
         """Tests that a RuntimeError is raised if `module load` fails.
 
         Mocks
@@ -491,7 +489,6 @@ class TestExceptions:
         - Raises RuntimeError with a message indicating failure of the "module load" command.
         - subprocess.run is called with the expected commands `reset` and `load`
         """
-
         # Define side effects for subprocess.run
         side_effects = [
             subprocess.CompletedProcess(

--- a/cstar/tests/unit_tests/test_simulation.py
+++ b/cstar/tests/unit_tests/test_simulation.py
@@ -23,16 +23,16 @@ class MockExternalCodeBase(ExternalCodeBase):
 
     Attributes
     ----------
-        default_source_repo : str
-            The default URL of the source repository.
-        default_checkout_target : str
-            The default branch or tag to checkout from the repository.
-        expected_env_var : str
-            The expected environment variable associated with this external codebase.
+    default_source_repo : str
+        The default URL of the source repository.
+    default_checkout_target : str
+        The default branch or tag to checkout from the repository.
+    expected_env_var : str
+        The expected environment variable associated with this external codebase.
 
     Methods
     -------
-        get(target)
+    get(target)
         A placeholder method that does nothing. In a real implementation, this
         would fetch and store the external codebase at the specified target.
     """
@@ -786,7 +786,7 @@ class TestSimulationPersistence:
         Mocks & Fixtures
         ----------------
         - `example_simulation` : Provides a mock `Simulation` instance.
-        - `MagicMock(spec=LocalProcess)` : Mocks an LocalProcess with a
+        - `MagicMock(spec=LocalProcess)` : Mocks a LocalProcess with a
           running status.
 
         Assertions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,27 +12,25 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import logging
 import os
 import pathlib
 import sys
-import logging
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-logger.info("python exec:", sys.executable)
-logger.info("sys.path:", sys.path)
+logger.info(f"python exec: {sys.executable}")
+logger.info(f"sys.path: {sys.path}")
 root = pathlib.Path(__file__).parent.parent.absolute()
 os.environ["PYTHONPATH"] = str(root)
 # cstar will look for os.environ["CONDA_PREFIX"] but this is not available on RTD; let's fill it with dummy
 os.environ["CONDA_PREFIX"] = str(root)
 sys.path.insert(0, str(root))
 
-import cstar  # isort:skip
-
 
 project = "C-Star"
-copyright = "2024, [C]Worthy"
+copyright = "2024, [C]Worthy"  # noqa: A001
 author = "C-Star developers"
 
 # -- Early stage of development Warning banner -----------------------------------------------------
@@ -41,7 +39,7 @@ rst_prolog = """.. attention::
     **This project is still in an early phase of development.**
 
     The `python API <https://c-star.readthedocs.io/en/latest/api.html>`_ is not yet stable, and some aspects of the schema for the `blueprint <https://c-star.readthedocs.io/en/latest/terminology.html#term-blueprint>`_ will likely evolve.
-    Therefore whilst you are welcome to try out using the package, we cannot yet guarantee backwards compatibility. 
+    Therefore whilst you are welcome to try out using the package, we cannot yet guarantee backwards compatibility.
     We expect to reach a more stable version in Q1 2025.
 """
 
@@ -62,8 +60,7 @@ napolean_google_docstring = False
 napolean_numpy_docstring = True
 
 templates_path = ["_templates"]
-exclude_patterns = []
-# exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = []  # previous value - ['_build', 'Thumbs.db', '.DS_Store']
 
 napoleon_custom_sections = [
     ("Returns", "params_style"),
@@ -78,7 +75,6 @@ napoleon_custom_sections = [
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_book_theme"
-# html_theme = 'alabaster'
 html_static_path = ["_static"]
 
 bibtex_bibfiles = ["references.bib"]

--- a/docs/howto_guides/1_working_with_additionalcode.ipynb
+++ b/docs/howto_guides/1_working_with_additionalcode.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d9db998f-5303-4bee-b17a-6615942c5596",
    "metadata": {},
    "outputs": [
@@ -66,13 +66,13 @@
    "source": [
     "from cstar.base import AdditionalCode\n",
     "\n",
-    "compile_time_code = AdditionalCode(location = \"~/Code/my_ucla_roms/Examples/Rivers_real/\", \n",
+    "compile_time_code = AdditionalCode(location = \"~/Code/my_ucla_roms/Examples/Rivers_real/\",\n",
     "                                   files=[\"cppdefs.opt\",\n",
     "                                          \"flux_frc.opt\",\n",
     "                                          \"ocean_vars.opt\",\n",
     "                                          \"param.opt\",\n",
     "                                          \"river_frc.opt\"])\n",
-    "print(compile_time_code)"
+    "print(compile_time_code)\n"
    ]
   },
   {
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "9cfb0349-2b97-4fa5-9cbe-31ded6c35123",
    "metadata": {},
    "outputs": [
@@ -110,12 +110,12 @@
     }
    ],
    "source": [
-    "compile_time_code.get(local_dir = \"~/Code/my_c_star/examples/additional_code_example\")"
+    "compile_time_code.get(local_dir = \"~/Code/my_c_star/examples/additional_code_example\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8ce15a65-f1d2-467b-aafb-81fb0e7f038f",
    "metadata": {},
    "outputs": [
@@ -139,7 +139,7 @@
     }
    ],
    "source": [
-    "print(compile_time_code)"
+    "print(compile_time_code)\n"
    ]
   },
   {
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "6f983ecc-e830-4253-a73a-31e33eb22b8f",
    "metadata": {},
    "outputs": [
@@ -186,7 +186,7 @@
     }
    ],
    "source": [
-    "compile_time_code = AdditionalCode(location = \"https://github.com/CESR-lab/ucla-roms.git\", \n",
+    "compile_time_code = AdditionalCode(location = \"https://github.com/CESR-lab/ucla-roms.git\",\n",
     "                                   files=[\"cppdefs.opt\",\n",
     "                                          \"flux_frc.opt\",\n",
     "                                          \"ocean_vars.opt\",\n",
@@ -194,7 +194,7 @@
     "                                          \"river_frc.opt\"],\n",
     "                                          subdir = \"Examples/Rivers_real\",\n",
     "                                          checkout_target = \"main\")\n",
-    "print(compile_time_code)"
+    "print(compile_time_code)\n"
    ]
   },
   {
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "d41d722f-ed03-4b13-8351-ac3df005f1c3",
    "metadata": {},
    "outputs": [
@@ -227,12 +227,12 @@
     }
    ],
    "source": [
-    "compile_time_code.get(local_dir = \"~/Code/my_c_star/examples/additional_code_example\")"
+    "compile_time_code.get(local_dir = \"~/Code/my_c_star/examples/additional_code_example\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "d5c09bba-c513-44e1-b170-28b55022ae09",
    "metadata": {},
    "outputs": [
@@ -257,13 +257,13 @@
     }
    ],
    "source": [
-    "print(compile_time_code)"
+    "print(compile_time_code)\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -277,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/howto_guides/2_working_with_inputdatasets.ipynb
+++ b/docs/howto_guides/2_working_with_inputdatasets.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "8c858dfe-e0db-4dc4-87d7-b0a3416cf329",
    "metadata": {},
    "outputs": [
@@ -82,8 +82,9 @@
    ],
    "source": [
     "from cstar.roms import ROMSModelGrid\n",
+    "\n",
     "my_grid = ROMSModelGrid(location=\"~/Code/my_ucla_roms/Examples/input_data/sample_grd_riv.nc\")\n",
-    "print(my_grid)"
+    "print(my_grid)\n"
    ]
   },
   {
@@ -105,17 +106,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "315cbb80-2111-4c2a-bb53-65152416cdfb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_grid.get(local_dir = \"~/Code/my_c_star/examples/input_dataset_example\")"
+    "my_grid.get(local_dir = \"~/Code/my_c_star/examples/input_dataset_example\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c0ebe25e-1425-4359-b52b-311af81d9f00",
    "metadata": {},
    "outputs": [
@@ -133,7 +134,7 @@
     }
    ],
    "source": [
-    "print(my_grid)"
+    "print(my_grid)\n"
    ]
   },
   {
@@ -165,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "93acbca5-fe0d-43bb-8c2c-53d90ca8e230",
    "metadata": {},
    "outputs": [
@@ -184,9 +185,10 @@
    ],
    "source": [
     "from cstar.roms import ROMSModelGrid\n",
+    "\n",
     "my_grid = ROMSModelGrid(location=\"https://github.com/dafyddstephenson/ucla_roms_examples_input_data/raw/main/sample_grd_riv.nc\",\n",
     "                       file_hash=\"8e2f1ca3135ac7f5696d3eaec79b035a1bae15c8a34e751a7f9d925787ab3f6e\")\n",
-    "print(my_grid)"
+    "print(my_grid)\n"
    ]
   },
   {
@@ -207,17 +209,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f1dbfc11-11f0-4d01-8ea9-e1fcfdb3a027",
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_grid.get(local_dir = \"~/Code/my_c_star/examples/input_dataset_example\")"
+    "my_grid.get(local_dir = \"~/Code/my_c_star/examples/input_dataset_example\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "97f7f98b-a6d7-4294-a442-1115a9568420",
    "metadata": {},
    "outputs": [
@@ -236,7 +238,7 @@
     }
    ],
    "source": [
-    "print(my_grid)"
+    "print(my_grid)\n"
    ]
   },
   {
@@ -254,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "5050b236-bd91-400f-8c68-966fc6f6a273",
    "metadata": {},
    "outputs": [
@@ -274,13 +276,14 @@
    ],
    "source": [
     "from cstar.roms import ROMSSurfaceForcing\n",
+    "\n",
     "my_surface_forcing = ROMSSurfaceForcing(\n",
     "    location=\"~/Code/my_c_star/blueprints/cstar_blueprint_roms_marbl_example/input_datasets_yaml/roms_frc.yaml\",\n",
     "    start_date=\"2012-01-01 12:00:00\",\n",
-    "    end_date = \"2012-01-04 12:00:00\"\n",
+    "    end_date = \"2012-01-04 12:00:00\",\n",
     ")\n",
     "\n",
-    "print(my_surface_forcing)"
+    "print(my_surface_forcing)\n"
    ]
   },
   {
@@ -300,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "631529f0-244c-46d3-95ba-b7b88922e66c",
    "metadata": {},
    "outputs": [
@@ -322,7 +325,7 @@
     }
    ],
    "source": [
-    "my_surface_forcing.get(local_dir=\"~/Code/my_c_star/examples/input_dataset_example/\")"
+    "my_surface_forcing.get(local_dir=\"~/Code/my_c_star/examples/input_dataset_example/\")\n"
    ]
   },
   {
@@ -347,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "acec39e0-8b3f-4f16-9d49-06b72352fad9",
    "metadata": {},
    "outputs": [
@@ -360,7 +363,7 @@
     }
    ],
    "source": [
-    "my_surface_forcing.partition(np_xi=3,np_eta=3)"
+    "my_surface_forcing.partition(np_xi=3,np_eta=3)\n"
    ]
   },
   {
@@ -373,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "335fb90e-1a7f-40c5-b4fa-8eca0fae1900",
    "metadata": {},
    "outputs": [
@@ -397,7 +400,7 @@
     }
    ],
    "source": [
-    "print(my_surface_forcing)"
+    "print(my_surface_forcing)\n"
    ]
   },
   {
@@ -421,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "c7fae636-b01a-47c3-91ee-cfcfb31454ff",
    "metadata": {},
    "outputs": [
@@ -441,17 +444,18 @@
    ],
    "source": [
     "from cstar.roms import ROMSModelGrid\n",
+    "\n",
     "my_partitioned_grid = ROMSModelGrid(\n",
     "    location = \"~/Code/my_c_star/blueprints/cstar_blueprint_roms_marbl_example/input_datasets_netcdf/partitioned/roms_grd.0.nc\",\n",
     "    source_np_xi = 3,\n",
     "    source_np_eta =3,\n",
     ")\n",
-    "my_partitioned_grid"
+    "my_partitioned_grid\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "477402d7-c9f9-43c8-902b-565171a9e6ac",
    "metadata": {},
    "outputs": [
@@ -471,7 +475,7 @@
    ],
    "source": [
     "my_partitioned_grid.get(\"~/Code/my_c_star/examples/input_dataset_example\")\n",
-    "my_partitioned_grid.partitioning"
+    "my_partitioned_grid.partitioning\n"
    ]
   },
   {
@@ -494,7 +498,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -508,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/howto_guides/3_working_with_externalcodebases.ipynb
+++ b/docs/howto_guides/3_working_with_externalcodebases.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f52a6b4c-92ca-4177-9469-154c20456f40",
    "metadata": {},
    "outputs": [
@@ -41,8 +41,9 @@
    ],
    "source": [
     "from cstar.roms import ROMSExternalCodeBase\n",
+    "\n",
     "roms_codebase = ROMSExternalCodeBase()\n",
-    "print(roms_codebase)"
+    "print(roms_codebase)\n"
    ]
   },
   {
@@ -58,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f39172e5-e8f6-45cf-8f61-907e94bc36c9",
    "metadata": {},
    "outputs": [
@@ -76,8 +77,9 @@
    ],
    "source": [
     "from cstar.marbl import MARBLExternalCodeBase\n",
+    "\n",
     "marbl_codebase = MARBLExternalCodeBase()\n",
-    "print(marbl_codebase)"
+    "print(marbl_codebase)\n"
    ]
   },
   {
@@ -104,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0e6cb1e3-a68f-4a14-8e6f-fdc7b085fddd",
    "metadata": {},
    "outputs": [
@@ -121,9 +123,9 @@
     }
    ],
    "source": [
-    "my_roms_codebase = ROMSExternalCodeBase(source_repo=\"https://github.com/dafyddstephenson/ucla-roms\", \n",
+    "my_roms_codebase = ROMSExternalCodeBase(source_repo=\"https://github.com/dafyddstephenson/ucla-roms\",\n",
     "                                        checkout_target=\"f71c4e29ff45043bc6ef564da98a16366f9cd19b\")\n",
-    "print(my_roms_codebase)"
+    "print(my_roms_codebase)\n"
    ]
   },
   {
@@ -145,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "6d448341-49a4-4eb3-a8f8-5ccc6e65d121",
    "metadata": {},
    "outputs": [
@@ -158,12 +160,12 @@
     }
    ],
    "source": [
-    "my_roms_codebase.get(target=\"~/Code/my_c_star/examples/external_codebase_example/ucla_roms\")"
+    "my_roms_codebase.get(target=\"~/Code/my_c_star/examples/external_codebase_example/ucla_roms\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "fcb29929-fac6-4368-9e5c-e0ea5623d911",
    "metadata": {},
    "outputs": [
@@ -180,7 +182,7 @@
     }
    ],
    "source": [
-    "print(my_roms_codebase)"
+    "print(my_roms_codebase)\n"
    ]
   },
   {
@@ -194,7 +196,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -208,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/howto_guides/4_running_on_personal_computers.ipynb
+++ b/docs/howto_guides/4_running_on_personal_computers.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a301fe04-638c-4312-8068-cd4b26249c5f",
    "metadata": {},
    "outputs": [],
@@ -65,9 +65,9 @@
     "from cstar.roms import ROMSSimulation\n",
     "\n",
     "example_simulation_1 = ROMSSimulation.from_blueprint(blueprint  = \"../tutorials/roms_marbl_example_simulation.yaml\",\n",
-    "                                                     directory   = \"../../examples/example_case\", \n",
-    "                                                     start_date = \"2012-01-03 12:00:00\", \n",
-    "                                                     end_date   = \"2012-01-06 12:00:00\")"
+    "                                                     directory   = \"../../examples/example_case\",\n",
+    "                                                     start_date = \"2012-01-03 12:00:00\",\n",
+    "                                                     end_date   = \"2012-01-06 12:00:00\")\n"
    ]
   },
   {
@@ -89,7 +89,7 @@
     "example_simulation_1.setup()\n",
     "example_simulation_1.build()\n",
     "example_simulation_1.pre_run()\n",
-    "# Cell output cleared for brevity"
+    "# Cell output cleared for brevity\n"
    ]
   },
   {
@@ -107,12 +107,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "071b0e23-1f7f-402d-a2b5-1ae2fae90317",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cstar_task = example_simulation_1.run()"
+    "cstar_task = example_simulation_1.run()\n"
    ]
   },
   {
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "41630183-ecde-4dc2-bfba-41a1457ede1a",
    "metadata": {},
    "outputs": [
@@ -149,7 +149,7 @@
     }
    ],
    "source": [
-    "cstar_task.status"
+    "cstar_task.status\n"
    ]
   },
   {
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "216bbc79-f578-44d2-867b-7da38b252778",
    "metadata": {},
    "outputs": [
@@ -179,7 +179,7 @@
     }
    ],
    "source": [
-    "cstar_task.output_file"
+    "cstar_task.output_file\n"
    ]
   },
   {
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0a79a7cc-9281-4bd8-ad4e-ecb32e17a1c0",
    "metadata": {},
    "outputs": [
@@ -277,7 +277,7 @@
     }
    ],
    "source": [
-    "cstar_task.updates(seconds=0.5)"
+    "cstar_task.updates(seconds=0.5)\n"
    ]
   },
   {
@@ -294,17 +294,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "428f25ea-43d8-4462-9b80-d912552aa403",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cstar_task.cancel()"
+    "cstar_task.cancel()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "10926495-2da3-4a20-b663-d238d6d96a43",
    "metadata": {},
    "outputs": [
@@ -320,7 +320,7 @@
     }
    ],
    "source": [
-    "cstar_task.status"
+    "cstar_task.status\n"
    ]
   },
   {
@@ -338,7 +338,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -352,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/howto_guides/5_handling_jobs_on_hpc_systems.ipynb
+++ b/docs/howto_guides/5_handling_jobs_on_hpc_systems.ipynb
@@ -71,8 +71,8 @@
     "from cstar.roms import ROMSSimulation\n",
     "\n",
     "example_simulation_1 = ROMSSimulation.from_blueprint(blueprint  = \"https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/main/cstar_blueprint_example_with_netcdf_inputs.yaml\",\n",
-    "                                                     directory  = \"../../examples/example_case/\", \n",
-    "                                                     start_date = \"2012-01-03 12:00:00\", \n",
+    "                                                     directory  = \"../../examples/example_case/\",\n",
+    "                                                     start_date = \"2012-01-03 12:00:00\",\n",
     "                                                     end_date   = \"2012-01-06 12:00:00\")"
    ]
   },
@@ -120,6 +120,7 @@
    ],
    "source": [
     "from cstar.system.manager import cstar_sysmgr\n",
+    "\n",
     "print(cstar_sysmgr.scheduler)"
    ]
   },

--- a/docs/tutorials/1_building_a_simulation_and_exporting_it_as_a_blueprint.ipynb
+++ b/docs/tutorials/1_building_a_simulation_and_exporting_it_as_a_blueprint.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c256a2ce-1742-4747-a515-f845073a49a4",
    "metadata": {},
    "outputs": [
@@ -113,18 +113,19 @@
    ],
    "source": [
     "from cstar.base import AdditionalCode\n",
+    "\n",
     "roms_runtime_code = AdditionalCode(\n",
-    "    location = \"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
-    "    subdir = \"roms_runtime_code\",\n",
-    "    checkout_target = \"main\",\n",
-    "    files = [\n",
+    "    location=\"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
+    "    subdir=\"roms_runtime_code\",\n",
+    "    checkout_target=\"main\",\n",
+    "    files=[\n",
     "        \"roms.in_TEMPLATE\",\n",
     "        \"marbl_in\",\n",
     "        \"marbl_tracer_output_list\",\n",
-    "        \"marbl_diagnostic_output_list\"\n",
-    "    ]\n",
+    "        \"marbl_diagnostic_output_list\",\n",
+    "    ],\n",
     ")\n",
-    "print(roms_runtime_code)"
+    "print(roms_runtime_code)\n"
    ]
   },
   {
@@ -150,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "360fdd39-0012-4add-b2cb-73dee1c17511",
    "metadata": {},
    "outputs": [
@@ -181,24 +182,24 @@
    ],
    "source": [
     "roms_compile_time_code = AdditionalCode(\n",
-    "    location = \"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
-    "    subdir = \"roms_compile_time_code\",\n",
-    "    checkout_target = \"main\",\n",
-    "    files = [\n",
+    "    location=\"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
+    "    subdir=\"roms_compile_time_code\",\n",
+    "    checkout_target=\"main\",\n",
+    "    files=[\n",
     "        \"bgc.opt\",\n",
-    "         \"bulk_frc.opt\",\n",
-    "         \"cppdefs.opt\",\n",
-    "         \"diagnostics.opt\",\n",
-    "         \"ocean_vars.opt\",\n",
-    "         \"param.opt\",\n",
-    "         \"tracers.opt\",\n",
-    "         \"river_frc.opt\",\n",
-    "         \"Makefile\",\n",
-    "         \"Make.depend\",\n",
-    "    ]\n",
+    "        \"bulk_frc.opt\",\n",
+    "        \"cppdefs.opt\",\n",
+    "        \"diagnostics.opt\",\n",
+    "        \"ocean_vars.opt\",\n",
+    "        \"param.opt\",\n",
+    "        \"tracers.opt\",\n",
+    "        \"river_frc.opt\",\n",
+    "        \"Makefile\",\n",
+    "        \"Make.depend\",\n",
+    "    ],\n",
     ")\n",
     "\n",
-    "print(roms_compile_time_code)"
+    "print(roms_compile_time_code)\n"
    ]
   },
   {
@@ -250,12 +251,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4f20a4bc-28cb-46a5-9a29-0b33515be140",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar.roms import ROMSModelGrid, ROMSInitialConditions, ROMSTidalForcing, ROMSBoundaryForcing, ROMSSurfaceForcing, ROMSRiverForcing\n",
+    "from cstar.roms import (\n",
+    "    ROMSBoundaryForcing,\n",
+    "    ROMSInitialConditions,\n",
+    "    ROMSModelGrid,\n",
+    "    ROMSRiverForcing,\n",
+    "    ROMSSurfaceForcing,\n",
+    "    ROMSTidalForcing,\n",
+    ")\n",
+    "\n",
     "netcdf_dataset_location = \"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/\"\n",
     "\n",
     "# Boundary\n",
@@ -264,8 +273,8 @@
     "    file_hash=\"3b51a46b1bd50d8a0e7c7f96c7b153c9d2c7fb26a8e9d97ce957d43210944909\",\n",
     ")\n",
     "roms_bgc_boundary_forcing = ROMSBoundaryForcing(\n",
-    "    location = netcdf_dataset_location+\"roms_bry_bgc.nc\",\n",
-    "    file_hash = \"366af33acf309c7644fab8f7bd5385c99123634c82d5c15f09d2033ec7103a6e\",\n",
+    "    location=netcdf_dataset_location + \"roms_bry_bgc.nc\",\n",
+    "    file_hash=\"366af33acf309c7644fab8f7bd5385c99123634c82d5c15f09d2033ec7103a6e\",\n",
     ")\n",
     "\n",
     "# Surface\n",
@@ -278,7 +287,7 @@
     "    file_hash=\"f78fce51e2178adcd128ea8d92bf091a450e4245dcb023027faae8e2d3963e72\",\n",
     ")\n",
     "\n",
-    "#Grid\n",
+    "# Grid\n",
     "roms_model_grid = ROMSModelGrid(\n",
     "    location=netcdf_dataset_location + \"roms_grd.nc\",\n",
     "    file_hash=\"41397c80fd00536dc414f6b8039b08fbe5d9f234aec66c3fc9b5a8e13353502a\",\n",
@@ -300,8 +309,7 @@
     "roms_river_forcing = ROMSRiverForcing(\n",
     "    location=netcdf_dataset_location + \"roms_riv_frc.nc\",\n",
     "    file_hash=\"43f99a44ef85d648c1e940172400f031bf6c41cd283883938543b7ca8b39a800\",\n",
-    ")\n",
-    "\n"
+    ")\n"
    ]
   },
   {
@@ -314,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "680420f2-2105-4907-ae4a-3e78e11ed336",
    "metadata": {},
    "outputs": [
@@ -332,7 +340,7 @@
     }
    ],
    "source": [
-    "print(roms_phys_boundary_forcing)"
+    "print(roms_phys_boundary_forcing)\n"
    ]
   },
   {
@@ -352,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "bd717504-7e5a-4217-8b0c-d689664f04a9",
    "metadata": {},
    "outputs": [
@@ -371,10 +379,12 @@
    "source": [
     "from cstar.roms import ROMSDiscretization\n",
     "\n",
-    "roms_discretization = ROMSDiscretization(time_step = 60,\n",
-    "                                         n_procs_x = 3,\n",
-    "                                         n_procs_y = 3)\n",
-    "print(roms_discretization)"
+    "roms_discretization = ROMSDiscretization(\n",
+    "    time_step=60,\n",
+    "    n_procs_x=3,\n",
+    "    n_procs_y=3,\n",
+    ")\n",
+    "print(roms_discretization)\n"
    ]
   },
   {
@@ -409,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "30955e95-7c36-4d0d-a2a4-fc30ef1fc91e",
    "metadata": {},
    "outputs": [
@@ -463,24 +473,25 @@
    ],
    "source": [
     "from cstar.roms import ROMSSimulation\n",
+    "\n",
     "roms_simulation = ROMSSimulation(\n",
     "    # Instantiation parameters:\n",
-    "    name='roms_marbl_example_cstar_simulation',\n",
-    "    directory = \"../../examples/roms_marbl_example_case\",\n",
-    "    valid_start_date = \"20120101 12:00:00\",\n",
-    "    valid_end_date = \"20120131 12:00:00\",\n",
+    "    name=\"roms_marbl_example_cstar_simulation\",\n",
+    "    directory=\"../../examples/roms_marbl_example_case\",\n",
+    "    valid_start_date=\"20120101 12:00:00\",\n",
+    "    valid_end_date=\"20120131 12:00:00\",\n",
     "    # Constructs from above:\n",
-    "    runtime_code = roms_runtime_code,\n",
-    "    compile_time_code = roms_compile_time_code,\n",
-    "    discretization = roms_discretization,\n",
-    "    model_grid = roms_model_grid,\n",
-    "    initial_conditions = roms_initial_conditions,\n",
-    "    tidal_forcing = roms_tidal_forcing,\n",
-    "    river_forcing = roms_river_forcing,\n",
-    "    boundary_forcing = [roms_phys_boundary_forcing,roms_bgc_boundary_forcing],\n",
-    "    surface_forcing = [roms_phys_surface_forcing, roms_bgc_surface_forcing]\n",
+    "    runtime_code=roms_runtime_code,\n",
+    "    compile_time_code=roms_compile_time_code,\n",
+    "    discretization=roms_discretization,\n",
+    "    model_grid=roms_model_grid,\n",
+    "    initial_conditions=roms_initial_conditions,\n",
+    "    tidal_forcing=roms_tidal_forcing,\n",
+    "    river_forcing=roms_river_forcing,\n",
+    "    boundary_forcing=[roms_phys_boundary_forcing, roms_bgc_boundary_forcing],\n",
+    "    surface_forcing=[roms_phys_surface_forcing, roms_bgc_surface_forcing],\n",
     ")\n",
-    "print(roms_simulation)"
+    "print(roms_simulation)\n"
    ]
   },
   {
@@ -510,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "80f5664b-2403-4582-88a1-a85c3bb4a369",
    "metadata": {},
    "outputs": [
@@ -550,7 +561,7 @@
     }
    ],
    "source": [
-    "print(roms_simulation.tree())"
+    "print(roms_simulation.tree())\n"
    ]
   },
   {
@@ -568,12 +579,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "868f69f3-9f34-4105-942d-1926c15f96e5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "roms_simulation.to_blueprint(\"roms_marbl_example_simulation.yaml\")"
+    "roms_simulation.to_blueprint(\"roms_marbl_example_simulation.yaml\")\n"
    ]
   },
   {
@@ -586,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4af4a516-aeae-4a4f-90bc-bf2bf62f584e",
    "metadata": {},
    "outputs": [
@@ -659,13 +670,14 @@
    ],
    "source": [
     "from pathlib import Path\n",
-    "print(Path(\"roms_marbl_example_simulation.yaml\").read_text())"
+    "\n",
+    "print(Path(\"roms_marbl_example_simulation.yaml\").read_text())\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -679,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/2_importing_and_running_a_simulation_from_a_blueprint.ipynb
+++ b/docs/tutorials/2_importing_and_running_a_simulation_from_a_blueprint.ipynb
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "dcfdd8c2-ddf5-4738-9481-39280634d1f1",
    "metadata": {
     "editable": true,
@@ -72,10 +72,12 @@
    "source": [
     "from cstar.roms import ROMSSimulation\n",
     "\n",
-    "example_simulation_1 = ROMSSimulation.from_blueprint(blueprint  = \"roms_marbl_example_simulation.yaml\", # this can be a local path or URL to your blueprint \n",
-    "                                           directory  = \"../../examples/roms_marbl_example_case\", # where you would like to setup and run the simulation\n",
-    "                                           start_date = \"2012-01-01 12:00:00\", # The dates between which you would like to run the Simulation\n",
-    "                                           end_date   = \"2012-01-03 12:00:00\")\n"
+    "example_simulation_1 = ROMSSimulation.from_blueprint(\n",
+    "    blueprint=\"roms_marbl_example_simulation.yaml\",  # this can be a local path or URL to your blueprint\n",
+    "    directory=\"../../examples/roms_marbl_example_case\",  # where you would like to setup and run the simulation\n",
+    "    start_date=\"2012-01-01 12:00:00\",  # The dates between which you would like to run the Simulation\n",
+    "    end_date=\"2012-01-03 12:00:00\",\n",
+    ")\n"
    ]
   },
   {
@@ -93,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "05fa6474-acb6-43ea-863f-1de4e751a8af",
    "metadata": {
     "tags": []
@@ -132,12 +134,12 @@
     }
    ],
    "source": [
-    "print(example_simulation_1)"
+    "print(example_simulation_1)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "3348e8c2-f0cd-4300-bf5e-a18d619e7fd0",
    "metadata": {},
    "outputs": [
@@ -177,7 +179,7 @@
     }
    ],
    "source": [
-    "print(example_simulation_1.tree())"
+    "print(example_simulation_1.tree())\n"
    ]
   },
   {
@@ -215,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "a9280f90-fec9-429b-b28d-da7976fea3da",
    "metadata": {
     "tags": []
@@ -237,7 +239,7 @@
      ]
     },
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Would you like to do this now? ('y', 'n', or 'custom' to install at a custom path)\n",
@@ -260,7 +262,7 @@
      ]
     },
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Would you like to do this now? ('y', 'n', or 'custom' to install at a custom path)\n",
@@ -310,7 +312,7 @@
     }
    ],
    "source": [
-    "example_simulation_1.setup()"
+    "example_simulation_1.setup()\n"
    ]
   },
   {
@@ -326,20 +328,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "50d7a445-378d-4ecb-9322-d0e181eeec90",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "#The Case.build() method compiles the code:\n",
+    "# The Case.build() method compiles the code:\n",
     "example_simulation_1.build()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "5283a931-a32c-4b3c-8934-f2f5a4097809",
    "metadata": {
     "tags": []
@@ -362,7 +364,7 @@
    ],
    "source": [
     "# The Case.pre_run() method performs pre-processing:\n",
-    "example_simulation_1.pre_run()"
+    "example_simulation_1.pre_run()\n"
    ]
   },
   {
@@ -377,14 +379,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "31d9f08e-481d-415f-9605-1c46164c5e49",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "simulation_run = example_simulation_1.run()"
+    "simulation_run = example_simulation_1.run()\n"
    ]
   },
   {
@@ -408,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "737060e4-ef85-4c73-b63f-5865a522e71c",
    "metadata": {
     "tags": []
@@ -426,7 +428,7 @@
     }
    ],
    "source": [
-    "simulation_run.status"
+    "simulation_run.status\n"
    ]
   },
   {
@@ -439,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4037688e-68b2-4334-b92e-2c492d3128b5",
    "metadata": {
     "tags": []
@@ -457,7 +459,7 @@
     }
    ],
    "source": [
-    "simulation_run.status"
+    "simulation_run.status\n"
    ]
   },
   {
@@ -479,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "9de44981-6e2d-4b9c-ab9d-64fe12a73d65",
    "metadata": {
     "editable": true,
@@ -502,7 +504,7 @@
     }
    ],
    "source": [
-    "example_simulation_1.post_run()"
+    "example_simulation_1.post_run()\n"
    ]
   },
   {
@@ -524,17 +526,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "1b06bc82-ee3c-4320-b94f-3bded6d15c73",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "%matplotlib inline\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "0eeb0d73-1120-4216-b5be-2e909662d853",
    "metadata": {
     "editable": true,
@@ -566,39 +568,58 @@
     }
    ],
    "source": [
-    "import numpy as np\n",
-    "import xarray as xr\n",
-    "import matplotlib.pyplot as plt\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
+    "import matplotlib.pyplot as plt\n",
+    "import xarray as xr\n",
     "\n",
-    "grd_ds = xr.open_dataset(example_simulation_1.directory / 'ROMS/input_datasets/roms_grd.nc') # Our ROMS grid file for lat and lon data\n",
-    "ini_ds = xr.open_dataset(example_simulation_1.directory / 'ROMS/input_datasets/roms_ini.nc') # Our initial condition file\n",
-    "rst_ds = xr.open_dataset(example_simulation_1.directory / 'output/ROMS_MARBL_rst.20120103120000.nc') # Our restart file\n",
+    "# Our ROMS grid file for lat and lon data\n",
+    "grd_ds = xr.open_dataset(\n",
+    "    example_simulation_1.directory / \"ROMS/input_datasets/roms_grd.nc\"\n",
+    ")\n",
+    "# Our initial condition file\n",
+    "ini_ds = xr.open_dataset(\n",
+    "    example_simulation_1.directory / \"ROMS/input_datasets/roms_ini.nc\"\n",
+    ")\n",
+    "# Our restart file\n",
+    "rst_ds = xr.open_dataset(\n",
+    "    example_simulation_1.directory / \"output/ROMS_MARBL_rst.20120103120000.nc\",\n",
+    ")\n",
     "\n",
-    "var=\"temp\"\n",
+    "var = \"temp\"\n",
     "ini_data = ini_ds[var].where(grd_ds.mask_rho).isel(s_rho=-1, ocean_time=0)\n",
     "rst_data = rst_ds[var].where(grd_ds.mask_rho).isel(s_rho=-1, time=0)\n",
     "\n",
     "# Create figure and axes\n",
-    "fig, ax = plt.subplots(1,2, subplot_kw={'projection': ccrs.PlateCarree()}, figsize=(15, 9))\n",
+    "fig, ax = plt.subplots(\n",
+    "    1,\n",
+    "    2,\n",
+    "    subplot_kw={\"projection\": ccrs.PlateCarree()},\n",
+    "    figsize=(15, 9),\n",
+    ")\n",
     "\n",
     "# Plot the data\n",
-    "cmap=plt.get_cmap('Spectral_r')\n",
-    "cmap.set_bad('gray')\n",
+    "cmap = plt.get_cmap(\"Spectral_r\")\n",
+    "cmap.set_bad(\"gray\")\n",
     "vmin = min(ini_data.where(grd_ds.mask_rho).min(), rst_data.where(grd_ds.mask_rho).min())\n",
     "vmax = max(ini_data.where(grd_ds.mask_rho).max(), rst_data.where(grd_ds.mask_rho).max())\n",
     "kwargs = {\"cmap\": cmap, \"vmin\": vmin, \"vmax\": vmax}\n",
-    "p0=ax[0].pcolormesh(grd_ds.lon_rho, grd_ds.lat_rho, ini_data, transform=ccrs.PlateCarree(), **kwargs)\n",
-    "p1=ax[1].pcolormesh(grd_ds.lon_rho, grd_ds.lat_rho, rst_data, transform=ccrs.PlateCarree(), **kwargs)\n",
+    "p0 = ax[0].pcolormesh(\n",
+    "    grd_ds.lon_rho, grd_ds.lat_rho, ini_data, transform=ccrs.PlateCarree(), **kwargs\n",
+    ")\n",
+    "p1 = ax[1].pcolormesh(\n",
+    "    grd_ds.lon_rho, grd_ds.lat_rho, rst_data, transform=ccrs.PlateCarree(), **kwargs\n",
+    ")\n",
     "\n",
-    "# Add coastlines and land mask \n",
+    "# Add coastlines and land mask\n",
     "[a.add_feature(cfeature.COASTLINE, linewidth=1) for a in ax]\n",
     "\n",
     "# Add a colorbar\n",
     "ax[0].set_title(\"Initial condition file\")\n",
     "ax[1].set_title(\"Restart file\")\n",
-    "plt.colorbar(p1, ax=ax, orientation='horizontal', pad=0.05,label=\"Sea surface temperature (°C)\")\n",
+    "plt.colorbar(\n",
+    "    p1, ax=ax, orientation=\"horizontal\", pad=0.05, label=\"Sea surface temperature (°C)\"\n",
+    ")\n",
     "fig.show()\n",
     "grd_ds.close()\n"
    ]
@@ -629,7 +650,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -643,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/3_restarting_and_continuing_a_simulation.ipynb
+++ b/docs/tutorials/3_restarting_and_continuing_a_simulation.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "6dd41c06-4235-489a-b490-6f4715139b80",
    "metadata": {
     "tags": []
@@ -75,7 +75,10 @@
    "outputs": [],
    "source": [
     "from cstar.roms import ROMSSimulation\n",
-    "original_simulation = ROMSSimulation.restore(directory = \"../../examples/roms_marbl_example_case\")"
+    "\n",
+    "original_simulation = ROMSSimulation.restore(\n",
+    "    directory=\"../../examples/roms_marbl_example_case\"\n",
+    ")\n"
    ]
   },
   {
@@ -92,14 +95,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "20431ecb-cc52-4f6a-90a6-be9dd0e38051",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "restarted_simulation = original_simulation.restart(new_end_date=\"2012-01-31 12:00:00\")"
+    "restarted_simulation = original_simulation.restart(new_end_date=\"2012-01-31 12:00:00\")\n"
    ]
   },
   {
@@ -112,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "dff7dcf6-9488-4b28-8980-27b8071da508",
    "metadata": {
     "tags": []
@@ -134,7 +137,7 @@
     }
    ],
    "source": [
-    "restarted_simulation.initial_conditions"
+    "restarted_simulation.initial_conditions\n"
    ]
   },
   {
@@ -155,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "73914b94-a078-4255-a1f4-041a12225f23",
    "metadata": {
     "tags": []
@@ -190,19 +193,19 @@
     }
    ],
    "source": [
-    "restarted_simulation"
+    "restarted_simulation\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "880c47a3-acca-4e47-a7c3-9b81d05938df",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "restarted_simulation.discretization.time_step = 360"
+    "restarted_simulation.discretization.time_step = 360\n"
    ]
   },
   {
@@ -215,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "2ce98d85-1e60-44cb-be9a-9f049cbb3c13",
    "metadata": {
     "editable": true,
@@ -254,7 +257,7 @@
     }
    ],
    "source": [
-    "restarted_simulation"
+    "restarted_simulation\n"
    ]
   },
   {
@@ -271,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "25624c31-24fe-4f08-a5f8-2057adb803c0",
    "metadata": {},
    "outputs": [
@@ -284,12 +287,12 @@
     }
    ],
    "source": [
-    "restarted_simulation.log.info(\"OI\")"
+    "restarted_simulation.log.info(\"OI\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "e1fcc4df-ccc0-40a9-9346-335281cccfaa",
    "metadata": {
     "tags": []
@@ -333,19 +336,19 @@
    "source": [
     "restarted_simulation.setup()\n",
     "restarted_simulation.build()\n",
-    "restarted_simulation.pre_run()"
+    "restarted_simulation.pre_run()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "3bb88089-59a6-4ec8-ab9f-56fd67ecdd17",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "simulation_run = restarted_simulation.run()"
+    "simulation_run = restarted_simulation.run()\n"
    ]
   },
   {
@@ -358,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "e77a3f87-159c-49c0-bce8-047afb940a77",
    "metadata": {
     "editable": true,
@@ -380,7 +383,7 @@
     }
    ],
    "source": [
-    "simulation_run.status"
+    "simulation_run.status\n"
    ]
   },
   {
@@ -399,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "2d851602-6fb1-46bd-8f5d-6665939daedc",
    "metadata": {
     "editable": true,
@@ -421,12 +424,12 @@
     }
    ],
    "source": [
-    "simulation_run.status"
+    "simulation_run.status\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "bd65d68f-bbf6-47e0-9fca-fadee6f1aa18",
    "metadata": {
     "editable": true,
@@ -475,7 +478,7 @@
     }
    ],
    "source": [
-    "restarted_simulation.post_run()"
+    "restarted_simulation.post_run()\n"
    ]
   },
   {
@@ -494,17 +497,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "7ca524f6-43ef-4bec-a74b-9c95eb5ec006",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "%matplotlib inline\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "f3183519-1ce6-4838-8218-83d1e8c27cb2",
    "metadata": {
     "editable": true,
@@ -526,75 +529,77 @@
     }
    ],
    "source": [
+    "%matplotlib inline\n",
+    "import datetime as dt\n",
+    "\n",
+    "import cartopy.crs as ccrs\n",
+    "import cartopy.feature as cfeature\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import xarray as xr\n",
-    "import cartopy.crs as ccrs\n",
-    "import datetime as dt\n",
-    "import cartopy.feature as cfeature\n",
+    "from matplotlib.gridspec import GridSpec\n",
     "\n",
-    "bgc_ds = xr.open_dataset(restarted_simulation.directory / 'output/ROMS_MARBL_bgc.20120103120000.nc') # this contains 6-hourly data, with the date in the filename reflecting the first time entry\n",
-    "grd_ds = xr.open_dataset(restarted_simulation.directory / 'ROMS/input_datasets/roms_grd.nc')\n",
-    "lon,lat=grd_ds.lon_rho,grd_ds.lat_rho\n",
-    "output_time=[dt.datetime(2000,1,1)+dt.timedelta(seconds=t) for t in bgc_ds.ocean_time.values]\n",
+    " # this contains 6-hourly data, with the date in the filename reflecting the first time entry\n",
+    "bgc_ds = xr.open_dataset(restarted_simulation.directory / \"output/ROMS_MARBL_bgc.20120103120000.nc\")\n",
+    "grd_ds = xr.open_dataset(restarted_simulation.directory / \"ROMS/input_datasets/roms_grd.nc\")\n",
+    "lon, lat = grd_ds.lon_rho, grd_ds.lat_rho\n",
+    "output_time = [dt.datetime(2000, 1, 1) + dt.timedelta(seconds=t) for t in bgc_ds.ocean_time.values]\n",
     "\n",
-    "var = 'DOC'\n",
+    "var = \"DOC\"\n",
     "i_idx = 10\n",
-    "j_idx = 15 \n",
+    "j_idx = 15\n",
     "k_idx = 19\n",
-    "t_idx = [0,-1]\n",
+    "t_idx = [0, -1]\n",
     "\n",
     "plot_data = bgc_ds[var].where(grd_ds.mask_rho).isel(s_rho=k_idx)\n",
     "\n",
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "from matplotlib.gridspec import GridSpec\n",
-    "\n",
     "\n",
     "fig = plt.figure()\n",
-    "cmap=plt.get_cmap('Spectral_r')\n",
-    "cmap.set_bad('grey')\n",
+    "cmap = plt.get_cmap(\"Spectral_r\")\n",
+    "cmap.set_bad(\"grey\")\n",
     "\n",
     "gs = GridSpec(3, 2, figure=fig, hspace=0.5)\n",
     "\n",
     "# time series\n",
     "ax1 = fig.add_subplot(gs[0, :])\n",
     "\n",
-    "ax1.plot(output_time,plot_data[:,j_idx,i_idx])\n",
-    "ax1.set_xlim(output_time[0],output_time[-1])\n",
-    "ax1.set_xlabel('time')\n",
-    "ax1.plot(output_time[t_idx[0]],plot_data[t_idx[0],j_idx,i_idx],'kx')\n",
-    "ax1.plot(output_time[t_idx[-1]],plot_data[t_idx[-1],j_idx,i_idx],'kx')\n",
+    "ax1.plot(output_time, plot_data[:, j_idx, i_idx])\n",
+    "\n",
+    "ax1.set_xlim(output_time[0], output_time[-1])\n",
+    "ax1.set_xlabel(\"time\")\n",
+    "ax1.plot(output_time[t_idx[0]], plot_data[t_idx[0], j_idx, i_idx], \"kx\")\n",
+    "ax1.plot(output_time[t_idx[-1]], plot_data[t_idx[-1], j_idx, i_idx], \"kx\")\n",
     "\n",
     "\n",
     "# Maps\n",
-    "ax2 = fig.add_subplot(gs[1:, 0],projection=ccrs.PlateCarree())\n",
-    "ax3 = fig.add_subplot(gs[1:, 1],projection=ccrs.PlateCarree())\n",
+    "ax2 = fig.add_subplot(gs[1:, 0], projection=ccrs.PlateCarree())\n",
+    "ax3 = fig.add_subplot(gs[1:, 1], projection=ccrs.PlateCarree())\n",
     "\n",
     "VMIN = np.min(plot_data.values[plot_data.values > 0])\n",
     "VMAX = np.max(plot_data.values[plot_data.values > 0])\n",
     "\n",
-    "p2 = ax2.pcolormesh(lon,lat,plot_data.isel(time=0).values, vmin=VMIN, vmax=VMAX, cmap=cmap)\n",
-    "p3 = ax3.pcolormesh(lon,lat,plot_data.isel(time=-1).values, vmin=VMIN, vmax=VMAX, cmap=cmap)\n",
+    "p2 = ax2.pcolormesh(lon, lat, plot_data.isel(time=0).values, vmin=VMIN, vmax=VMAX, cmap=cmap)\n",
+    "p3 = ax3.pcolormesh(lon, lat, plot_data.isel(time=-1).values, vmin=VMIN, vmax=VMAX, cmap=cmap)\n",
     "[a.set_xticks([]) for a in [ax2, ax3]]\n",
     "[a.set_yticks([]) for a in [ax2, ax3]]\n",
     "\n",
     "ax2.set_title(\"\")\n",
-    "ax2.plot(lon[j_idx,i_idx].values-360, lat[j_idx,i_idx].values, 'kx')\n",
-    "ax3.plot(lon[j_idx,i_idx].values-360, lat[j_idx,i_idx].values, 'kx')\n",
+    "ax2.plot(lon[j_idx, i_idx].values - 360, lat[j_idx, i_idx].values, \"kx\")\n",
+    "ax3.plot(lon[j_idx, i_idx].values - 360, lat[j_idx, i_idx].values, \"kx\")\n",
     "\n",
-    "[a.add_feature(cfeature.COASTLINE, linewidth=1) for a in [ax3,ax2]]\n",
+    "[a.add_feature(cfeature.COASTLINE, linewidth=1) for a in [ax3, ax2]]\n",
     "fig.colorbar(p2, ax=ax2)\n",
     "fig.colorbar(p3, ax=ax3)\n",
     "\n",
-    "fig.suptitle(f'Surface {bgc_ds[var].long_name}, ({bgc_ds[var].units})')\n",
-    "fig.set_size_inches(12,6)\n",
-    "grd_ds.close()"
+    "fig.suptitle(f\"Surface {bgc_ds[var].long_name}, ({bgc_ds[var].units})\")\n",
+    "fig.set_size_inches(12, 6)\n",
+    "grd_ds.close()\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -608,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/examples/cstar_example.py
+++ b/examples/cstar_example.py
@@ -1,10 +1,10 @@
-"""
-This is a condensed version of the cstar_example_notebook.ipynb designed to be run in an interactive python session.
+"""Demonstrate the same behaviors as cstar_example_notebook.ipynb.
+
+This code is designed to be run in an interactive python session.
 For more details, see ../README.md or cstar_example_notebook.ipynb
 """
 
 import cstar
-import os
 
 roms_marbl_case = cstar.Case.from_blueprint(
     blueprint="cstar_blueprint_yaml_test.yaml",
@@ -17,5 +17,11 @@ roms_marbl_case = cstar.Case.from_blueprint(
 roms_marbl_case.setup()
 roms_marbl_case.build()
 roms_marbl_case.pre_run()
-#roms_marbl_case.run(account_key=os.environ.get('ACCOUNT_KEY')) #substituting your account key on any HPC system
-#roms_marbl_case.post_run()
+
+"""
+To execute on an HPC, substitute your credentials as follows:
+roms_marbl_case.run(account_key=os.environ.get('ACCOUNT_KEY'))
+
+The post_run method should be executed when the simulation completes:
+roms_marbl_case.post_run()
+"""

--- a/examples/cstar_example_notebook.ipynb
+++ b/examples/cstar_example_notebook.ipynb
@@ -11,13 +11,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f1d2251a-8687-4feb-bafc-5e1d82460af3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import cstar"
+    "from pathlib import Path\n"
    ]
   },
   {
@@ -68,36 +67,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c19986ee-6f21-41df-b0bb-8604ba25fdb9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar.roms import ROMSBaseModel\n",
-    "from cstar.marbl import MARBLBaseModel"
+    "from cstar.marbl import MARBLBaseModel\n",
+    "from cstar.roms import ROMSBaseModel\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "fe00d6d5-c203-4174-b02d-52fb5d8d8ce4",
    "metadata": {},
    "outputs": [],
    "source": [
     "roms_base_model = ROMSBaseModel(\n",
-    "    source_repo='https://github.com/CESR-lab/ucla-roms.git',\n",
-    "    checkout_target='246c11fa537145ba5868f2256dfb4964aeb09a25',\n",
+    "    source_repo=\"https://github.com/CESR-lab/ucla-roms.git\",\n",
+    "    checkout_target=\"246c11fa537145ba5868f2256dfb4964aeb09a25\",\n",
     ")\n",
     "\n",
     "marbl_base_model = MARBLBaseModel(\n",
-    "    source_repo='https://github.com/marbl-ecosys/MARBL.git',\n",
-    "    checkout_target='marbl0.45.0',\n",
-    ")"
+    "    source_repo=\"https://github.com/marbl-ecosys/MARBL.git\",\n",
+    "    checkout_target=\"marbl0.45.0\",\n",
+    ")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "28cb3e6d-78c1-45a6-bae8-aea3fac47835",
    "metadata": {},
    "outputs": [
@@ -114,12 +113,12 @@
     }
    ],
    "source": [
-    "print(roms_base_model)"
+    "print(roms_base_model)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "5c681aa1-0cdd-4b6a-b1b4-91bce6bd98ec",
    "metadata": {},
    "outputs": [
@@ -136,7 +135,7 @@
     }
    ],
    "source": [
-    "print(marbl_base_model)"
+    "print(marbl_base_model)\n"
    ]
   },
   {
@@ -155,17 +154,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "d078a027-e9aa-4a20-b075-d41099101e29",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar.base import AdditionalCode"
+    "from cstar.base import AdditionalCode\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8ab3bf2f-0066-457f-a484-697ab5b04637",
    "metadata": {},
    "outputs": [
@@ -189,22 +188,22 @@
    ],
    "source": [
     "roms_namelists = AdditionalCode(\n",
-    "    location = \"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
-    "    subdir = \"additional_code/ROMS/namelists\",\n",
-    "    checkout_target = \"a9762a46a36c09225423305a1aaa59bdeb984074\",\n",
-    "    files = [\n",
+    "    location=\"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
+    "    subdir=\"additional_code/ROMS/namelists\",\n",
+    "    checkout_target=\"a9762a46a36c09225423305a1aaa59bdeb984074\",\n",
+    "    files=[\n",
     "        \"roms.in_TEMPLATE\",\n",
     "        \"marbl_in\",\n",
     "        \"marbl_tracer_output_list\",\n",
-    "        \"marbl_diagnostic_output_list\"\n",
-    "    ]\n",
+    "        \"marbl_diagnostic_output_list\",\n",
+    "    ],\n",
     ")\n",
-    "print(roms_namelists)"
+    "print(roms_namelists)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "360fdd39-0012-4add-b2cb-73dee1c17511",
    "metadata": {},
    "outputs": [
@@ -233,23 +232,23 @@
    ],
    "source": [
     "roms_additional_source_code = AdditionalCode(\n",
-    "    location = \"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
-    "    subdir = \"additional_code/ROMS/source_mods\",\n",
-    "    checkout_target = \"a9762a46a36c09225423305a1aaa59bdeb984074\",\n",
-    "    files = [\n",
+    "    location=\"https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git\",\n",
+    "    subdir=\"additional_code/ROMS/source_mods\",\n",
+    "    checkout_target=\"a9762a46a36c09225423305a1aaa59bdeb984074\",\n",
+    "    files=[\n",
     "        \"bgc.opt\",\n",
-    "         \"bulk_frc.opt\",\n",
-    "         \"cppdefs.opt\",\n",
-    "         \"diagnostics.opt\",\n",
-    "         \"ocean_vars.opt\",\n",
-    "         \"param.opt\",\n",
-    "         \"tracers.opt\",\n",
-    "         \"Makefile\",\n",
-    "         \"Make.depend\",\n",
-    "    ]\n",
+    "        \"bulk_frc.opt\",\n",
+    "        \"cppdefs.opt\",\n",
+    "        \"diagnostics.opt\",\n",
+    "        \"ocean_vars.opt\",\n",
+    "        \"param.opt\",\n",
+    "        \"tracers.opt\",\n",
+    "        \"Makefile\",\n",
+    "        \"Make.depend\",\n",
+    "    ],\n",
     ")\n",
     "\n",
-    "print(roms_additional_source_code)"
+    "print(roms_additional_source_code)\n"
    ]
   },
   {
@@ -278,22 +277,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4f20a4bc-28cb-46a5-9a29-0b33515be140",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar.roms import ROMSModelGrid, ROMSInitialConditions, ROMSTidalForcing, ROMSBoundaryForcing, ROMSSurfaceForcing"
+    "from cstar.roms import (\n",
+    "    ROMSBoundaryForcing,\n",
+    "    ROMSInitialConditions,\n",
+    "    ROMSModelGrid,\n",
+    "    ROMSSurfaceForcing,\n",
+    "    ROMSTidalForcing,\n",
+    ")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "02c2bf05-15a0-45b5-bd1e-16a0032b5b1e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Grid\n",
+    "# Grid\n",
     "roms_model_grid = ROMSModelGrid(\n",
     "    location=\"https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_grd.nc\",\n",
     "    file_hash=\"fd537ef8159fabb18e38495ec8d44e2fa1b7fb615fcb1417dd4c0e1bb5f4e41d\",\n",
@@ -314,8 +319,8 @@
     "    file_hash=\"c3b0e14aae6dd5a0d54703fa04cf95960c1970e732c0a230427bf8b0fbbd8bf1\",\n",
     ")\n",
     "roms_bgc_boundary_forcing = ROMSBoundaryForcing(\n",
-    "    location = \"https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_bgc_MARBL.nc\",\n",
-    "    file_hash = \"897a8df8ed45841a98b3906f2dd07750decc5c2b50095ba648a855c869c7d3ee\",\n",
+    "    location=\"https://github.com/CWorthy-ocean/input_datasets_roms_marbl_example/raw/main/roms_bry_bgc_MARBL.nc\",\n",
+    "    file_hash=\"897a8df8ed45841a98b3906f2dd07750decc5c2b50095ba648a855c869c7d3ee\",\n",
     ")\n",
     "# Surface\n",
     "roms_bgc_surface_forcing = ROMSSurfaceForcing(\n",
@@ -338,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "680420f2-2105-4907-ae4a-3e78e11ed336",
    "metadata": {},
    "outputs": [
@@ -356,7 +361,7 @@
     }
    ],
    "source": [
-    "print(roms_phys_boundary_forcing)"
+    "print(roms_phys_boundary_forcing)\n"
    ]
   },
   {
@@ -372,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "bd717504-7e5a-4217-8b0c-d689664f04a9",
    "metadata": {},
    "outputs": [
@@ -391,10 +396,12 @@
    "source": [
     "from cstar.roms import ROMSDiscretization\n",
     "\n",
-    "roms_discretization = ROMSDiscretization(time_step = 360,\n",
-    "                                         n_procs_x = 3,\n",
-    "                                         n_procs_y = 3)\n",
-    "print(roms_discretization)"
+    "roms_discretization = ROMSDiscretization(\n",
+    "    time_step=360,\n",
+    "    n_procs_x=3,\n",
+    "    n_procs_y=3,\n",
+    ")\n",
+    "print(roms_discretization)\n"
    ]
   },
   {
@@ -408,13 +415,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "30955e95-7c36-4d0d-a2a4-fc30ef1fc91e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar.roms import ROMSComponent\n",
-    "from cstar.marbl import MARBLComponent"
+    "from cstar.marbl import MARBLComponent\n",
+    "from cstar.roms import ROMSComponent\n"
    ]
   },
   {
@@ -427,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "b3f01b55-9a80-4b18-a74b-59ffea7f2758",
    "metadata": {},
    "outputs": [
@@ -442,10 +449,8 @@
     }
    ],
    "source": [
-    "marbl_component = MARBLComponent(\n",
-    "    base_model = marbl_base_model\n",
-    ")\n",
-    "print(marbl_component)"
+    "marbl_component = MARBLComponent(base_model=marbl_base_model)\n",
+    "print(marbl_component)\n"
    ]
   },
   {
@@ -459,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "1533dbbf-593b-452d-9d72-120c4eb65a2d",
    "metadata": {},
    "outputs": [
@@ -489,17 +494,17 @@
    ],
    "source": [
     "roms_component = ROMSComponent(\n",
-    "    base_model = roms_base_model,\n",
-    "    namelists = roms_namelists,\n",
-    "    additional_source_code = roms_additional_source_code,\n",
-    "    discretization = roms_discretization,\n",
-    "    model_grid = roms_model_grid,\n",
-    "    initial_conditions = roms_initial_conditions,\n",
-    "    tidal_forcing = roms_tidal_forcing,\n",
-    "    boundary_forcing = [roms_phys_boundary_forcing,roms_bgc_boundary_forcing],\n",
-    "    surface_forcing = [roms_phys_surface_forcing, roms_bgc_surface_forcing]\n",
+    "    base_model=roms_base_model,\n",
+    "    namelists=roms_namelists,\n",
+    "    additional_source_code=roms_additional_source_code,\n",
+    "    discretization=roms_discretization,\n",
+    "    model_grid=roms_model_grid,\n",
+    "    initial_conditions=roms_initial_conditions,\n",
+    "    tidal_forcing=roms_tidal_forcing,\n",
+    "    boundary_forcing=[roms_phys_boundary_forcing, roms_bgc_boundary_forcing],\n",
+    "    surface_forcing=[roms_phys_surface_forcing, roms_bgc_surface_forcing],\n",
     ")\n",
-    "print(roms_component)"
+    "print(roms_component)\n"
    ]
   },
   {
@@ -513,17 +518,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "def7ac3e-3de8-4ca9-806d-b5ac385a437c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cstar import Case"
+    "from cstar import Case\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "1a32ad6f-8701-416f-ae50-598f7650cf5e",
    "metadata": {},
    "outputs": [
@@ -561,12 +566,12 @@
    "source": [
     "roms_marbl_case = Case(\n",
     "    components=[roms_component, marbl_component],\n",
-    "    name='roms_marbl_example_cstar_case',\n",
-    "    caseroot=os.getcwd() + '/roms_marbl_example_cstar_case',\n",
-    "    start_date='20120103 12:00:00',\n",
-    "    end_date='20120131 12:00:00',\n",
+    "    name=\"roms_marbl_example_cstar_case\",\n",
+    "    caseroot=Path.cwd() + \"/roms_marbl_example_cstar_case\",\n",
+    "    start_date=\"20120103 12:00:00\",\n",
+    "    end_date=\"20120131 12:00:00\",\n",
     ")\n",
-    "print(roms_marbl_case)"
+    "print(roms_marbl_case)\n"
    ]
   },
   {
@@ -580,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "80f5664b-2403-4582-88a1-a85c3bb4a369",
    "metadata": {},
    "outputs": [
@@ -620,7 +625,7 @@
     }
    ],
    "source": [
-    "roms_marbl_case.tree()"
+    "roms_marbl_case.tree()\n"
    ]
   },
   {
@@ -643,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "8074ca7c-e795-468a-8c2f-784837a24dfc",
    "metadata": {
     "scrolled": true
@@ -727,7 +732,7 @@
     }
    ],
    "source": [
-    "roms_marbl_case.setup()"
+    "roms_marbl_case.setup()\n"
    ]
   },
   {
@@ -742,17 +747,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "868f69f3-9f34-4105-942d-1926c15f96e5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "roms_marbl_case.persist(roms_marbl_case.caseroot / 'roms_marbl_case.yaml')"
+    "roms_marbl_case.persist(roms_marbl_case.caseroot / \"roms_marbl_case.yaml\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "4af4a516-aeae-4a4f-90bc-bf2bf62f584e",
    "metadata": {},
    "outputs": [
@@ -824,7 +829,7 @@
     }
    ],
    "source": [
-    "print((roms_marbl_case.caseroot/\"roms_marbl_case.yaml\").read_text())"
+    "print((roms_marbl_case.caseroot / \"roms_marbl_case.yaml\").read_text())\n"
    ]
   },
   {
@@ -838,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "a6149e10-bcd2-4138-aa9a-9ead141336a4",
    "metadata": {
     "scrolled": true
@@ -861,7 +866,7 @@
     }
    ],
    "source": [
-    "roms_marbl_case.build()"
+    "roms_marbl_case.build()\n"
    ]
   },
   {
@@ -878,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "7f180c3c-58b7-43ca-a87e-7e5f2fe8b243",
    "metadata": {
     "scrolled": true
@@ -911,7 +916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "93e65e2d-e016-494c-9c20-f828f8063ae9",
    "metadata": {
     "scrolled": true
@@ -978,12 +983,12 @@
     }
    ],
    "source": [
-    "roms_marbl_case.run()"
+    "roms_marbl_case.run()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "c2ed7080-53cb-404b-abb4-60707260678e",
    "metadata": {
     "scrolled": true
@@ -1077,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "dde01e3d-352c-40b7-91f6-a9bbb38a859c",
    "metadata": {},
    "outputs": [
@@ -1119,35 +1124,35 @@
     }
    ],
    "source": [
-    "ls {roms_marbl_case.caseroot}/output/"
+    "!ls {roms_marbl_case.caseroot}/output/\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "d28e94db-0722-4b63-9c82-91ff3c5d289a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import xarray as xr"
+    "import xarray as xr\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "39ace729-e553-412c-a0b6-4a50a86e5ae7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "BGC_DS = xr.open_dataset(roms_marbl_case.caseroot + '/output/ROMS_MARBL_bgc.20120103120000.nc')\n",
-    "var = 'DOC'\n",
-    "BGC_DA = BGC_DS[var].isel(s_rho=99)"
+    "BGC_DS = xr.open_dataset(roms_marbl_case.caseroot + \"/output/ROMS_MARBL_bgc.20120103120000.nc\")\n",
+    "var = \"DOC\"\n",
+    "BGC_DA = BGC_DS[var].isel(s_rho=99)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "6e52ba38-986d-4943-8301-33e0a682ca23",
    "metadata": {},
    "outputs": [
@@ -1168,8 +1173,8 @@
     "from matplotlib.gridspec import GridSpec\n",
     "\n",
     "fig = plt.figure()\n",
-    "CMAP = plt.colormaps['Spectral_r'].__copy__()\n",
-    "CMAP.set_under('k')\n",
+    "CMAP = plt.colormaps[\"Spectral_r\"].__copy__()\n",
+    "CMAP.set_under(\"k\")\n",
     "\n",
     "gs = GridSpec(3, 2, figure=fig, hspace=0.5)\n",
     "ax1 = fig.add_subplot(gs[0, :])\n",
@@ -1184,20 +1189,20 @@
     "p3 = ax3.pcolormesh(BGC_DA.isel(time=-1).values, vmin=VMIN, vmax=VMAX, cmap=CMAP)\n",
     "[a.set_xticks([]) for a in [ax2, ax3]]\n",
     "[a.set_yticks([]) for a in [ax2, ax3]]\n",
-    "ax2.plot(10, 15, 'kx')\n",
-    "ax3.plot(10, 15, 'kx')\n",
+    "ax2.plot(10, 15, \"kx\")\n",
+    "ax3.plot(10, 15, \"kx\")\n",
     "\n",
-    "ax1.plot(3 + BGC_DA.time * 3600 * 6 / 86400, BGC_DA[:,15,10])\n",
+    "ax1.plot(3 + BGC_DA.time * 3600 * 6 / 86400, BGC_DA[:, 15, 10])\n",
     "ax1.set_xlim(3, 31)\n",
-    "ax1.set_xlabel('Date (January)')\n",
-    "#ax1.set_ylim(VMIN, VMAX)\n",
-    "ax1.plot(3 + BGC_DA.time[0] * 3600 * 6 / 86400, BGC_DA[0,15,10],'kx')\n",
-    "ax1.plot(3 + BGC_DA.time[-1] * 3600 * 6 / 86400, BGC_DA[-1,15,10],'kx')\n",
+    "ax1.set_xlabel(\"Date (January)\")\n",
+    "\n",
+    "ax1.plot(3 + BGC_DA.time[0] * 3600 * 6 / 86400, BGC_DA[0, 15, 10], \"kx\")\n",
+    "ax1.plot(3 + BGC_DA.time[-1] * 3600 * 6 / 86400, BGC_DA[-1, 15, 10], \"kx\")\n",
     "fig.colorbar(p2, ax=ax2)\n",
     "fig.colorbar(p3, ax=ax3)\n",
     "\n",
-    "fig.suptitle(f'Surface {BGC_DS[var].long_name}, ({BGC_DS[var].units})')\n",
-    "fig.set_size_inches(12,6)"
+    "fig.suptitle(f\"Surface {BGC_DS[var].long_name}, ({BGC_DS[var].units})\")\n",
+    "fig.set_size_inches(12, 6)\n"
    ]
   },
   {
@@ -1211,7 +1216,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "cstar",
    "language": "python",
    "name": "python3"
   },
@@ -1225,7 +1230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,93 @@ exclude = "properties|asv_bench|docs"
 # Configuration for ruff linter and formatter
 [tool.ruff]
 fix = true
+show-fixes = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = [
+    "I",
+    "D",
+    "A001",
+    "ANN401",
+    "ARG001",
+    "ARG002",
+    "ARG003",
+    "B018",
+    "BLE001",
+    "COM812",
+    "C901",
+#    "D413",
+    "E402",
+    "F401",
+    "RUF100",
+    "N806",
+    "S301",
+    "TRY004",
+    "PLE1205",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PTH123",
+    "PT006",
+    "PT011",
+    "PT012",
+    "PT019",
+    "PT022",
+    "S102",
+    "SIM102",
+    "SIM115",
+    "SLF001",
+    "UP015",
+    "UP034",
+
+]
+
+ignore = [
+    "B005",     # https://docs.astral.sh/ruff/rules/strip-with-multi-characters/
+    "COM812",   # 
+    "DTZ001",   # https://docs.astral.sh/ruff/rules/call-datetime-without-tzinfo/
+    "D100",     # https://docs.astral.sh/ruff/rules/undocumented-public-module/
+    "D104",     # https://docs.astral.sh/ruff/rules/undocumented-public-package/
+    "D205",     # https://docs.astral.sh/ruff/rules/missing-blank-line-after-summary/
+    "D209",     # https://docs.astral.sh/ruff/rules/new-line-after-last-paragraph/
+    "D213",     # https://docs.astral.sh/ruff/rules/multi-line-summary-second-line/
+#   "D413",     # https://docs.astral.sh/ruff/rules/missing-blank-line-after-last-section/
+    "D416",     # https://docs.astral.sh/ruff/rules/missing-section-name-colon/
+    "DTZ005",   # https://docs.astral.sh/ruff/rules/call-datetime-now-without-tzinfo/
+    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long/
+    "EM101",    # https://docs.astral.sh/ruff/rules/raw-string-in-exception/
+    "EM102",    # https://docs.astral.sh/ruff/rules/f-string-in-exception/
+    "FBT001",   # https://docs.astral.sh/ruff/rules/boolean-type-hint-positional-argument/
+    "FBT002",   # https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/
+    "INP001",   # https://docs.astral.sh/ruff/rules/implicit-namespace-package/
+    "G004",     # https://docs.astral.sh/ruff/rules/logging-f-string/
+    "FIX002",   # https://docs.astral.sh/ruff/rules/line-contains-todo/
+    "PLR0915",  # https://docs.astral.sh/ruff/rules/too-many-statements/
+    "PLR2004",  # https://docs.astral.sh/ruff/rules/magic-value-comparison/
+    "RUF002",   # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring/
+    "RUF015",   # https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element/
+    "S101",     # https://docs.astral.sh/ruff/rules/assert/
+    "S113",     # https://docs.astral.sh/ruff/rules/request-without-timeout/
+    "S603",     # https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/
+    "S604",     # https://docs.astral.sh/ruff/rules/call-with-shell-equals-true/
+    "T201",     # https://docs.astral.sh/ruff/rules/print/
+    "TD002",    # https://docs.astral.sh/ruff/rules/missing-todo-author/
+    "TD003",    # https://docs.astral.sh/ruff/rules/missing-todo-link/
+    "TRY003",   # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
+    "UP007",    # https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/
+]    
+
+[tool.ruff.lint.pylint]
+max-positional-args = 10
+max-args = 14
+max-branches = 15  # PLR0912, default is 12
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15  # C901, default is 10  
 
 [tool.pre-commit]
 config = ".pre-commit-config.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ extend-select = [
     "SIM115",
     "SLF001",
     "UP015",
+    "UP024",
     "UP034",
 
 ]


### PR DESCRIPTION
1. Add full typehinting support to the test suite. 
2. Add rules to pyproject.toml to get consistent formatting behavior from `ruff check` and `precommit run`
3. Fix some bugs in tests (misplaced asserts after `pytest.raise`
4. Added `noqa` and `type[ignore]` mitigations for items for later review

- [X] Tests passing
- [X] Full type hint coverage