### PR TITLE
avoid setting non-nullable members to null

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1626,8 +1626,8 @@ class ROMSSimulation(Simulation):
 
         # Reset cached data for input datasets
         for inp in new_sim.input_datasets:
-            inp._local_file_hash_cache = None
-            inp._local_file_stat_cache = None
+            inp._local_file_hash_cache.clear()
+            inp._local_file_stat_cache.clear()
             inp.working_path = None
 
         return new_sim


### PR DESCRIPTION
This PR fixes a bug where a simulation that is restarted is left in a non-viable state. Potential access of the variables that were improperly set to null would break.

- [X] Tests passing
