### PR TITLE
Add class to track metadata of local files

### DIFF
--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -132,7 +132,7 @@ class AdditionalCode(LoggingMixin):
     @property
     def exists_locally(self):
         if not self.local_file_stats:
-            return None
+            return False
         try:
             self.local_file_stats.validate()
         except (FileNotFoundError, ValueError):

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -135,7 +135,7 @@ class AdditionalCode(LoggingMixin):
             return False
         try:
             self.local_file_stats.validate()
-        except (FileNotFoundError, ValueError):
+        except (FileNotFoundError, ValueError, KeyError):
             return False
         return True
 

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -76,7 +76,15 @@ class AdditionalCode(LoggingMixin):
         self.source: DataSource = DataSource(location)
         self.subdir: str = subdir
         self._checkout_target = checkout_target
-        self.files: Optional[list[str]] = [] if files is None else files
+
+        self.files: Optional[list[str]]
+        if files is None:
+            self.files = []
+        elif any((not f) for f in files):
+            raise ValueError("An invalid filename was supplied to AdditionalCode")
+        else:
+            self.files = files
+
         # Initialize object state
         self.local_file_stats: Optional[LocalFileStatistics] = None
 

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -121,18 +121,26 @@ class AdditionalCode(LoggingMixin):
 
     @property
     def checkout_target(self) -> Optional[str]:
+        """If in a repository, the commit hash or tag at which to checkout this
+        additional code."""
         return self._checkout_target
 
     @property
     def working_path(self) -> Optional[Path]:
+        """The current local path where this AdditionalCode exists on the local system,
+        if it has been fetched."""
+
         if self.local_file_stats is None:
             return None
         return self.local_file_stats.parent_dir
 
     @property
-    def exists_locally(self):
+    def exists_locally(self) -> bool:
+        """Determines whether this AdditionalCode instance exists on the local
+        system."""
         if not self.local_file_stats:
             return False
+
         try:
             self.local_file_stats.validate()
         except (FileNotFoundError, ValueError, KeyError):
@@ -212,7 +220,6 @@ class AdditionalCode(LoggingMixin):
                 paths=[local_dir / Path(f).name for f in self.files]
             )
             self.log.info("✅ All files copied successfully")
-            # self.working_path = local_dir
 
         finally:
             if tmp_dir:

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -225,7 +225,7 @@ class AdditionalCode(LoggingMixin):
                     raise FileNotFoundError(f"Error: {src_file_path} does not exist.")
 
             self.local_file_stats = LocalFileStatistics(
-                paths=[local_dir / Path(f).name for f in self.files]
+                files=[local_dir / Path(f).name for f in self.files]
             )
             self.log.info("✅ All files copied successfully")
 

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -78,7 +78,6 @@ class AdditionalCode(LoggingMixin):
         self._checkout_target = checkout_target
         self.files: Optional[list[str]] = [] if files is None else files
         # Initialize object state
-        # self.working_path: Optional[Path] = None
         self.local_file_stats: Optional[LocalFileStatistics] = None
 
     def __str__(self) -> str:
@@ -89,8 +88,8 @@ class AdditionalCode(LoggingMixin):
             base_str += f"\nSubdirectory: {self.subdir}"
         if self.checkout_target is not None:
             base_str += f"\nCheckout target: {self.checkout_target}"
-        # base_str += f"\nWorking path: {self.working_path}"
-        # base_str += f"\nExists locally: {self.exists_locally}"
+        base_str += f"\nWorking path: {self.working_path}"
+        base_str += f"\nExists locally: {self.exists_locally}"
         if not self.exists_locally:
             base_str += " (get with AdditionalCode.get())"
         if self.files is not None:
@@ -112,9 +111,9 @@ class AdditionalCode(LoggingMixin):
         # Additional info:
         info_str = ""
 
-        # if self.working_path is not None:
-        #     info_str += f"working_path = {self.working_path},"
-        #     info_str += f"exists_locally = {self.exists_locally}"
+        if self.working_path is not None:
+            info_str += f"working_path = {self.working_path},"
+            info_str += f"exists_locally = {self.exists_locally}"
 
         if len(info_str) > 0:
             repr_str += f"\nState: <{info_str}>"
@@ -123,6 +122,12 @@ class AdditionalCode(LoggingMixin):
     @property
     def checkout_target(self) -> Optional[str]:
         return self._checkout_target
+
+    @property
+    def working_path(self) -> Optional[Path]:
+        if self.local_file_stats is None:
+            return None
+        return self.local_file_stats.parent_dir
 
     @property
     def exists_locally(self):

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -205,9 +205,6 @@ class AdditionalCode(LoggingMixin):
                 )
                 if src_file_path.exists():
                     shutil.copy(src_file_path, tgt_file_path)
-                    # self._local_file_hash_cache[tgt_file_path] = _get_sha256_hash(
-                    #     tgt_file_path
-                    # )
                 else:
                     raise FileNotFoundError(f"Error: {src_file_path} does not exist.")
 

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -8,7 +8,7 @@ import dateutil.parser
 import pooch
 
 from cstar.base.datasource import DataSource
-from cstar.base.local_file_stats import LocalFileStatistics
+from cstar.base.local_file_stats import FileInfo, LocalFileStatistics
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import _get_sha256_hash
 
@@ -196,11 +196,9 @@ class InputDataset(ABC, LoggingMixin):
 
         p = target_path.absolute()
         self.local_file_stats = LocalFileStatistics(
-            paths=[
-                p,
-            ],
-            stats={p: p.stat()},
-            hashes={p: computed_file_hash},
+            files=[
+                FileInfo(path=p, stat=p.stat(), sha256=computed_file_hash),
+            ]
         )
 
     @staticmethod

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -191,7 +191,6 @@ class InputDataset(ABC, LoggingMixin):
             logger=self.log,
         )
 
-        # TODO
         p = target_path.absolute()
         self.local_file_stats = LocalFileStatistics(
             paths=[
@@ -211,7 +210,7 @@ class InputDataset(ABC, LoggingMixin):
     ) -> str:
         if location_type == "path":
             source_location = Path(source_location).expanduser().resolve()
-            # TODO this probably doesn't need to be calculated here
+            # TODO when refactoring get(), avoid calculating hash here
             computed_file_hash = _get_sha256_hash(source_location)
             if (expected_file_hash is not None) and (
                 expected_file_hash != computed_file_hash

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -148,7 +148,7 @@ class InputDataset(ABC, LoggingMixin):
             return False
         try:
             self.local_file_stats.validate()
-        except (FileNotFoundError, ValueError):
+        except (FileNotFoundError, ValueError, KeyError):
             return False
         return True
 
@@ -291,12 +291,13 @@ class InputDataset(ABC, LoggingMixin):
         )
 
         # TODO
+        p = target_path.absolute()
         self.local_file_stats = LocalFileStatistics(
             paths=[
-                target_path,
+                p,
             ],
-            stats={target_path: target_path.stat()},
-            hashes={target_path: computed_file_hash},
+            stats={p: p.stat()},
+            hashes={p: computed_file_hash},
         )
         # self.working_path = target_path
         # self._local_file_hash_cache.update({target_path: computed_file_hash})  # 27

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -85,6 +85,7 @@ class InputDataset(ABC, LoggingMixin):
 
     @property
     def exists_locally(self):
+        """Determines whether this InputDataset instance exists on the local system."""
         if not self.local_file_stats:
             return False
         try:
@@ -95,6 +96,8 @@ class InputDataset(ABC, LoggingMixin):
 
     @property
     def working_path(self) -> Optional[Path | list[Path]]:
+        """The current local path where this InputDataset exists on the local system, if
+        it has been fetched."""
         if self.local_file_stats is None:
             return None
         if len(self.local_file_stats.paths) == 1:
@@ -208,6 +211,8 @@ class InputDataset(ABC, LoggingMixin):
         target_path: Path,
         logger: "logging.Logger",
     ) -> str:
+        """Helper method to either create a symbolic link to this InputDataset (if it
+        exists on the local filesystem) or download it (if it is located remotely)."""
         if location_type == "path":
             source_location = Path(source_location).expanduser().resolve()
             # TODO when refactoring get(), avoid calculating hash here

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -62,7 +62,7 @@ class InputDataset(ABC, LoggingMixin):
         ):
             raise ValueError(
                 f"Cannot create InputDataset for \n {self.source.location}:\n "
-                + "InputDataset.source.file_hash cannot be 'None if InputDataset.source.location_type is 'url'.\n"
+                + "InputDataset.source.file_hash cannot be None if InputDataset.source.location_type is 'url'.\n"
                 + "A file hash is required to verify non-plaintext files downloaded from remote sources."
             )
         if isinstance(start_date, str):
@@ -76,71 +76,12 @@ class InputDataset(ABC, LoggingMixin):
 
         # Initialize object state:
         self.local_file_stats: Optional[LocalFileStatistics] = None
-        # TODO
-        # self.working_path: Optional[Path | List[Path]] = None
-        # self._local_file_hash_cache: Dict = {}
-        # self._local_file_stat_cache: Dict = {}
 
         # Subclass-specific  confirmation that everything is set up correctly:
         self.validate()
 
     def validate(self):
         pass
