### PR TITLE
Manager refactor

### DIFF
--- a/cstar/base/exceptions.py
+++ b/cstar/base/exceptions.py
@@ -1,0 +1,20 @@
+class CstarError(Exception):
+    """Base class for all Cstar exceptions."""
+
+
+class BlueprintError(CstarError):
+    """Exception raised for errors in blueprint processing."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize BlueprintError with a message."""
+        super().__init__(message)
+        self.message = message
+
+
+class SimulationError(CstarError):
+    """Exception raised for errors in simulation processing."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize SimulationError with a message."""
+        super().__init__(message)
+        self.message = message

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -73,11 +73,13 @@ class CStarEnvironment:
         os.environ.update(self.environment_variables)
 
     @property
-    def mpi_exec_prefix(self):
+    def mpi_exec_prefix(self) -> str:
+        """Get the MPI prefix used when calling mpiexec in the environment."""
         return self._mpi_exec_prefix
 
     @property
-    def compiler(self):
+    def compiler(self) -> str:
+        """Get the compiler used when building in the environment."""
         return self._compiler
 
     def __str__(self) -> str:

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -71,8 +71,8 @@ class HostNameEvaluator:
     def name(self) -> str:
         """Determine the system name that will be used by C-Star.
 
-        Makes use of environment variables and platform details. Prioritizes an LMOD-
-        based system name first, then falls back to
+        Prioritizes the LMOD-based system name. When LMOD-specific environment
+        variables are not present, the name is determiend by the OS.
 
         Raises
         ------

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -128,13 +128,8 @@ def register_sys_context(
     return _inner()
 
 
-def _get_system_context(name: str) -> _SystemContext:
+def _get_system_context() -> _SystemContext:
     """Retrieve a system context from the context registry.
-
-    Parameters
-    ----------
-    name : str
-        The name of the system to retrieve a context for
 
     Returns
     -------
@@ -146,10 +141,12 @@ def _get_system_context(name: str) -> _SystemContext:
     CStarError
         If the supplied name has not been registered.
     """
-    if type_ := _registry.get(name):
+    namer = HostNameEvaluator()
+
+    if type_ := _registry.get(namer.name):
         return type_()
 
-    raise CstarError(f"Unknown system requested: {name}")
+    raise CstarError(f"Unknown system requested: {namer.name}")
 
 
 @register_sys_context
@@ -281,8 +278,8 @@ class CStarSystemManager:
         Initialize the system manager by determining the system name and initializing
         the environment and scheduler based on that name.
         """
