### PR TITLE
fix unnecessary keys iteration

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -173,12 +173,12 @@ class ExternalCodeBase(ABC, LoggingMixin):
         """
 
         # check 1: X_ROOT variable is in user's env
-        env_var_exists = cstar_sysmgr.environment.environment_variables.get(
+        env_var = cstar_sysmgr.environment.environment_variables.get(
             self.expected_env_var, None
         )
 
         # check 2: X_ROOT points to the correct repository
-        if env_var_exists:
+        if env_var:
             local_root = Path(
                 cstar_sysmgr.environment.environment_variables[self.expected_env_var]
             )

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -173,9 +173,8 @@ class ExternalCodeBase(ABC, LoggingMixin):
         """
 
         # check 1: X_ROOT variable is in user's env
-        env_var_exists = (
-            self.expected_env_var
-            in cstar_sysmgr.environment.environment_variables.keys()
+        env_var_exists = cstar_sysmgr.environment.environment_variables.get(
+            self.expected_env_var, None
         )
 
         # check 2: X_ROOT points to the correct repository


### PR DESCRIPTION
This PR makes a minor tweak to avoid iterating over all keys in a dictionary when a specific key is not found (by getting the key directly instead of checking membership).

- [x] Tests passing
