### PR TITLE
fix 1 char varname reported by linter

### DIFF
--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -238,8 +238,8 @@ class CStarEnvironment:
         self._call_lmod("reset")
         with open(
             f"{self.package_root}/additional_files/lmod_lists/{self._system_name}.lmod"
-        ) as F:
-            lmod_list = F.readlines()
+        ) as fp:
+            lmod_list = fp.readlines()
             for mod in lmod_list:
                 self._call_lmod(f"load {mod}")
 


### PR DESCRIPTION
This PR fixes a minor issue reported by the linter on a non-standard, 1-character (upper-case) naming of a local var.


- [x] Tests passing
