### PR TITLE
Improved CStarEnvironment loading behavior

### DIFF
--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -157,6 +157,9 @@ class CStarEnvironment:
     def _find_package_root(cls) -> Path:
         """Determine the root directory containing the source for this package.
 
+        Uses `importlib.util.find_spec` to locate the package directory, enabling
+        access to additional configuration files within the package structure.
+
         Returns
         -------
         Path

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -3,7 +3,7 @@ import os
 import platform
 from pathlib import Path
 
-from dotenv import dotenv_values, load_dotenv, set_key
+from dotenv import dotenv_values, set_key
 
 from cstar.base.utils import _run_cmd
 
@@ -59,11 +59,23 @@ class CStarEnvironment:
         mpi_exec_prefix: str,
         compiler: str,
     ):
-        # Initialize private attributes
+        """Initialize the instance.
+
+        Parameters
+        ----------
+        system_name : str
+            The name of the hosting platform
+        mpi_exec_prefix : str
+            The MPI prefix
+        compiler : str
+            The compiler to use for builds
+        """
         self._system_name = system_name
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
+        self._package_root: Path = self._find_package_root()
         self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
+        self._env_vars = self._load_env()
 
         if self.uses_lmod:
             self.load_lmod_modules(lmod_file=self.lmod_path)
@@ -113,14 +125,54 @@ class CStarEnvironment:
             ">"
         )
 
-    @property
-    def environment_variables(self) -> dict:
-        env_vars = dotenv_values(
-            self.package_root / f"additional_files/env_files/{self._system_name}.env"
-        )
+    def _load_env(self) -> dict[str, str]:
+        """Load environment variables from system and user .env files into memory.
+
+        Returns
+        -------
+        dict[str, str]
+            The variables that were loaded
+        """
+        env_vars = dotenv_values(self.system_env_path)
         user_env_vars = dotenv_values(self.user_env_path)
         env_vars.update(user_env_vars)
+
+        env_vars = {k: v for k, v in env_vars.items() if v is not None}
+        os.environ.update(env_vars)
+
         return env_vars
+
+    @property
+    def environment_variables(self) -> dict[str, str]:
+        """Return the environment variables that were loaded from .env files.
+
+        Returns
+        -------
+        dict[str, str]
+            The key-value pairs that have been loaded.
+        """
+        return self._env_vars.copy()
+
+    @classmethod
+    def _find_package_root(cls) -> Path:
+        """Determine the root directory containing the source for this package.
+
+        Returns
+        -------
+        Path
+            The path to the source code directory.
+
+        Raises
+        ------
+        ImportError
+            When the package root directory cannot be identified.
+        """
+        top_level_package_name = __name__.split(".")[0]
+        spec = importlib.util.find_spec(top_level_package_name)
+        if spec is not None and isinstance(spec.submodule_search_locations, list):
+            return Path(spec.submodule_search_locations[0])
+
+        raise ImportError(f"Top-level package '{top_level_package_name}' not found.")
 
     @property
     def package_root(self) -> Path:
@@ -139,13 +191,7 @@ class CStarEnvironment:
         ImportError
             If the top-level package cannot be located.
         """
-
-        top_level_package_name = __name__.split(".")[0]
-        spec = importlib.util.find_spec(top_level_package_name)
-        if spec is not None:
-            if isinstance(spec.submodule_search_locations, list):
-                return Path(spec.submodule_search_locations[0])
-        raise ImportError(f"Top-level package '{top_level_package_name}' not found.")
+        return self._package_root
 
     # Environment management related
     @property
@@ -171,6 +217,18 @@ class CStarEnvironment:
             The path to the `.env` file.
         """
         return self._CSTAR_USER_ENV_PATH
+
+    @property
+    def system_env_path(self) -> Path:
+        """Identify the expected path to a .env file for the current system.
+
+        Returns
+        -------
+        Path
+            The path to the `.env` file.
+        """
+        pkg_relative_path = f"additional_files/env_files/{self._system_name}.env"
+        return self.package_root / pkg_relative_path
 
     @property
     def lmod_path(self) -> Path:
@@ -274,4 +332,4 @@ class CStarEnvironment:
             The value to set for the environment variable.
         """
         set_key(self.user_env_path, key, value)
-        load_dotenv(self.user_env_path, override=True)
+        self._env_vars = self._load_env()

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -73,7 +73,7 @@ class CStarEnvironment:
         self._system_name = system_name
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
-        self._package_root: Path = self._find_package_root()
+        self._PACKAGE_ROOT: Path = self._find_package_root()
         self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
         self._env_vars = self._load_env()
 
