### PR TITLE
Centralise mocks of Path.resolve

### DIFF
--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -467,7 +467,6 @@ class TestAdditionalCodeGet:
         - tempfile.mkdtemp: Mocked to simulate creating temporary directories.
         - shutil.rmtree: Mocked to simulate cleaning up temporary directories.
         - cstar.base.utils._clone_and_checkout: Mocked to simulate cloning a remote repository.
-        - Path.resolve: Mocked to simulate resolving paths.
         - DataSource.location_type and DataSource.source_type: Mocked to simulate
         different source types for the AdditionalCode object.
         """
@@ -492,10 +491,6 @@ class TestAdditionalCodeGet:
         self.patch_rmtree = mock.patch("shutil.rmtree")
         self.mock_rmtree = self.patch_rmtree.start()
 
-        # Set up common mocks for Path.resolve and DataSource attributes
-        self.patch_resolve = mock.patch.object(Path, "resolve")
-        self.mock_resolve = self.patch_resolve.start()
-
         self.patch_location_type = mock.patch.object(
             DataSource, "location_type", new_callable=mock.PropertyMock
         )
@@ -513,7 +508,7 @@ class TestAdditionalCodeGet:
         """Stop all the patches after each test to clean up the mock environment."""
         mock.patch.stopall()
 
-    def test_get_from_local_directory(self, local_additional_code):
+    def test_get_from_local_directory(self, mock_path_resolve, local_additional_code):
         """Test the `get` method when fetching additional code from elsewhere on the
         current filesystem.
 
@@ -522,7 +517,7 @@ class TestAdditionalCodeGet:
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path"
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory"
-        - mock_resolve: Mocks resolving the target directory, returning a mocked resolved path.
+        - mock_path_resolve: Mocks resolving the target directory, returning a mocked resolved path.
         - mock_mkdir: Mocks the creation of the target directory if it doesn’t exist.
         - mock_copy: Mocks the copying of files from the source to the target directory.
 
@@ -537,7 +532,6 @@ class TestAdditionalCodeGet:
         # Set specific mock return values for this test
         self.mock_location_type.return_value = "path"
         self.mock_source_type.return_value = "directory"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_hash.return_value = "mock_hash_value"
 
         # Call the get() method to simulate fetching additional code from a local directory
@@ -566,7 +560,9 @@ class TestAdditionalCodeGet:
         # Ensure that the working_path is set correctly
         assert local_additional_code.working_path == Path("/mock/local/dir")
 
-    def test_get_from_remote_repository(self, remote_additional_code):
+    def test_get_from_remote_repository(
+        self, mock_path_resolve, remote_additional_code
+    ):
         """Test the `get` method when fetching additional code from a remote Git
         repository.
 
@@ -575,7 +571,7 @@ class TestAdditionalCodeGet:
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url"
         - mock_source_type: Mocks AdditionalCode.source.source_type  as "repository"
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_clone: Mocks cloning the repository and checking out the correct branch or commit.
         - mock_mkdir: Mocks the creation of the target directory (if needed).
         - mock_mkdtemp: Mocks the creation of a temporary directory for cloning the repo into.
@@ -596,7 +592,6 @@ class TestAdditionalCodeGet:
         # Set specific return values for this test
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "repository"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_hash.return_value = "mock_hash_value"
         # Call get method
         remote_additional_code.get("/mock/local/dir")
@@ -697,7 +692,9 @@ class TestAdditionalCodeGet:
 
         assert str(exception_info.value) == expected_message
 
-    def test_get_raises_if_missing_files(self, local_additional_code):
+    def test_get_raises_if_missing_files(
+        self, mock_path_resolve, local_additional_code
+    ):
         """Test that `get` raises a `FileNotFoundError` when a file is missing in a
         local directory.
 
@@ -706,7 +703,7 @@ class TestAdditionalCodeGet:
         - local_additional_code: An example AdditionalCode instance representing local code.
         - mock_location_type: Mocks AdditionalCode.source.location_type as "path".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "directory".
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_exists: Mocks file existence checks, simulating the third file as missing.
         - mock_copy: Mocks the copying of files to the target directory.
 
@@ -719,7 +716,6 @@ class TestAdditionalCodeGet:
         # Simulate local directory source with missing files
         self.mock_hash.return_value = "mock_hash_value"
         self.mock_exists.side_effect = [True, True, False]  # Third file is missing