-        namer = HostNameEvaluator()
-        self._context = _get_system_context(namer.name)
+
+        self._context = _get_system_context()
         """A context object configured for the current system."""
         self._environment = CStarEnvironment(
             system_name=self._context.name,

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -91,18 +91,18 @@ class HostNameEvaluator:
 
 
 class _SystemContext(Protocol):
-    """The contextual dependencies for a given system/platform."""
+    """The contextual dependencies for the system/platform."""
 
     name: ClassVar[str]
     """The unique name identifying the context."""
     compiler: ClassVar[str]
-    """The compiler that will be used when building software for a system."""
+    """The compiler used when building software for the system."""
     mpi_prefix: ClassVar[str]
-    """The prefix used when executing mpiexec for a system."""
+    """The prefix used when executing mpiexec for the system."""
 
     @classmethod
     def create_scheduler(cls) -> Scheduler | None:
-        """Instantiate a scheduler configured for a system."""
+        """Instantiate a scheduler configured for the system."""
 
 
 _registry: dict[str, type[_SystemContext]] = {}
@@ -168,13 +168,6 @@ class _PerlmutterSystemContext(_SystemContext):
 
     @classmethod
     def create_scheduler(cls) -> Scheduler | None:
-        """Instantiate a scheduler configured for Perlmutter.
-
-        Returns
-        -------
-        Scheduler
-            A SlurmScheduler instance
-        """
         per_regular_q = SlurmQOS(name="regular", query_name="regular_1")
         per_shared_q = SlurmQOS(name="shared")
         per_debug_q = SlurmQOS(name="debug")
@@ -206,13 +199,6 @@ class _DerechoSystemContext(_SystemContext):
 
     @classmethod
     def create_scheduler(cls) -> Scheduler | None:
-        """Instantiate a scheduler configured for Perlmutter.
-
-        Returns
-        -------
-        Scheduler
-            A PBSScheduler instance
-        """
         # https://ncar-hpc-docs.readthedocs.io/en/latest/pbs/charging/
         der_main_q = PBSQueue(name="main", max_walltime="12:00:00")
         der_preempt_q = PBSQueue(name="preempt", max_walltime="24:00:00")
@@ -242,13 +228,6 @@ class _ExpanseSystemContext(_SystemContext):
 
     @classmethod
     def create_scheduler(cls) -> Scheduler | None:
-        """Instantiate a scheduler configured for Perlmutter.
-
-        Returns
-        -------
-        Scheduler
-            A SlurmScheduler instance
-        """
         exp_compute_q = SlurmPartition(name="compute")
         exp_debug_q = SlurmPartition(name="debug")
         return SlurmScheduler(

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -241,7 +241,7 @@ class _ExpanseSystemContext(_SystemContext):
     """URI for documentation of the Expanse system."""
 
     @classmethod
-    def create_scheduler(cls) -> Scheduler:
+    def create_scheduler(cls) -> Scheduler | None:
         """Instantiate a scheduler configured for Perlmutter.
 
         Returns

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -46,7 +46,9 @@ class HostNameEvaluator:
         setattr_ = object.__setattr__
         setattr_(self, "lmod_syshost", os.environ.get(self.ENV_LMOD_SYSHOST, ""))
         setattr_(self, "lmod_sysname", os.environ.get(self.ENV_LMOD_SYSNAME, ""))
-        setattr_(self, "lmod_hostname", (self.lmod_syshost or self.lmod_sysname).casefold())
+        setattr_(
+            self, "lmod_hostname", (self.lmod_syshost or self.lmod_sysname).casefold()
+        )
         setattr_(self, "platform_name", platform.system())
         setattr_(self, "machine_name", platform.machine())
         setattr_(

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -1,6 +1,6 @@
 import functools
 import os
-import platform as platform_
+import platform as platform
 from dataclasses import dataclass, field
 from typing import ClassVar, Protocol
 
@@ -25,13 +25,13 @@ class HostNameEvaluator:
     """The lmod-specific hostname."""
     lmod_sysname: str = field(default="", init=False)
     """The lmod-specific system name."""
-    lmod_name: str = field(default="", init=False)
+    lmod_hostname: str = field(default="", init=False)
     """Aggregate of lmod host and lmod name."""
-    platform: str = field(default="", init=False)
-    """The platform name."""
-    machine: str = field(default="", init=False)
-    """The machine name."""
     platform_name: str = field(default="", init=False)
+    """The platform name."""
+    machine_name: str = field(default="", init=False)
+    """The machine name."""
+    platform_hostname: str = field(default="", init=False)
     """Aggregate of machine and platform sysname."""
 
     ENV_LMOD_SYSHOST: ClassVar[str] = "LMOD_SYSHOST"
@@ -46,15 +46,15 @@ class HostNameEvaluator:
         setattr_ = object.__setattr__
         setattr_(self, "lmod_syshost", os.environ.get(self.ENV_LMOD_SYSHOST, ""))
         setattr_(self, "lmod_sysname", os.environ.get(self.ENV_LMOD_SYSNAME, ""))
-        setattr_(self, "lmod_name", (self.lmod_syshost or self.lmod_sysname).casefold())
-        setattr_(self, "platform", platform_.system())
-        setattr_(self, "machine", platform_.machine())
+        setattr_(self, "lmod_hostname", (self.lmod_syshost or self.lmod_sysname).casefold())
+        setattr_(self, "platform_name", platform.system())
+        setattr_(self, "machine_name", platform.machine())
         setattr_(
             self,
-            "platform_name",
+            "platform_hostname",
             (
-                f"{self.platform}_{self.machine}"
-                if self.platform and self.machine
+                f"{self.platform_name}_{self.machine_name}"
+                if self.platform_name and self.machine_name
                 else ""
             ).casefold(),
         )
@@ -64,7 +64,7 @@ class HostNameEvaluator:
         """Return a string useful for diagnosing failures to identify the name."""
         return (
             f"{self.lmod_syshost=}, {self.lmod_sysname=}, "
-            f"{self.platform=}, {self.machine=}"
+            f"{self.platform_name=}, {self.machine_name=}"
         )
 
     @property
@@ -79,11 +79,11 @@ class HostNameEvaluator:
         EnvironmentError
             If the name cannot be determined.
         """
-        if self.lmod_name:
-            return self.lmod_name
+        if self.lmod_hostname:
+            return self.lmod_hostname
 
-        if self.platform_name:
-            return self.platform_name
+        if self.platform_hostname:
+            return self.platform_hostname
 
         raise EnvironmentError(
             f"C-Star cannot determine your system name. Diagnostics: {self._diagnostic}"

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -109,12 +109,12 @@ _registry: dict[str, type[_SystemContext]] = {}
 
 
 def register_sys_context(
-    cls_: type[_SystemContext],
+    wrapped_cls: type[_SystemContext],
 ) -> type[_SystemContext]:
     """Register the decorated type as an available _SystemContext."""
-    _registry[cls_.name] = cls_
+    _registry[wrapped_cls.name] = wrapped_cls
 
-    @functools.wraps(cls_)
+    @functools.wraps(wrapped_cls)
     def _inner() -> type[_SystemContext]:
         """Return the original type after it is registered.
 
@@ -123,7 +123,7 @@ def register_sys_context(
         type[_SystemContext]
             The decorated type.
         """
-        return cls_
+        return wrapped_cls
 
     return _inner()
 

--- a/cstar/tests/unit_tests/system/test_context_registry.py
+++ b/cstar/tests/unit_tests/system/test_context_registry.py
@@ -1,0 +1,100 @@
+from typing import ClassVar
+
+import pytest
+
+from cstar.base.exceptions import CstarError
+from cstar.system.manager import (
+    _DerechoSystemContext,
+    _ExpanseSystemContext,
+    _get_system_context,
+    _LinuxSystemContext,
+    _MacOSSystemContext,
+    _PerlmutterSystemContext,
+    _registry,
+    _SystemContext,
+    register_sys_context,
+)
+from cstar.system.scheduler import Scheduler
+
+DEFAULT_MOCK_MACHINE_NAME = "mock_machine"
+DEFAULT_MOCK_HOST_NAME = "mock_system"
+
+
+def test_unique_context_names() -> None:
+    """Verify that known contexts have a unique key."""
+    context_types = (
+        _PerlmutterSystemContext,
+        _MacOSSystemContext,
+        _DerechoSystemContext,
+        _ExpanseSystemContext,
+        _LinuxSystemContext,
+    )
+
+    registered_names = set(_registry.keys())
+
+    assert len({ctx.name for ctx in context_types}) == len(registered_names)
+
+
+@pytest.mark.parametrize(
+    "cls_",
+    [
+        _PerlmutterSystemContext,
+        _MacOSSystemContext,
+        _DerechoSystemContext,
+        _ExpanseSystemContext,
+        _LinuxSystemContext,
+    ],
+)
+def test_context_registry(cls_: type[_SystemContext]) -> None:
+    """Verify that all known system contexts are registered."""
+    ctx = _get_system_context(cls_.name)
+
+    # confirm all properties of the factory produced context match
+    assert ctx.name == cls_.name
+    assert ctx.compiler == cls_.compiler
+    assert ctx.mpi_prefix == cls_.mpi_prefix
+    assert isinstance(ctx.create_scheduler(), type(cls_.create_scheduler()))
+
+
+@pytest.mark.parametrize(
+    ("expected_name", "cls_"),
+    [
+        ("perlmutter", _PerlmutterSystemContext),
+        ("darwin_arm64", _MacOSSystemContext),
+        ("derecho", _DerechoSystemContext),
+        ("expanse", _ExpanseSystemContext),
+        ("linux_x86_64", _LinuxSystemContext),
+    ],
+)
+def test_registry_keys(expected_name: str, cls_: type[_SystemContext]) -> None:
+    """Verify that the system contexts have the names expected from using
+    HostNameEvaluator for all known systems."""
+    assert expected_name == cls_.name
+
+
+def test_new_registration() -> None:
+    """Verify that registrations of new context types are immediately available."""
+
+    @register_sys_context
+    class MockSystemContext(_SystemContext):
+        """Mock system context to test the context registry."""
+
+        name: ClassVar[str] = "mock-system-name"
+        compiler: ClassVar[str] = "mock-compiler"
+        mpi_prefix: ClassVar[str] = "mock-mpi-prefix"
+
+        @classmethod
+        def create_scheduler(cls) -> Scheduler | None:
+            """Mock scheduler creation."""
+            raise NotImplementedError
+
+    ctx = _get_system_context(MockSystemContext.name)
+
+    assert ctx
+    assert ctx.name == MockSystemContext.name
+
+
+def test_unknown_context_name() -> None:
+    """Verify that requesting an unregistered context fails."""
+    with pytest.raises(CstarError):
+        _ = _get_system_context("invalid-name")

--- a/cstar/tests/unit_tests/system/test_context_registry.py
+++ b/cstar/tests/unit_tests/system/test_context_registry.py
@@ -37,7 +37,7 @@ def test_unique_context_names() -> None:
 
 
 @pytest.mark.parametrize(
-    "cls_",
+    "wrapped_class",
     [
         _PerlmutterSystemContext,
         _MacOSSystemContext,
@@ -46,24 +46,24 @@ def test_unique_context_names() -> None:
         _LinuxSystemContext,
     ],
 )
-def test_context_registry(cls_: type[_SystemContext]) -> None:
+def test_context_registry(wrapped_class: type[_SystemContext]) -> None:
     """Verify that all known system contexts are registered."""
     with patch(
         "cstar.system.manager.HostNameEvaluator.name",
         new_callable=PropertyMock,
-        return_value=cls_.name,
+        return_value=wrapped_class.name,
     ):
         ctx = _get_system_context()
 
     # confirm all properties of the factory produced context match
-    assert ctx.name == cls_.name
-    assert ctx.compiler == cls_.compiler
-    assert ctx.mpi_prefix == cls_.mpi_prefix
-    assert isinstance(ctx.create_scheduler(), type(cls_.create_scheduler()))
+    assert ctx.name == wrapped_class.name
+    assert ctx.compiler == wrapped_class.compiler
+    assert ctx.mpi_prefix == wrapped_class.mpi_prefix
+    assert isinstance(ctx.create_scheduler(), type(wrapped_class.create_scheduler()))
 
 
 @pytest.mark.parametrize(
-    ("expected_name", "cls_"),
+    ("expected_name", "wrapped_class"),
     [
         ("perlmutter", _PerlmutterSystemContext),
         ("darwin_arm64", _MacOSSystemContext),
@@ -72,10 +72,10 @@ def test_context_registry(cls_: type[_SystemContext]) -> None:
         ("linux_x86_64", _LinuxSystemContext),
     ],
 )
-def test_registry_keys(expected_name: str, cls_: type[_SystemContext]) -> None:
+def test_registry_keys(expected_name: str, wrapped_class: type[_SystemContext]) -> None:
     """Verify that the system contexts have the names expected from using
     HostNameEvaluator for all known systems."""
-    assert expected_name == cls_.name
+    assert expected_name == wrapped_class.name
 
 
 def test_new_registration() -> None:

--- a/cstar/tests/unit_tests/system/test_context_schedulers.py
+++ b/cstar/tests/unit_tests/system/test_context_schedulers.py
@@ -1,0 +1,41 @@
+import pytest
+
+from cstar.system.manager import (
+    _DerechoSystemContext,
+    _ExpanseSystemContext,
+    _LinuxSystemContext,
+    _MacOSSystemContext,
+    _PerlmutterSystemContext,
+    _SystemContext,
+)
+from cstar.system.scheduler import PBSScheduler, Scheduler, SlurmScheduler
+
+DEFAULT_MOCK_MACHINE_NAME = "mock_machine"
+DEFAULT_MOCK_HOST_NAME = "mock_system"
+
+
+@pytest.mark.parametrize(
+    ("cls_", "exp_sched_type", "exp_queue_names"),
+    [
+        (_PerlmutterSystemContext, SlurmScheduler, {"regular", "shared", "debug"}),
+        (_MacOSSystemContext, None, None),
+        (_DerechoSystemContext, PBSScheduler, {"main", "preempt", "develop"}),
+        (_ExpanseSystemContext, SlurmScheduler, {"compute", "debug"}),
+        (_LinuxSystemContext, None, None),
+    ],
+)
+def test_context_registry(
+    cls_: type[_SystemContext],
+    exp_sched_type: type[Scheduler],
+    exp_queue_names: set[str] | None,
+) -> None:
+    """Verify that the type of scheduler created by each of the known system contexts
+    matches expectations."""
+    scheduler = cls_.create_scheduler()
+
+    if exp_sched_type is not None:
+        assert type(scheduler) is exp_sched_type
+        queues = getattr(scheduler, "queues")  # noqa: B009
+        assert {q.name for q in queues} == exp_queue_names
+    else:
+        assert exp_sched_type is None

--- a/cstar/tests/unit_tests/system/test_context_schedulers.py
+++ b/cstar/tests/unit_tests/system/test_context_schedulers.py
@@ -38,4 +38,4 @@ def test_context_registry(
         queues = getattr(scheduler, "queues")  # noqa: B009
         assert {q.name for q in queues} == exp_queue_names
     else:
-        assert exp_sched_type is None
+        assert scheduler is None

--- a/cstar/tests/unit_tests/system/test_context_schedulers.py
+++ b/cstar/tests/unit_tests/system/test_context_schedulers.py
@@ -15,7 +15,7 @@ DEFAULT_MOCK_HOST_NAME = "mock_system"
 
 
 @pytest.mark.parametrize(
-    ("cls_", "exp_sched_type", "exp_queue_names"),
+    ("wrapped_class", "exp_sched_type", "exp_queue_names"),
     [
         (_PerlmutterSystemContext, SlurmScheduler, {"regular", "shared", "debug"}),
         (_MacOSSystemContext, None, None),
@@ -25,13 +25,13 @@ DEFAULT_MOCK_HOST_NAME = "mock_system"
     ],
 )
 def test_context_registry(
-    cls_: type[_SystemContext],
+    wrapped_class: type[_SystemContext],
     exp_sched_type: type[Scheduler],
     exp_queue_names: set[str] | None,
 ) -> None:
     """Verify that the type of scheduler created by each of the known system contexts
     matches expectations."""
-    scheduler = cls_.create_scheduler()
+    scheduler = wrapped_class.create_scheduler()
 
     if exp_sched_type is not None:
         assert type(scheduler) is exp_sched_type

--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -42,8 +42,8 @@ def env_no_lmod() -> Generator[mock._patch, None, None]:
 def test_no_lmod_in_env(
     mock_system: mock.MagicMock, mock_machine: mock.MagicMock
 ) -> None:
-    """Verify that the an environment that specifies no lmod environment variables
-    return a platform-based name."""
+    """Verify that an environment without lmod environment variables returns a platform-
+    based name."""
     namer = HostNameEvaluator()
 
     mock_system.assert_called_once()
@@ -101,8 +101,8 @@ def test_partial_lmod_results_in_lmod_name(
     lmod_syshost: str,
     lmod_sysname: str,
 ) -> None:
-    """Verify that the an environment that specifies incomplete lmod variables returns
-    the value that is set."""
+    """Verify that an environment specifying incomplete lmod variables returns the value
+    that is set."""
     with patch.dict(
         os.environ,
         {

--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -1,0 +1,204 @@
+import os
+from collections.abc import Generator
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+
+from cstar.system.manager import HostNameEvaluator
+
+DEFAULT_MOCK_MACHINE_NAME = "mock_machine"
+DEFAULT_MOCK_HOST_NAME = "mock_system"
+
+
+@pytest.fixture
+def env_full_lmod() -> Generator[mock._patch, None, None]:
+    """Configure environment variables to have both lmod sys host and sys name."""
+    lmod_syshost = "sys-host"
+    lmod_sysname = "sys-name"
+    with patch.dict(
+        os.environ,
+        {
+            HostNameEvaluator.ENV_LMOD_SYSHOST: lmod_syshost,
+            HostNameEvaluator.ENV_LMOD_SYSNAME: lmod_sysname,
+        },
+    ) as _:
+        yield _
+
+
+@pytest.fixture
+def env_no_lmod() -> Generator[mock._patch, None, None]:
+    """Configure environment variables to omit both lmod sys host and sys name."""
+    with patch.dict(
+        os.environ,
+        {},
+    ) as _:
+        yield _
+
+
+@patch("platform.machine", return_value=DEFAULT_MOCK_MACHINE_NAME)
+@patch("platform.system", return_value=DEFAULT_MOCK_HOST_NAME)
+@patch.dict(os.environ, {})
+def test_no_lmod_in_env(
+    mock_system: mock.MagicMock, mock_machine: mock.MagicMock
+) -> None:
+    """Verify that the an environment that specifies no lmod environment variables
+    return a platform-based name."""
+    namer = HostNameEvaluator()
+
+    mock_system.assert_called_once()
+    mock_machine.assert_called_once()
+
+    assert namer.lmod_syshost == ""
+    assert namer.lmod_sysname == ""
+    assert namer.platform == DEFAULT_MOCK_HOST_NAME
+    assert namer.machine == DEFAULT_MOCK_MACHINE_NAME
+    assert namer.lmod_name == ""
+    assert namer.platform_name == f"{namer.platform}_{namer.machine}"
+    assert namer.name == namer.platform_name
+
+
+@patch("platform.machine", return_value="x86_64")
+@patch("platform.system", return_value="Linux")
+@patch.dict(os.environ, {})
+def test_known_linux_platform(
+    mock_system: mock.MagicMock, mock_machine: mock.MagicMock
+) -> None:
+    """Verify that known values for a linux platform result in the correct name.
+
+    NOTE: this test also confirms that the platform name is case-folded.
+    """
+    namer = HostNameEvaluator()
+
+    mock_system.assert_called_once()
+    mock_machine.assert_called_once()
+
+    expected_name = f"{namer.platform}_{namer.machine}".casefold()
+
+    assert namer.lmod_syshost == ""
+    assert namer.lmod_sysname == ""
+    assert namer.platform == "Linux"
+    assert namer.machine == "x86_64"
+    assert namer.lmod_name == ""
+    assert namer.platform_name == expected_name
+    assert namer.name == namer.platform_name
+
+
+@pytest.mark.parametrize(
+    ("lmod_syshost", "lmod_sysname"),
+    [
+        pytest.param("", "sys-name", id="No syshost"),
+        pytest.param("sys-host", "", id="No sysname"),
+        pytest.param("Expanse", "", id="Expanse (actual)"),
+        pytest.param("", "Perlmutter", id="Perlmutter (actual)"),
+    ],
+)
+@patch("platform.machine", return_value=DEFAULT_MOCK_MACHINE_NAME)
+@patch("platform.system", return_value=DEFAULT_MOCK_HOST_NAME)
+def test_partial_lmod_results_in_lmod_name(
+    mock_system: mock.MagicMock,
+    mock_machine: mock.MagicMock,
+    lmod_syshost: str,
+    lmod_sysname: str,
+) -> None:
+    """Verify that the an environment that specifies incomplete lmod variables returns
+    the value that is set."""
+    with patch.dict(
+        os.environ,
+        {
+            HostNameEvaluator.ENV_LMOD_SYSHOST: lmod_syshost,
+            HostNameEvaluator.ENV_LMOD_SYSNAME: lmod_sysname,
+        },
+    ):
+        namer = HostNameEvaluator()
+
+    mock_system.assert_called_once()
+    mock_machine.assert_called_once()
+
+    assert namer.lmod_syshost == lmod_syshost
+    assert namer.lmod_sysname == lmod_sysname
+    if lmod_syshost:
+        expected_name = namer.lmod_syshost.casefold()
+        assert namer.lmod_name == expected_name
+    elif lmod_sysname:
+        expected_name = namer.lmod_sysname.casefold()
+        assert namer.lmod_name == expected_name
+    assert namer.name == namer.lmod_name
+
+
+@pytest.mark.usefixtures("env_full_lmod")
+@patch("platform.machine", return_value=DEFAULT_MOCK_MACHINE_NAME)
+@patch("platform.system", return_value=DEFAULT_MOCK_HOST_NAME)
+def test_lmod_prioritizes_syshost(
+    mock_system: mock.MagicMock,
+    mock_machine: mock.MagicMock,
+) -> None:
+    """Verify that the an when both LMOD env vars are set, the value from sys host is
+    prioritized as the lmod name."""
+
+    namer = HostNameEvaluator()
+
+    mock_system.assert_called_once()
+    mock_machine.assert_called_once()
+
+    assert namer.lmod_name == namer.lmod_syshost
+    assert namer.name == namer.lmod_name
+
+
+@pytest.mark.usefixtures("env_full_lmod")
+@pytest.mark.parametrize(
+    ("system_name", "machine_name"),
+    [
+        pytest.param("", "system-name", id="No system name"),
+        pytest.param("machine-name", "", id="No machine name"),
+    ],
+)
+def test_partial_platform_naming(
+    system_name: str,
+    machine_name: str,
+) -> None:
+    """Verify that when the system name and machine name are not both found, the
+    platform name is empty."""
+
+    with (
+        patch("platform.system", return_value=system_name),
+        patch("platform.machine", return_value=machine_name),
+    ):
+        namer = HostNameEvaluator()
+
+    assert namer.platform == system_name
+    assert namer.machine == machine_name
+    assert namer.platform_name == ""
+
+    # partial platform info shouldn't affect overall name when lmod is available
+    assert namer.name
+
+
+@pytest.mark.usefixtures("env_no_lmod")
+@pytest.mark.parametrize(
+    ("system_name", "machine_name"),
+    [
+        pytest.param("", "system-name", id="No system name"),
+        pytest.param("machine-name", "", id="No machine name"),
+    ],
+)
+def test_partial_platform_fallback(
+    system_name: str,
+    machine_name: str,
+) -> None:
+    """Verify that when there is no lmod information and the system name and machine
+    name are not both found, accessing the name fails."""
+
+    with (
+        patch("platform.system", return_value=system_name),
+        patch("platform.machine", return_value=machine_name),
+    ):
+        namer = HostNameEvaluator()
+
+    assert namer.platform == system_name
+    assert namer.machine == machine_name
+    assert namer.platform_name == ""
+
+    # without lmod env vars, falling back on partial platform name should fail.
+    with pytest.raises(EnvironmentError):
+        _ = namer.name

--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -52,11 +52,11 @@ def test_no_lmod_in_env(
 
     assert namer.lmod_syshost == ""
     assert namer.lmod_sysname == ""
-    assert namer.platform == DEFAULT_MOCK_HOST_NAME
-    assert namer.machine == DEFAULT_MOCK_MACHINE_NAME
-    assert namer.lmod_name == ""
-    assert namer.platform_name == f"{namer.platform}_{namer.machine}"
-    assert namer.name == namer.platform_name
+    assert namer.platform_name == DEFAULT_MOCK_HOST_NAME
+    assert namer.machine_name == DEFAULT_MOCK_MACHINE_NAME
+    assert namer.lmod_hostname == ""
+    assert namer.platform_hostname == f"{namer.platform_name}_{namer.machine_name}"
+    assert namer.name == namer.platform_hostname
 
 
 @patch("platform.machine", return_value="x86_64")
@@ -74,15 +74,15 @@ def test_known_linux_platform(
     mock_system.assert_called_once()
     mock_machine.assert_called_once()
 
-    expected_name = f"{namer.platform}_{namer.machine}".casefold()
+    expected_name = f"{namer.platform_name}_{namer.machine_name}".casefold()
 
     assert namer.lmod_syshost == ""
     assert namer.lmod_sysname == ""
-    assert namer.platform == "Linux"
-    assert namer.machine == "x86_64"
-    assert namer.lmod_name == ""
-    assert namer.platform_name == expected_name
-    assert namer.name == namer.platform_name
+    assert namer.platform_name == "Linux"
+    assert namer.machine_name == "x86_64"
+    assert namer.lmod_hostname == ""
+    assert namer.platform_hostname == expected_name
+    assert namer.name == namer.platform_hostname
 
 
 @pytest.mark.parametrize(
@@ -120,11 +120,11 @@ def test_partial_lmod_results_in_lmod_name(
     assert namer.lmod_sysname == lmod_sysname
     if lmod_syshost:
         expected_name = namer.lmod_syshost.casefold()
-        assert namer.lmod_name == expected_name
+        assert namer.lmod_hostname == expected_name
     elif lmod_sysname:
         expected_name = namer.lmod_sysname.casefold()
-        assert namer.lmod_name == expected_name
-    assert namer.name == namer.lmod_name
+        assert namer.lmod_hostname == expected_name
+    assert namer.name == namer.lmod_hostname
 
 
 @pytest.mark.usefixtures("env_full_lmod")
@@ -142,8 +142,8 @@ def test_lmod_prioritizes_syshost(
     mock_system.assert_called_once()
     mock_machine.assert_called_once()
 
-    assert namer.lmod_name == namer.lmod_syshost
-    assert namer.name == namer.lmod_name
+    assert namer.lmod_hostname == namer.lmod_syshost
+    assert namer.name == namer.lmod_hostname
 
 
 @pytest.mark.usefixtures("env_full_lmod")
@@ -167,9 +167,9 @@ def test_partial_platform_naming(
     ):
         namer = HostNameEvaluator()
 
-    assert namer.platform == system_name
-    assert namer.machine == machine_name
-    assert namer.platform_name == ""
+    assert namer.platform_name == system_name
+    assert namer.machine_name == machine_name
+    assert namer.platform_hostname == ""
 
     # partial platform info shouldn't affect overall name when lmod is available
     assert namer.name
@@ -196,9 +196,9 @@ def test_partial_platform_fallback(
     ):
         namer = HostNameEvaluator()
 
-    assert namer.platform == system_name
-    assert namer.machine == machine_name
-    assert namer.platform_name == ""
+    assert namer.platform_name == system_name
+    assert namer.machine_name == machine_name
+    assert namer.platform_hostname == ""
 
     # without lmod env vars, falling back on partial platform name should fail.
     with pytest.raises(EnvironmentError):

--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -32,13 +32,14 @@ def env_no_lmod() -> Generator[mock._patch, None, None]:
     with patch.dict(
         os.environ,
         {},
+        clear=True,
     ) as _:
         yield _
 
 
 @patch("platform.machine", return_value=DEFAULT_MOCK_MACHINE_NAME)
 @patch("platform.system", return_value=DEFAULT_MOCK_HOST_NAME)
-@patch.dict(os.environ, {})
+@patch.dict(os.environ, {}, clear=True)
 def test_no_lmod_in_env(
     mock_system: mock.MagicMock, mock_machine: mock.MagicMock
 ) -> None:
@@ -60,7 +61,7 @@ def test_no_lmod_in_env(
 
 @patch("platform.machine", return_value="x86_64")
 @patch("platform.system", return_value="Linux")
-@patch.dict(os.environ, {})
+@patch.dict(os.environ, {}, clear=True)
 def test_known_linux_platform(
     mock_system: mock.MagicMock, mock_machine: mock.MagicMock
 ) -> None:

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -1,109 +1,41 @@
 import os
-from unittest.mock import PropertyMock, patch
+from collections.abc import Generator
+from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
 from cstar.system.environment import CStarEnvironment
-from cstar.system.manager import CStarSystemManager
-from cstar.system.scheduler import PBSScheduler, SlurmScheduler
+from cstar.system.manager import (
+    CStarSystemManager,
+    HostNameEvaluator,
+    _DerechoSystemContext,
+    _ExpanseSystemContext,
+    _LinuxSystemContext,
+    _MacOSSystemContext,
+    _PerlmutterSystemContext,
+    _SystemContext,
+)
 
 
 @pytest.fixture
-def mock_environment_vars():
-    """Fixture to mock environment variables."""
-    with patch.dict(os.environ, {}, clear=True):
-        yield
+def mock_environment_vars() -> Generator[None, None, None]:
+    """Fixture to mock environment variables.
 
+    Configures the environment to simulate execution on Perlmutter.
 
-class TestSystemName:
-    """Tests for the `name` property of the `CStarSystemManager` class.
-
-    Tests
-    -----
-    test_system_name
-        Validates that the system name is correctly determined based on environment
-        variables and platform properties.
-    test_system_name_raise
-        Ensures that an `EnvironmentError` is raised if the system name cannot be
-        determined.
-    test_unsupported_name
-        Confirms that a `ValueError` is raised when an unsupported system name
-        is encountered.
+    Returns
+    -------
     """
-
-    @pytest.mark.parametrize(
-        "env_vars, platform_values, expected_sysname",
-        [
-            ({"LMOD_SYSHOST": "expanse"}, None, "expanse"),
-            ({"LMOD_SYSTEM_NAME": "perlmutter"}, None, "perlmutter"),
-            ({}, ("Linux", "x86_64"), "linux_x86_64"),
-        ],
-    )
-    @patch("platform.system", return_value=None)  # Default mock for platform.system
-    @patch("platform.machine", return_value=None)  # Default mock for platform.machine
-    def test_system_name(
-        self,
-        mock_machine,
-        mock_system,
-        env_vars,
-        platform_values,
-        expected_sysname,
-        mock_environment_vars,
-    ):
-        """Validates that the system name is correctly determined based on environment
-        variables and platform properties.
-
-        This test uses parameterization to evaluate multiple combinations of environment
-        variables and platform values.
-
-        Mocks
-        -----
-        platform.system
-            Returns a mocked system name when platform detection is used.
-        platform.machine
-            Returns a mocked machine architecture when platform detection is used.
-        os.environ
-            Environment variables are patched to simulate specific configurations.
-
-        Asserts
-        -------
-        - That the system name matches the expected value for various input scenarios.
-        """
-
-        # Override platform mocks if values are provided
-        if platform_values:
-            mock_system.return_value = platform_values[0]
-            mock_machine.return_value = platform_values[1]
-
-        # Patch environment variables
-        with patch.dict(os.environ, env_vars):
-            # Instantiate the system and compute the name
-            system = CStarSystemManager()
-            assert system.name == expected_sysname
-
-    @patch("platform.system", return_value=None)
-    @patch("platform.machine", return_value=None)
-    def test_system_name_raise(self, mock_machine, mock_system, mock_environment_vars):
-        """Test that an error is raised when system name cannot be determined."""
-        with pytest.raises(
-            EnvironmentError, match="C-Star cannot determine your system name"
-        ):
-            system = CStarSystemManager()
-            _ = system.name
-
-    def test_unsupported_name(self, mock_environment_vars):
-        """Test that an unsupported system name raises a ValueError."""
-        with patch.object(
-            CStarSystemManager,
-            "name",
-            new_callable=PropertyMock,
-            return_value="unsupported_name",
-        ):
-            with pytest.raises(
-                ValueError, match="'unsupported_name' is not a valid SystemName"
-            ):
-                system = CStarSystemManager()
-                _ = system.environment
+    with patch.dict(
+        os.environ,
+        {
+            HostNameEvaluator.ENV_LMOD_SYSHOST: "",
+            HostNameEvaluator.ENV_LMOD_SYSNAME: "Perlmutter",
+        },
+        clear=True,
+    ) as _:
+        yield _
 
 
 class TestEnvironmentProperty:
@@ -116,52 +48,64 @@ class TestEnvironmentProperty:
         the expected attributes based on the system name.
     """
 
+    @pytest.mark.usefixtures("mock_environment_vars")
     @pytest.mark.parametrize(
-        "system_name, expected_attributes",
+        ("system_ctx", "expected_attributes"),
         [
             (
-                "expanse",
+                _ExpanseSystemContext,
                 {
                     "mpi_exec_prefix": "srun --mpi=pmi2",
                     "compiler": "intel",
                 },
             ),
             (
-                "perlmutter",
+                _PerlmutterSystemContext,
                 {
                     "mpi_exec_prefix": "srun",
                     "compiler": "gnu",
                 },
             ),
             (
-                "derecho",
+                _DerechoSystemContext,
                 {
                     "mpi_exec_prefix": "mpirun",
                     "compiler": "intel",
                 },
             ),
+            (
+                _MacOSSystemContext,
+                {
+                    "mpi_exec_prefix": "mpirun",
+                    "compiler": "gnu",
+                },
+            ),
+            (
+                _LinuxSystemContext,
+                {
+                    "mpi_exec_prefix": "mpirun",
+                    "compiler": "gnu",
+                },
+            ),
         ],
     )
     def test_environment_initialization(
-        self, system_name, expected_attributes, mock_environment_vars
-    ):
-        """Test that the environment is initialized with the correct attributes."""
-        with patch.object(
-            CStarSystemManager,
-            "name",
-            new_callable=PropertyMock,
-            return_value=system_name,
-        ):
+        self,
+        system_ctx: type[_SystemContext],
+        expected_attributes: dict[str, str],
+    ) -> None:
+        """Verify that environment attributes are correctly initialized."""
+        mock_get_sys_ctx = mock.MagicMock(return_value=system_ctx())
+
+        with mock.patch("cstar.system.manager._get_system_context", mock_get_sys_ctx):
             system = CStarSystemManager()
-            environment = system.environment
 
-            # Verify that the environment object matches the expected attributes
-            assert isinstance(environment, CStarEnvironment)
-            for attr, value in expected_attributes.items():
-                assert getattr(environment, attr) == value
+        environment = system.environment
 
-
-##
+        # Compare the actual and expected attributes of the environment.
+        assert isinstance(environment, CStarEnvironment)
+        for attr, value in expected_attributes.items():
+            assert getattr(environment, attr) == value
 
 
 class TestSchedulerProperty:
@@ -169,93 +113,19 @@ class TestSchedulerProperty:
 
     Tests
     -----
-    test_scheduler_initialization
-        Validates that the scheduler is initialized with the correct type and queue names
-        based on the system name.
-    test_no_scheduler
-        Ensures that the scheduler property is `None` for supported systems without a scheduler.
     test_scheduler_caching
-        Confirms that the scheduler property is cached after the first access.
+        Confirms that the scheduler property is cached after instantiation.
     """
 
-    @pytest.mark.parametrize(
-        "system_name, expected_scheduler_type, expected_queue_names",
-        [
-            (
-                "perlmutter",
-                SlurmScheduler,
-                ["regular", "shared", "debug"],
-            ),
-            (
-                "derecho",
-                PBSScheduler,
-                ["main", "preempt", "develop"],
-            ),
-        ],
-    )
-    def test_scheduler_initialization(
+    def test_scheduler_caching(
         self,
-        system_name,
-        expected_scheduler_type,
-        expected_queue_names,
-        mock_environment_vars,
-    ):
-        """Validates that the scheduler is initialized with the correct type and queue
-        names based on the system name.
+        mock_environment_vars: dict[str, str],  # noqa: ARG002
+    ) -> None:
+        """Verify that the scheduler property is cached after first access."""
+        system = CStarSystemManager()
 
-        This test uses parameterization to evaluate multiple system names and their
-        corresponding scheduler types and queue names.
+        first_scheduler = system.scheduler
+        second_scheduler = system.scheduler
 
-        Mocks
-        -----
-        CStarSystemManager.name
-            Returns a mocked system name to simulate different environments.
-        os.environ
-            Environment variables are patched to simulate a clean environment.
-
-        Asserts
-        -------
-        - That the scheduler is an instance of the expected type.
-        - That the queue names of the scheduler match the expected names.
-        """
-
-        with patch.object(
-            CStarSystemManager,
-            "name",
-            new_callable=PropertyMock,
-            return_value=system_name,
-        ):
-            system = CStarSystemManager()
-            scheduler = system.scheduler
-
-            # Verify that the scheduler is of the expected type
-            assert isinstance(scheduler, expected_scheduler_type)
-
-            # Verify that the queue names match
-            assert set(q.name for q in scheduler.queues) == set(expected_queue_names)
-
-    def test_no_scheduler(self, mock_environment_vars):
-        """Asserts that a supported system without a scheduler returns 'None'."""
-        with patch.object(
-            CStarSystemManager,
-            "name",
-            new_callable=PropertyMock,
-            return_value="darwin_arm64",
-        ):
-            system = CStarSystemManager()
-            assert system.scheduler is None
-
-    def test_scheduler_caching(self, mock_environment_vars):
-        """Asserts that the scheduler property is cached after first access."""
-        with patch.object(
-            CStarSystemManager,
-            "name",
-            new_callable=PropertyMock,
-            return_value="perlmutter",
-        ):
-            system = CStarSystemManager()
-            first_scheduler = system.scheduler
-            second_scheduler = system.scheduler
-
-            # Verify that the scheduler is cached
-            assert first_scheduler is second_scheduler
+        # Verify that the scheduler is cached
+        assert first_scheduler is second_scheduler

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -117,10 +117,8 @@ class TestSchedulerProperty:
         Confirms that the scheduler property is cached after instantiation.
     """
 
-    def test_scheduler_caching(
-        self,
-        mock_environment_vars: dict[str, str],  # noqa: ARG002
-    ) -> None:
+    @pytest.mark.usefixtures("mock_environment_vars")
+    def test_scheduler_caching(self) -> None:
         """Verify that the scheduler property is cached after first access."""
         system = CStarSystemManager()
 


### PR DESCRIPTION
This PR refactors system-specific logic out of the `CStarSystemManager` by implementing configuration classes for the known platforms. By extracting config into individual dataclasses, it reduces the code churn necessary for the platform-specific additions or modifications. 

The `HostNameEvaluator` class was added to encapsulate logic for identifying the current platform and further focus the responsibilities of `CStarSystemManager`.

These changes are laying groundwork for the upcoming worker PR.


- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
