### PR TITLE
fix typechecker issue on potentially null value

### DIFF
--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -153,6 +153,7 @@ class TestROMSExternalCodeBaseGet:
             assert v0 == actual_value
 
             actual_value = cfg[k1]
+            assert actual_value is not None
             assert v1.split(":")[1] in actual_value
 
             self.mock_subprocess_run.assert_any_call(


### PR DESCRIPTION
This PR mitigates a type-checking issue when static analysis cannot confirm an object is non-null prior to accessing a member.


- [x] Tests added