-        self.mock_resolve.return_value = Path("/mock/local/dir")
         self.mock_location_type.return_value = "path"
         self.mock_source_type.return_value = "directory"
 
@@ -753,7 +749,7 @@ class TestAdditionalCodeGet:
 
         assert str(exception_info.value) == expected_message
 
-    def test_cleanup_temp_directory(self, remote_additional_code):
+    def test_cleanup_temp_directory(self, mock_path_resolve, remote_additional_code):
         """Test that the temporary directory is cleaned up (deleted) after fetching
         remote additional code.
 
@@ -762,7 +758,7 @@ class TestAdditionalCodeGet:
         - remote_additional_code: An example AdditionalCode instance representing code in a remote repo
         - mock_location_type: Mocks AdditionalCode.source.location_type as "url".
         - mock_source_type: Mocks AdditionalCode.source.source_type as "repository".
-        - mock_resolve: Mocks resolving the target directory.
+        - mock_path_resolve: Mocks resolving the target directory.
         - mock_clone: Mocks cloning the repository and checking out the correct branch or commit.
         - mock_mkdtemp: Mocks the creation of a temporary directory for cloning the repo.
         - mock_rmtree: Mocks the cleanup (removal) of the temporary directory.
@@ -773,7 +769,6 @@ class TestAdditionalCodeGet:
         """
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "repository"
-        self.mock_resolve.return_value = Path("/mock/local/dir")
 
         # Call get method
         remote_additional_code.get("/mock/local/dir")

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -560,6 +560,8 @@ class TestAdditionalCodeGet:
         # Ensure that the working_path is set correctly
         assert local_additional_code.working_path == Path("/mock/local/dir")
 
+        assert mock_path_resolve.called
+
     def test_get_from_remote_repository(
         self, mock_path_resolve, remote_additional_code
     ):

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -621,6 +621,8 @@ class TestInputDatasetGet:
             f"but got {local_input_dataset.working_path}"
         )
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
     def test_get_with_local_source(
         self, mock_get_hash, local_input_dataset, mock_path_resolve

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -655,6 +655,8 @@ class TestInputDatasetGet:
                 local_input_dataset.working_path == expected_target_path
             ), f"Expected working_path to be {expected_target_path}, but got {local_input_dataset.working_path}"
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
     def test_get_local_wrong_hash(
         self, mock_get_hash, local_input_dataset, mock_path_resolve

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -848,22 +848,26 @@ class TestLocalHash:
 
     def test_local_hash_multiple_files(self, local_input_dataset, mock_path_resolve):
         """Test `local_hash` calculation for multiple files."""
+
+        expected_path_1 = Path("/some/local/path1")
+        expected_path_2 = Path("/some/local/path2")
+
         local_input_dataset._local_file_hash_cache = {}
         local_input_dataset.working_path = [
-            Path("/some/local/path1"),
-            Path("/some/local/path2"),
+            expected_path_1,
+            expected_path_2,
         ]
         result = local_input_dataset.local_hash
 
         assert result == {
-            Path("/some/local/path1"): "mocked_hash",
-            Path("/some/local/path2"): "mocked_hash",
+            expected_path_1: "mocked_hash",
+            expected_path_2: "mocked_hash",
         }, f"Expected calculated local_hash for multiple files, but got {result}"
 
         self.mock_get_hash.assert_has_calls(
             [
-                mock.call(Path("/some/local/path1")),
-                mock.call(Path("/some/local/path2")),
+                mock.call(expected_path_1),
+                mock.call(expected_path_2),
             ],
             any_order=True,
         )

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -810,9 +810,7 @@ class TestLocalHash:
         """Stop all patches."""
         mock.patch.stopall()
 
-    def test_local_hash_single_file(
-        self, local_input_dataset, log: logging.Logger, mock_path_resolve
-    ):
+    def test_local_hash_single_file(self, local_input_dataset, log: logging.Logger):
         """Test `local_hash` calculation for a single file."""
         local_input_dataset._local_file_hash_cache = {}
         local_input_dataset.working_path = Path("/some/local/path")
@@ -826,7 +824,6 @@ class TestLocalHash:
 
         # Verify _get_sha256_hash was called with the resolved path
         self.mock_get_hash.assert_called_once_with(Path("/some/local/path"))
-        mock_path_resolve.assert_called()
 
     def test_local_hash_cached(self, local_input_dataset):
         """Test `local_hash` when the hash is cached."""

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -824,6 +824,7 @@ class TestLocalHash:
 
         # Verify _get_sha256_hash was called with the resolved path
         self.mock_get_hash.assert_called_once_with(Path("/some/local/path"))
+        mock_path_resolve.assert_called()
 
     def test_local_hash_cached(self, local_input_dataset):
         """Test `local_hash` when the hash is cached."""

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -54,7 +54,7 @@ def local_input_dataset():
         mock_basename.return_value = "local_file.nc"
 
         dataset = MockInputDataset(
-            location=Path("some/local/source/path/local_file.nc"),
+            location="some/local/source/path/local_file.nc",
             start_date="2024-10-22 12:34:56",
             end_date="2024-12-31 23:59:59",
         )

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -677,6 +677,8 @@ class TestInputDatasetGet:
         # Ensure `_get_sha256_hash` was called with the source path
         mock_get_hash.assert_called_once_with(source_filepath_local)
 
+        mock_path_resolve.assert_called()
+
     @mock.patch("pooch.create")
     @mock.patch("pooch.HTTPDownloader")
     @mock.patch("cstar.base.input_dataset._get_sha256_hash", return_value="mocked_hash")
@@ -758,6 +760,8 @@ class TestInputDatasetGet:
         with pytest.raises(ValueError) as exception_info:
             remote_input_dataset.get(self.target_dir)
         assert str(exception_info.value) == expected_message
+
+        mock_path_resolve.assert_called()
 
 
 class TestLocalHash:
@@ -863,3 +867,5 @@ class TestLocalHash:
             ],
             any_order=True,
         )