@@ -191,7 +191,7 @@ class CStarEnvironment:
         ImportError
             If the top-level package cannot be located.
         """
-        return self._package_root
+        return self._PACKAGE_ROOT
 
     # Environment management related
     @property

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -176,10 +176,7 @@ class CStarEnvironment:
 
     @property
     def package_root(self) -> Path:
-        """Identifies the root directory of the top-level package.
-
-        Uses `importlib.util.find_spec` to locate the package directory, enabling
-        access to additional configuration files within the package structure.
+        """Return the root directory of the top-level package.
 
         Returns
         -------

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -115,14 +115,12 @@ def test_codebase_str(generic_codebase):
 
 
 @mock.patch.dict(os.environ, {})
-def test_codebase_repr(generic_codebase, mock_system_name):
+def test_codebase_repr(generic_codebase: ExternalCodeBase) -> None:
     """Test the repr representation of the `ExternalCodeBase` class."""
 
-    cstar_sysmgr.environment._system_name = mock_system_name
-
     with mock.patch(
-        "cstar.system.environment.dotenv_values",
-        new_callable=mock.Mock,
+        "cstar.system.environment.CStarEnvironment.environment_variables",
+        new_callable=mock.PropertyMock,
         return_value={},
     ):
         result_repr = repr(generic_codebase)

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -370,8 +370,6 @@ class TestSetupEnvironmentFromFiles:
         tmp_path: Path,
         package_root: str,
         system_name: str,
-        # custom_system_env: Callable[[dict[str, str]], Generator[Mock, None, None]],
-        # custom_user_env: Callable[[dict[str, str]], Generator[Mock, None, None]],
     ):
         """Verify that the system env property is based on package root and system name.
 
@@ -485,7 +483,6 @@ class TestSetupEnvironmentFromFiles:
         sys_var = "system-var"
         exp_system_env = {sys_var: "system-value"}
 
