### PR TITLE
fix missing typehint on simulation.from_blueprint

### DIFF
--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -496,7 +496,7 @@ class Simulation(ABC, LoggingMixin):
         cls,
         blueprint: str,
         directory: str | Path,
-    ):
+    ) -> "Simulation":
         """Abstract method to create a Simulation instance from a blueprint file.
 
         This method should be implemented in subclasses to read a YAML file containing


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation