### PR TITLE
fix incorrect path in coverage file

### DIFF
--- a/coverage.toml
+++ b/coverage.toml
@@ -1,7 +1,7 @@
 [tool.coverage.run]
 source = ["cstar"]
 omit = [
-    "tests/*",
+    "**/tests/*",
     "**/__init__.py",
     "setup.py",
 ]


### PR DESCRIPTION
This PR fixes a minor defect in the `coverage.toml` file. It fixes the path to the tests directory so they are excluded from code coverage metrics.


- [x] Tests passing
