### PR TITLE
Get rid of global var for user env file path

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -10,7 +10,6 @@ from cstar.base.gitutils import (
     _get_repo_remote,
 )
 from cstar.base.log import LoggingMixin
-from cstar.system.environment import CSTAR_USER_ENV_PATH
 from cstar.system.manager import cstar_sysmgr
 
 
@@ -288,6 +287,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                     cstar_sysmgr.environment.package_root
                     / f"externals/{self.repo_basename}"
                 )
+                user_env_path = cstar_sysmgr.environment.user_env_path
                 print(
                     (
                         "#######################################################\n"
@@ -298,7 +298,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                         "you will need to set it up.\n"
                         "It is recommended that you install this external codebase in \n"
                         f"{ext_dir}\n"
-                        f"This will also modify your `{CSTAR_USER_ENV_PATH}` file.\n"
+                        f"This will also modify your `{user_env_path}` file.\n"
                         "#######################################################"
                     )
                 )

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -7,8 +7,6 @@ from dotenv import dotenv_values, load_dotenv, set_key
 
 from cstar.base.utils import _run_cmd
 
-CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
-
 
 class CStarEnvironment:
     """Encapsulates the configuration and management of a computing environment for a
@@ -65,6 +63,7 @@ class CStarEnvironment:
         self._system_name = system_name
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
+        self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
 
         if self.uses_lmod:
             self.load_lmod_modules(
@@ -122,7 +121,7 @@ class CStarEnvironment:
         env_vars = dotenv_values(
             self.package_root / f"additional_files/env_files/{self._system_name}.env"
         )
-        user_env_vars = dotenv_values(CSTAR_USER_ENV_PATH)
+        user_env_vars = dotenv_values(self._CSTAR_USER_ENV_PATH)
         env_vars.update(user_env_vars)
         return env_vars
 
@@ -164,6 +163,17 @@ class CStarEnvironment:
         """
 
         return (platform.system() == "Linux") and ("LMOD_CMD" in list(os.environ))
+
+    @property
+    def user_env_path(self) -> Path:
+        """Identify the expected path to a .env file for the current user.
+
+        Returns
+        -------
+        Path
+            The path to the `.env` file.
+        """
+        return self._CSTAR_USER_ENV_PATH
 
     def _call_lmod(self, *args) -> None:
         """Calls Linux Environment Modules with specified arguments in python mode.
@@ -254,5 +264,5 @@ class CStarEnvironment:
         value : str
             The value to set for the environment variable.
         """
-        set_key(CSTAR_USER_ENV_PATH, key, value)
-        load_dotenv(CSTAR_USER_ENV_PATH, override=True)
+        set_key(self.user_env_path, key, value)
+        load_dotenv(self._CSTAR_USER_ENV_PATH, override=True)

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -121,7 +121,7 @@ class CStarEnvironment:
         env_vars = dotenv_values(
             self.package_root / f"additional_files/env_files/{self._system_name}.env"
         )
-        user_env_vars = dotenv_values(self._CSTAR_USER_ENV_PATH)
+        user_env_vars = dotenv_values(self.user_env_path)
         env_vars.update(user_env_vars)
         return env_vars
 