-
-    # @property
-    # def exists_locally(self) -> bool:
-    #     """Check if this InputDataset exists on the local filesystem.
-
-    #     This method verifies the following for each file in `InputDataset.working_path`:
-    #     1. The file exists at the specified path.
-    #     2. The file's current size and modification date match values cached by `InputDataset.get()`
-    #     3. If the size matches but the modification time does not, the file's SHA-256 hash
-    #        is computed and compared against a value cached by `InputDataset.get()`
-
-    #     Returns:
-    #     --------
-    #     exists_locally (bool): True if all files pass the existence, size, modification
-    #         time, and (if necessary) hash checks. Returns False otherwise.
-
-    #     Notes:
-    #     ------
-    #         If C-Star cannot access cached file statistics, it is impossible to verify
-    #         whether the InputDataset is correct, and so `False` is returned.
-    #     """
-    #     if (self.working_path is None) or (not self._local_file_stat_cache):
-    #         return False
-
-    #     # Ensure working_path is a list for unified iteration
-    #     paths = (
-    #         self.working_path
-    #         if isinstance(self.working_path, list)
-    #         else [self.working_path]
-    #     )
-
-    #     for path in paths:
-    #         # Check if the file exists
-    #         if not path.exists():
-    #             return False
-
-    #         # Retrieve the cached stats
-    #         cached_stats = self._local_file_stat_cache.get(path)
-    #         if cached_stats is None:
-    #             return False  # No stats cached for this file
-
-    #         # Compare size first
-    #         current_stats = path.stat()
-    #         if current_stats.st_size != cached_stats.st_size:
-    #             return False  # Size mismatch, no need to check further
-
-    #         # Compare modification time, fallback to hash check if mismatched
-    #         if current_stats.st_mtime != cached_stats.st_mtime:
-    #             current_hash = _get_sha256_hash(path.resolve())
-    #             if (self._local_file_hash_cache is None) or (
-    #                 self._local_file_hash_cache.get(path) != current_hash
-    #             ):
-    #                 return False
-
-    #     return True
 
     @property
     def exists_locally(self):
@@ -160,41 +101,6 @@ class InputDataset(ABC, LoggingMixin):
             return self.local_file_stats.paths[0]
         return self.local_file_stats.paths
 
-    # @property #TODO
-    # def local_hash(self) -> Optional[Dict]:
-    #     """Compute or retrieve the cached SHA-256 hash of the local dataset.
-
-    #     This property calculates the SHA-256 hash for the dataset located at `working_path`.
-    #     If the hash has been previously computed and cached by InputDataset.get(),
-    #     it will return the cached value instead of recomputing it.
-
-    #     If `working_path` is a list of paths, the hash is computed for each file
-    #     individually. The hashes are stored as a dictionary mapping paths to their
-    #     respective hash values.
-
-    #     Returns
-    #     -------
-    #     local_hash (dict or None)
-    #         - A dictionary where the keys are `Path` objects representing file paths
-    #           and the values are their respective SHA-256 hashes.
-    #         - `None` if `working_path` is not set or no files exist locally.
-    #     """
-
-    #     if self._local_file_hash_cache:
-    #         return self._local_file_hash_cache
-
-    #     if (not self.exists_locally) or (self.working_path is None):
-    #         local_hash = {}
-    #     elif isinstance(self.working_path, list):
-    #         local_hash = {
-    #             path: _get_sha256_hash(path.resolve()) for path in self.working_path
-    #         }
-    #     elif isinstance(self.working_path, Path):
-    #         local_hash = {self.working_path: _get_sha256_hash(self.working_path)}
-
-    #     self._local_file_hash_cache.update(local_hash)
-    #     return local_hash
-
     def __str__(self) -> str:
         name = self.__class__.__name__
         base_str = f"{name}"
@@ -210,12 +116,9 @@ class InputDataset(ABC, LoggingMixin):
             base_str += f"\nend_date: {self.end_date}"
         base_str += f"\nWorking path: {self.working_path}"
         if self.exists_locally:
-            base_str += " (exists)"
+            base_str += " (exists. Query local file statistics with InputDataset.local_file_stats)"
         else:
             base_str += " ( does not yet exist. Call InputDataset.get() )"
-
-        # if self.local_hash: #TODO
-        #     base_str += f"\nLocal hash: {self.local_hash}"
         return base_str
 
     def __repr__(self) -> str:
@@ -233,8 +136,6 @@ class InputDataset(ABC, LoggingMixin):
             info_str += f"working_path = {self.working_path}"
             if not self.exists_locally:
                 info_str += " (does not exist)"
-        # if self.local_hash:
-        #     info_str += f", local_hash = {self.local_hash}"
         if len(info_str) > 0:
             repr_str += f"\nState: <{info_str}>"
         # Additional info
@@ -299,9 +200,6 @@ class InputDataset(ABC, LoggingMixin):
             stats={p: p.stat()},
             hashes={p: computed_file_hash},
         )
-        # self.working_path = target_path
-        # self._local_file_hash_cache.update({target_path: computed_file_hash})  # 27
-        # self._local_file_stat_cache.update({target_path: target_path.stat()})
 
     @staticmethod
     def _symlink_or_download_from_source(

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -251,3 +251,8 @@ class InputDataset(ABC, LoggingMixin):
                     + "Cannot proceed."
                 )
         return computed_file_hash
+
+    def _clear(self):
+        """Reset the internal state of this InputDataset, clearing any cached
+        information such as local file statistics."""
+        self.local_file_stats = None

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -6,13 +6,57 @@ from pathlib import Path
 from typing import Optional
 
 from cstar.base.utils import _get_sha256_hash
+from cstar.base.log import get_logger
 
+logger = get_logger(__name__)
 
-@dataclass
 class FileInfo:
-    path: Path
-    stat: Optional[os.stat_result] = None
-    sha256: Optional[str] = None
+
+    def __init__(self, path: Path|str, stat: os.stat_result | None = None, sha256: str | None = None):
+
+        self.path = Path(path).absolute()
+        self._stat = stat
+        self._sha256 = sha256
+
+    @property
+    def stat(self) -> os.stat_result:
+        if self._stat is None:
+            self._stat = self.path.stat()
+        return self._stat
+
+    @property
+    def sha256(self) -> str:
+        if self._sha256 is None:
+            self._sha256 = _get_sha256_hash(self.path)
+        return self._sha256
+
+    def validate(self) -> bool:
+        if not self.path.exists():
+            raise FileNotFoundError(f"File {self.path} does not exist locally")
+
+        current_stat = self.path.stat()
+
+        if not self._stat:
+            logger.debug(f"File {self.path} has no cached stat")
+            self._stat = current_stat
+        else:
+
+            if (
+                current_stat.st_size != self.stat.st_size
+                or current_stat.st_mtime != self.stat.st_mtime
+            ):
+                raise ValueError(f"File statistics for {self.path} do not match those in cache")
+
+        current_hash = _get_sha256_hash(self.path)
+        if not self._sha256:
+            logger.debug(f"File {self.path} has no cached hash")
+        else:
+
+            if current_hash != self.sha256:
+                raise ValueError(
+                    f"Computed SHA256 hash for {self.path} ({current_hash}) does not "
+                    f"match value in cache ({self.sha256})"
+                )
 
 
 class LocalFileStatistics:
@@ -80,9 +124,7 @@ class LocalFileStatistics:
             raise ValueError("At least one file must be provided.")
 
         # Initialize attributes
-        self._stat_cache: dict[Path, os.stat_result] = {}
-        self._hash_cache: dict[Path, str] = {}
-        self.paths: list[Path] = []
+        self.files: dict[Path, FileInfo] = {}
 
         # Normalize files to all be FileInfo instances:
         def to_fileinfo(item: Path | FileInfo) -> FileInfo:
@@ -90,25 +132,30 @@ class LocalFileStatistics:
                 return item
             return FileInfo(path=item)
 
-        normalized_files = [to_fileinfo(f) for f in files]
+        self.files: dict[Path: FileInfo] = {f: to_fileinfo(f) for f in files}
 
         # For checking all files are colocated with the first:
-        first_parent = normalized_files[0].path.absolute().parent
+        first_parent = self.paths[0].parent
 
-        for f in normalized_files:
-            abs_path = f.path.absolute()
+        for f in self.paths:
 
-            if abs_path.parent != first_parent:
+            if f.parent != first_parent:
                 raise ValueError("All files must be in the same directory")
 
-            self.paths.append(abs_path)
-
-            if f.stat is not None:
-                self._stat_cache[abs_path] = f.stat
-            if f.sha256 is not None:
-                self._hash_cache[abs_path] = f.sha256
-
         self.parent_dir: Path = first_parent
+
+    @property
+    def paths(self) -> list[Path]:
+        return [f.path for f in self.files.values()]
+
+    @property
+    def stats(self) -> list[os.stat_result]:
+        return [f.stat for f in self.files.values()]
+
+    @property
+    def hashes(self) -> list[str]:
+        return [f.sha256 for f in self.files.values()]
+
 
     def __getitem__(self, key: str | Path) -> FileInfo:
         path = Path(key).absolute()
@@ -116,48 +163,8 @@ class LocalFileStatistics:
         if path not in self.paths:
             raise KeyError(f"{path} not found.")
 
-        return FileInfo(
-            path=path,
-            stat=self.stats[path],
-            sha256=self.hashes[path],
-        )
+        return self.files[path]
 