-        # patch the _load function so we can show loads only occur after updates
         with patch(
             "cstar.system.environment.CStarEnvironment._load_env",
             new_callable=Mock,

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Callable, Generator
+from typing import Callable, ChainMap, Generator
 from unittest import mock
 from unittest.mock import Mock, PropertyMock, call, mock_open, patch
 
@@ -107,7 +107,7 @@ class TestSetupEnvironmentFromFiles:
 
             mock_run.assert_has_calls(expected_calls, any_order=False)
 
-    def get_expected_lmod_modules(self, env):
+    def get_expected_lmod_modules(self, env: CStarEnvironment) -> list[str]:
         """Retrieves the expected list of Lmod modules for a given system from a .lmod
         file.
 
@@ -116,12 +116,8 @@ class TestSetupEnvironmentFromFiles:
         lmod_list: Module names to be loaded, based on the system's `.lmod` file.
         """
 
-        lmod_file_path = (
-            f"{env.package_root}/additional_files/lmod_lists/{env._system_name}.lmod"
-        )
-        with open(lmod_file_path) as file:
-            lmod_list = file.readlines()
-            return lmod_list
+        with open(env.lmod_path) as file:
+            return file.readlines()
 
     @patch.dict(
         "os.environ",
@@ -236,12 +232,14 @@ class TestSetupEnvironmentFromFiles:
         # Patch the root path and expanduser to point to our temporary files
         with (
             patch(
+                "cstar.system.environment.CStarEnvironment.system_env_path",
+                new_callable=PropertyMock,
+                return_value=system_dotenv_path,
+            ),
+            patch(
                 "cstar.system.environment.CStarEnvironment.user_env_path",
                 new_callable=PropertyMock,
                 return_value=dotenv_path,
-            ),
-            patch.object(
-                cstar.system.environment.CStarEnvironment, "package_root", new=tmp_path
             ),
         ):
             # Instantiate the environment to trigger loading the environment variables
@@ -273,7 +271,7 @@ class TestSetupEnvironmentFromFiles:
 
             for key, exp_value in updated_vars:
                 # Confirm the active environment variable is updated
-                assert exp_value in os.environ.get(key, "")
+                assert exp_value in os.environ.get(key, "key-not-found")
 
                 # Confirm the value stored in the user environment is updated
                 assert exp_value in env.environment_variables[key]
@@ -348,6 +346,167 @@ class TestSetupEnvironmentFromFiles:
             )
 
             assert env.lmod_path == tmp_path / expected_path
+
+    @patch.dict(
+        "os.environ",
+        {
+            "NETCDF_FORTRANHOME": "/mock/netcdf",
+            "MVAPICH2HOME": "/mock/mpi",
+            "LMOD_SYSHOST": "perlmutter",
+            "LMOD_DIR": "/mock/lmod",  # Ensures `uses_lmod` is valid
+        },
+        clear=True,
+    )
+    @pytest.mark.parametrize(
+        ("package_root", "system_name"),
+        [
+            ["foo/bar", "system-name-1"],
+            ["boo/far", "system-name-2"],
+            ["foz/baz", "system-name-3"],
+        ],
+    )
+    def test_system_env_path(
+        self,
+        tmp_path: Path,
+        package_root: str,
+        system_name: str,
+        # custom_system_env: Callable[[dict[str, str]], Generator[Mock, None, None]],
+        # custom_user_env: Callable[[dict[str, str]], Generator[Mock, None, None]],
+    ):
+        """Verify that the system env property is based on package root and system name.
+
+        Mocks
+        -----
+        - tmp_path creates temporary, emulated system and user .env files
+        - CStarEnvironment.package_root is patched to the temporary directory to load these .env files
+        - system_name provides a test-safe system name
+
+        Asserts
+        -------
+        - Confirms merged environment variables with expected values after expansion.
+        """
+
+        # Patch the root path and expanduser to point to our temporary files
+        tmp_pkg_root = tmp_path / package_root
+
+        env = CStarEnvironment(
+            system_name=system_name,
+            mpi_exec_prefix="mpi-prefix",
+            compiler="gnu",
+        )
+
+        with patch.object(CStarEnvironment, "package_root", new=tmp_pkg_root):
+            # Instantiate the environment to trigger loading the environment variables
+
+            system_actual = env.system_env_path
+            expected = tmp_pkg_root / f"additional_files/env_files/{system_name}.env"
+
+            assert system_actual == expected
+
+    @patch.dict(
+        "os.environ",
+        {},
+        clear=True,
+    )
+    def test_env_file_load_count(
+        self,
+        mock_system_name: str,
+    ) -> None:
+        """Verify that env files are reloaded after an update.
+
+        Mocks
+        -----
+        - mock_system_name provides a temporary system name for the environment
+
+        Asserts
+        -------
+        - Confirms merged environment variables with expected values after expansion.
+        """
+        sys_var = "system-var"
+        usr_var = "user-var"
+        exp_system_env = {sys_var: "system-value"}
+        exp_user_env = {usr_var: "user-value"}
+
+        new_var, new_value = "new-user-var", "new-user-value"
+        updates = {new_var: new_value}
+
+        env0 = ChainMap(exp_system_env, exp_user_env)
+        env1 = ChainMap(env0, updates)
+
+        # patch the _load function so we can show loads only occur after updates
+        with patch(
+            "cstar.system.environment.CStarEnvironment._load_env",
+            new_callable=Mock,
+            side_effect=[env0, env1],
+        ) as loader:
+            # Instantiate the environment to trigger loading the environment variables
+            env = CStarEnvironment(
+                system_name=mock_system_name,
+                mpi_exec_prefix="mpi-prefix",
+                compiler="gnu",
+            )
+
+            initial_num_calls = 1
+            assert loader.call_count == initial_num_calls
+
+            assert sys_var in env.environment_variables
+            assert usr_var in env.environment_variables
+
+            # no load from disk should occur
+            assert loader.call_count == initial_num_calls
+
+            env.set_env_var(new_var, new_value)
+
+            # update should trigger load from disk
+            assert loader.call_count == initial_num_calls + 1
+            assert new_var in env.environment_variables
+
+    @patch.dict(
+        "os.environ",
+        {},
+        clear=True,
+    )
+    def test_env_vars_frozen(
+        self,
+        mock_system_name: str,
+    ) -> None:
+        """Verify that modifying the output from the .environment_variables property
+        does not result in a change to the actual environment.
+
+        Mocks
+        -----
+        - mock_system_name provides a temporary system name for the environment
+
+        Asserts
+        -------
+        - Confirm that CStarEnvironment does not allow environment variables to
+          be manipulated outside of using `set_env_var`
+        """
+        sys_var = "system-var"
+        exp_system_env = {sys_var: "system-value"}
+
+        # patch the _load function so we can show loads only occur after updates
+        with patch(
+            "cstar.system.environment.CStarEnvironment._load_env",
+            new_callable=Mock,
+            side_effect=[exp_system_env],
+        ):
+            # Instantiate the environment to trigger loading the environment variables
+            env = CStarEnvironment(
+                system_name=mock_system_name,
+                mpi_exec_prefix="mpi-prefix",
+                compiler="gnu",
+            )
+
+            # baseline test the property and expected values match
+            loaded_vars = env.environment_variables
+            assert loaded_vars == exp_system_env
+
+            # manipulate loaded vars and verify env is not changed
+            inserted_var = "inserted-var"
+            loaded_vars[inserted_var] = "inserted-value"
+
+            assert inserted_var not in env.environment_variables
 
 
 class TestStrAndReprMethods:


### PR DESCRIPTION
This PR includes the following features:
1. Expose the `system_env_path` property consistent w/`lmod_path` and `user_env_path`
2. Avoids unnecessary reloading of environment files and package root


- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage