### PR TITLE
Refactor lmod path calculation to one location

### DIFF
--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -66,10 +66,7 @@ class CStarEnvironment:
         self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
 
         if self.uses_lmod:
-            self.load_lmod_modules(
-                lmod_file=f"{self.package_root}/additional_files/lmod_lists/{self._system_name}.lmod"
-            )
-        os.environ.update(self.environment_variables)
+            self.load_lmod_modules(lmod_file=self.lmod_path)
 
     @property
     def mpi_exec_prefix(self):
@@ -175,6 +172,18 @@ class CStarEnvironment:
         """
         return self._CSTAR_USER_ENV_PATH
 
+    @property
+    def lmod_path(self) -> Path:
+        """Identify the expected path to a .lmod file for the current system.
+
+        Returns
+        -------
+        Path
+            The complete path to the `.lmod` file.
+        """
+        pkg_relative_path = f"additional_files/lmod_lists/{self._system_name}.lmod"
+        return self.package_root / pkg_relative_path
+
     def _call_lmod(self, *args) -> None:
         """Calls Linux Environment Modules with specified arguments in python mode.
 
@@ -246,12 +255,12 @@ class CStarEnvironment:
                 "Your system does not appear to use Linux Environment Modules"
             )
         self._call_lmod("reset")
-        with open(
-            f"{self.package_root}/additional_files/lmod_lists/{self._system_name}.lmod"
-        ) as fp:
+
+        with open(self.lmod_path) as fp:
             lmod_list = fp.readlines()
-            for mod in lmod_list:
-                self._call_lmod(f"load {mod}")
+
+        for mod in lmod_list:
+            self._call_lmod(f"load {mod}")
 
     def set_env_var(self, key: str, value: str) -> None:
         """Set value of an environment variable and store it in the user environment

--- a/cstar/tests/integration_tests/conftest.py
+++ b/cstar/tests/integration_tests/conftest.py
@@ -1,6 +1,7 @@
 import builtins
 import logging
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
@@ -46,3 +47,38 @@ def mock_user_input():
 @pytest.fixture
 def log() -> logging.Logger:
     return get_logger("cstar.tests.integration_tests")
+
+
+@pytest.fixture
+def mock_lmod_filename() -> str:
+    """Provide a unique .lmod filename for tests.
+
+    Returns
+    -------
+    str
+        The filename
+    """
+    return "mock.lmod"
+
+
+@pytest.fixture
+def mock_lmod_path(tmp_path: Path, mock_lmod_filename: str) -> Path:
+    """Create an empty, temporary .lmod file and return the path.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        The path to a temporary location to write the lmod file
+    mock_lmod_filename : str
+        The filename to use for the .lmod file
+
+    Returns
+    -------
+    str
+        The complete path to the file
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    path = tmp_path / mock_lmod_filename
+    path.touch()  # CStarEnvironment expects the file to exist & opens it
+    return path

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -23,6 +23,7 @@ class TestCStar:
         self,
         tmp_path: Path,
         mock_user_input,
+        mock_lmod_path: Path,
         modify_template_blueprint,
         fetch_roms_tools_source_data,
         fetch_remote_test_case_data,
@@ -66,6 +67,9 @@ class TestCStar:
                 "cstar.system.environment.CStarEnvironment.user_env_path",
                 new_callable=mock.PropertyMock,
                 return_value=dotenv_path,
