### PR TITLE
fix param that fails typecheck

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -793,7 +793,7 @@ class ROMSSimulation(Simulation):
 
         Parameters
         ----------
-        filename : str
+        filename : str or Path
             The name of the YAML file where the blueprint will be saved.
 
         Raises

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -785,7 +785,7 @@ class ROMSSimulation(Simulation):
             bp_dict, directory=directory, start_date=start_date, end_date=end_date
         )
 
-    def to_blueprint(self, filename: str) -> None:
+    def to_blueprint(self, filename: str | Path) -> None:
         """Save the `ROMSSimulation` instance as a YAML blueprint.
 
         This method converts the simulation instance into a dictionary representation

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -533,7 +533,7 @@ class Simulation(ABC, LoggingMixin):
 
         Parameters
         ----------
-        filename : str
+        filename : str or Path
             The path to the YAML file that will be created.
 
         See Also

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -524,7 +524,7 @@ class Simulation(ABC, LoggingMixin):
         pass
 
     @abstractmethod
-    def to_blueprint(self, filename: str) -> None:
+    def to_blueprint(self, filename: str | Path) -> None:
         """Abstract method to save the Simulation instance as a YAML blueprint file.
 
         This method should be implemented in subclasses to serialize the Simulation

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -101,7 +101,7 @@ class TestCStar:
             with mock_user_input("y"):
                 cstar_test_case.setup()
 
-            cstar_test_case.to_blueprint(tmp_path / "test_blueprint_export.yaml")
+            cstar_test_case.to_blueprint(str(tmp_path / "test_blueprint_export.yaml"))
             cstar_test_case.build()
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -101,7 +101,7 @@ class TestCStar:
             with mock_user_input("y"):
                 cstar_test_case.setup()
 
-            cstar_test_case.to_blueprint(str(tmp_path / "test_blueprint_export.yaml"))
+            cstar_test_case.to_blueprint(tmp_path / "test_blueprint_export.yaml")
             cstar_test_case.build()
             cstar_test_case.pre_run()
             test_process = cstar_test_case.run()

--- a/cstar/tests/unit_tests/test_simulation.py
+++ b/cstar/tests/unit_tests/test_simulation.py
@@ -96,7 +96,7 @@ class MockSimulation(Simulation):
     def from_blueprint(cls, blueprint, directory):
         pass
 
-    def to_blueprint(self, filename):
+    def to_blueprint(self, filename: str | Path) -> None:
         pass
 
     def setup(self):


### PR DESCRIPTION
This PR updates the signature of the `to_blueprint` method on `Simulation` and its subclasses to allow strings or paths. This modification enables the type checker to pass a test that previously failed.

- [X] Tests passing
- [X] Full type hint coverage