+
+        mock_path_resolve.assert_called()

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,5 +1,7 @@
 import logging
 import pathlib
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -40,6 +42,17 @@ def system_dotenv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
 def mock_system_name() -> str:
     # A name for the mock system/platform executing the tests.
     return "mock_system"
+
+
+@pytest.fixture
+def mock_path_resolve():
+    """Fixture to mock Path.resolve() so it returns the calling Path."""
+
+    def fake_resolve(self: Path) -> Path:
+        return self
+
+    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True):
+        yield
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -51,8 +51,8 @@ def mock_path_resolve():
     def fake_resolve(self: Path) -> Path:
         return self
 
-    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True):
-        yield
+    with patch.object(Path, "resolve", side_effect=fake_resolve, autospec=True) as mock:
+        yield mock
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -612,6 +612,8 @@ class TestROMSInputDatasetGet:
         # Assertions to ensure everything worked as expected
         self.mock_yaml_load.assert_called_once()
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
         new_callable=mock.PropertyMock,
@@ -664,6 +666,8 @@ class TestROMSInputDatasetGet:
         # Ensure no further operations were performed
         self.mock_get.assert_not_called()
         self.mock_yaml_load.assert_not_called()
+
+        mock_path_resolve.assert_called()
 
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
@@ -719,6 +723,8 @@ class TestROMSInputDatasetGet:
         self.mock_get.assert_not_called()
         self.mock_yaml_load.assert_not_called()
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.base.input_dataset.InputDataset.exists_locally",
         new_callable=mock.PropertyMock,
@@ -768,6 +774,8 @@ class TestROMSInputDatasetGet:
                 not self.mock_yaml_load.called
             ), "Expected no calls to yaml.safe_load, but some occurred."
 
+        mock_path_resolve.assert_called()
+
     @mock.patch(
         "cstar.roms.input_dataset.ROMSInputDataset._get_from_partitioned_source",
         autospec=True,
@@ -808,6 +816,8 @@ class TestROMSInputDatasetGet:
             source_np_xi=4,
             source_np_eta=3,
         )
+
+        mock_path_resolve.assert_called()
 
     @mock.patch(
         "cstar.roms.input_dataset.ROMSInputDataset._symlink_or_download_from_source",


### PR DESCRIPTION
This PR refactors mocking of `Path.resolve()`. Previously calls to `resolve` were patched on a case-by-case basis and `return_value`s and `side_effect`s were set individually. 

In this PR, a fixture is added to `cstar/tests/unit_tests/conftest.py` to mock `Path.resolve()` by just returning whatever the calling `Path` is, eliminating the need for setting every `return_value` individually. 