+            ),
+            mock.patch(
+                "cstar.system.environment.CStarEnvironment.lmod_path", mock_lmod_path
             ),
             mock.patch.object(
                 cstar.system.environment.CStarEnvironment, "package_root", new=ext_root

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,6 +1,9 @@
+import functools
 import logging
-import pathlib
+from collections.abc import Callable
+from pathlib import Path
 
+import dotenv
 import pytest
 
 from cstar.base.log import get_logger
@@ -12,25 +15,19 @@ def log() -> logging.Logger:
 
 
 @pytest.fixture
-def dotenv_path(tmp_path: pathlib.Path) -> pathlib.Path:
-    # A path to a temporary user environment configuration file
-    return tmp_path / ".cstar.env"
-
-
-@pytest.fixture
-def marbl_path(tmp_path: pathlib.Path) -> pathlib.Path:
+def marbl_path(tmp_path: Path) -> Path:
     # A path to a temporary directory for writing the marbl code
     return tmp_path / "marbl"
 
 
 @pytest.fixture
-def roms_path(tmp_path: pathlib.Path) -> pathlib.Path:
+def roms_path(tmp_path: Path) -> Path:
     # A path to a temporary directory for writing the roms code
     return tmp_path / "roms"
 
 
 @pytest.fixture
-def system_dotenv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+def system_dotenv_dir(tmp_path: Path) -> Path:
     # A path to a temporary directory for writing system-level
     # environment configuration file
     return tmp_path / "additional_files" / "env_files"
@@ -43,11 +40,132 @@ def mock_system_name() -> str:
 
 
 @pytest.fixture
-def system_dotenv_path(
-    mock_system_name: str, system_dotenv_dir: pathlib.Path
-) -> pathlib.Path:
+def mock_user_env_name() -> str:
+    """Return a unique name for a temporary user .env config file.
+
+    Returns
+    -------
+    str
+        The name of the .env file
+    """
+    return ".mock.env"
+
+
+@pytest.fixture
+def system_dotenv_path(system_dotenv_dir: Path, mock_system_name: str) -> Path:
     # A path to a temporary, system-level environment configuration file
     if not system_dotenv_dir.exists():
         system_dotenv_dir.mkdir(parents=True)
 
     return system_dotenv_dir / f"{mock_system_name}.env"
+
+
+@pytest.fixture
+def dotenv_path(tmp_path: Path, mock_user_env_name: str) -> Path:
+    """Return a complete path to a temporary user .env file.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        The path to a temporary location to write the env file
+    mock_user_env_name : str
+        The name of the file that will be written
+
+    Returns
+    -------
+    Path
+        The complete path to the config file
+    """
+    return tmp_path / mock_user_env_name
+
+
+def _write_custom_env(path: Path, variables: dict[str, str]) -> None:
+    """Populate a .env configuration file.
+
+    NOTE: repeated calls will update the file
+
+    Parameters
+    ----------
+    path: Path
+        The complete file path to write to
+    variables : dict[str, str]
+        The key-value pairs to be written to the env file
+    """
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True)
+
+    for k, v in variables.items():
+        dotenv.set_key(path, k, v)
+
+
+@pytest.fixture
+def custom_system_env(
+    system_dotenv_path: Path,
+) -> Callable[[dict[str, str]], None]:
+    """Return a function to populate a mocked system environment config file.
+
+    Parameters
+    ----------
+    system_dotenv_path: Path
+        The path to a temporary location to write the env file
+
+    Returns
+    -------
+    Callable[[dict[str, str]], None]
+        A function that will write a new env config file.
+    """
+    return functools.partial(_write_custom_env, system_dotenv_path)
+
+
+@pytest.fixture
+def custom_user_env(
+    dotenv_path: Path,
+) -> Callable[[dict[str, str]], None]:
+    """Return a function to populate a mocked user environment config file.
+
+    Parameters
+    ----------
+    dotenv_path: Path
+        The path to a temporary location to write the env file
+
+    Returns
+    -------
+    Callable[[dict[str, str]], None]
+        A function that will write a new env config file.
+    """
+    return functools.partial(_write_custom_env, dotenv_path)
+
+
+@pytest.fixture
+def mock_lmod_filename() -> str:
+    """Return a complete path to an empty, temporary .lmod config file for tests.
+
+    Returns
+    -------
+    str
+        The filename
+    """
+    return "mock.lmod"
+
+
+@pytest.fixture
+def mock_lmod_path(tmp_path: Path, mock_lmod_filename: str) -> Path:
+    """Create an empty, temporary .lmod file and return the path.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        The path to a temporary location to write the lmod file
+    mock_lmod_filename : str
+        The filename to use for the .lmod file
+
+    Returns
+    -------
+    str
+        The complete path to the file
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    path = tmp_path / mock_lmod_filename
+    path.touch()  # CStarEnvironment expects the file to exist & opens it
+    return path


### PR DESCRIPTION
This PR refactors the creation of the lmod path into a property on `CStarEnvironment` and updates two locations indepdentdently calculating the same path. It also adds some fixtures for mocking the lmod path.


- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
