### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > The [python API](https://c-star.readthedocs.io/en/latest/api.html) is not yet stable, and some aspects of the schema for the [blueprint](https://c-star.readthedocs.io/en/latest/terminology.html#term-blueprint) will likely evolve. 
 > Therefore whilst you are welcome to try out using the package, we cannot yet guarantee backwards compatibility. 
-We expect to reach a more stable version in Q1 2025.
+We expect to reach a more stable version in Q1 2026.
 >
 > To see which systems C-Star has been tested on so far, see [Supported Systems](https://c-star.readthedocs.io/en/latest/machines.html).
 


### PR DESCRIPTION
Changing "early stage of development" disclaimer language from Q1 2025 to Q1 2026 (post-MVP).