-    @property
-    def stats(self) -> dict[Path, os.stat_result]:
-        """File stat metadata for each tracked file.
-
-        Lazily computes and caches the output of `os.stat()` for each tracked
-        file path if not already provided. Returned as a dictionary mapping
-        absolute file paths to their `os.stat_result` values.
-
-        Returns
-        -------
-        dict of Path to os.stat_result
-            Mapping from file paths to their stat metadata.
-        """
-        if not self._stat_cache:
-            self._stat_cache = {path: path.stat() for path in self.paths}
-        return self._stat_cache
-
-    @property
-    def hashes(self) -> dict[Path, str]:
-        """SHA-256 hashes for each tracked file.
-
-        Lazily computes and caches the SHA-256 hash for each file using
-        `_get_sha256_hash()` if not already provided. Returned as a dictionary
-        mapping absolute file paths to their hash strings.
-
-        Returns
-        -------
-        dict of Path to str
-            Mapping from file paths to their SHA-256 hash values.
-        """
-
-        if not self._hash_cache:
-            self._hash_cache = {
-                path: _get_sha256_hash(path.resolve()) for path in self.paths
-            }
-        return self._hash_cache
 
     def validate(self) -> None:
         """Validate that all tracked files exist and match cached metadata.
@@ -174,26 +181,8 @@ class LocalFileStatistics:
             If the current size, modification time, or SHA-256 hash of a file
             differs from the cached value.
         """
+        [f.validate() for f in self.files.values()]
 
-        for f in self.paths:
-            if not f.exists():
-                raise FileNotFoundError(f"File {f} does not exist locally")
-
-            cached_stats = self.stats[f]
-            current_stats = f.stat()
-
-            if (
-                current_stats.st_size != cached_stats.st_size
-                or current_stats.st_mtime != cached_stats.st_mtime
-            ):
-                raise ValueError(f"File statistics for {f} do not match those in cache")
-
-            current_hash = _get_sha256_hash(f)
-            if current_hash != self.hashes[f]:
-                raise ValueError(
-                    f"Computed SHA256 hash for {f} ({current_hash}) does not "
-                    f"match value in cache ({self.hashes[f]})"
-                )
 
     def __str__(self) -> str:
         base_str = self.__class__.__name__ + "\n"
@@ -227,21 +216,19 @@ class LocalFileStatistics:
         header = f"{'Name':<40} {'Hash':<12} {'Size (bytes)':<12} {'Modified'}"
         rows = []
 
-        for path in self.paths[:max_rows]:
-            abspath = path.absolute()
-            stat = self.stats.get(abspath)
-            hash_ = self.hashes.get(abspath)
+        for p in self.paths[:max_rows]:
+            fi = self.files[p]
+            abspath = fi.path
+            stat = fi.stat
+            hash_ = fi.sha256
 
