### PR TITLE
fix incorrect method names in class level docstring

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -207,9 +207,9 @@ class ExternalCodeBase(ABC, LoggingMixin):
 
     def handle_config_status(self) -> None:
         """Perform actions depending on the output of
-        ExternalCodeBase.get_local_config_status()
+        ExternalCodeBase.local_config_status()
 
-        The config_status attribute should be set by the get_local_config_status method
+        The config_status attribute should be set by the local_config_status method
 
         The method then proceeds as follows:
         config_status =

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -45,11 +45,11 @@ class ExternalCodeBase(ABC, LoggingMixin):
 
     Methods
     -------
-    get_local_config_status()
+    local_config_status()
         Perform a series of checks to determine how the external codebase is configured on this machine
         relative to this ExternalCodeBase instance.
     handle_local_config_status()
-        Perform actions depending on the output of get_local_config_status()
+        Perform actions depending on the output of local_config_status()
     get()
         Obtain and configure the external codebase on this machine if it is not already.
         handle_local_config_status() prompts the user to run get() if the model cannot be found.


### PR DESCRIPTION
This PR fixes a minor documentation defects. Some method names were changed in `cstar/base/external_codebase.py`, resulting in a class-level docstring falling out of sync. Additional method level documentation was also updated. 


- [x] Tests added