@@ -265,4 +265,4 @@ class CStarEnvironment:
             The value to set for the environment variable.
         """
         set_key(self.user_env_path, key, value)
-        load_dotenv(self._CSTAR_USER_ENV_PATH, override=True)
+        load_dotenv(self.user_env_path, override=True)

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -63,8 +63,9 @@ class TestCStar:
 
         with (
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
             ),
             mock.patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=ext_root

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from unittest import mock
 
@@ -113,20 +114,27 @@ def test_codebase_str(generic_codebase):
         )
 
 
-def test_codebase_repr(generic_codebase):
+@mock.patch.dict(os.environ, {})
+def test_codebase_repr(generic_codebase, mock_system_name):
     """Test the repr representation of the `ExternalCodeBase` class."""
 
-    result_repr = repr(generic_codebase)
-    expected_repr = (
-        "MockExternalCodeBase("
-        + "\nsource_repo = 'https://github.com/test/repo.git',"
-        + "\ncheckout_target = 'test_target'"
-        + "\n)"
-        + "\nState: <local_config_status = 3>"
-    )
+    cstar_sysmgr.environment._system_name = mock_system_name
 
-    assert result_repr == expected_repr
-    pass
+    with mock.patch(
+        "cstar.system.environment.dotenv_values",
+        new_callable=mock.Mock,
+        return_value={},
+    ):
+        result_repr = repr(generic_codebase)
+        expected_repr = (
+            "MockExternalCodeBase("
+            + "\nsource_repo = 'https://github.com/test/repo.git',"
+            + "\ncheckout_target = 'test_target'"
+            + "\n)"
+            + "\nState: <local_config_status = 3>"
+        )
+
+        assert result_repr == expected_repr
 
 
 class TestExternalCodeBaseConfig:

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -108,8 +108,9 @@ class TestMARBLExternalCodeBaseGet:
         value = str(marbl_path)
 
         with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
+            "cstar.system.environment.CStarEnvironment.user_env_path",
+            new_callable=mock.PropertyMock,
+            return_value=dotenv_path,
         ):
             # Test
             ## Call the get method
@@ -158,8 +159,9 @@ class TestMARBLExternalCodeBaseGet:
                 ),
             ),
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
             ),
         ):
             marbl_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -116,8 +116,9 @@ class TestROMSExternalCodeBaseGet:
         """Test that the get method succeeds when subprocess calls succeed."""
         # Setup:
         with mock.patch(
-            "cstar.system.environment.CSTAR_USER_ENV_PATH",
-            dotenv_path,
+            "cstar.system.environment.CStarEnvironment.user_env_path",
+            new_callable=mock.PropertyMock,
+            return_value=dotenv_path,
         ):
             ## Mock success of calls to subprocess.run:
             self.mock_subprocess_run.return_value.returncode = 0
@@ -190,8 +191,9 @@ class TestROMSExternalCodeBaseGet:
                 match="Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\nCompiling NHMG library failed successfully",
             ),
             mock.patch(
-                "cstar.system.environment.CSTAR_USER_ENV_PATH",
-                dotenv_path,
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=mock.PropertyMock,
+                return_value=dotenv_path,
             ),
         ):
             roms_codebase.get(target=tmp_path)

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
+from unittest import mock
 from unittest.mock import PropertyMock, call, mock_open, patch
 
 import pytest
@@ -163,7 +164,11 @@ class TestSetupEnvironmentFromFiles:
         )  # fmt: skip
         # Patch the root path and expanduser to point to our temporary files
         with (
-            patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
+            patch(
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=PropertyMock,
+                return_value=dotenv_path,
+            ),
             patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=tmp_path
             ),
@@ -229,7 +234,11 @@ class TestSetupEnvironmentFromFiles:
 
         # Patch the root path and expanduser to point to our temporary files
         with (
-            patch("cstar.system.environment.CSTAR_USER_ENV_PATH", dotenv_path),
+            patch(
+                "cstar.system.environment.CStarEnvironment.user_env_path",
+                new_callable=PropertyMock,
+                return_value=dotenv_path,
+            ),
             patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=tmp_path
             ),
@@ -300,11 +309,6 @@ class TestStrAndReprMethods:
         """
         # Set up our mock environment with some sample properties
 
-        vars = {"VAR1": "value1", "VAR2": "value2"}
-
-        env = MockEnvironment()
-        env._env_vars = vars
-
         # Manually construct the expected string output
         expected_str = (
             "MockEnvironment\n"
@@ -317,7 +321,13 @@ class TestStrAndReprMethods:
             "    VAR2: value2"
         )
 
-        assert str(env) == expected_str
+        with mock.patch(
+            "cstar.system.environment.CStarEnvironment.environment_variables",
+            new_callable=PropertyMock,
+            return_value={"VAR1": "value1", "VAR2": "value2"},
+        ):
+            env = MockEnvironment()
+            assert str(env) == expected_str
 
     @patch.object(
         CStarEnvironment,

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -282,7 +282,7 @@ class TestStrAndReprMethods:
     """
 
     @patch.object(
-        cstar.system.environment.CStarEnvironment,
+        CStarEnvironment,
         "uses_lmod",
         new_callable=PropertyMock(return_value=False),
     )
@@ -299,30 +299,28 @@ class TestStrAndReprMethods:
           like system name, scheduler, compiler, primary queue, and environment variables.
         """
         # Set up our mock environment with some sample properties
-        with (
-            patch.object(
-                MockEnvironment, "environment_variables", new_callable=PropertyMock
-            ) as mock_env_vars,
-        ):
-            mock_env_vars.return_value = {"VAR1": "value1", "VAR2": "value2"}
 
-            env = MockEnvironment()
-            # Manually construct the expected string output
-            expected_str = (
-                "MockEnvironment\n"
-                "---------------\n"  # Length of dashes matches "MockEnvironment"
-                "Compiler: mock_compiler\n"
-                "MPI Exec Prefix: mock_mpi_prefix\n"
-                "Uses Lmod: False\n"
-                "Environment Variables:\n"
-                "    VAR1: value1\n"
-                "    VAR2: value2"
-            )
+        vars = {"VAR1": "value1", "VAR2": "value2"}
 
-            assert str(env) == expected_str
+        env = MockEnvironment()
+        env._env_vars = vars
+
+        # Manually construct the expected string output
+        expected_str = (
+            "MockEnvironment\n"
+            "---------------\n"  # Length of dashes matches "MockEnvironment"
+            "Compiler: mock_compiler\n"
+            "MPI Exec Prefix: mock_mpi_prefix\n"
+            "Uses Lmod: False\n"
+            "Environment Variables:\n"
+            "    VAR1: value1\n"
+            "    VAR2: value2"
+        )
+
+        assert str(env) == expected_str
 
     @patch.object(
-        cstar.system.environment.CStarEnvironment,
+        CStarEnvironment,
         "uses_lmod",
         new_callable=PropertyMock(return_value=False),
     )


### PR DESCRIPTION
This PR gets rid of a globally accessible constant in favor of a private constant in the only location where it should be used. A property is added to access the value and enable mocking in tests.  Existing tests were updated to mock the property in places of the global.


- [X] Tests added
- [X] Tests passing