-            name = str(path.name)
-            size = stat.st_size if stat else "UNKNOWN"
-            mtime = (
-                datetime.fromtimestamp(stat.st_mtime).isoformat(
+            name = str(abspath.name)
+            size = stat.st_size
+            mtime = datetime.fromtimestamp(stat.st_mtime).isoformat(
                     sep=" ", timespec="seconds"
                 )
-                if stat
-                else "UNKNOWN"
-            )
-            short_hash = hash_[:10] + "…" if hash_ else "UNKNOWN"
+
+            short_hash = hash_[:10] + "…"
 
             rows.append(f"{name:<40} {short_hash:<12} {size:<12} {mtime}")
 

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -97,8 +97,8 @@ class LocalFileStatistics:
                 raise FileNotFoundError(f"File {f} does not exist locally")
 
             current_stats = f.stat()
-            if (f.stat.st_size != current_stats.st_size) or (
-                f.stat.st_mtime != current_stats.st_mtime
+            if (f.stat().st_size != current_stats.st_size) or (
+                f.stat().st_mtime != current_stats.st_mtime
             ):
                 raise ValueError(f"File statistics for {f} do not match those in cache")
 

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -62,14 +62,15 @@ class LocalFileStatistics:
         self.parent_dir = paths[0].parent
 
         if stats is not None:
-            if set(k.resolve() for k in stats.keys()) != self.paths:
+            if set(k.resolve() for k in stats.keys()) != set(self.paths):
+                # import pdb;pdb.set_trace()
                 raise ValueError("Provided 'stats' keys must match provided 'paths'")
             self._stat_cache = stats
         else:
             self._stat_cache = dict[Path, os.stat_result]()
 
         if hashes is not None:
-            if set(k.resolve() for k in hashes.keys()) != self.paths:
+            if set(k.resolve() for k in hashes.keys()) != set(self.paths):
                 raise ValueError("Provided 'hashes' keys must provided 'paths'")
             self._hash_cache = hashes
         else:

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -3,13 +3,11 @@ from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 
-from cstar.base.log import get_logger
+from cstar.base.log import LoggingMixin
 from cstar.base.utils import _get_sha256_hash
 
-logger = get_logger(__name__)
 
-
-class FileInfo:
+class FileInfo(LoggingMixin):
     """Holds information about an individual file on the local system."""
 
     def __init__(
@@ -56,8 +54,7 @@ class FileInfo:
         current_stat = self.path.stat()
 
         if not self._stat:
-            logger.debug(f"File {self.path} has no cached stat")
-            self._stat = current_stat
+            self.log.debug(f"File {self.path} has no cached stat")
         else:
             if (
                 current_stat.st_size != self.stat.st_size
@@ -69,7 +66,7 @@ class FileInfo:
 
         current_hash = _get_sha256_hash(self.path)
         if not self._sha256:
-            logger.debug(f"File {self.path} has no cached hash")
+            self.log.debug(f"File {self.path} has no cached hash")
         else:
             if current_hash != self.sha256:
                 raise ValueError(
@@ -78,7 +75,7 @@ class FileInfo:
                 )
 
 
-class LocalFileStatistics:
+class LocalFileStatistics(LoggingMixin):
     """Tracks file metadata (stat and SHA-256 hash) for a list of local files."""
 
     def __init__(self, files: Sequence[Path | FileInfo]):

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -79,7 +79,7 @@ class LocalFileStatistics:
 
         self.paths = [p.absolute() for p in paths]
 
-        if not all([d.parent == self.paths[0].parent for d in self.paths]):
+        if not all(d.parent == self.paths[0].parent for d in self.paths):
             raise ValueError(
                 "LocalFileStatistics requires paths to exist in a common directory"
             )

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -101,7 +101,7 @@ class LocalFileStatistics:
             self._hash_cache = dict[Path, str]()
 
     @property
-    def stats(self):
+    def stats(self) -> dict[Path, os.stat_result]:
         """File stat metadata for each tracked file.
 
         Lazily computes and caches the output of `os.stat()` for each tracked
@@ -118,7 +118,7 @@ class LocalFileStatistics:
         return self._stat_cache
 
     @property
-    def hashes(self):
+    def hashes(self) -> dict[Path, str]:
         """SHA-256 hashes for each tracked file.
 
         Lazily computes and caches the SHA-256 hash for each file using

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -70,7 +70,7 @@ class LocalFileStatistics:
 
         if hashes is not None:
             if set(k.absolute() for k in hashes.keys()) != set(self.paths):
-                raise ValueError("Provided 'hashes' keys must provided 'paths'")
+                raise ValueError("Provided 'hashes' keys must match provided 'paths'")
             self._hash_cache = hashes
         else:
             self._hash_cache = dict[Path, str]()
@@ -96,9 +96,12 @@ class LocalFileStatistics:
             if not f.exists():
                 raise FileNotFoundError(f"File {f} does not exist locally")
 
+            cached_stats = self.stats[f]
             current_stats = f.stat()
-            if (f.stat().st_size != current_stats.st_size) or (
-                f.stat().st_mtime != current_stats.st_mtime
+
+            if (
+                current_stats.st_size != cached_stats.st_size
+                or current_stats.st_mtime != cached_stats.st_mtime
             ):
                 raise ValueError(f"File statistics for {f} do not match those in cache")
 

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -148,12 +148,12 @@ class LocalFileStatistics:
         return [f.path for f in self.files.values()]
 
     @property
-    def stats(self) -> list[os.stat_result]:
-        return [f.stat for f in self.files.values()]
+    def stats(self) -> dict[Path, os.stat_result]:
+        return {f.path: f.stat for f in self.files.values()}
 
     @property
-    def hashes(self) -> list[str]:
-        return [f.sha256 for f in self.files.values()]
+    def hashes(self) -> dict[Path, str]:
+        return {f.path: f.sha256 for f in self.files.values()}
 
     def __getitem__(self, key: str | Path) -> FileInfo:
         path = Path(key).absolute()

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -1,0 +1,165 @@
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from cstar.base.utils import _get_sha256_hash
+
+
+class LocalFileStatistics:
+    """Tracks file metadata (stat and SHA-256 hash) for a list of local files.
+
+    Parameters
+    ----------
+    paths : list of Path
+        List of file paths to track. All paths must be in the same parent directory.
+    stats : dict of Path to os.stat_result, optional
+        Optional precomputed stat results. If not provided, they will be computed lazily.
+    hashes : dict of Path to str, optional
+        Optional precomputed SHA-256 hashes. If not provided, they will be computed lazily.
+
+    Attributes
+    ----------
+    paths : list of Path
+        The list of tracked file paths.
+    parent_dir : Path
+        The common parent directory of all paths.
+    stats : dict of Path to os.stat_result
+        Mapping of paths to their `os.stat()` results. Evaluated lazily.
+    hashes : dict of Path to str
+        Mapping of paths to their SHA-256 hash strings. Evaluated lazily.
+
+    Raises
+    ------
+    ValueError
+        If the provided paths are not all in the same directory
+        or if the keys of the `stats` or `hashes` dictionaries do not exactly
+        match the resolved set of `paths`.
+
+    Examples
+    --------
+    >>> files = [Path("data/a.txt"), Path("data/b.txt")]
+    >>> tracker = LocalFileStatistics(files)
+    >>> tracker.stats[files[0]]
+    os.stat_result(...)
+    >>> tracker.hashes[files[0]]
+    'e3b0c44298fc1c149afbf4c8996fb924...'
+    """
+
+    def __init__(
+        self,
+        paths: list[Path],
+        stats: Optional[dict[Path, os.stat_result]] = None,
+        hashes: Optional[dict[Path, str]] = None,
+    ):
+        self.paths = [p.resolve() for p in paths]
+
+        if not all([d.parent == self.paths[0].parent for d in self.paths]):
+            raise ValueError(
+                "LocalFileStatistics requires paths to exist in a common directory"
+            )
+
+        self.parent_dir = paths[0].parent
+
+        if stats is not None:
+            if set(k.resolve() for k in stats.keys()) != self.paths:
+                raise ValueError("Provided 'stats' keys must match provided 'paths'")
+            self._stat_cache = stats
+        else:
+            self._stat_cache = dict[Path, os.stat_result]()
+
+        if hashes is not None:
+            if set(k.resolve() for k in hashes.keys()) != self.paths:
+                raise ValueError("Provided 'hashes' keys must provided 'paths'")
+            self._hash_cache = hashes
+        else:
+            self._hash_cache = dict[Path, str]()
+
+    @property
+    def stats(self):
+        if not self._stat_cache:
+            self._stat_cache = {path: path.stat() for path in self.paths}
+        return self._stat_cache
+
+    @property
+    def hashes(self):
+        if not self._hash_cache:
+            self._hash_cache = {
+                path: _get_sha256_hash(path.resolve()) for path in self.paths
+            }
+        return self._hash_cache
+
+    def validate(self) -> None:
+        """TOOD docstring."""
+
+        for f in self.paths:
+            if not f.exists():
+                raise FileNotFoundError(f"File {f} does not exist locally")
+
+            current_stats = f.stat()
+            if (f.stat.st_size != current_stats.st_size) or (
+                f.stat.st_mtime != current_stats.st_mtime
+            ):
+                raise ValueError(f"File statistics for {f} do not match those in cache")
+
+            current_hash = _get_sha256_hash(f)
+            if current_hash != self.hashes[f]:
+                raise ValueError(
+                    f"Computed SHA256 hash for {f} ({current_hash}) does not "
+                    f"match value in cache ({self.hashes[f]})"
+                )
+
+    def __str__(self) -> str:
+        base_str = self.__class__.__name__ + "\n"
+        base_str += "-" * (len(base_str) - 1) + "\n"
+        base_str += "Parent directory: "
+        base_str += f"{self.parent_dir}\n"
+        base_str += "Files: \n\n"
+        base_str += self.as_table()
+        return base_str
+
+    def __repr__(self) -> str:
+        repr_str = self.__class__.__name__ + "("
+        repr_str += "paths="
+        repr_str += f"{(',\n'+' '*len(repr_str)).join([str(p) for p in self.paths])}"
+        repr_str += ")"
+        return repr_str
+
+    def as_table(self, max_rows: int = 20) -> str:
+        """Return a tabular string view of tracked files with basic metadata.
+
+        Parameters
+        ----------
+        max_rows : int
+            Maximum number of rows to show (truncate with ... if more)
+
+        Returns
+        -------
+        str
+            Formatted table of file metadata.
+        """
+        header = f"{'Name':<40} {'Hash':<12} {'Size (bytes)':<12} {'Modified'}"
+        rows = []
+
+        for path in self.paths[:max_rows]:
+            resolved = path.resolve()
+            stat = self.stats.get(resolved)
+            hash_ = self.hashes.get(resolved)
+
+            name = str(path.name)
+            size = stat.st_size if stat else "UNKNOWN"
+            mtime = (
+                datetime.fromtimestamp(stat.st_mtime).isoformat(
+                    sep=" ", timespec="seconds"
+                )
+                if stat
+                else "UNKNOWN"
+            )
+            short_hash = hash_[:10] + "…" if hash_ else "UNKNOWN"
+
+            rows.append(f"{name:<40} {short_hash:<12} {size:<12} {mtime}")
+
+        if len(self.paths) > max_rows:
+            rows.append(f"... ({len(self.paths) - max_rows} more files)")
+
+        return "\n".join([header] + rows)

--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -52,7 +52,7 @@ class LocalFileStatistics:
         stats: Optional[dict[Path, os.stat_result]] = None,
         hashes: Optional[dict[Path, str]] = None,
     ):
-        self.paths = [p.resolve() for p in paths]
+        self.paths = [p.absolute() for p in paths]
 
         if not all([d.parent == self.paths[0].parent for d in self.paths]):
             raise ValueError(
@@ -62,15 +62,14 @@ class LocalFileStatistics:
         self.parent_dir = paths[0].parent
 
         if stats is not None:
-            if set(k.resolve() for k in stats.keys()) != set(self.paths):
-                # import pdb;pdb.set_trace()
+            if set(k.absolute() for k in stats.keys()) != set(self.paths):
                 raise ValueError("Provided 'stats' keys must match provided 'paths'")
             self._stat_cache = stats
         else:
             self._stat_cache = dict[Path, os.stat_result]()
 
         if hashes is not None:
-            if set(k.resolve() for k in hashes.keys()) != set(self.paths):
+            if set(k.absolute() for k in hashes.keys()) != set(self.paths):
                 raise ValueError("Provided 'hashes' keys must provided 'paths'")
             self._hash_cache = hashes
         else:
@@ -143,9 +142,9 @@ class LocalFileStatistics:
         rows = []
 
         for path in self.paths[:max_rows]:
-            resolved = path.resolve()
-            stat = self.stats.get(resolved)
-            hash_ = self.hashes.get(resolved)
+            abspath = path.absolute()
+            stat = self.stats.get(abspath)
+            hash_ = self.hashes.get(abspath)
 
             name = str(path.name)
             size = stat.st_size if stat else "UNKNOWN"

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -314,7 +314,6 @@ class ROMSInputDataset(InputDataset, ABC):
         self._update_partitioning_attribute(
             new_np_xi=source_np_xi, new_np_eta=source_np_eta, parted_files=parted_files
         )
-        # self.working_path = parted_files
         assert self.partitioning is not None
         self.local_file_stats = LocalFileStatistics(
             paths=[p.resolve() for p in parted_files]

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -273,8 +273,7 @@ class ROMSInputDataset(InputDataset, ABC):
         local_dir = Path(local_dir).expanduser().resolve()
         local_dir.mkdir(parents=True, exist_ok=True)
         if self.exists_locally:
-            assert self.local_file_stats is not None
-            if self.local_file_stats.parent_dir == local_dir:
+            if self.local_file_stats.parent_dir == local_dir:  # type: ignore[union-attr]
                 self.log.info(f"⏭️ {self.working_path} already exists, skipping.")
                 return
 

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -328,7 +328,9 @@ class ROMSInputDataset(InputDataset, ABC):
         )
         # self.working_path = parted_files
         assert self.partitioning is not None
-        self.local_file_stats = LocalFileStatistics(paths=parted_files)
+        self.local_file_stats = LocalFileStatistics(
+            paths=[p.resolve() for p in parted_files]
+        )
 
         # self._local_file_stat_cache.update(self.partitioning._local_file_stat_cache)
         # self._local_file_hash_cache.update(self.partitioning._local_file_hash_cache)
@@ -419,7 +421,9 @@ class ROMSInputDataset(InputDataset, ABC):
 
         savepath = roms_tools_class_instance.save(**save_kwargs)
         # TODO
-        self.local_file_stats = LocalFileStatistics(paths=savepath)
+        self.local_file_stats = LocalFileStatistics(
+            paths=[p.resolve() for p in savepath]
+        )
         # self.working_path = savepath[0] if len(savepath) == 1 else savepath
 
         # self._local_file_hash_cache.update(
@@ -433,7 +437,9 @@ class ROMSInputDataset(InputDataset, ABC):
         self.partitioning = ROMSPartitioning(
             np_xi=new_np_xi, np_eta=new_np_eta, files=parted_files
         )
-        self.partitioning.local_file_stats = LocalFileStatistics(paths=parted_files)
+        self.partitioning.local_file_stats = LocalFileStatistics(
+            paths=[p.resolve() for p in parted_files]
+        )
         # self.partitioning._local_file_hash_cache = {
         #     path: _get_sha256_hash(path.resolve()) for path in parted_files
         # }  # 27

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -47,8 +47,6 @@ class ROMSPartitioning:
         self.np_eta = np_eta
         self.files = files
         self.local_file_stats: Optional[LocalFileStatistics] = None
-        # self._local_file_hash_cache: Dict = {}
-        # self._local_file_stat_cache: Dict = {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(np_xi={self.np_xi}, np_eta={self.np_eta}, files={_list_to_concise_str(self.files,pad=43)})"
@@ -274,15 +272,6 @@ class ROMSInputDataset(InputDataset, ABC):
         # Ensure we're working with a Path object
         local_dir = Path(local_dir).expanduser().resolve()
         local_dir.mkdir(parents=True, exist_ok=True)
-
-        # # If `working_path` is set, determine we're not fetching to the same parent dir:
-        # if self.working_path is None:
-        #     working_path_parent = None
-        # elif isinstance(self.working_path, list):
-        #     working_path_parent = self.working_path[0].parent
-        # else:
-        #     working_path_parent = self.working_path.parent
-
         if self.exists_locally:
             assert self.local_file_stats is not None
             if self.local_file_stats.parent_dir == local_dir:
@@ -331,9 +320,6 @@ class ROMSInputDataset(InputDataset, ABC):
         self.local_file_stats = LocalFileStatistics(
             paths=[p.resolve() for p in parted_files]
         )
-
-        # self._local_file_stat_cache.update(self.partitioning._local_file_stat_cache)
-        # self._local_file_hash_cache.update(self.partitioning._local_file_hash_cache)
 
     def _get_from_yaml(self, local_dir: str | Path) -> None:
         """Handle the special case where the input dataset source is a `roms-tools`
@@ -424,12 +410,6 @@ class ROMSInputDataset(InputDataset, ABC):
         self.local_file_stats = LocalFileStatistics(
             paths=[p.resolve() for p in savepath]
         )
-        # self.working_path = savepath[0] if len(savepath) == 1 else savepath
-
-        # self._local_file_hash_cache.update(
-        #     {path: _get_sha256_hash(path.resolve()) for path in savepath}
-        # )  # 27
-        # self._local_file_stat_cache.update({path: path.stat() for path in savepath})
 
     def _update_partitioning_attribute(
         self, new_np_xi: int, new_np_eta: int, parted_files: list[Path]
@@ -440,12 +420,6 @@ class ROMSInputDataset(InputDataset, ABC):
         self.partitioning.local_file_stats = LocalFileStatistics(
             paths=[p.resolve() for p in parted_files]
         )
-        # self.partitioning._local_file_hash_cache = {
-        #     path: _get_sha256_hash(path.resolve()) for path in parted_files
-        # }  # 27
-        # self.partitioning._local_file_stat_cache = {
-        #     path: path.stat() for path in parted_files
-        # }
 
     @property
     def path_for_roms(self) -> list[Path]:

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -316,7 +316,7 @@ class ROMSInputDataset(InputDataset, ABC):
         )
         assert self.partitioning is not None
         self.local_file_stats = LocalFileStatistics(
-            paths=[p.resolve() for p in parted_files]
+            paths=parted_files,
         )
 
     def _get_from_yaml(self, local_dir: str | Path) -> None:
@@ -404,10 +404,7 @@ class ROMSInputDataset(InputDataset, ABC):
         )
 
         savepath = roms_tools_class_instance.save(**save_kwargs)
-        # TODO
-        self.local_file_stats = LocalFileStatistics(
-            paths=[p.resolve() for p in savepath]
-        )
+        self.local_file_stats = LocalFileStatistics(paths=savepath)
 
     def _update_partitioning_attribute(
         self, new_np_xi: int, new_np_eta: int, parted_files: list[Path]
@@ -415,9 +412,7 @@ class ROMSInputDataset(InputDataset, ABC):
         self.partitioning = ROMSPartitioning(
             np_xi=new_np_xi, np_eta=new_np_eta, files=parted_files
         )
-        self.partitioning.local_file_stats = LocalFileStatistics(
-            paths=[p.resolve() for p in parted_files]
-        )
+        self.partitioning.local_file_stats = LocalFileStatistics(paths=parted_files)
 
     @property
     def path_for_roms(self) -> list[Path]:

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -316,7 +316,7 @@ class ROMSInputDataset(InputDataset, ABC):
         )
         assert self.partitioning is not None
         self.local_file_stats = LocalFileStatistics(
-            paths=parted_files,
+            files=parted_files,
         )
 
     def _get_from_yaml(self, local_dir: str | Path) -> None:
@@ -404,7 +404,7 @@ class ROMSInputDataset(InputDataset, ABC):
         )
 
         savepath = roms_tools_class_instance.save(**save_kwargs)
-        self.local_file_stats = LocalFileStatistics(paths=savepath)
+        self.local_file_stats = LocalFileStatistics(files=savepath)
 
     def _update_partitioning_attribute(
         self, new_np_xi: int, new_np_eta: int, parted_files: list[Path]
@@ -412,7 +412,7 @@ class ROMSInputDataset(InputDataset, ABC):
         self.partitioning = ROMSPartitioning(
             np_xi=new_np_xi, np_eta=new_np_eta, files=parted_files
         )
-        self.partitioning.local_file_stats = LocalFileStatistics(paths=parted_files)
+        self.partitioning.local_file_stats = LocalFileStatistics(files=parted_files)
 
     @property
     def path_for_roms(self) -> list[Path]:

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1594,6 +1594,6 @@ class ROMSSimulation(Simulation):
         # Reset cached data for input datasets
 
         for inp in new_sim.input_datasets:
-            inp.local_file_stats = None
+            inp._clear()
 
         return new_sim

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1592,9 +1592,8 @@ class ROMSSimulation(Simulation):
         new_sim.initial_conditions = new_ic
 
         # Reset cached data for input datasets
+
         for inp in new_sim.input_datasets:
-            inp._local_file_hash_cache = None
-            inp._local_file_stat_cache = None
-            inp.working_path = None
+            inp.local_file_stats = None
 
         return new_sim

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -467,7 +467,6 @@ class TestAdditionalCodeGet:
         - tempfile.mkdtemp: Mocked to simulate creating temporary directories.
         - shutil.rmtree: Mocked to simulate cleaning up temporary directories.
         - cstar.base.utils._clone_and_checkout: Mocked to simulate cloning a remote repository.
-        - Path.resolve: Mocked to simulate resolving paths.
         - DataSource.location_type and DataSource.source_type: Mocked to simulate
         different source types for the AdditionalCode object.
         """
@@ -492,10 +491,6 @@ class TestAdditionalCodeGet:
         self.patch_rmtree = mock.patch("shutil.rmtree")
         self.mock_rmtree = self.patch_rmtree.start()
 
-        # Set up common mocks for Path.resolve and DataSource attributes
-        self.patch_resolve = mock.patch.object(Path, "resolve")
-        self.mock_resolve = self.patch_resolve.start()
-
         self.patch_location_type = mock.patch.object(
             DataSource, "location_type", new_callable=mock.PropertyMock
         )
@@ -513,7 +508,7 @@ class TestAdditionalCodeGet:
         """Stop all the patches after each test to clean up the mock environment."""
         mock.patch.stopall()
 
-    def test_get_from_local_directory(self, local_additional_code):
+    def test_get_from_local_directory(self, mock_path_resolve, local_additional_code):
         """Test the `get` method when fetching additional code from elsewhere on the
         current filesystem.
 
@@ -522,7 +517,7 @@ class TestAdditionalCodeGet:
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path"
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory"
-        - mock_resolve: Mocks resolving the target directory, returning a mocked resolved path.
+        - mock_path_resolve: Mocks resolving the target directory, returning a mocked resolved path.
         - mock_mkdir: Mocks the creation of the target directory if it doesn’t exist.
         - mock_copy: Mocks the copying of files from the source to the target directory.
 
@@ -537,7 +532,6 @@ class TestAdditionalCodeGet:
         # Set specific mock return values for this test
         self.mock_location_type.return_value = "path"
         self.mock_source_type.return_value = "directory"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_hash.return_value = "mock_hash_value"
 
         # Call the get() method to simulate fetching additional code from a local directory
@@ -566,7 +560,9 @@ class TestAdditionalCodeGet:
         # Ensure that the working_path is set correctly
         assert local_additional_code.working_path == Path("/mock/local/dir")
 
-    def test_get_from_remote_repository(self, remote_additional_code):
+    def test_get_from_remote_repository(
+        self, mock_path_resolve, remote_additional_code
+    ):
         """Test the `get` method when fetching additional code from a remote Git
         repository.
 
@@ -575,7 +571,7 @@ class TestAdditionalCodeGet:
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url"
         - mock_source_type: Mocks AdditionalCode.source.source_type  as "repository"
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_clone: Mocks cloning the repository and checking out the correct branch or commit.
         - mock_mkdir: Mocks the creation of the target directory (if needed).
         - mock_mkdtemp: Mocks the creation of a temporary directory for cloning the repo into.
@@ -596,7 +592,6 @@ class TestAdditionalCodeGet:
         # Set specific return values for this test
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "repository"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_hash.return_value = "mock_hash_value"
         # Call get method
         remote_additional_code.get("/mock/local/dir")
@@ -697,7 +692,9 @@ class TestAdditionalCodeGet:
 
         assert str(exception_info.value) == expected_message
 
-    def test_get_raises_if_missing_files(self, local_additional_code):
+    def test_get_raises_if_missing_files(
+        self, mock_path_resolve, local_additional_code
+    ):
         """Test that `get` raises a `FileNotFoundError` when a file is missing in a
         local directory.
 
@@ -706,7 +703,7 @@ class TestAdditionalCodeGet:
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory".
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_exists: Mocks file existence checks, simulating the third file as missing.
         - mock_copy: Mocks the copying of files to the target directory.
 
@@ -719,7 +716,6 @@ class TestAdditionalCodeGet:
         # Simulate local directory source with missing files
         self.mock_hash.return_value = "mock_hash_value"
         self.mock_exists.side_effect = [True, True, False]  # Third file is missing
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_location_type.return_value = "path"
         self.mock_source_type.return_value = "directory"
 
@@ -753,7 +749,7 @@ class TestAdditionalCodeGet:
 
         assert str(exception_info.value) == expected_message
 
-    def test_cleanup_temp_directory(self, remote_additional_code):
+    def test_cleanup_temp_directory(self, mock_path_resolve, remote_additional_code):
         """Test that the temporary directory is cleaned up (deleted) after fetching
         remote additional code.
 
@@ -762,7 +758,7 @@ class TestAdditionalCodeGet:
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "repository".
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_clone: Mocks cloning the repository and checking out the correct branch or commit.
         - mock_mkdtemp: Mocks the creation of a temporary directory for cloning the repo.
         - mock_rmtree: Mocks the cleanup (removal) of the temporary directory.
@@ -773,7 +769,6 @@ class TestAdditionalCodeGet:
         """
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "repository"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
 
         # Call get method
         remote_additional_code.get("/mock/local/dir")

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -102,6 +102,14 @@ class TestInit:
         assert additional_code.checkout_target is None
         assert len(additional_code.files) == 0
 
+    def test_init_raises_if_any_files_falsy(self):
+        """Test that initializing an AdditionalCode instance with an empty or none entry
+        in 'files' raises a ValueError."""
+        with pytest.raises(
+            ValueError, match="An invalid filename was supplied to AdditionalCode"
+        ):
+            AdditionalCode(location="test/location", files=["file1", "", "file3"])
+
 
 class TestStrAndRepr:
     """Test class for the `__str__` and `__repr__` methods of the AdditionalCode class.

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -560,6 +560,8 @@ class TestAdditionalCodeGet:
         # Ensure that the working_path is set correctly
         assert local_additional_code.working_path == Path("/mock/local/dir")
 
+        assert mock_path_resolve.called
+
     def test_get_from_remote_repository(
         self, mock_path_resolve, remote_additional_code
     ):

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -621,6 +621,8 @@ class TestInputDatasetGet:
             f"but got {local_input_dataset.working_path}"
         )
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
     def test_get_with_local_source(
         self, mock_get_hash, local_input_dataset, mock_path_resolve

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -655,6 +655,8 @@ class TestInputDatasetGet:
                 local_input_dataset.working_path == expected_target_path
             ), f"Expected working_path to be {expected_target_path}, but got {local_input_dataset.working_path}"
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
     def test_get_local_wrong_hash(
         self, mock_get_hash, local_input_dataset, mock_path_resolve

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -642,3 +642,13 @@ class TestInputDatasetGet:
         assert str(exception_info.value) == expected_message
 
         mock_path_resolve.assert_called()
+
+
+def test_clear(remote_input_dataset):
+    """Test the 'clear' method resets the local_file_stats attribute to None."""
+
+    remote_input_dataset.local_file_stats = mock.Mock()
+    assert remote_input_dataset.local_file_stats is not None
+
+    remote_input_dataset._clear()
+    assert remote_input_dataset.local_file_stats is None

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -848,22 +848,26 @@ class TestLocalHash:
 
     def test_local_hash_multiple_files(self, local_input_dataset, mock_path_resolve):
         """Test `local_hash` calculation for multiple files."""
+
+        expected_path_1 = Path("/some/local/path1")
+        expected_path_2 = Path("/some/local/path2")
+
         local_input_dataset._local_file_hash_cache = {}
         local_input_dataset.working_path = [
-            Path("/some/local/path1"),
-            Path("/some/local/path2"),
+            expected_path_1,
+            expected_path_2,
         ]
         result = local_input_dataset.local_hash
 
         assert result == {
-            Path("/some/local/path1"): "mocked_hash",
-            Path("/some/local/path2"): "mocked_hash",
+            expected_path_1: "mocked_hash",
+            expected_path_2: "mocked_hash",
         }, f"Expected calculated local_hash for multiple files, but got {result}"
 
         self.mock_get_hash.assert_has_calls(
             [
-                mock.call(Path("/some/local/path1")),
-                mock.call(Path("/some/local/path2")),
+                mock.call(expected_path_1),
+                mock.call(expected_path_2),
             ],
             any_order=True,
         )

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -810,9 +810,7 @@ class TestLocalHash:
         """Stop all patches."""
         mock.patch.stopall()
 
-    def test_local_hash_single_file(
-        self, local_input_dataset, log: logging.Logger, mock_path_resolve
-    ):
+    def test_local_hash_single_file(self, local_input_dataset, log: logging.Logger):
         """Test `local_hash` calculation for a single file."""
         local_input_dataset._local_file_hash_cache = {}
         local_input_dataset.working_path = Path("/some/local/path")
@@ -826,7 +824,6 @@ class TestLocalHash:
 
         # Verify _get_sha256_hash was called with the resolved path
         self.mock_get_hash.assert_called_once_with(Path("/some/local/path"))
-        mock_path_resolve.assert_called()
 
     def test_local_hash_cached(self, local_input_dataset):
         """Test `local_hash` when the hash is cached."""

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -824,6 +824,7 @@ class TestLocalHash:
 
         # Verify _get_sha256_hash was called with the resolved path
         self.mock_get_hash.assert_called_once_with(Path("/some/local/path"))
+        mock_path_resolve.assert_called()
 
     def test_local_hash_cached(self, local_input_dataset):
         """Test `local_hash` when the hash is cached."""

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -54,7 +54,7 @@ def local_input_dataset():
         mock_basename.return_value = "local_file.nc"
 
         dataset = MockInputDataset(
-            location=Path("some/local/source/path/local_file.nc"),
+            location="some/local/source/path/local_file.nc",
             start_date="2024-10-22 12:34:56",
             end_date="2024-12-31 23:59:59",
         )

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -677,6 +677,8 @@ class TestInputDatasetGet:
         # Ensure `_get_sha256_hash` was called with the source path
         mock_get_hash.assert_called_once_with(source_filepath_local)
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("pooch.create")
     @mock.patch("pooch.HTTPDownloader")
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
@@ -758,6 +760,8 @@ class TestInputDatasetGet:
         with pytest.raises(ValueError) as exception_info:
             remote_input_dataset.get(self.target_dir)
         assert str(exception_info.value) == expected_message
+
+        mock_path_resolve.assert_called()
 
 
 class TestLocalHash:
@@ -863,3 +867,5 @@ class TestLocalHash:
             ],
             any_order=True,
         )
+
+        mock_path_resolve.assert_called()

--- a/cstar/tests/unit_tests/base/test_local_file_stats.py
+++ b/cstar/tests/unit_tests/base/test_local_file_stats.py
@@ -1,0 +1,236 @@
+import os
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from cstar.base.local_file_stats import LocalFileStatistics
+
+
+@pytest.fixture
+def tmp_file_pair(tmp_path):
+    file1 = tmp_path / "a.txt"
+    file2 = tmp_path / "b.txt"
+    file1.touch()
+    file2.touch()
+    return file1, file2
+
+
+class TestLocalFileStatisticsInit:
+    def test_init_with_paths_only(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        lfs = LocalFileStatistics(paths=[file1, file2])
+
+        assert lfs.paths == [file1.resolve(), file2.resolve()]
+        assert lfs.parent_dir.resolve() == file1.parent
+        assert lfs._stat_cache == {}
+        assert lfs._hash_cache == {}
+
+    def test_init_raises_if_paths_not_colocated(self, tmp_path):
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        file1 = dir1 / "a.txt"
+        file2 = dir2 / "b.txt"
+        file1.touch()
+        file2.touch()
+
+        with pytest.raises(ValueError, match="paths to exist in a common directory"):
+            LocalFileStatistics(paths=[file1, file2])
+
+    def test_init_with_stats(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        stats = {
+            file1.absolute(): file1.stat(),
+            file2.absolute(): file2.stat(),
+        }
+
+        lfs = LocalFileStatistics(paths=[file1, file2], stats=stats)
+
+        assert lfs._stat_cache == stats
+        assert lfs._hash_cache == {}
+        assert lfs.stats == stats
+
+    def test_init_raises_if_stats_keys_mismatch(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        stats = {file1.parent: file1.stat(), file2.resolve(): file2.stat()}
+
+        with pytest.raises(ValueError, match="keys must match"):
+            LocalFileStatistics(paths=[file1, file2], stats=stats)
+
+    def test_init_with_hashes(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        dummy_hash = "a0b1c2d3" * 8
+
+        hashes = {
+            file1.absolute(): dummy_hash,
+            file2.absolute(): dummy_hash,
+        }
+
+        lfs = LocalFileStatistics(paths=[file1, file2], hashes=hashes)
+
+        assert lfs._hash_cache == hashes
+        assert lfs._stat_cache == {}
+        assert lfs.hashes == hashes
+
+    def test_init_raises_if_hash_keys_mismatch(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+        dummy_hash = "a0b1c2d3" * 8
+
+        hashes = {
+            file1.parent: dummy_hash,
+            file2.absolute(): dummy_hash,
+        }
+
+        with pytest.raises(ValueError, match="keys must match"):
+            LocalFileStatistics(paths=[file1, file2], hashes=hashes)
+
+
+class TestStatsAndHasesProperties:
+    @patch("cstar.base.local_file_stats._get_sha256_hash")
+    def test_hashes_is_computed_and_cached(self, mock_hash, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+        mock_hash.side_effect = ["fakehash1", "fakehash2"]
+
+        lfs = LocalFileStatistics(paths=[file1, file2])
+        assert lfs._hash_cache == {}
+
+        hashes = lfs.hashes
+        assert hashes[file1.resolve()] == "fakehash1"
+        assert hashes[file2.resolve()] == "fakehash2"
+        assert mock_hash.call_count == 2
+
+        # Second access should not re-call the hash function
+        _ = lfs.hashes
+        assert mock_hash.call_count == 2  # still 2
+
+    def test_stats_is_computed_and_cached(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        lfs = LocalFileStatistics(paths=[file1, file2])
+        assert lfs._stat_cache == {}
+
+        stats = lfs.stats
+
+        # Check keys match
+        assert set(stats.keys()) == {file1.absolute(), file2.absolute()}
+
+        # Check values are stat_result instances
+        for stat in stats.values():
+            assert isinstance(stat, os.stat_result)
+
+        # Check second access returns same object (i.e. no recomputation)
+        assert lfs.stats is stats
+
+
+class TestValidate:
+    @patch("cstar.base.local_file_stats._get_sha256_hash", return_value="fakehash")
+    def test_validate_completes_with_matching_stats_and_hashes(
+        self, mock_hash, tmp_file_pair
+    ):
+        file1, file2 = tmp_file_pair
+        stats = {file1: file1.stat(), file2: file2.stat()}
+        hashes = {file1: "fakehash", file2: "fakehash"}
+
+        lfs = LocalFileStatistics(paths=[file1, file2], stats=stats, hashes=hashes)
+        lfs.validate()
+
+        assert True  # if validate does not raise, then pass
+
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_validate_raises_if_file_missing(self, mock_exists, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+        lfs = LocalFileStatistics(paths=[file1, file2])
+        with pytest.raises(FileNotFoundError, match="does not exist locally"):
+            lfs.validate()
+
+    def test_validate_raises_if_stats_mismatch(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        lfs = LocalFileStatistics(
+            paths=[file1, file2], stats={file1: file1.stat(), file2: file2.stat()}
+        )
+
+        # Set mtime to Jan 1, 2000
+        old_time = 946684800  # epoch seconds
+        os.utime(file1, (old_time, old_time))
+
+        with pytest.raises(ValueError, match="do not match those in cache"):
+            lfs.validate()
+
+    def test_validate_raises_if_hashes_mismatch(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        lfs = LocalFileStatistics(
+            paths=[file1, file2],
+            hashes={file1: "incorrect_hash1", file2: "incorrect_hash2"},
+        )
+        with pytest.raises(ValueError, match="does not match value in cache"):
+            lfs.validate()
+
+
+class TestStrAndReprFunctions:
+    def test_str(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+
+        lfs = LocalFileStatistics(paths=[file1, file2])
+        out = str(lfs)
+
+        expected = f"""LocalFileStatistics
+-------------------
+Parent directory: {file1.parent}
+Files:
+"""
+
+        assert expected.strip() in out.strip()
+
+    def test_repr(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+        lfs = LocalFileStatistics(paths=[file1, file2])
+        rep = repr(lfs)
+
+        # Basic structure checks
+        assert rep.startswith("LocalFileStatistics(")
+        assert str(file1) in rep
+        assert str(file2) in rep
+        assert rep.endswith(")")  # multiline repr still ends this way
+
+    def test_as_table(self, tmp_file_pair):
+        file1, file2 = tmp_file_pair
+        file1.write_text("abc")
+        file2.write_text("def")
+
+        ts1 = datetime.fromtimestamp(file1.stat().st_mtime).isoformat(
+            sep=" ", timespec="seconds"
+        )
+        ts2 = datetime.fromtimestamp(file2.stat().st_mtime).isoformat(
+            sep=" ", timespec="seconds"
+        )
+
+        lfs = LocalFileStatistics(paths=[file1, file2])
+
+        tab = lfs.as_table()
+        expected_tab = (
+            f"""Name                                     Hash         Size (bytes) Modified
+a.txt                                    ba7816bf8f…  3            {ts1}
+b.txt                                    cb8379ac20…  3            {ts2}"""
+        ).strip()
+
+        assert expected_tab == tab
+
+    def test_as_table_with_many_files(self, tmp_path):
+        paths = []
+        for f in range(20):
+            new_file = tmp_path / f"{f}.txt"
+            new_file.touch()
+            paths.append(new_file)
+
+        lfs = LocalFileStatistics(paths=paths)
+        tab = lfs.as_table(max_rows=10)
+        assert "... (10 more files)" in tab

--- a/cstar/tests/unit_tests/base/test_local_file_stats.py
+++ b/cstar/tests/unit_tests/base/test_local_file_stats.py
@@ -123,8 +123,8 @@ class TestLocalFileStatisticsInit:
 
         lfs = LocalFileStatistics(files=[fileinfo1, fileinfo2])
 
-        expected_stats = [stat1, stat2]
-        expected_hashes = [hash1, hash2]
+        expected_stats = {file1: stat1, file2: stat2}
+        expected_hashes = {file1: hash1, file2: hash2}
 
         assert lfs.stats == expected_stats
         assert lfs.hashes == expected_hashes
@@ -172,8 +172,8 @@ class TestStatsAndHasesProperties:
         lfs = LocalFileStatistics(files=[file1, file2])
 
         hashes = lfs.hashes
-        assert hashes[0] == "fakehash1"
-        assert hashes[1] == "fakehash2"
+        assert hashes[file1] == "fakehash1"
+        assert hashes[file2] == "fakehash2"
         assert mock_hash.call_count == 2
 
         # Second access should not re-call the hash function
@@ -206,7 +206,7 @@ class TestStatsAndHasesProperties:
         assert set(lfs.paths) == {file1.absolute(), file2.absolute()}
 
         # Check values are stat_result instances
-        for stat in stats:
+        for stat in stats.values():
             assert isinstance(stat, os.stat_result)
 
         # Check second access returns same object (i.e. no recomputation)

--- a/cstar/tests/unit_tests/base/test_local_file_stats.py
+++ b/cstar/tests/unit_tests/base/test_local_file_stats.py
@@ -69,8 +69,6 @@ class TestLocalFileStatisticsInit:
 
         assert lfs.paths == [file1.resolve(), file2.resolve()]
         assert lfs.parent_dir.resolve() == file1.parent
-        assert lfs._stat_cache == {}
-        assert lfs._hash_cache == {}
 
     def test_init_raises_if_paths_not_colocated(self, tmp_path):
         """Raise ValueError if paths do not share a common parent directory.
@@ -125,11 +123,9 @@ class TestLocalFileStatisticsInit:
 
         lfs = LocalFileStatistics(files=[fileinfo1, fileinfo2])
 
-        expected_stats = {file1: stat1, file2: stat2}
-        expected_hashes = {file1: hash1, file2: hash2}
+        expected_stats = [stat1, stat2]
+        expected_hashes = [hash1, hash2]
 
-        assert lfs._stat_cache == expected_stats
-        assert lfs._hash_cache == expected_hashes
         assert lfs.stats == expected_stats
         assert lfs.hashes == expected_hashes
 
@@ -174,11 +170,10 @@ class TestStatsAndHasesProperties:
         mock_hash.side_effect = ["fakehash1", "fakehash2"]
 
         lfs = LocalFileStatistics(files=[file1, file2])
-        assert lfs._hash_cache == {}
 
         hashes = lfs.hashes
-        assert hashes[file1.resolve()] == "fakehash1"
-        assert hashes[file2.resolve()] == "fakehash2"
+        assert hashes[0] == "fakehash1"
+        assert hashes[1] == "fakehash2"
         assert mock_hash.call_count == 2
 
         # Second access should not re-call the hash function
@@ -204,19 +199,18 @@ class TestStatsAndHasesProperties:
         file1, file2 = tmp_file_pair
 
         lfs = LocalFileStatistics(files=[file1, file2])
-        assert lfs._stat_cache == {}
 
         stats = lfs.stats
 
         # Check keys match
-        assert set(stats.keys()) == {file1.absolute(), file2.absolute()}
+        assert set(lfs.paths) == {file1.absolute(), file2.absolute()}
 
         # Check values are stat_result instances
-        for stat in stats.values():
+        for stat in stats:
             assert isinstance(stat, os.stat_result)
 
         # Check second access returns same object (i.e. no recomputation)
-        assert lfs.stats is stats
+        assert lfs.stats == stats
 
 
 class TestValidate:

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,5 +1,7 @@
 import logging
 import pathlib
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -40,6 +42,17 @@ def system_dotenv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
 def mock_system_name() -> str:
     # A name for the mock system/platform executing the tests.
     return "mock_system"
+
+
+@pytest.fixture
+def mock_path_resolve():
+    """Fixture to mock Path.resolve() so it returns the calling Path."""
+
+    def fake_resolve(self: Path) -> Path:
+        return self
+
+    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True):
+        yield
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -51,8 +51,8 @@ def mock_path_resolve():
     def fake_resolve(self: Path) -> Path:
         return self
 
-    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True):
-        yield
+    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True) as mock:
+        yield mock
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -612,6 +612,8 @@ class TestROMSInputDatasetGet:
         # Assertions to ensure everything worked as expected
         self.mock_yaml_load.assert_called_once()
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
         new_callable=mock.PropertyMock,
@@ -664,6 +666,8 @@ class TestROMSInputDatasetGet:
         # Ensure no further operations were performed
         self.mock_get.assert_not_called()
         self.mock_yaml_load.assert_not_called()
+
+        mock_path_resolve.assert_called()
 
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
@@ -719,6 +723,8 @@ class TestROMSInputDatasetGet:
         self.mock_get.assert_not_called()
         self.mock_yaml_load.assert_not_called()
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
         new_callable=mock.PropertyMock,
@@ -768,6 +774,8 @@ class TestROMSInputDatasetGet:
                 not self.mock_yaml_load.called
             ), "Expected no calls to yaml.safe_load, but some occurred."
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.roms.input_dataset.ROMSInputDataset._get_from_partitioned_source",
         autospec=True,
@@ -808,6 +816,8 @@ class TestROMSInputDatasetGet:
             source_np_xi=4,
             source_np_eta=3,
         )
+
+        mock_path_resolve.assert_called()
 
     @mock.patch(
         "cstar.roms.input_dataset.ROMSInputDataset._symlink_or_download_from_source",

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -498,7 +498,7 @@ class TestROMSSimulationInitialization:
         # Set working paths of forcing types to fake paths
         for ds, fake_path in zip(datasets, fake_paths):
             for d in ds if isinstance(ds, list) else [ds]:
-                d.local_file_stats = LocalFileStatistics(paths=fake_path)
+                d.local_file_stats = LocalFileStatistics(files=fake_path)
 
         # Flatten list of fake paths (contains a list as an entry)
         flat_paths = [

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -11,6 +11,7 @@ import yaml
 
 from cstar.base.additional_code import AdditionalCode
 from cstar.base.external_codebase import ExternalCodeBase
+from cstar.base.local_file_stats import LocalFileStatistics
 from cstar.execution.handler import ExecutionStatus
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.roms import ROMSRuntimeSettings
@@ -473,10 +474,16 @@ class TestROMSSimulationInitialization:
         the relevant forcing files."""
         sim, _ = example_roms_simulation
         fake_paths = [
-            Path("tidal.nc"),
+            [
+                Path("tidal.nc"),
+            ],
             [Path("surface.nc"), Path("surface2.nc")],
-            Path("boundary.nc"),
-            Path("sw_corr.nc"),
+            [
+                Path("boundary.nc"),
+            ],
+            [
+                Path("sw_corr.nc"),
+            ],
         ]
         datasets = [
             sim.tidal_forcing,
@@ -491,11 +498,11 @@ class TestROMSSimulationInitialization:
         # Set working paths of forcing types to fake paths
         for ds, fake_path in zip(datasets, fake_paths):
             for d in ds if isinstance(ds, list) else [ds]:
-                d.working_path = fake_path
+                d.local_file_stats = LocalFileStatistics(paths=fake_path)
 
         # Flatten list of fake paths (contains a list as an entry)
         flat_paths = [
-            i
+            i.absolute()
             for item in fake_paths
             for i in (item if isinstance(item, list) else [item])
         ]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,13 @@ Input Datasets
    cstar.roms.ROMSForcingCorrections
    cstar.roms.ROMSRuntimeSettings
 
+Local File Statistics
+---------------------
+.. autosummary::
+   :toctree: generated/
+
+   cstar.base.LocalFileStatistics
+   
 Discretization
 ----------------
 

--- a/docs/howto_guides/2_working_with_inputdatasets.ipynb
+++ b/docs/howto_guides/2_working_with_inputdatasets.ipynb
@@ -107,7 +107,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "315cbb80-2111-4c2a-bb53-65152416cdfb",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "my_grid.get(local_dir = \"~/Code/my_c_star/examples/input_dataset_example\")"
@@ -127,8 +129,7 @@
       "ROMSModelGrid\n",
       "-------------\n",
       "Source location: ~/Code/my_ucla_roms/Examples/input_data/sample_grd_riv.nc\n",
-      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc (exists)\n",
-      "Local hash: {PosixPath('/Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc'): '8e2f1ca3135ac7f5696d3eaec79b035a1bae15c8a34e751a7f9d925787ab3f6e'}\n"
+      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc (exists. Query local file statistics with InputDataset.local_file_stats)\n"
      ]
     }
    ],
@@ -230,13 +231,44 @@
       "-------------\n",
       "Source location: https://github.com/dafyddstephenson/ucla_roms_examples_input_data/raw/main/sample_grd_riv.nc\n",
       "Source file hash: 8e2f1ca3135ac7f5696d3eaec79b035a1bae15c8a34e751a7f9d925787ab3f6e\n",
-      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc (exists)\n",
-      "Local hash: {PosixPath('/Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc'): '8e2f1ca3135ac7f5696d3eaec79b035a1bae15c8a34e751a7f9d925787ab3f6e'}\n"
+      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/sample_grd_riv.nc (exists. Query local file statistics with InputDataset.local_file_stats)\n"
      ]
     }
    ],
    "source": [
     "print(my_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9c0f4c8-f060-427d-92b8-53bfebbd29f9",
+   "metadata": {},
+   "source": [
+    "We now see that we are asked to query `InputDataset.local_file_stats` for more information about the local files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "37484ae0-b384-4ad5-8b33-aacb27870326",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LocalFileStatistics\n",
+      "-------------------\n",
+      "Parent directory: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example\n",
+      "Files: \n",
+      "\n",
+      "Name                                     Hash         Size (bytes) Modified\n",
+      "sample_grd_riv.nc                        8e2f1ca313…  2291237      2024-07-23 10:41:48\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(my_grid.local_file_stats)"
    ]
   },
   {
@@ -317,7 +349,7 @@
      "output_type": "stream",
      "text": [
       "[INFO] 💾 Saving roms-tools dataset created from ~/Code/my_c_star/blueprints/cstar_blueprint_roms_marbl_example/input_datasets_yaml/roms_frc.yaml...\n",
-      "[########################################] | 100% Completed | 2.70 sms\n"
+      "[########################################] | 100% Completed | 3.74 sms\n"
      ]
     }
    ],
@@ -387,8 +419,7 @@
       "Source location: ~/Code/my_c_star/blueprints/cstar_blueprint_roms_marbl_example/input_datasets_yaml/roms_frc.yaml\n",
       "start_date: 2012-01-01 12:00:00\n",
       "end_date: 2012-01-04 12:00:00\n",
-      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/roms_frc_201201.nc (exists)\n",
-      "Local hash: {PosixPath('/Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/roms_frc_201201.nc'): 'a911c5ad87f0fa4d3ae9fb42798e955fbdca3d808471982f4bef65241f8b892d'}\n",
+      "Working path: /Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/roms_frc_201201.nc (exists. Query local file statistics with InputDataset.local_file_stats)\n",
       "Partitioning: ROMSPartitioning(np_xi=3, np_eta=3, files=[PosixPath('/Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/roms_frc_201201.0.nc'),\n",
       "                                           PosixPath('/Users/dafyddstephenson/Code/my_c_star/examples/input_dataset_example/roms_frc_201201.1.nc'),\n",
       "                                              ...\n",

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -23,6 +23,7 @@ Internal Changes:
 - Update internal/test blueprints to reflect new structure
 - Add ROMSRuntimeSettings class with ability to parse and create roms `.in` files
 - Save partitioned `ROMSInputDatasets` in the same directory as their un-partitioned versions, rather than a subdirectory "PARTITIONED"
+- Refactor local file metadata tracking with `LocalFileStatistics` class
 
 Documentation:
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
> WIP! Opening as a draft to solicit feedback on the high-level structure

EDIT: ready to go!
NOTE: this is built on top of the commits in #288 , merge #288 first and then update diffs.


- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`
- [x] New functions/methods are listed in `api.rst`
- [x] New functionality has documentation

As part of consolidating the various `get()` and `get()`-like methods on classes like `AdditionalCode`, `InputDataset`, etc. into a single `DataSource.get()` method, this PR first consolidates related attributes _set_ by the `get()`-like methods on these classes that are used to track local file metadata, e.g. `AdditionalCode._local_file_hash_cache` or `InputDataset._local_file_stat_cache`.

This PR introduces a class `LocalFileStatistics` to track modification times, filesizes, SHA256 hashes, and names for a selection of (or single) co-located files. For now an instance of this class will be assigned to an attribute on the various "getting" classes, and they will keep their existing `get()` methods. In the future, `DataSource.get()` will return a `LocalFileStatistics` instance which can then optionally be assigned to an attribute on the class in question.

Example :

```
In [1]: from cstar.base import AdditionalCode

In [2]: compile_time_code = AdditionalCode(location = "~/Code/my_ucla_roms/Examples/Rivers_real/",
                                   files=["cppdefs.opt",
                                          "flux_frc.opt",
                                          "ocean_vars.opt",
                                          "param.opt",
                                          "river_frc.opt"])

In [3]: print(compile_time_code.local_file_stats)
None

In [4]: compile_time_code.get("tmp/")
[INFO] • Copying cppdefs.opt to /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
[INFO] • Copying flux_frc.opt to /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
[INFO] • Copying ocean_vars.opt to /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
[INFO] • Copying param.opt to /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
[INFO] • Copying river_frc.opt to /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
[INFO] ✅ All files copied successfully

In [5]: print(compile_time_code.local_file_stats)
LocalFileStatistics
-------------------
Parent directory: /Users/dafyddstephenson/Code/my_c_star/cstar/base/tmp
Files: 

Name                                     Hash         Size (bytes) Modified
cppdefs.opt                              65de992b17…  1202         2025-06-17 16:56:25
flux_frc.opt                             2600e40001…  1068         2025-06-17 16:56:25
ocean_vars.opt                           90fc1cf1e1…  2346         2025-06-17 16:56:25
param.opt                                48cc34acaa…  908          2025-06-17 16:56:25
river_frc.opt                            1f23e50bf4…  728          2025-06-17 16:56:25
```