### PR TITLE
New linting rules (`main`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 files: '^cstar/'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     
     hooks:
       - id: trailing-whitespace
@@ -17,13 +17,14 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.4.7"
+    rev: v0.12.2
     hooks:
-      - id: ruff
+      - id: ruff-check
+        args: ["--fix"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         additional_dependencies: [
@@ -38,10 +39,10 @@ repos:
     hooks:
       - id: absolufy-imports
         args: [--application-directories=.]
-
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5  
-    hooks:
-      - id: docformatter
-        language: python
-        args: ["--in-place", "--recursive", "--wrap-summaries=88", "--wrap-descriptions=88"]
+# TODO: figure out the contradiction, or determine if ruff is doing everything we need here
+#  - repo: https://github.com/PyCQA/docformatter
+#    rev: v1.7.7
+#    hooks:
+#      - id: docformatter
+#        language: python
+#        args: ["--in-place", "--recursive", "--wrap-summaries=88", "--wrap-descriptions=88"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,3 @@ repos:
     hooks:
       - id: absolufy-imports
         args: [--application-directories=.]
-# TODO: figure out the contradiction, or determine if ruff is doing everything we need here
-#  - repo: https://github.com/PyCQA/docformatter
-#    rev: v1.7.7
-#    hooks:
-#      - id: docformatter
-#        language: python
-#        args: ["--in-place", "--recursive", "--wrap-summaries=88", "--wrap-descriptions=88"]

--- a/cstar/base/additional_code.py
+++ b/cstar/base/additional_code.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional
 
 from cstar.base.datasource import DataSource
 from cstar.base.gitutils import _clone_and_checkout
@@ -48,8 +47,8 @@ class AdditionalCode(LoggingMixin):
         self,
         location: str,
         subdir: str = "",
-        checkout_target: Optional[str] = None,
-        files: Optional[list[str]] = None,
+        checkout_target: str | None = None,
+        files: list[str] | None = None,
     ):
         """Initialize an AdditionalCode object from a DataSource  and a list of code
         files.
@@ -75,10 +74,10 @@ class AdditionalCode(LoggingMixin):
         self.source: DataSource = DataSource(location)
         self.subdir: str = subdir
         self._checkout_target = checkout_target
-        self.files: Optional[list[str]] = [] if files is None else files
+        self.files: list[str] | None = [] if files is None else files
         # Initialize object state
-        self.working_path: Optional[Path] = None
-        self._local_file_hash_cache: Dict = {}
+        self.working_path: Path | None = None
+        self._local_file_hash_cache: dict = {}
 
     def __str__(self) -> str:
         base_str = self.__class__.__name__ + "\n"
@@ -118,13 +117,14 @@ class AdditionalCode(LoggingMixin):
         return repr_str
 
     @property
-    def checkout_target(self) -> Optional[str]:
+    def checkout_target(self) -> str | None:
         return self._checkout_target
 
     @property
     def exists_locally(self):
         """Determine whether a local working copy of the AdditionalCode exists at
-        self.working_path (bool)"""
+        self.working_path (bool)
+        """
         if (self.working_path is None) or (self._local_file_hash_cache is None):
             return False
 
@@ -167,9 +167,9 @@ class AdditionalCode(LoggingMixin):
                         "AdditionalCode.source points to a repository but AdditionalCode.checkout_target is None"
                     )
                 else:
-                    assert isinstance(
-                        self.checkout_target, str
-                    ), "We have just verified checkout_target is not None"
+                    assert isinstance(self.checkout_target, str), (
+                        "We have just verified checkout_target is not None"
+                    )
                 tmp_dir = tempfile.mkdtemp()
                 _clone_and_checkout(
                     source_repo=self.source.location,

--- a/cstar/base/datasource.py
+++ b/cstar/base/datasource.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urlparse
 
 
@@ -21,7 +20,7 @@ class DataSource:
        The basename of self.location, typically the file name
     """
 
-    def __init__(self, location: str | Path, file_hash: Optional[str] = None):
+    def __init__(self, location: str | Path, file_hash: str | None = None):
         """Initialize a DataSource from a location string.
 
         Parameters:
@@ -42,13 +41,14 @@ class DataSource:
         return self._location
 
     @property
-    def file_hash(self) -> Optional[str]:
+    def file_hash(self) -> str | None:
         return self._file_hash
 
     @property
     def location_type(self) -> str:
         """Get the location type (e.g. "path" or "url") from the "location"
-        attribute."""
+        attribute.
+        """
         urlparsed_location = urlparse(self.location)
         if all([urlparsed_location.scheme, urlparsed_location.netloc]):
             return "url"

--- a/cstar/base/discretization.py
+++ b/cstar/base/discretization.py
@@ -6,7 +6,6 @@ class Discretization(ABC):
 
     Attributes:
     -----------
-
     time_step: int
         The time step with which to run the Component
     """
@@ -27,7 +26,6 @@ class Discretization(ABC):
         Discretization:
             An initialized Discretization object
         """
-
         self.time_step: int = time_step
 
     def __str__(self) -> str:

--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -1,7 +1,6 @@
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
 
 from cstar.base.gitutils import (
     _checkout,
@@ -56,7 +55,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
     """
 
     def __init__(
-        self, source_repo: Optional[str] = None, checkout_target: Optional[str] = None
+        self, source_repo: str | None = None, checkout_target: str | None = None
     ):
         """Initialize a ExternalCodeBase object manually from a source repository and
         checkout target.
@@ -73,7 +72,6 @@ class ExternalCodeBase(ABC, LoggingMixin):
         ExternalCodeBase
             An initialized ExternalCodeBase object
         """
-
         self._source_repo = source_repo
         self._checkout_target = checkout_target
 
@@ -151,7 +149,8 @@ class ExternalCodeBase(ABC, LoggingMixin):
     @abstractmethod
     def expected_env_var(self) -> str:
         """Environment variable associated with the external codebase, e.g.
-        MARBL_ROOT."""
+        MARBL_ROOT.
+        """
 
     @property
     def local_config_status(self) -> int:
@@ -172,7 +171,6 @@ class ExternalCodeBase(ABC, LoggingMixin):
            2: The expected environment variable is present, points to the correct repository remote, but is checked out at the wrong hash
            3: The expected environment variable is not present and it is assumed the external codebase is not installed locally
         """
-
         # check 1: X_ROOT variable is in user's env
         env_var_exists = (
             self.expected_env_var
@@ -239,29 +237,25 @@ class ExternalCodeBase(ABC, LoggingMixin):
             case 1:
                 env_var_repo_remote = _get_repo_remote(local_root)
 
-                raise EnvironmentError(
-                    (
-                        "System environment variable "
-                        f"'{self.expected_env_var}' points to "
-                        "a github repository whose "
-                        f"remote: \n '{env_var_repo_remote}' \n"
-                        "does not match that expected by C-Star: \n"
-                        f"{self.source_repo}."
-                        "Your environment may be misconfigured."
-                    )
+                raise OSError(
+                    "System environment variable "
+                    f"'{self.expected_env_var}' points to "
+                    "a github repository whose "
+                    f"remote: \n '{env_var_repo_remote}' \n"
+                    "does not match that expected by C-Star: \n"
+                    f"{self.source_repo}."
+                    "Your environment may be misconfigured."
                 )
             case 2:
                 head_hash = _get_repo_head_hash(local_root)
                 print(
-                    (
-                        "############################################################\n"
-                        f"C-STAR: {self.expected_env_var} points to the correct repo "
-                        f"{self.source_repo} but HEAD is at: \n"
-                        f"{head_hash}, rather than the hash associated with "
-                        f"checkout_target {self.checkout_target}:\n"
-                        f"{self.checkout_hash}\n"
-                        "############################################################"
-                    )
+                    "############################################################\n"
+                    f"C-STAR: {self.expected_env_var} points to the correct repo "
+                    f"{self.source_repo} but HEAD is at: \n"
+                    f"{head_hash}, rather than the hash associated with "
+                    f"checkout_target {self.checkout_target}:\n"
+                    f"{self.checkout_hash}\n"
+                    "############################################################"
                 )
                 while True:
                     yn = "y"
@@ -277,7 +271,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
                             print(ex)
                         return
                     elif yn.casefold() in ["n", "no"]:
-                        raise EnvironmentError()
+                        raise OSError()
                     else:
                         print("invalid selection; enter 'y' or 'n'")
             case 3:
@@ -286,18 +280,16 @@ class ExternalCodeBase(ABC, LoggingMixin):
                     / f"externals/{self.repo_basename}"
                 )
                 print(
-                    (
-                        "#######################################################\n"
-                        f"C-STAR: {self.expected_env_var}"
-                        " not found in current cstar_sysmgr.environment. \n"
-                        "if this is your first time running C-Star with "
-                        f"an instance of {self.__class__.__name__}, "
-                        "you will need to set it up.\n"
-                        "It is recommended that you install this external codebase in \n"
-                        f"{ext_dir}\n"
-                        f"This will also modify your `{CSTAR_USER_ENV_PATH}` file.\n"
-                        "#######################################################"
-                    )
+                    "#######################################################\n"
+                    f"C-STAR: {self.expected_env_var}"
+                    " not found in current cstar_sysmgr.environment. \n"
+                    "if this is your first time running C-Star with "
+                    f"an instance of {self.__class__.__name__}, "
+                    "you will need to set it up.\n"
+                    "It is recommended that you install this external codebase in \n"
+                    f"{ext_dir}\n"
+                    f"This will also modify your `{CSTAR_USER_ENV_PATH}` file.\n"
+                    "#######################################################"
                 )
                 while True:
                     if not ext_dir.exists():
@@ -306,16 +298,14 @@ class ExternalCodeBase(ABC, LoggingMixin):
                     yn = "y"
                     if interactive:
                         yn = input(
-                            (
-                                "Would you like to do this now? "
-                                "('y', 'n', or 'custom' to install at a custom path)\n"
-                            )
+                            "Would you like to do this now? "
+                            "('y', 'n', or 'custom' to install at a custom path)\n"
                         )
                     if yn.casefold() in ["y", "yes", "ok"]:
                         self.get(ext_dir)
                         break
                     elif yn.casefold() in ["n", "no"]:
-                        raise EnvironmentError()
+                        raise OSError()
                     elif yn.casefold() == "custom":
                         custom_path = input("Enter custom path for install:\n")
                         self.get(Path(custom_path).resolve())

--- a/cstar/base/gitutils.py
+++ b/cstar/base/gitutils.py
@@ -37,7 +37,8 @@ def _clone_and_checkout(
 
 def _get_repo_remote(local_path: str | Path) -> str:
     """Take a local repository path string (local_path) and return as a string the
-    remote URL."""
+    remote URL.
+    """
     return _run_cmd(
         f"git -C {local_path} remote get-url origin",
         msg_pre=f"Retrieving URL for remote in repository `{local_path}`.",
@@ -48,7 +49,8 @@ def _get_repo_remote(local_path: str | Path) -> str:
 
 def _get_repo_head_hash(local_path: str | Path) -> str:
     """Take a local repository path string (local_path) and return as a string the
-    commit hash of HEAD."""
+    commit hash of HEAD.
+    """
     return _run_cmd(
         f"git -C {local_path} rev-parse HEAD",
         msg_pre=f"Retrieving commit hash for repository `{local_path}`.",
@@ -77,7 +79,6 @@ def _get_hash_from_checkout_target(repo_url: str, checkout_target: str) -> str:
     git_hash: str
         A git commit hash associated with the checkout target
     """
-
     # Get list of targets from git ls-remote
     ls_remote = _run_cmd(
         f"git ls-remote {repo_url}",

--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from abc import ABC
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 import dateutil.parser
@@ -37,9 +37,9 @@ class InputDataset(ABC, LoggingMixin):
     def __init__(
         self,
         location: str,
-        file_hash: Optional[str] = None,
-        start_date: Optional[str | dt.datetime] = None,
-        end_date: Optional[str | dt.datetime] = None,
+        file_hash: str | None = None,
+        start_date: str | dt.datetime | None = None,
+        end_date: str | dt.datetime | None = None,
     ):
         """Initialize an InputDataset object associated with a model simulation using a
         source URL and file hash.
@@ -52,7 +52,6 @@ class InputDataset(ABC, LoggingMixin):
         file_hash: str, optional
             The 256 bit SHA sum associated with the file for verification if remote
         """
-
         self.source: DataSource = DataSource(location=location, file_hash=file_hash)
         if (
             (self.source.location_type == "url")
@@ -74,9 +73,9 @@ class InputDataset(ABC, LoggingMixin):
         assert self.end_date is None or isinstance(self.end_date, dt.datetime)
 
         # Initialize object state:
-        self.working_path: Optional[Path | List[Path]] = None
-        self._local_file_hash_cache: Dict = {}
-        self._local_file_stat_cache: Dict = {}
+        self.working_path: Path | list[Path] | None = None
+        self._local_file_hash_cache: dict = {}
+        self._local_file_stat_cache: dict = {}
 
         # Subclass-specific  confirmation that everything is set up correctly:
         self.validate()
@@ -140,7 +139,7 @@ class InputDataset(ABC, LoggingMixin):
         return True
 
     @property
-    def local_hash(self) -> Optional[Dict]:
+    def local_hash(self) -> dict | None:
         """Compute or retrieve the cached SHA-256 hash of the local dataset.
 
         This property calculates the SHA-256 hash for the dataset located at `working_path`.
@@ -158,7 +157,6 @@ class InputDataset(ABC, LoggingMixin):
               and the values are their respective SHA-256 hashes.
             - `None` if `working_path` is not set or no files exist locally.
         """
-
         if self._local_file_hash_cache:
             return self._local_file_hash_cache
 

--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -24,7 +24,6 @@ def get_logger(
     logging.Logger
         A logger instance with the specified name.
     """
-
     fmt = fmt or DEFAULT_LOG_FORMAT
 
     logger = logging.getLogger(name)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -22,7 +22,6 @@ def _get_sha256_hash(file_path: str | Path) -> str:
     file_hash: str
        The SHA-256 checksum of the file at file_path
     """
-
     file_path = Path(file_path)
     if not file_path.is_file():
         raise FileNotFoundError(
@@ -62,7 +61,7 @@ def _replace_text_in_file(file_path: str | Path, old_text: str, new_text: str) -
     file_path = Path(file_path).resolve()
     temp_file_path = Path(str(file_path) + ".tmp")
 
-    with open(file_path, "r") as read_file, open(temp_file_path, "w") as write_file:
+    with open(file_path) as read_file, open(temp_file_path, "w") as write_file:
         for line in read_file:
             if old_text in line:
                 text_replaced = True

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -85,7 +85,6 @@ class ExecutionHandler(ABC, LoggingMixin):
         The specific implementation should query the underlying process or
         system to determine the task's status.
         """
-
         pass
 
     @property
@@ -98,7 +97,6 @@ class ExecutionHandler(ABC, LoggingMixin):
         output_file (Path):
             Path to the file in which stdout and stderr will be written.
         """
-
         pass
 
     def updates(self, seconds: float = 10, confirm_indefinite: bool = True):
@@ -128,7 +126,6 @@ class ExecutionHandler(ABC, LoggingMixin):
         - When streaming indefinitely (`seconds=0`), user confirmation is
           required before proceeding.
         """
-
         if self.status != ExecutionStatus.RUNNING:
             error_msg = f"This job is currently not running ({self.status}). Live updates cannot be provided."
             is_complete = self.status in {
@@ -160,7 +157,7 @@ class ExecutionHandler(ABC, LoggingMixin):
                 return
 
         try:
-            with open(self.output_file, "r") as f:
+            with open(self.output_file) as f:
                 f.seek(0, 2)  # Move to the end of the file
                 start_time = time.time()
                 while seconds == 0 or (time.time() - start_time < seconds):

--- a/cstar/execution/local_process.py
+++ b/cstar/execution/local_process.py
@@ -1,7 +1,6 @@
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 
@@ -40,8 +39,8 @@ class LocalProcess(ExecutionHandler):
     def __init__(
         self,
         commands: str,
-        output_file: Optional[str | Path] = None,
-        run_path: Optional[str | Path] = None,
+        output_file: str | Path | None = None,
+        run_path: str | Path | None = None,
     ):
         """Initialize a `LocalProcess` instance.
 
@@ -57,7 +56,6 @@ class LocalProcess(ExecutionHandler):
             The directory from which the subprocess will be executed.
             Defaults to the current working directory.
         """
-
         self.commands = commands
         self.run_path = Path(run_path) if run_path is not None else Path.cwd()
         self._default_name = (
@@ -110,7 +108,6 @@ class LocalProcess(ExecutionHandler):
         --------
         cancel : Terminates the running subprocess.
         """
-
         # Open the output file to write to
         self._output_file_handle = open(self.output_file, "w")
         local_process = subprocess.Popen(
@@ -179,7 +176,6 @@ class LocalProcess(ExecutionHandler):
         If the _process attribute is not set, no action is taken.
         If it is set to a running process, a RuntimeError is raised.
         """
-
         if self._process is None:
             return
         elif self._process.poll() is not None:
@@ -213,7 +209,6 @@ class LocalProcess(ExecutionHandler):
         --------
         wait : Wait for the local process to finish
         """
-
         if self._process and self.status == ExecutionStatus.RUNNING:
             try:
                 self._process.terminate()  # Send SIGTERM to allow graceful shutdown
@@ -237,7 +232,6 @@ class LocalProcess(ExecutionHandler):
         --------
         cancel : end the current process
         """
-
         if self.status == ExecutionStatus.RUNNING:
             self._process.wait()
         else:

--- a/cstar/roms/discretization.py
+++ b/cstar/roms/discretization.py
@@ -40,7 +40,6 @@ class ROMSDiscretization(Discretization):
         ROMSDiscretization:
             An initialized ROMSDiscretization object
         """
-
         super().__init__(time_step)
         self.n_procs_x = n_procs_x
         self.n_procs_y = n_procs_y

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 from abc import ABC
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import requests
 import roms_tools
@@ -41,15 +41,15 @@ class ROMSPartitioning:
         Paths to the partitioned files.
     """
 
-    def __init__(self, np_xi: int, np_eta: int, files: List[Path]):
+    def __init__(self, np_xi: int, np_eta: int, files: list[Path]):
         self.np_xi = np_xi
         self.np_eta = np_eta
         self.files = files
-        self._local_file_hash_cache: Dict = {}
-        self._local_file_stat_cache: Dict = {}
+        self._local_file_hash_cache: dict = {}
+        self._local_file_stat_cache: dict = {}
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(np_xi={self.np_xi}, np_eta={self.np_eta}, files={_list_to_concise_str(self.files,pad=43)})"
+        return f"{self.__class__.__name__}(np_xi={self.np_xi}, np_eta={self.np_eta}, files={_list_to_concise_str(self.files, pad=43)})"
 
     def __len__(self):
         return len(self.files)
@@ -74,11 +74,11 @@ class ROMSInputDataset(InputDataset, ABC):
     def __init__(
         self,
         location: str,
-        file_hash: Optional[str] = None,
-        start_date: Optional[str | dt.datetime] = None,
-        end_date: Optional[str | dt.datetime] = None,
-        source_np_xi: Optional[int] = None,
-        source_np_eta: Optional[int] = None,
+        file_hash: str | None = None,
+        start_date: str | dt.datetime | None = None,
+        end_date: str | dt.datetime | None = None,
+        source_np_xi: int | None = None,
+        source_np_eta: int | None = None,
     ):
         super().__init__(
             location=location,
@@ -89,7 +89,7 @@ class ROMSInputDataset(InputDataset, ABC):
 
         self.source_np_xi = source_np_xi
         self.source_np_eta = source_np_eta
-        self.partitioning: Optional[ROMSPartitioning] = None
+        self.partitioning: ROMSPartitioning | None = None
 
     @property
     def source_partitioning(self) -> tuple[int, int] | None:
@@ -176,7 +176,8 @@ class ROMSInputDataset(InputDataset, ABC):
 
         def get_files_to_partition():
             """Helper function to obtain a list of files associated with this
-            ROMSInputDataset to partition."""
+            ROMSInputDataset to partition.
+            """
             if isinstance(self.working_path, list):
                 # if single InputDataset corresponds to many files, check they're colocated
                 if not all(
@@ -197,7 +198,8 @@ class ROMSInputDataset(InputDataset, ABC):
 
         def partition_files(files: list[Path]) -> list[Path]:
             """Helper function that wraps the actual roms_tools.partition_netcdf
-            call."""
+            call.
+            """
             new_parted_files = []
 
             for idfile in files:
@@ -210,7 +212,8 @@ class ROMSInputDataset(InputDataset, ABC):
 
         def backup_existing_partitioned_files(files: list[Path]):
             """Helper function to move existing parted files to a tmp dir while
-            attempting to create new ones."""
+            attempting to create new ones.
+            """
             tmpdir = tempfile.TemporaryDirectory()
             backup_path = Path(tmpdir.name)
 
@@ -222,8 +225,8 @@ class ROMSInputDataset(InputDataset, ABC):
             backup_dir: Path, restore_paths: list[Path]
         ):
             """Helper function to restore existing parted files if partitioning
-            fails."""
-
+            fails.
+            """
             for f in restore_paths:
                 shutil.move(backup_dir / f.name, f.resolve())
 
@@ -341,7 +344,6 @@ class ROMSInputDataset(InputDataset, ABC):
         local_dir (Path):
             Directory where the resulting NetCDF files should be saved.
         """
-
         # Ensure we're working with a Path object
         local_dir = Path(local_dir).expanduser().resolve()
         local_dir.mkdir(parents=True, exist_ok=True)
@@ -407,7 +409,7 @@ class ROMSInputDataset(InputDataset, ABC):
         )
         save_kwargs: dict[Any, Any] = {}
         save_kwargs["filepath"] = Path(
-            f"{local_dir/Path(self.source.location).stem}.nc"
+            f"{local_dir / Path(self.source.location).stem}.nc"
         )
 
         savepath = roms_tools_class_instance.save(**save_kwargs)
@@ -463,7 +465,8 @@ class ROMSModelGrid(ROMSInputDataset):
 
 class ROMSInitialConditions(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model initial condition
-    files."""
+    files.
+    """
 
     pass
 
@@ -476,14 +479,16 @@ class ROMSTidalForcing(ROMSInputDataset):
 
 class ROMSBoundaryForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model boundary condition
-    files."""
+    files.
+    """
 
     pass
 
 
 class ROMSSurfaceForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model surface forcing
-    files."""
+    files.
+    """
 
     pass
 

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import (
     Any,
     ClassVar,
-    Optional,
     Self,
     Union,
     get_args,
@@ -49,7 +48,8 @@ def _format_float(val: float) -> str:
 
 def _format_value(val: Any) -> str:
     """Format floats using _format_float, otherwise just return the string of the
-    value."""
+    value.
+    """
     if isinstance(val, float):
         return _format_float(val)
     return str(val)
@@ -73,7 +73,8 @@ def _get_alias(field_name: str) -> str:
 
 class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
     """Base class containing common serialization/deserialization methods used by
-    subsections of the ROMS runtime input file."""
+    subsections of the ROMS runtime input file.
+    """
 
     multi_line: ClassVar[bool] = False
     """If true, multiple values are split across multiple lines in the inputs file; if
@@ -88,7 +89,8 @@ class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
     @property
     def key_order(self):
         """Return the pydantic fields (no class vars or properties) in the order they
-        are specified."""
+        are specified.
+        """
         return list(self.__pydantic_fields__.keys())
 
     @model_validator(mode="wrap")
@@ -139,8 +141,8 @@ class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
 
     def _format_and_join_values(self, *args):
         """Formats any number of args corresponding to a single value, and joins them as
-        appropriate."""
-
+        appropriate.
+        """
         # if args is a single, non-list item, just format it (no join needed)
         if len(args) == 1 and not isinstance(args[0], list):
             return _format_value(args[0])
@@ -211,7 +213,6 @@ class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
         >>> InitialConditions.from_lines(["1", "input_datasets/roms_ini.nc"])
             InitialConditions(nrrec=1, ininame=Path("input_datasets/roms_ini.nc"))
         """
-
         if not lines:
             raise ValueError("Received empty input.")
 
@@ -279,7 +280,6 @@ class SingleEntryROMSRuntimeSettingsSection(ROMSRuntimeSettingsSection):
         a relevant ValidationError) if the type does not strictly match and can't be
         validated as a dict/object either.
         """
-
         # If no data is provided (None, empty list, etc.), set the whole section to None.
         # We do need to explicitly let 0 through as a valid value, though.
         if data in [None, [], ""]:
@@ -375,12 +375,12 @@ class BottomDrag(ROMSRuntimeSettingsSection):
 
 class InitialConditions(ROMSRuntimeSettingsSection):
     nrrec: int
-    ininame: Optional[Path]
+    ininame: Path | None
 
     multi_line = True
 
     @classmethod
-    def from_lines(cls, lines: Optional[list[str]]) -> Self:
+    def from_lines(cls, lines: list[str] | None) -> Self:
         """Bespoke `from_lines` for the InitialConditions section, which may have a
         single '0' line, as in, e.g. `$ROMS_ROOT/Examples/Rivers_ana/river_ana.in`
 
@@ -393,12 +393,12 @@ class InitialConditions(ROMSRuntimeSettingsSection):
 
 
 class Forcing(ROMSRuntimeSettingsSection):
-    filenames: Optional[list[Path]]
+    filenames: list[Path] | None
 
     multi_line = True
 
     @classmethod
-    def from_lines(cls, lines: Optional[list[str]]) -> Self:
+    def from_lines(cls, lines: list[str] | None) -> Self:
         """Bespoke `from_lines` for the Forcing section, which must exist in ROMS but
         may be empty, as in, e.g. `$ROMS_ROOT/Examples/Rivers_ana/river_ana.in`
 
@@ -450,21 +450,21 @@ class ROMSRuntimeSettings(BaseModel):
     forcing: Forcing
     output_root_name: OutputRootName
 
-    s_coord: Optional[SCoord] = None
-    grid: Optional[Grid] = None
-    marbl_biogeochemistry: Optional[MARBLBiogeochemistry] = None
-    lateral_visc: Optional[LateralVisc] = None
-    rho0: Optional[Rho0] = None
-    lin_rho_eos: Optional[LinRhoEos] = None
-    gamma2: Optional[Gamma2] = None
-    tracer_diff2: Optional[TracerDiff2] = None
-    vertical_mixing: Optional[VerticalMixing] = None
-    my_bak_mixing: Optional[MYBakMixing] = None
-    sss_correction: Optional[SSSCorrection] = None
-    sst_correction: Optional[SSTCorrection] = None
-    ubind: Optional[UBind] = None
-    v_sponge: Optional[VSponge] = None
-    climatology: Optional[Climatology] = None
+    s_coord: SCoord | None = None
+    grid: Grid | None = None
+    marbl_biogeochemistry: MARBLBiogeochemistry | None = None
+    lateral_visc: LateralVisc | None = None
+    rho0: Rho0 | None = None
+    lin_rho_eos: LinRhoEos | None = None
+    gamma2: Gamma2 | None = None
+    tracer_diff2: TracerDiff2 | None = None
+    vertical_mixing: VerticalMixing | None = None
+    my_bak_mixing: MYBakMixing | None = None
+    sss_correction: SSSCorrection | None = None
+    sst_correction: SSTCorrection | None = None
+    ubind: UBind | None = None
+    v_sponge: VSponge | None = None
+    climatology: Climatology | None = None
 
     # Pydantic model configuration
     model_config = {"populate_by_name": True, "alias_generator": _get_alias}
@@ -602,7 +602,6 @@ class ROMSRuntimeSettings(BaseModel):
         - `ROMSRuntimeSettings.to_file()`: writes a ROMSRuntimeSettings instance to a
            ROMS-compatible `.in` file
         """
-
         # Read file
         sections = cls._load_raw_sections(filepath)
         required_fields = {"title", "time_stepping", "bottom_drag", "output_root_name"}
@@ -656,7 +655,7 @@ class ROMSRuntimeSettings(BaseModel):
             f"Initial conditions file (`ROMSRuntimeSettings.initial`): {self.initial.ininame}"
         )
         lines.append(
-            f"Forcing file(s): {_list_to_concise_str(self.forcing.filenames,pad=10)}"
+            f"Forcing file(s): {_list_to_concise_str(self.forcing.filenames, pad=10)}"
         )
         if self.s_coord is not None:
             lines.append("S-coordinate parameters (`ROMSRuntimeSettings.s_coord`):")
@@ -798,7 +797,8 @@ class ROMSRuntimeSettings(BaseModel):
     @model_serializer()
     def serialize_to_string(self) -> str:
         """Serialize the model (excluding null sections) to a single string as would be
-        found in a ROMS-compatible `.in` file."""
+        found in a ROMS-compatible `.in` file.
+        """
         output = ""
         for field_name, field_info in type(self).model_fields.items():
             section = getattr(self, field_name)
@@ -816,6 +816,5 @@ class ROMSRuntimeSettings(BaseModel):
         filepath : str or Path
             Path where the output file will be written.
         """
-
         with Path(filepath).open("w") as f:
             f.write(self.model_dump())

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -1,10 +1,10 @@
 import abc
+import types
 from pathlib import Path
 from typing import (
     Any,
     ClassVar,
     Self,
-    Union,
     get_args,
     get_origin,
 )
@@ -229,7 +229,7 @@ class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
             annotation_origin = get_origin(annotation)
 
             # if, e.g. Optional[list[Path]] we just want list[Path]
-            if annotation_origin is Union:
+            if annotation_origin is types.UnionType:
                 annotation_args = get_args(annotation)
                 if (
                     type(None) in annotation_args and len(annotation_args) == 2

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -75,10 +75,10 @@ class Simulation(ABC, LoggingMixin):
         runtime_code: Optional["AdditionalCode"] = None,
         compile_time_code: Optional["AdditionalCode"] = None,
         codebase: Optional["ExternalCodeBase"] = None,
-        start_date: Optional[str | datetime] = None,
-        end_date: Optional[str | datetime] = None,
-        valid_start_date: Optional[str | datetime] = None,
-        valid_end_date: Optional[str | datetime] = None,
+        start_date: str | datetime | None = None,
+        end_date: str | datetime | None = None,
+        valid_start_date: str | datetime | None = None,
+        valid_end_date: str | datetime | None = None,
     ):
         """Initialize a Simulation object with a given name, directory, codebase, and
         configuration parameters.
@@ -106,7 +106,6 @@ class Simulation(ABC, LoggingMixin):
         valid_end_date : str or datetime, optional
             The latest allowed end date, based on, e.g., the availability of input data.
         """
-
         self.directory: Path = self._validate_simulation_directory(directory)
         self.name = name
 
@@ -183,8 +182,8 @@ class Simulation(ABC, LoggingMixin):
         return resolved_directory
 
     def _parse_date(
-        self, date: Optional[str | datetime], field_name: str
-    ) -> Optional[datetime]:
+        self, date: str | datetime | None, field_name: str
+    ) -> datetime | None:
         """Converts a date string to a datetime object if it's not None.
 
         If the input is a string, it attempts to parse it into a `datetime` object.
@@ -216,8 +215,8 @@ class Simulation(ABC, LoggingMixin):
 
     def _get_date_or_fallback(
         self,
-        date: Optional[str | datetime],
-        fallback: Optional[datetime],
+        date: str | datetime | None,
+        fallback: datetime | None,
         field_name: str,
     ) -> datetime:
         """Ensures a date is set, using a fallback if needed.
@@ -278,7 +277,6 @@ class Simulation(ABC, LoggingMixin):
         ValueError
             If `start_date` is later than `end_date`.
         """
-
         if self.valid_start_date and self.start_date < self.valid_start_date:
             raise ValueError(
                 f"start_date {self.start_date} is before the earliest valid start date {self.valid_start_date}."
@@ -304,7 +302,6 @@ class Simulation(ABC, LoggingMixin):
         str
             A formatted string summarizing the simulation's attributes.
         """
-
         class_name = self.__class__.__name__
         base_str = f"{class_name}\n" + ("-" * len(class_name)) + "\n"
 
@@ -353,7 +350,6 @@ class Simulation(ABC, LoggingMixin):
         str
             A string representation of the simulation suitable for debugging.
         """
-
         repr_str = f"{self.__class__.__name__}("
         repr_str += f"\nname = {self.name},"
         repr_str += f"\ndirectory = {self.directory},"
@@ -421,7 +417,6 @@ class Simulation(ABC, LoggingMixin):
         to_dict : Converts an existing Simulation instance into a dictionary representation.
         from_blueprint: Reads an equivalent representation from a yaml file.
         """
-
         pass
 
     def to_dict(self) -> dict:
@@ -441,7 +436,6 @@ class Simulation(ABC, LoggingMixin):
         from_dict : Constructs a Simulation instance from a dictionary.
         to_blueprint: Writes an equivalent representation to a yaml file.
         """
-
         simulation_dict: dict[Any, Any] = {}
 
         # Top-level information
@@ -520,7 +514,6 @@ class Simulation(ABC, LoggingMixin):
         to_blueprint : Saves the Simulation instance to a YAML blueprint file.
         from_dict : Creates a Simulation instance from a dictionary.
         """
-
         pass
 
     @abstractmethod

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -90,7 +90,6 @@ class CStarEnvironment:
         str
             Human-readable string representation of the environment's key attributes.
         """
-
         base_str = self.__class__.__name__ + "\n"
         base_str += "-" * (len(base_str) - 1)
         base_str += f"\nCompiler: {self.compiler}"
@@ -145,7 +144,6 @@ class CStarEnvironment:
         ImportError
             If the top-level package cannot be located.
         """
-
         top_level_package_name = __name__.split(".")[0]
         spec = importlib.util.find_spec(top_level_package_name)
         if spec is not None:
@@ -164,7 +162,6 @@ class CStarEnvironment:
         bool
             True if the OS is Linux and `LMOD_DIR` is present in environment variables.
         """
-
         return (platform.system() == "Linux") and ("LMOD_CMD" in list(os.environ))
 
     def _call_lmod(self, *args) -> None:
@@ -205,7 +202,6 @@ class CStarEnvironment:
 
         >>> CStarEnvironment._call_lmod("unload", "gcc")
         """
-
         lmod_path = Path(os.environ.get("LMOD_CMD", ""))
         command = f"{lmod_path} python {' '.join(list(args))}"
         stdout = _run_cmd(
@@ -232,9 +228,8 @@ class CStarEnvironment:
         RuntimeError
             If any `module load <module_name>` command fails.
         """
-
         if not self.uses_lmod:
-            raise EnvironmentError(
+            raise OSError(
                 "Your system does not appear to use Linux Environment Modules"
             )
         self._call_lmod("reset")

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -19,7 +19,8 @@ from cstar.system.scheduler import (
 @dataclass(frozen=True)
 class HostNameEvaluator:
     """Container of host-specific names used to determine the system name that will be
-    used by C-Star."""
+    used by C-Star.
+    """
 
     lmod_syshost: str = field(default="", init=False)
     """The lmod-specific hostname."""
@@ -87,7 +88,7 @@ class HostNameEvaluator:
         if self.platform_hostname:
             return self.platform_hostname
 
-        raise EnvironmentError(
+        raise OSError(
             f"C-Star cannot determine your system name. Diagnostics: {self._diagnostic}"
         )
 
@@ -280,7 +281,6 @@ class CStarSystemManager:
         Initialize the system manager by determining the system name and initializing
         the environment and scheduler based on that name.
         """
-
         self._context = _get_system_context()
         """A context object configured for the current system."""
         self._environment = CStarEnvironment(

--- a/cstar/tests/integration_tests/blueprints/fixtures.py
+++ b/cstar/tests/integration_tests/blueprints/fixtures.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
 
@@ -45,10 +45,9 @@ def modify_template_blueprint(tmpdir) -> Callable[[Path | str, dict[str, str]], 
         modified_blueprint_path:
            A temporary path to a modified version of the template blueprint file.
         """
-
         template_blueprint_path = Path(template_blueprint_path)
 
-        with open(template_blueprint_path, "r") as template_file:
+        with open(template_blueprint_path) as template_file:
             template_content = template_file.read()
 
         modified_template_content = template_content

--- a/cstar/tests/integration_tests/config.py
+++ b/cstar/tests/integration_tests/config.py
@@ -55,7 +55,7 @@ TEST_CONFIG = {
     "test_case_local_with_netcdf_datasets": {
         "template_blueprint_path": f"{TEST_DIRECTORY}/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml",
         "strs_to_replace": {
-            "<input_datasets_location>": f"{CSTAR_TEST_DATA_DIRECTORY/'input_datasets/ROMS'}",
+            "<input_datasets_location>": f"{CSTAR_TEST_DATA_DIRECTORY / 'input_datasets/ROMS'}",
             "<additional_code_location>": f"{CSTAR_TEST_DATA_DIRECTORY}",
         },
     },
@@ -63,7 +63,7 @@ TEST_CONFIG = {
     "test_case_local_with_yaml_datasets": {
         "template_blueprint_path": f"{TEST_DIRECTORY}/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml",
         "strs_to_replace": {
-            "<input_datasets_location>": f"{CSTAR_TEST_DATA_DIRECTORY/'roms_tools_yaml_files'}",
+            "<input_datasets_location>": f"{CSTAR_TEST_DATA_DIRECTORY / 'roms_tools_yaml_files'}",
             "<additional_code_location>": f"{CSTAR_TEST_DATA_DIRECTORY}",
         },
     },

--- a/cstar/tests/integration_tests/fixtures.py
+++ b/cstar/tests/integration_tests/fixtures.py
@@ -1,7 +1,7 @@
 import shutil
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pooch
 import pytest
@@ -58,7 +58,6 @@ def fetch_roms_tools_source_data(request, log) -> Callable[[str | Path], None]:
         -------
         None
         """
-
         if isinstance(symlink_path, str):
             symlink_path = Path(symlink_path)
 
@@ -123,7 +122,6 @@ def fetch_remote_test_case_data() -> Callable[[], None]:
         -------
         None
         """
-
         test_case_repo_url = (
             "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/"
         )

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -57,7 +57,6 @@ class TestCStar:
         log (logging.Logger):
             Logger instance for logging messages during test execution.
         """
-
         dotenv_path = tmp_path / ".cstar.env"
         ext_root = tmp_path / "externals"
 

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -43,10 +43,10 @@ def test_modify_template_blueprint(modify_template_blueprint, tmpdir):
         },
     )
 
-    assert isinstance(
-        test_blueprint, LocalPath
-    ), f"Expected type LocalPath, but got {type(test_blueprint)}"
-    with open(test_blueprint, "r") as bpfile:
+    assert isinstance(test_blueprint, LocalPath), (
+        f"Expected type LocalPath, but got {type(test_blueprint)}"
+    )
+    with open(test_blueprint) as bpfile:
         bpyaml = yaml.safe_load(bpfile)
 
     assert (
@@ -57,7 +57,8 @@ def test_modify_template_blueprint(modify_template_blueprint, tmpdir):
 
 class TestFetchData:
     """Test class for testing data-fetching fixtures defined in the roms/fixtures.py
-    file."""
+    file.
+    """
 
     def test_fetch_roms_tools_source_data(
         self, request, tmpdir, fetch_roms_tools_source_data
@@ -84,17 +85,16 @@ class TestFetchData:
         - The symlink exists and is valid
         - All expected data files are present in the symlinked directory
         """
-
         test_data_directory = Path(tmpdir / "test_data_directory")
         fetch_roms_tools_source_data(test_data_directory)
 
-        assert (
-            test_data_directory.resolve() == ROMS_TOOLS_DATA_DIRECTORY.resolve()
-        ), f"{test_data_directory} links to {test_data_directory.resolve}, not {ROMS_TOOLS_DATA_DIRECTORY}"
+        assert test_data_directory.resolve() == ROMS_TOOLS_DATA_DIRECTORY.resolve(), (
+            f"{test_data_directory} links to {test_data_directory.resolve}, not {ROMS_TOOLS_DATA_DIRECTORY}"
+        )
         assert test_data_directory.exists(), f"{test_data_directory} does not exist"
-        assert (
-            test_data_directory.is_symlink()
-        ), f"{test_data_directory} is not a symbolic link as expected"
+        assert test_data_directory.is_symlink(), (
+            f"{test_data_directory} is not a symbolic link as expected"
+        )
 
         file_list = [f.name for f in test_data_directory.glob("*")]
         expected_files = [
@@ -127,7 +127,9 @@ class TestFetchData:
         fetch_remote_test_case_data()
 
         zip_files = list(CSTAR_TEST_DATA_DIRECTORY.glob("*.zip"))
-        assert not zip_files, f"Zip file was not removed: {zip_files[0] if zip_files else 'Unknown zip file'}"
+        assert not zip_files, (
+            f"Zip file was not removed: {zip_files[0] if zip_files else 'Unknown zip file'}"
+        )
 
         expected_files = [
             "additional_code/ROMS/namelists/roms.in",
@@ -144,6 +146,6 @@ class TestFetchData:
             if not expected_path.exists():
                 missing_items.append(expected_file)
 
-        assert (
-            not missing_items
-        ), f"Missing expected files in the test data directory: {missing_items}"
+        assert not missing_items, (
+            f"Missing expected files in the test data directory: {missing_items}"
+        )

--- a/cstar/tests/unit_tests/base/test_additional_code.py
+++ b/cstar/tests/unit_tests/base/test_additional_code.py
@@ -81,7 +81,8 @@ class TestInit:
 
     def test_init(self, remote_additional_code):
         """Test that an AdditionalCode object is initialized with the correct
-        attributes."""
+        attributes.
+        """
         assert (
             remote_additional_code.source.location == "https://github.com/test/repo.git"
         )
@@ -95,7 +96,8 @@ class TestInit:
 
     def test_defaults(self):
         """Test that a minimal AdditionalCode object is initialized with correct default
-        values."""
+        values.
+        """
         additional_code = AdditionalCode(location="test/location")
 
         assert additional_code.source.location == "test/location"
@@ -131,7 +133,8 @@ class TestStrAndRepr:
 
     def test_repr_remote(self, remote_additional_code):
         """Test that the __repr__ method returns the correct string for the example
-        remote AdditionalCode instance defined in the above fixture."""
+        remote AdditionalCode instance defined in the above fixture.
+        """
         expected_repr = dedent("""\
         AdditionalCode(
         location = 'https://github.com/test/repo.git',
@@ -141,14 +144,14 @@ class TestStrAndRepr:
                  'test_file_2.py',
                  'test_file_3.opt']
         )""")
-        assert (
-            repr(remote_additional_code) == expected_repr
-        ), f"expected \n{repr(remote_additional_code)}\n, got \n{expected_repr}"
+        assert repr(remote_additional_code) == expected_repr, (
+            f"expected \n{repr(remote_additional_code)}\n, got \n{expected_repr}"
+        )
 
     def test_repr_local(self, local_additional_code):
         """Test that the __repr__ method returns the correct string for the example
-        local AdditionalCode instance defined in the above fixture."""
-
+        local AdditionalCode instance defined in the above fixture.
+        """
         expected_repr = dedent("""\
         AdditionalCode(
         location = '/some/local/directory',
@@ -174,7 +177,6 @@ class TestStrAndRepr:
         - mock_exists: Patches Path.exists() to ensure exists_locally property used in __repr__ returns True.
         - local_additional_code: An example AdditionalCode instance representing local code
         """
-
         local_additional_code.working_path = Path("/mock/local/dir")
         assert "State: <working_path = /mock/local/dir,exists_locally = True>" in repr(
             local_additional_code
@@ -182,8 +184,8 @@ class TestStrAndRepr:
 
     def test_str_remote(self, remote_additional_code):
         """Test that the __str__ method returns the correct string for the example
-        remote AdditionalCode instance defined in the above fixture."""
-
+        remote AdditionalCode instance defined in the above fixture.
+        """
         expected_str = dedent("""\
         AdditionalCode
         --------------
@@ -197,14 +199,14 @@ class TestStrAndRepr:
             test_file_2.py
             test_file_3.opt""")
 
-        assert (
-            str(remote_additional_code) == expected_str
-        ), f"expected \n{str(remote_additional_code)}\n, got \n{expected_str}"
+        assert str(remote_additional_code) == expected_str, (
+            f"expected \n{str(remote_additional_code)}\n, got \n{expected_str}"
+        )
 
     def test_str_local(self, local_additional_code):
         """Test that the __str__ method returns the correct string for the example local
-        AdditionalCode instance defined in the above fixture."""
-
+        AdditionalCode instance defined in the above fixture.
+        """
         expected_str = dedent("""\
         AdditionalCode
         --------------
@@ -217,9 +219,9 @@ class TestStrAndRepr:
             test_file_2.py
             test_file_3.opt""")
 
-        assert (
-            str(local_additional_code) == expected_str
-        ), f"expected \n{str(local_additional_code)}\n, got \n{expected_str}"
+        assert str(local_additional_code) == expected_str, (
+            f"expected \n{str(local_additional_code)}\n, got \n{expected_str}"
+        )
 
 
 class TestExistsLocally:
@@ -364,7 +366,6 @@ class TestExistsLocally:
         - `exists_locally` is False when a hash mismatch occurs for any file.
         - `Path.exists` and `_get_sha256_hash` are only called up to the first mismatch.
         """
-
         self.mock_exists.return_value = True
 
         additional_code = AdditionalCode(
@@ -406,7 +407,6 @@ class TestExistsLocally:
         - `exists_locally` is False when `working_path` is None.
         - `_get_sha256_hash` is not called, as no files are checked.
         """
-
         additional_code = AdditionalCode(
             location="/mock/local",
             subdir="subdir",
@@ -429,7 +429,6 @@ class TestExistsLocally:
         - `exists_locally` is False when `_local_file_hash_cache` is None.
         - `_get_sha256_hash` is not called, as no hashes are available for comparison.
         """
-
         additional_code = AdditionalCode(
             location="/mock/local",
             subdir="subdir",
@@ -647,7 +646,6 @@ class TestAdditionalCodeGet:
         - The repository is not cloned (mock_clone is not called).
         - No files are copied (mock_copy is not called).
         """
-
         # Simulate a remote repository source but without checkout_target
         remote_additional_code._checkout_target = None  # This should raise a ValueError
         self.mock_location_type.return_value = "url"
@@ -676,7 +674,6 @@ class TestAdditionalCodeGet:
         - A `ValueError` is raised with the correct message when AdditionalCode.source.source_type is "directory" and AdditionalCode.source.location_type is "url"
         - No files are copied (mock_copy is not called).
         """
-
         self.mock_location_type.return_value = "url"
         self.mock_source_type.return_value = "directory"
 

--- a/cstar/tests/unit_tests/base/test_datasource.py
+++ b/cstar/tests/unit_tests/base/test_datasource.py
@@ -42,24 +42,24 @@ def mock_git_path(tmp_path):
 # Tests for the `location_type` property
 def test_location_type_url():
     """Check the DataSource.location_type property correctly returns 'url' for a remote
-    data source."""
-
+    data source.
+    """
     data_source = DataSource("https://example.com/data.nc")
     assert data_source.location_type == "url"
 
 
 def test_location_type_path(mock_netcdf_file_path):
     """Check the DataSource.location_type property correctly returns 'path' for a local
-    data file."""
-
+    data file.
+    """
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.location_type == "path"
 
 
 def test_location_type_invalid():
     """Test the DataSource.location_type property raises a ValueError for an invalid
-    location."""
-
+    location.
+    """
     with pytest.raises(ValueError):
         data_source = DataSource("invalid_location")
         data_source.location_type
@@ -68,39 +68,40 @@ def test_location_type_invalid():
 # Tests for the `source_type` property
 def test_source_type_netcdf(mock_netcdf_file_path):
     """Test the DataSource.source_type property correctly returns 'netcdf' for a mock
-    '.nc' file."""
-
+    '.nc' file.
+    """
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.source_type == "netcdf"
 
 
 def test_source_type_directory(mock_directory_path):
     """Test the DataSource.source_type property correctly returns 'directory' for a
-    temporary directory."""
-
+    temporary directory.
+    """
     data_source = DataSource(mock_directory_path)
     assert data_source.source_type == "directory"
 
 
 def test_source_type_repository(mock_git_path):
     """Test the DataSource.source_type property correctly returns 'repository' for a
-    mock git repository."""
-
+    mock git repository.
+    """
     data_source = DataSource(mock_git_path)
     assert data_source.source_type == "repository"
 
 
 def test_source_type_yaml(mock_yaml_file_path):
     """Test the DataSource.source_type property correctly returns 'yaml' for a mock
-    '.yaml' file."""
+    '.yaml' file.
+    """
     data_source = DataSource(mock_yaml_file_path)
     assert data_source.source_type == "yaml"
 
 
 def test_source_type_unsupported_extension(tmp_path):
     """Test the DataSource.source_type property raises a ValueError for an unsupported
-    file."""
-
+    file.
+    """
     unsupported_file = tmp_path / "data.unsupported"
     unsupported_file.touch()
     data_source = DataSource(unsupported_file)
@@ -110,14 +111,14 @@ def test_source_type_unsupported_extension(tmp_path):
 
 def test_basename(mock_netcdf_file_path):
     """Test the DataSource.basename property correctly returns the filename and
-    extension."""
+    extension.
+    """
     data_source = DataSource(mock_netcdf_file_path)
     assert data_source.basename == "testfile.nc"
 
 
 def test_str(mock_netcdf_file_path):
     """Test the string representation of DataSource."""
-
     expected_str = f"""DataSource
 ----------
  location: {mock_netcdf_file_path.resolve()}

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -12,7 +12,8 @@ from cstar.system.manager import cstar_sysmgr
 
 class MockExternalCodeBase(ExternalCodeBase):
     """A mock subclass of the `ExternalCodeBase` abstract base class used for testing
-    purposes."""
+    purposes.
+    """
 
     def __init__(self, log: logging.Logger):
         super().__init__(None, None)
@@ -38,7 +39,8 @@ class MockExternalCodeBase(ExternalCodeBase):
 @pytest.fixture
 def generic_codebase(log: logging.Logger):
     """Yields a generic codebase (instance of MockExternalCodeBase defined above) for
-    use in testing."""
+    use in testing.
+    """
     # Correctly patch the imported _get_hash_from_checkout_target in the ExternalCodeBase's module
     with mock.patch(
         "cstar.base.external_codebase._get_hash_from_checkout_target",
@@ -111,7 +113,6 @@ def test_codebase_str(generic_codebase):
 
 def test_codebase_repr(generic_codebase):
     """Test the repr representation of the `ExternalCodeBase` class."""
-
     result_repr = repr(generic_codebase)
     expected_repr = (
         "MockExternalCodeBase("
@@ -366,8 +367,8 @@ class TestExternalCodeBaseConfigHandling:
         tmp_path: Path,
     ):
         """Test handling when local_config_status == 2 (right remote, wrong hash) and
-        user agrees to checkout."""
-
+        user agrees to checkout.
+        """
         self.mock_local_config_status.return_value = 2
 
         self.mock_get_repo_remote.return_value = "https://github.com/test/repo.git"

--- a/cstar/tests/unit_tests/base/test_input_dataset.py
+++ b/cstar/tests/unit_tests/base/test_input_dataset.py
@@ -79,7 +79,6 @@ def remote_input_dataset():
     ------
     MockInputDataset: Instance representing a remote input dataset for testing.
     """
-
     # Using context managers to patch properties on DataSource
     with (
         mock.patch.object(
@@ -135,16 +134,15 @@ class TestInputDatasetInit:
         - The `basename` is "local_file.nc".
         - The dataset is an instance of MockInputDataset.
         """
-
-        assert (
-            local_input_dataset.source.location_type == "path"
-        ), "Expected location_type to be 'path'"
-        assert (
-            local_input_dataset.source.basename == "local_file.nc"
-        ), "Expected basename to be 'local_file.nc'"
-        assert isinstance(
-            local_input_dataset, MockInputDataset
-        ), "Expected an instance of MockInputDataset"
+        assert local_input_dataset.source.location_type == "path", (
+            "Expected location_type to be 'path'"
+        )
+        assert local_input_dataset.source.basename == "local_file.nc", (
+            "Expected basename to be 'local_file.nc'"
+        )
+        assert isinstance(local_input_dataset, MockInputDataset), (
+            "Expected an instance of MockInputDataset"
+        )
 
     def test_remote_init(self, remote_input_dataset):
         """Test initialization of an InputDataset with a remote source.
@@ -160,18 +158,18 @@ class TestInputDatasetInit:
         - The `file_hash` is set to "abc123".
         - The dataset is an instance of MockInputDataset.
         """
-        assert (
-            remote_input_dataset.source.location_type == "url"
-        ), "Expected location_type to be 'url'"
-        assert (
-            remote_input_dataset.source.basename == "remote_file.nc"
-        ), "Expected basename to be 'remote_file.nc'"
-        assert (
-            remote_input_dataset.source.file_hash == "abc123"
-        ), "Expected file_hash to be 'abc123'"
-        assert isinstance(
-            remote_input_dataset, MockInputDataset
-        ), "Expected an instance of MockInputDataset"
+        assert remote_input_dataset.source.location_type == "url", (
+            "Expected location_type to be 'url'"
+        )
+        assert remote_input_dataset.source.basename == "remote_file.nc", (
+            "Expected basename to be 'remote_file.nc'"
+        )
+        assert remote_input_dataset.source.file_hash == "abc123", (
+            "Expected file_hash to be 'abc123'"
+        )
+        assert isinstance(remote_input_dataset, MockInputDataset), (
+            "Expected an instance of MockInputDataset"
+        )
 
     def test_remote_requires_file_hash(self, remote_input_dataset):
         """Test that a remote InputDataset raises an error when the file hash is
@@ -389,9 +387,9 @@ class TestExistsLocally:
         """
         local_input_dataset.working_path = None
         local_input_dataset._local_file_stat_cache = None
-        assert (
-            not local_input_dataset.exists_locally
-        ), "Expected exists_locally to be False when working_path or stat cache is None"
+        assert not local_input_dataset.exists_locally, (
+            "Expected exists_locally to be False when working_path or stat cache is None"
+        )
 
     def test_file_does_not_exist(self, local_input_dataset):
         """Test exists_locally when the file does not exist.
@@ -405,9 +403,9 @@ class TestExistsLocally:
         }
 
         with mock.patch.object(Path, "exists", return_value=False):
-            assert (
-                not local_input_dataset.exists_locally
-            ), "Expected exists_locally to be False when the file does not exist"
+            assert not local_input_dataset.exists_locally, (
+                "Expected exists_locally to be False when the file does not exist"
+            )
 
     def test_no_cached_stats(self, local_input_dataset):
         """Test exists_locally when no cached stats are available.
@@ -419,9 +417,9 @@ class TestExistsLocally:
         local_input_dataset._local_file_stat_cache = {}
 
         with mock.patch.object(Path, "exists", return_value=True):
-            assert (
-                not local_input_dataset.exists_locally
-            ), "Expected exists_locally to be False when no cached stats are available"
+            assert not local_input_dataset.exists_locally, (
+                "Expected exists_locally to be False when no cached stats are available"
+            )
 
     def test_size_mismatch(self, local_input_dataset):
         """Test exists_locally when the file size does not match the cached value.
@@ -436,7 +434,9 @@ class TestExistsLocally:
 
         with mock.patch.object(Path, "exists", return_value=True):
             with mock.patch.object(Path, "stat", return_value=mock.Mock(st_size=200)):
-                assert not local_input_dataset.exists_locally, "Expected exists_locally to be False when file size does not match cached stats"
+                assert not local_input_dataset.exists_locally, (
+                    "Expected exists_locally to be False when file size does not match cached stats"
+                )
 
     def test_modification_time_mismatch_with_hash_match(self, local_input_dataset):
         """Test exists_locally when the modification time does not match but the hash
@@ -465,7 +465,9 @@ class TestExistsLocally:
                     "cstar.base.input_dataset._get_sha256_hash",
                     return_value="mocked_hash",
                 ):
-                    assert local_input_dataset.exists_locally, "Expected exists_locally to be True when modification time mismatches but hash matches"
+                    assert local_input_dataset.exists_locally, (
+                        "Expected exists_locally to be True when modification time mismatches but hash matches"
+                    )
 
     def test_modification_time_and_hash_mismatch(self, local_input_dataset):
         """Test exists_locally when both modification time and hash do not match.
@@ -493,7 +495,9 @@ class TestExistsLocally:
                     "cstar.base.input_dataset._get_sha256_hash",
                     return_value="different_hash",
                 ):
-                    assert not local_input_dataset.exists_locally, "Expected exists_locally to be False when both modification time and hash do not match"
+                    assert not local_input_dataset.exists_locally, (
+                        "Expected exists_locally to be False when both modification time and hash do not match"
+                    )
 
     def test_all_checks_pass(self, local_input_dataset):
         """Test exists_locally when all checks pass.
@@ -513,9 +517,9 @@ class TestExistsLocally:
             with mock.patch.object(
                 Path, "stat", return_value=mock.Mock(st_size=100, st_mtime=12345)
             ):
-                assert (
-                    local_input_dataset.exists_locally
-                ), "Expected exists_locally to be True when all checks pass"
+                assert local_input_dataset.exists_locally, (
+                    "Expected exists_locally to be True when all checks pass"
+                )
 
 
 def test_to_dict(remote_input_dataset):
@@ -651,9 +655,9 @@ class TestInputDatasetGet:
 
             # Assert that working_path is updated to the resolved target path
             expected_target_path = self.target_dir / "local_file.nc"
-            assert (
-                local_input_dataset.working_path == expected_target_path
-            ), f"Expected working_path to be {expected_target_path}, but got {local_input_dataset.working_path}"
+            assert local_input_dataset.working_path == expected_target_path, (
+                f"Expected working_path to be {expected_target_path}, but got {local_input_dataset.working_path}"
+            )
 
         mock_path_resolve.assert_called()
 
@@ -728,9 +732,9 @@ class TestInputDatasetGet:
                 )
 
                 # Assert that working_path is updated to the expected target path
-                assert (
-                    remote_input_dataset.working_path == target_filepath_remote
-                ), f"Expected working_path to be {target_filepath_remote}, but got {remote_input_dataset.working_path}"
+                assert remote_input_dataset.working_path == target_filepath_remote, (
+                    f"Expected working_path to be {target_filepath_remote}, but got {remote_input_dataset.working_path}"
+                )
 
     def test_get_remote_with_no_file_hash(
         self, remote_input_dataset, mock_path_resolve
@@ -792,7 +796,6 @@ class TestLocalHash:
 
     def setup_method(self):
         """Set up common mocks for `local_hash` tests."""
-
         # Patch _get_sha256_hash
         self.patcher_get_hash = mock.patch("cstar.base.input_dataset._get_sha256_hash")
         self.mock_get_hash = self.patcher_get_hash.start()
@@ -818,9 +821,9 @@ class TestLocalHash:
         result = local_input_dataset.local_hash
 
         # Check that the result uses the resolved path
-        assert result == {
-            Path("/some/local/path"): "mocked_hash"
-        }, f"Expected calculated local_hash, but got {result}"
+        assert result == {Path("/some/local/path"): "mocked_hash"}, (
+            f"Expected calculated local_hash, but got {result}"
+        )
 
         # Verify _get_sha256_hash was called with the resolved path
         self.mock_get_hash.assert_called_once_with(Path("/some/local/path"))
@@ -841,14 +844,13 @@ class TestLocalHash:
 
         result = local_input_dataset.local_hash
 
-        assert (
-            result == {}
-        ), "Expected local_hash to be empty when working_path is not set."
+        assert result == {}, (
+            "Expected local_hash to be empty when working_path is not set."
+        )
         self.mock_get_hash.assert_not_called()
 
     def test_local_hash_multiple_files(self, local_input_dataset, mock_path_resolve):
         """Test `local_hash` calculation for multiple files."""
-
         expected_path_1 = Path("/some/local/path1")
         expected_path_2 = Path("/some/local/path2")
 

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -31,12 +31,11 @@ def test_get_sha256_hash(tmp_path):
     - The calculated hash matches the expected hash
     - A FileNotFoundError is raised if the file does not exist
     """
-
     file_path = tmp_path / "test_file.txt"
     file_path.write_text("Test data for hash")
 
     # Compute the expected hash manually
-    expected_hash = hashlib.sha256("Test data for hash".encode()).hexdigest()
+    expected_hash = hashlib.sha256(b"Test data for hash").hexdigest()
 
     # Call _get_sha256_hash and verify
     calculated_hash = _get_sha256_hash(file_path)
@@ -105,7 +104,6 @@ class TestCloneAndCheckout:
         -------
         - Verifies RuntimeError is raised with an appropriate error message on clone failure.
         """
-
         # Simulate failure in the clone command
         self.mock_subprocess_run.side_effect = [
             mock.Mock(returncode=1, stderr="Error: clone failed."),
@@ -336,11 +334,13 @@ class TestGetHashFromCheckoutTarget:
 
 class TestReplaceTextInFile:
     """Tests for `_replace_text_in_file`, verifying correct behavior for text
-    replacement within a file."""
+    replacement within a file.
+    """
 
     def setup_method(self):
         """Common setup for each test, initializing base content that can be modified
-        per test."""
+        per test.
+        """
         self.base_content = "This is a test file with some old_text to replace."
 
     def test_replace_text_success(self, tmp_path):
@@ -411,7 +411,8 @@ class TestReplaceTextInFile:
 
 class TestListToConciseStr:
     """Tests for `_list_to_concise_str`, verifying correct behavior under different list
-    lengths and parameter configurations."""
+    lengths and parameter configurations.
+    """
 
     def test_basic_case_no_truncation(self):
         """Test `_list_to_concise_str` with a short list that does not exceed
@@ -470,7 +471,8 @@ class TestListToConciseStr:
 
 class TestDictToTree:
     """Tests for `_dict_to_tree`, verifying the correct tree-like string representation
-    of various dictionary structures."""
+    of various dictionary structures.
+    """
 
     def test_simple_flat_dict(self):
         """Test `_dict_to_tree` with a single-level dictionary.

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -63,7 +63,6 @@ class TestExecutionHandlerUpdates:
         - That instructions for viewing the job output are provided if the job status
           is `COMPLETED` or similar.
         """
-
         caplog.set_level(logging.WARNING)
         handler = MockExecutionHandler(
             ExecutionStatus.COMPLETED, tmp_path / "mock_output.log"
@@ -105,7 +104,6 @@ class TestExecutionHandlerUpdates:
         - That previously existing content in the file is also logged.
         - That the method properly interacts with the output file in real-time.
         """
-
         # Create a temporary output file
         output_file = tmp_path / "output.log"
         initial_content = ["First line\n"]
@@ -234,7 +232,6 @@ class TestExecutionHandlerUpdates:
         caplog (pytest.LogCaptureFixture)
             Builtin fixture to capture log outputs
         """
-
         # Create a temporary output file
         output_file = tmp_path / "output.log"
         initial_content = ["First line\n"]

--- a/cstar/tests/unit_tests/execution/test_local_process.py
+++ b/cstar/tests/unit_tests/execution/test_local_process.py
@@ -64,7 +64,6 @@ class TestLocalProcess:
         - commands : str
             The shell command(s) to execute.
         """
-
         self.patcher = patch("subprocess.Popen")
         self.mock_popen = self.patcher.start()
 
@@ -125,9 +124,9 @@ class TestLocalProcess:
         State: <status = <ExecutionStatus.UNSUBMITTED: 1>>"""
         )
 
-        assert (
-            mock_local_process.__repr__() == test_repr
-        ), f"expected \n{test_repr}\n, got \n{mock_local_process.__repr__()}\n"
+        assert mock_local_process.__repr__() == test_repr, (
+            f"expected \n{test_repr}\n, got \n{mock_local_process.__repr__()}\n"
+        )
 
     def test_start_success(self, tmp_path, mock_local_process):
         """Verifies that the subprocess starts successfully with valid commands.
@@ -197,7 +196,6 @@ class TestLocalProcess:
         - That the `status` property reflects the correct `ExecutionStatus` for
           each stage of the process lifecycle.
         """
-
         assert mock_local_process.status == ExecutionStatus.UNSUBMITTED
 
         # After starting: RUNNING
@@ -248,7 +246,6 @@ class TestLocalProcess:
         - _process is un-set if _process is set to a complete subprocess
         - RuntimeError raised if _process is set to a running subprocess
         """
-
         # no process (return early):
         mock_local_process._process = None
         mock_local_process._drop_process()
@@ -298,7 +295,6 @@ class TestLocalProcess:
         - That `kill()` is not called if `terminate()` succeeds.
         - That the `status` property reflects the `CANCELLED` state after cancellation.
         """
-
         # Simulate a running process
         self.mock_subprocess.poll.return_value = None  # Process is active
         mock_local_process.start()
@@ -344,7 +340,6 @@ class TestLocalProcess:
         - That `kill()` is called if `terminate()` fails.
         - That the `status` property reflects the `CANCELLED` state after cancellation.
         """
-
         # Simulate a running process
         self.mock_subprocess.poll.return_value = None  # Process is active
         self.mock_subprocess.terminate.side_effect = subprocess.TimeoutExpired(
@@ -399,7 +394,6 @@ class TestLocalProcess:
         - That the correct message is logged
         - That neither `terminate` nor `kill` is called.
         """
-
         # Simulate a completed process
         self.mock_subprocess.poll.return_value = 0  # Process has completed
 
@@ -443,7 +437,6 @@ class TestLocalProcess:
         - subprocess.Popen.wait() is called once
         - Information message is not printed
         """
-
         # Simulate a running process
         self.mock_subprocess.poll.return_value = None  # Process is active
         mock_local_process._process = self.mock_subprocess  # Assign mock process
@@ -481,7 +474,6 @@ class TestLocalProcess:
         - An information message is logged
         - subprocess.Popen.wait is not called
         """
-
         mock_local_process._process = None  # Assign mock process
         mock_local_process._cancelled = True
         caplog.set_level(logging.INFO, logger=mock_local_process.log.name)

--- a/cstar/tests/unit_tests/execution/test_pbs_job.py
+++ b/cstar/tests/unit_tests/execution/test_pbs_job.py
@@ -57,7 +57,6 @@ class TestPBSJob:
           including `scheduler`, `commands`, `account_key`, `cpus`, `nodes`, `walltime`,
           `job_name`, `output_file`, and `queue_name`.
         """
-
         # Create PBSQueue with specified max_walltime
         self.mock_queue = PBSQueue(name="test_queue", max_walltime="02:00:00")
 
@@ -94,7 +93,6 @@ class TestPBSJob:
           - Custom scheduler directives provided in `other_scheduler_directives`.
           - Commands to execute in the job script (`echo Hello, World`).
         """
-
         # Initialize a PBSJob
         job = PBSJob(**self.common_job_params)
 
@@ -114,9 +112,9 @@ class TestPBSJob:
         )
 
         # Validate the script content
-        assert (
-            job.script.strip() == expected_script.strip()
-        ), f"Script mismatch!\nExpected:\n{expected_script}\n\nGot:\n{job.script}"
+        assert job.script.strip() == expected_script.strip(), (
+            f"Script mismatch!\nExpected:\n{expected_script}\n\nGot:\n{job.script}"
+        )
 
     @patch("subprocess.run")
     def test_submit(self, mock_subprocess, tmp_path):
@@ -139,7 +137,6 @@ class TestPBSJob:
         - That the script file is created in the specified path.
         - That the `qsub` command is executed with the correct arguments.
         """
-
         # Mock subprocess.run for qsub
         mock_subprocess.return_value = MagicMock(
             returncode=0, stdout="12345.mockserver\n", stderr=""
@@ -196,7 +193,6 @@ class TestPBSJob:
         -------
         - That a `RuntimeError` is raised with the expected error message when submission fails.
         """
-
         # Mock subprocess.run for qsub
         mock_subprocess.return_value = MagicMock(
             returncode=returncode, stdout=stdout, stderr=stderr
@@ -237,7 +233,6 @@ class TestPBSJob:
         - That the `qdel` command is called with the correct job ID and parameters.
         - That no exceptions are raised during the cancellation process.
         """
-
         # Mock the status to "running"
         mock_status.return_value = ExecutionStatus.RUNNING
 
@@ -489,7 +484,6 @@ class TestPBSJob:
         - That the job status is correctly determined for valid `qstat` outputs.
         - That appropriate exceptions are raised for invalid or error scenarios.
         """
-
         # Mock qstat command output
         if qstat_output is not None:
             if qstat_output == "invalid_json":
@@ -514,9 +508,9 @@ class TestPBSJob:
             with pytest.raises(expected_exception, match=expected_message):
                 job.status
         else:
-            assert (
-                job.status == expected_status
-            ), f"Expected status '{expected_status}' but got '{job.status}'"
+            assert job.status == expected_status, (
+                f"Expected status '{expected_status}' but got '{job.status}'"
+            )
 
     @patch("json.loads", side_effect=json.JSONDecodeError("Expecting value", "", 0))
     @patch("subprocess.run")

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -148,7 +148,6 @@ class TestSchedulerJobBase:
         - This test suppresses warnings about unspecified walltime using
           `@pytest.mark.filterwarnings`.
         """
-
         params = {
             key: value
             for key, value in self.common_job_params.items()
@@ -213,7 +212,6 @@ class TestSchedulerJobBase:
         - That a warning is logged about the missing queue walltime.
         - That the job's walltime matches the user-provided value ("01:00:00").
         """
-
         with patch.object(
             MockScheduler, "get_queue", return_value=MagicMock(max_walltime=None)
         ):
@@ -244,7 +242,6 @@ class TestSchedulerJobBase:
         - That a warning is logged about the unspecified walltime.
         - That the job's walltime matches the queue's maximum walltime ("02:00:00").
         """
-
         with patch.object(
             MockScheduler, "get_queue", return_value=MagicMock(max_walltime="02:00:00")
         ):
@@ -481,7 +478,8 @@ class TestCalculateNodeDistribution:
 
     def test_partial_division(self):
         """Test when `n_cores_required` is not an exact multiple of
-        `tot_cores_per_node`."""
+        `tot_cores_per_node`.
+        """
         n_cores_required = 300
         tot_cores_per_node = 64
 
@@ -492,7 +490,8 @@ class TestCalculateNodeDistribution:
 
     def test_single_node(self):
         """Test when `n_cores_required` is less than or equal to
-        `tot_cores_per_node`."""
+        `tot_cores_per_node`.
+        """
         n_cores_required = 50
         tot_cores_per_node = 64
 
@@ -612,7 +611,6 @@ class TestCreateSchedulerJob:
         - That the job's attributes (e.g., commands, CPUs, nodes, walltime) are assigned
           correctly based on the provided parameters.
         """
-
         # Mock global_max_cpus_per_node for the scheduler
         mock_global_max_cpus.return_value = 128
 
@@ -684,7 +682,6 @@ class TestCreateSchedulerJob:
         - That a `TypeError` is raised with a message indicating the missing
           required arguments.
         """
-
         with pytest.raises(TypeError, match="missing .* required positional argument"):
             create_scheduler_job(
                 cpus=4,

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -55,7 +55,6 @@ class TestSlurmJob:
           `scheduler`, `commands`, `account_key`, `cpus`, `walltime`, and more.
         - mock_env_vars: A dictionary simulating environment variables.
         """
-
         # Create a SlurmQOS and patch its max_walltime property
         self.mock_qos = SlurmQOS(name="test_queue", query_name="test_queue")
         self.mock_partition = SlurmPartition(name="test_queue")
@@ -107,7 +106,8 @@ class TestSlurmJob:
 
     def test_script_task_distribution_not_required(self):
         """Verifies that the correct script is generated when the node x cpu breakdown
-        is not required."""
+        is not required.
+        """
         # Initialize the job
         job = SlurmJob(
             **self.common_job_params,
@@ -127,9 +127,9 @@ class TestSlurmJob:
             "\necho Hello, World"
         )
 
-        assert (
-            job.script.strip() == expected_script.strip()
-        ), f"Expected:\n{expected_script}\n\nGot:\n{job.script}"
+        assert job.script.strip() == expected_script.strip(), (
+            f"Expected:\n{expected_script}\n\nGot:\n{job.script}"
+        )
 
     @pytest.mark.filterwarnings(
         r"ignore:.* Attempting to create scheduler job.*:UserWarning"
@@ -158,7 +158,6 @@ class TestSlurmJob:
         -------
         - That the generated job script matches a pre-specified expected script
         """
-
         mock_global_max_cpus.return_value = 64
 
         params = self.common_job_params
@@ -189,9 +188,9 @@ class TestSlurmJob:
             "\necho Hello, World"
         )
 
-        assert (
-            job.script.strip() == expected_script.strip()
-        ), f"Expected:\n{expected_script}\n\nGot:\n{job.script}"
+        assert job.script.strip() == expected_script.strip(), (
+            f"Expected:\n{expected_script}\n\nGot:\n{job.script}"
+        )
 
     @patch(
         "cstar.system.manager.CStarSystemManager.environment", new_callable=PropertyMock
@@ -226,7 +225,6 @@ class TestSlurmJob:
         - That the `sbatch` command is executed with the correct arguments.
         - That the job ID is correctly extracted and assigned.
         """
-
         # Mock environment
         mock_environment.return_value.environment_variables = self.mock_env_vars
         mock_environment.return_value.uses_lmod = False
@@ -253,9 +251,9 @@ class TestSlurmJob:
         assert script_path.exists()
         with script_path.open() as f:
             script_content = f.read()
-        assert (
-            script_content.strip() == job.script.strip()
-        ), f"Script content mismatch!\nExpected:\n{job.script}\nGot:\n{script_content}"
+        assert script_content.strip() == job.script.strip(), (
+            f"Script content mismatch!\nExpected:\n{job.script}\nGot:\n{script_content}"
+        )
 
         # Hardcoded expected environment (excluding SLURM_ variables)
         expected_env = {"SOME_ENV_VAR": "value"}
@@ -319,7 +317,6 @@ class TestSlurmJob:
         -------
         - That a `RuntimeError` is raised with the expected message for each failure scenario.
         """
-
         # Mock the subprocess.run behavior
         mock_subprocess.return_value = MagicMock(
             returncode=subprocess_returncode,
@@ -367,7 +364,6 @@ class TestSlurmJob:
         - That the job is successfully canceled when `scancel` succeeds.
         - That a `RuntimeError` is raised with an appropriate error message when `scancel` fails.
         """
-
         # Create a temporary directory for the job run path
         run_path = tmp_path
 
@@ -435,7 +431,6 @@ class TestSlurmJob:
         - That the job script file is created at the specified path.
         - That the content of the created file matches the expected script.
         """
-
         # Define paths for the script file
         script_path = tmp_path / "test_job.sh"
 
@@ -455,9 +450,9 @@ class TestSlurmJob:
         with script_path.open() as f:
             file_content = f.read()
 
-        assert (
-            file_content.strip() == job.script.strip()
-        ), f"Script content mismatch!\nExpected:\n{job.script}\nGot:\n{file_content}"
+        assert file_content.strip() == job.script.strip(), (
+            f"Script content mismatch!\nExpected:\n{job.script}\nGot:\n{file_content}"
+        )
 
     @patch("subprocess.run")
     @pytest.mark.parametrize(
@@ -514,7 +509,6 @@ class TestSlurmJob:
         - That the job status matches the expected state for valid `sacct` outputs.
         - That a `RuntimeError` is raised when `sacct` fails or returns invalid data.
         """
-
         # Initialize the job
         job = SlurmJob(**self.common_job_params)
 
@@ -536,6 +530,6 @@ class TestSlurmJob:
             ):
                 job.status
         else:
-            assert (
-                job.status == expected_status
-            ), f"Expected status '{expected_status}' but got '{job.status}'"
+            assert job.status == expected_status, (
+                f"Expected status '{expected_status}' but got '{job.status}'"
+            )

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -12,7 +12,8 @@ from cstar.system.manager import cstar_sysmgr
 @pytest.fixture
 def marbl_codebase():
     """Fixture providing a configured instance of `MARBLExternalCodeBase` for
-    testing."""
+    testing.
+    """
     source_repo = "https://github.com/marbl-ecosys/MARBL.git"
     checkout_target = "marbl0.45.0"
     return MARBLExternalCodeBase(
@@ -40,8 +41,8 @@ def test_expected_env_var(marbl_codebase):
 
 def test_defaults_are_set():
     """Test that the defaults are set correctly if MARBLExternalCodeBase initialized
-    without args."""
-
+    without args.
+    """
     marbl_codebase = MARBLExternalCodeBase()
     assert marbl_codebase.source_repo == "https://github.com/marbl-ecosys/MARBL.git"
     assert marbl_codebase.checkout_target == "marbl0.45.0"
@@ -140,7 +141,6 @@ class TestMARBLExternalCodeBaseGet:
 
     def test_make_failure(self, marbl_codebase, tmp_path):
         """Test that the get method raises an error when 'make' fails."""
-
         ## There are two subprocess calls, we'd like one fail, one pass:
         dotenv_path = tmp_path / ".cstar.env"
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -39,7 +39,6 @@ def test_expected_env_var(roms_codebase):
 
 def test_defaults_are_set():
     """Test that the defaults are set correctly."""
-
     roms_codebase = ROMSExternalCodeBase()
     assert roms_codebase.source_repo == "https://github.com/CWorthy-ocean/ucla-roms.git"
     assert roms_codebase.checkout_target == "main"
@@ -173,7 +172,6 @@ class TestROMSExternalCodeBaseGet:
 
     def test_make_nhmg_failure(self, roms_codebase, tmp_path):
         """Test that the get method raises an error when 'make nhmg' fails."""
-
         ## There are two subprocess calls, we'd like one fail, one pass:
         self.mock_subprocess_run.side_effect = [
             mock.Mock(
@@ -202,7 +200,6 @@ class TestROMSExternalCodeBaseGet:
 
     def test_make_tools_roms_failure(self, roms_codebase, tmp_path):
         """Test that the get method raises an error when 'make Tools-Roms' fails."""
-
         # Simulate success for `make nhmg` and failure for `make Tools-Roms`
         self.mock_subprocess_run.side_effect = [
             mock.Mock(returncode=0),  # Success for nhmg

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -175,9 +175,9 @@ class TestStrAndRepr:
         )
 
         actual_str = str(local_roms_netcdf_dataset).strip()
-        assert (
-            expected_str in actual_str
-        ), f"Expected:\n{expected_str}\nBut got:\n{actual_str}"
+        assert expected_str in actual_str, (
+            f"Expected:\n{expected_str}\nBut got:\n{actual_str}"
+        )
 
     def test_repr_with_partitioned_files(self, local_roms_netcdf_dataset):
         """Test the ROMSInputDataset repr includes `partitioned_files`.
@@ -195,7 +195,6 @@ class TestStrAndRepr:
         - The `partitioned_files` attribute is included in the repr output.
         - The format of the `partitioned_files` list matches the expected string output.
         """
-
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1,
             np_eta=2,
@@ -215,9 +214,9 @@ class TestStrAndRepr:
         expected_repr_normalized = " ".join(expected_repr.split())
         actual_repr_normalized = " ".join(actual_repr.split())
 
-        assert (
-            expected_repr_normalized in actual_repr_normalized
-        ), f"Expected:\n{expected_repr}\nBut got:\n{actual_repr}"
+        assert expected_repr_normalized in actual_repr_normalized, (
+            f"Expected:\n{expected_repr}\nBut got:\n{actual_repr}"
+        )
 
     def test_repr_with_partitioned_files_and_working_path(
         self, local_roms_netcdf_dataset
@@ -239,7 +238,6 @@ class TestStrAndRepr:
         - The `working_path` and `partitioned_files` attributes are included in the repr output.
         - The format of both attributes matches the expected string output.
         """
-
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
             np_xi=1,
             np_eta=2,
@@ -262,9 +260,9 @@ class TestStrAndRepr:
         expected_repr_normalized = " ".join(expected_repr.split())
         actual_repr_normalized = " ".join(actual_repr.split())
 
-        assert (
-            expected_repr_normalized in actual_repr_normalized
-        ), f"Expected:\n{expected_repr_normalized}\n to be in \n{actual_repr_normalized}"
+        assert expected_repr_normalized in actual_repr_normalized, (
+            f"Expected:\n{expected_repr_normalized}\n to be in \n{actual_repr_normalized}"
+        )
 
 
 class TestROMSInputDatasetGet:
@@ -312,7 +310,6 @@ class TestROMSInputDatasetGet:
             - Mocks the `from_yaml` method for creating instances.
             - Mocks specific SurfaceForcing instances, including their `save` method.
         """
-
         # Mocking InputDataset.get()
         self.patch_get = mock.patch(
             "cstar.roms.input_dataset.InputDataset.get", autospec=True
@@ -402,7 +399,6 @@ class TestROMSInputDatasetGet:
         - Verifies `roms_tools.Grid.save` saves files with correct parameters.
         - Ensures metadata and checksums for saved file is cached via `stat` and `_get_sha256_hash`.
         """
-
         # Mock the stat result
         mock_stat_result = mock.Mock(
             st_size=12345, st_mtime=1678901234, st_mode=0o100644
@@ -438,9 +434,9 @@ class TestROMSInputDatasetGet:
         )
 
         # Ensure stat was called for the saved file
-        assert (
-            mock_stat.call_count == 1
-        ), f"Expected stat to be called 1 time, but got {mock_stat.call_count} calls."
+        assert mock_stat.call_count == 1, (
+            f"Expected stat to be called 1 time, but got {mock_stat.call_count} calls."
+        )
 
     @mock.patch("pathlib.Path.stat", autospec=True)
     @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
@@ -474,7 +470,6 @@ class TestROMSInputDatasetGet:
         - Ensures `roms_tools.SurfaceForcing.save` saves the file with the correct parameters.
         - Verifies file metadata and checksum caching via `stat` and `_get_sha256_hash`.
         """
-
         # Mock yaml loading for a more complex YAML with both Grid and SurfaceForcing
         yaml_dict = {
             "Grid": {"fake": "entry", "topography_source": "ETOPO5"},
@@ -531,9 +526,9 @@ class TestROMSInputDatasetGet:
         )
 
         # Ensure stat was called for the saved file
-        assert (
-            mock_stat.call_count == 1
-        ), f"Expected stat to be called 1 time, but got {mock_stat.call_count} calls."
+        assert mock_stat.call_count == 1, (
+            f"Expected stat to be called 1 time, but got {mock_stat.call_count} calls."
+        )
 
     def test_get_from_yaml_raises_if_not_yaml(self, local_roms_netcdf_dataset):
         """Tests that the `ROMSInputDataset._get_from_yaml` method raises if called from
@@ -579,7 +574,6 @@ class TestROMSInputDatasetGet:
         - Confirms that a `ValueError` is raised when the YAML file contains more than two sections.
         - Validates that the exception message matches the expected error message.
         """
-
         # Mock yaml loading for a YAML with too many sections
         self.mock_yaml_load.return_value = {
             "Grid": {"fake": "entry", "topography_source": "ETOPO5"},
@@ -648,7 +642,6 @@ class TestROMSInputDatasetGet:
         - Confirms that no further operations (e.g., copying, YAML parsing) are performed.
         - An information message is logged
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_yaml_dataset.log.name)
 
         # Mock `working_path` to point to a file in `some/local/dir`
@@ -702,7 +695,6 @@ class TestROMSInputDatasetGet:
         - Ensures the skip message is printed when a `working_path` in the list exists in `local_dir`.
         - Confirms that no further operations (e.g., copying, YAML parsing) are performed.
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_yaml_dataset.log.name)
 
         # Mock `working_path` to be a list pointing to files in `some/local/dir`
@@ -770,9 +762,9 @@ class TestROMSInputDatasetGet:
             )
 
             # Ensure no further processing happened
-            assert (
-                not self.mock_yaml_load.called
-            ), "Expected no calls to yaml.safe_load, but some occurred."
+            assert not self.mock_yaml_load.called, (
+                "Expected no calls to yaml.safe_load, but some occurred."
+            )
 
         mock_path_resolve.assert_called()
 
@@ -800,7 +792,6 @@ class TestROMSInputDatasetGet:
         -------
         - _get_from_partitioned_source is called once with the expected arguments
         """
-
         # Set source partitioning attributes
         local_roms_netcdf_dataset.source._location = (
             "some/local/source/path/local_file.00.nc"
@@ -855,7 +846,6 @@ class TestROMSInputDatasetGet:
         - Asserts the calls to _symlink_or_download_from_source have expected arguments
         - Asserts the `ROMSInputDataset.partitioning` attribute is set as expected
         """
-
         # Set source partitioning attributes
         local_roms_netcdf_dataset.source._location = (
             "some/local/source/path/local_file.00.nc"
@@ -936,7 +926,6 @@ class TestROMSInputDatasetPartition:
 
     def test_to_dict_with_source_partitioning(self, local_roms_netcdf_dataset):
         """Test the ROMSInputDataset.to_dict() method with a partitioned source file."""
-
         local_roms_netcdf_dataset.source_np_xi = 4
         local_roms_netcdf_dataset.source_np_eta = 3
 
@@ -969,7 +958,6 @@ class TestROMSInputDatasetPartition:
         - `ROMSInputDataset.partitioning.files` is updated with the expected file paths.
         - `Path.stat` is called once for each partitioned file
         """
-
         np_xi, np_eta = 2, 3
         num_partitions = np_xi * np_eta
 
@@ -1018,9 +1006,9 @@ class TestROMSInputDatasetPartition:
                 )
 
                 # Ensure stat was called for each saved file
-                assert (
-                    mock_stat.call_count == 6
-                ), f"Expected stat to be called 6 times, but got {mock_stat.call_count} calls."
+                assert mock_stat.call_count == 6, (
+                    f"Expected stat to be called 6 times, but got {mock_stat.call_count} calls."
+                )
 
     @mock.patch("cstar.roms.input_dataset._get_sha256_hash", return_value="mocked_hash")
     @mock.patch("pathlib.Path.stat", autospec=True)
@@ -1047,7 +1035,6 @@ class TestROMSInputDatasetPartition:
         - `ROMSInputDataset.partitioning.files` is updated with the expected file paths.
         - `Path.stat` is called once for each partitioned file
         """
-
         np_xi, np_eta = 2, 2
         num_partitions = np_xi * np_eta
 
@@ -1100,9 +1087,9 @@ class TestROMSInputDatasetPartition:
                 )
 
                 # Ensure stat was called for each saved file
-                assert (
-                    mock_stat.call_count == 8
-                ), f"Expected stat to be called 8 times, but got {mock_stat.call_count} calls."
+                assert mock_stat.call_count == 8, (
+                    f"Expected stat to be called 8 times, but got {mock_stat.call_count} calls."
+                )
 
     @mock.patch("cstar.roms.input_dataset.roms_tools.partition_netcdf")
     def test_partition_skips_if_already_partitioned(
@@ -1128,7 +1115,6 @@ class TestROMSInputDatasetPartition:
         - Confirms that an appropriate message is logged
         - Confirms that roms_tools.partition_netcdf is not called
         """
-
         caplog.set_level(logging.INFO, logger=local_roms_netcdf_dataset.log.name)
 
         local_roms_netcdf_dataset.partitioning = ROMSPartitioning(
@@ -1166,7 +1152,6 @@ class TestROMSInputDatasetPartition:
         - A FileExistsError is raised with an appropriate message
         - roms_tools.partition_netcdf is not called
         """
-
         with pytest.raises(
             FileExistsError,
             match="The file has already been partitioned into a different arrangement",
@@ -1214,7 +1199,6 @@ class TestROMSInputDatasetPartition:
         - The last two calls restore files from the backup location.
         - The original exception (`RuntimeError`) is raised.
         """
-
         existing_files = [
             Path("/some/dir/local_file.0.nc"),
             Path("/some/dir/local_file.1.nc"),
@@ -1262,7 +1246,6 @@ class TestROMSInputDatasetPartition:
         --------
         - A `ValueError` is raised with the correct message.
         """
-
         # Simulate a dataset that does not exist locally
         with mock.patch.object(
             type(local_roms_netcdf_dataset),
@@ -1298,7 +1281,6 @@ class TestROMSInputDatasetPartition:
         --------
         - A `ValueError` is raised with the correct message.
         """
-
         # Set up the dataset with files in different directories
         local_roms_netcdf_dataset.working_path = [
             Path("some/local/source/path/file1.nc"),
@@ -1345,8 +1327,8 @@ class TestROMSInputDatasetPartition:
 
 def test_correction_cannot_be_yaml():
     """Checks that the `validate()` method correctly raises a TypeError if
-    `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)"""
-
+    `ROMSForcingCorrections.source.source_type` is `yaml` (unsupported)
+    """
     with pytest.raises(TypeError) as exception_info:
         ROMSForcingCorrections(
             location="https://www.totallylegityamlfiles.pk/downloadme.yaml"

--- a/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
+++ b/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
@@ -35,7 +35,6 @@ def example_runtime_settings():
     ROMSRuntimeSettings
        The example ROMSRuntimeSettings instance
     """
-
     yield ROMSRuntimeSettings(
         title="Example runtime settings",
         time_stepping={"ntimes": 360, "dt": 60, "ndtfast": 60, "ninfo": 1},
@@ -94,12 +93,14 @@ class MockSection(ROMSRuntimeSettingsSection):
 
 class EmptySection(ROMSRuntimeSettingsSection):
     """No actual values defined, just used to test some of the formatting/joining
-    functions."""
+    functions.
+    """
 
 
 class TestHelperMethods:
     """Test module-level non-public methods for formatting various types for use in
-    serializers."""
+    serializers.
+    """
 
     @pytest.mark.parametrize(
         "fl,st",
@@ -197,7 +198,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_validate_from_lines_calls_from_lines(self):
         """Test ROMSRuntimeSettingsSection.validate_from_lines calls `from_lines` if
-        given a list of strings."""
+        given a list of strings.
+        """
         mock_handler = MagicMock()
         test_lines = ["1", "2.0"]
 
@@ -212,7 +214,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_validate_from_lines_falls_back_to_handler(self):
         """Test ROMSRuntimeSettingsSection.validate_from_lines falls back to handler if
-        not given a list of strings."""
+        not given a list of strings.
+        """
         mock_handler = MagicMock(return_value="fallback")
         test_data = {"a": 1, "b": 2.0}
 
@@ -225,7 +228,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_validate_from_lines_raises_on_exception(self):
         """Test ROMSRuntimeSettingsSection.validate_from_lines falls back to handler if
-        from_lines fails."""
+        from_lines fails.
+        """
         mock_handler = MagicMock(return_value="handled")
         test_lines = ["bad", "data"]
 
@@ -234,7 +238,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_default_serializer(self):
         """Test the `ROMSRuntimeSettingsSection.default_serializer` returns an expected
-        string from a range of attributes."""
+        string from a range of attributes.
+        """
         obj = MockSection(
             floats=[0.0, 1e-5, 123.4],
             paths=[Path("a.nc"), Path("b.nc")],
@@ -268,13 +273,15 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_raises_if_no_lines(self):
         """Test the `ROMSRuntimeSettingsSection.from_lines` method returns None if given
-        an empty list."""
+        an empty list.
+        """
         with pytest.raises(ValueError):
             MockSection.from_lines([])
 
     def test_from_lines_on_float_section_with_D_formatting(self):
         """Test a ROMSRuntimeSettingsSection subclass with a single float entry is
-        correctly returned by `from_lines` with fortran-style formatting."""
+        correctly returned by `from_lines` with fortran-style formatting.
+        """
 
         class FloatSection(ROMSRuntimeSettingsSection):
             val: float
@@ -284,7 +291,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_multiple_fields(self):
         """Test a ROMSRuntimeSettingsSection with more than one entry is correctly
-        returned by `from_lines`"""
+        returned by `from_lines`
+        """
 
         class MixedSection(ROMSRuntimeSettingsSection):
             count: int
@@ -296,7 +304,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_list_field_at_end(self):
         """Test that ROMSRuntimeSettingsSection.from_lines correctly handles lines where
-        the final entry is a list (using all remaining values to populate it)"""
+        the final entry is a list (using all remaining values to populate it)
+        """
 
         class ListAtEnd(ROMSRuntimeSettingsSection):
             prefix: str
@@ -308,7 +317,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_list_field_only(self):
         """Test that ROMSRuntimeSettingsSection.from_lines correctly returns a valid
-        instance when the only entry is a list."""
+        instance when the only entry is a list.
+        """
 
         class OnlyList(ROMSRuntimeSettingsSection):
             entries: list[str]
@@ -318,7 +328,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_multiline_flag(self):
         """Test that ROMSRuntimeSettingsSection.from_lines correctly handles the case
-        where entries are on different lines."""
+        where entries are on different lines.
+        """
 
         class MultiLinePaths(ROMSRuntimeSettingsSection):
             multi_line = True
@@ -329,7 +340,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_on_initial_conditions_with_nrrec_0(self):
         """Test the bespoke InitialConditions.from_lines() method handles the situation
-        where nrrec is 0 and ininame is empty."""
+        where nrrec is 0 and ininame is empty.
+        """
         lines = [
             "0",
         ]
@@ -341,7 +353,8 @@ class TestROMSRuntimeSettingsSection:
 
     def test_from_lines_on_forcing_with_filenames_empty(self):
         """Test the bespoke Forcing.from_lines() method handles the situation where
-        filenames is empty."""
+        filenames is empty.
+        """
         lines = []
         fr = Forcing.from_lines(lines)
         assert fr.filenames is None
@@ -375,8 +388,8 @@ class TestSingleEntryROMSRuntimeSettingsSection:
 
     def test_single_entry_validator_returns_cls_when_type_matches(self):
         """Tests that the `single_entry_validator` method passes a correctly typed value
-        to cls() without requiring a dict or kwargs for initialization."""
-
+        to cls() without requiring a dict or kwargs for initialization.
+        """
         result = self.MockSingleEntrySection(3.14)
 
         assert isinstance(
@@ -386,7 +399,8 @@ class TestSingleEntryROMSRuntimeSettingsSection:
 
     def test_single_entry_validator_calls_handler_when_type_does_not_match(self):
         """Tests that `single_entry_validator` falls back to the handler if the value
-        supplied to __init__ is not of the expected type."""
+        supplied to __init__ is not of the expected type.
+        """
         handler = MagicMock(return_value="fallback")
         result = self.MockSingleEntrySection.single_entry_validator(
             "not a float", handler
@@ -421,14 +435,16 @@ class TestSingleEntryROMSRuntimeSettingsSection:
     def test_str_and_repr_return_value(self):
         """Tests that the `str` and `repr` functions for
         SingleEntryROMSRuntimeSettingsSection simply return a string of the single
-        entry's value."""
+        entry's value.
+        """
         section = self.MockSingleEntrySection(1.0)
         assert str(section) == "1.0"
         assert repr(section) == "1.0"
 
     def test_single_entry_section_raises_if_multiple_fields(self):
         """Tests that attempting to initialize a SingleEntryROMSRuntimeSettingsSection
-        with multiple entries raises a TypeError."""
+        with multiple entries raises a TypeError.
+        """
         with pytest.raises(TypeError):
 
             class InvalidSection(SingleEntryROMSRuntimeSettingsSection):
@@ -625,7 +641,6 @@ class TestROMSRuntimeSettings:
         - The ROMSRuntimeSettings instance returned by `from_file` with the modified
           file has `None` for its `climatology` attribute
         """
-
         modified_file = tmp_path / "modified_example_settings.in"
         shutil.copy2(
             Path(__file__).parent / "fixtures/example_runtime_settings.in",
@@ -662,7 +677,6 @@ class TestROMSRuntimeSettings:
         - Each attribute in the instance returned by `from_file` is equal
           to those in the instance passed to `to_file`
         """
-
         expected_settings = example_runtime_settings
         expected_settings.to_file(tmp_path / "test.in")
 
@@ -696,7 +710,8 @@ class TestROMSRuntimeSettings:
 
 class TestStrAndRepr:
     """Test that the __str__ and __repr__ functions of the ROMSRuntimeSettings class
-    behave as expected."""
+    behave as expected.
+    """
 
     def test_str(self, example_runtime_settings):
         """Test that the __str__ function of ROMSRuntimeSettings matches an expected
@@ -760,9 +775,9 @@ Open boundary binding velocity (`ROMSRuntimeSettings.ubind`, m/s) = 0.1
 Maximum sponge layer viscosity (`ROMSRuntimeSettings.v_sponge`, m2/s) = 0.0
 Climatology data files (`ROMSRuntimeSettings.climatology`): climfile2.nc"""
 
-        assert (
-            str(example_runtime_settings) == expected_str
-        ), f"expected \n{expected_str}\n, got\n{str(example_runtime_settings)}"
+        assert str(example_runtime_settings) == expected_str, (
+            f"expected \n{expected_str}\n, got\n{str(example_runtime_settings)}"
+        )
 
     def test_repr(self, example_runtime_settings):
         """Test that the __repr__ function of ROMSRuntimeSettings matches an expected
@@ -778,6 +793,6 @@ Climatology data files (`ROMSRuntimeSettings.climatology`): climfile2.nc"""
         - repr(example_runtime_settings) matches an expected reference string
         """
         expected_repr = """ROMSRuntimeSettings(title='Example runtime settings', time_stepping={'ntimes': 360, 'dt': 60, 'ndtfast': 60, 'ninfo': 1}, bottom_drag={'rdrg': 0.0, 'rdrg2': 0.001, 'zob': 0.01}, initial={'nrrec': 1, 'ininame': PosixPath('input_datasets/roms_ini.nc')}, forcing=["('filenames', [PosixPath('input_datasets/roms_frc.nc'), PosixPath('input_datasets/roms_frc_bgc.nc'), PosixPath('input_datasets/roms_bry.nc'), PosixPath('input_datasets/roms_bry_bgc.nc')])"], output_root_name='ROMS_test', grid='input_datasets/roms_grd.nc', climatology='climfile2.nc', s_coord={'theta_s': 5.0, 'theta_b': 2.0, 'tcline': 300.0}, rho0=1000.0, lin_rho_eos={'Tcoef': 0.2, 'T0': 1.0, 'Scoef': 0.822, 'S0': 1.0}, marbl_biogeochemistry={'marbl_namelist_fname': PosixPath('marbl_in'), 'marbl_tracer_list_fname': PosixPath('marbl_tracer_list_fname'), 'marbl_diag_list_fname': PosixPath('marbl_diagnostic_output_list')}, lateral_visc=0.0, gamma2=1.0, tracer_diff2=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], vertical_mixing={'Akv_bak': 0.0, 'Akt_bak': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}, my_bak_mixing={'Akq_bak': 1e-05, 'q2nu2': 0.0, 'q2nu4': 0.0}, sss_correction=7.777, sst_correction=10.0, ubind=0.1, v_sponge=0.0)"""
-        assert expected_repr == repr(
-            example_runtime_settings
-        ), f"expected \n{expected_repr}\n, got\n{repr(example_runtime_settings)}"
+        assert expected_repr == repr(example_runtime_settings), (
+            f"expected \n{expected_repr}\n, got\n{repr(example_runtime_settings)}"
+        )

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1,9 +1,10 @@
 import logging
 import pickle
 import re
+from collections.abc import Generator
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Generator, Tuple, cast
+from typing import Any, cast
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
@@ -34,7 +35,7 @@ from cstar.system.manager import cstar_sysmgr
 @pytest.fixture
 def example_roms_simulation(
     tmp_path,
-) -> Generator[Tuple[ROMSSimulation, Path], None, None]:
+) -> Generator[tuple[ROMSSimulation, Path], None, None]:
     """Fixture providing a `ROMSSimulation` instance for testing.
 
     This fixture initializes a `ROMSSimulation` with a comprehensive configuration,
@@ -158,7 +159,6 @@ class TestROMSSimulationInitialization:
         - `example_roms_simulation` : Provides a pre-configured `ROMSSimulation` instance
           and its corresponding directory.
         """
-
         sim, directory = example_roms_simulation
 
         assert sim.name == "ROMSTest"
@@ -237,7 +237,6 @@ class TestROMSSimulationInitialization:
         - `tmp_path` : A temporary directory fixture provided by `pytest` for
           safely testing file system interactions.
         """
-
         with pytest.raises(ValueError, match="could not find 'discretization' entry"):
             ROMSSimulation(
                 name="test",
@@ -267,7 +266,6 @@ class TestROMSSimulationInitialization:
         - `tmp_path` : A temporary directory fixture provided by `pytest` for
           safely testing file system interactions.
         """
-
         with pytest.raises(ValueError, match="could not find 'runtime_code' entry"):
             ROMSSimulation(
                 name="test",
@@ -298,7 +296,6 @@ class TestROMSSimulationInitialization:
         - `tmp_path` : A temporary directory fixture provided by `pytest` for
           safely testing file system interactions.
         """
-
         with pytest.raises(
             NotImplementedError, match="could not find a 'compile_time_code' entry"
         ):
@@ -338,7 +335,6 @@ class TestROMSSimulationInitialization:
         - caplog (pytest.LogCaptureFixture)
             Builtin fixture capturing log messages
         """
-
         sim = ROMSSimulation(
             name="test",
             directory=tmp_path,
@@ -373,15 +369,15 @@ class TestROMSSimulationInitialization:
 
     def test_find_dotin_file(self, example_roms_simulation):
         """Test that the `_find_dotin_file` helper function correctly finds and sets the
-        `_in_file` non-public attribute to the `.in` file."""
-
+        `_in_file` non-public attribute to the `.in` file.
+        """
         sim, _ = example_roms_simulation
         assert sim._in_file == "file2.in"
 
     def test_find_dotin_file_raises_if_no_dot_in_files(self, example_roms_simulation):
         """Test that the `_find_dotin_file` helper function correctly raises a
-        ValueError if a single `.in` file is not found."""
-
+        ValueError if a single `.in` file is not found.
+        """
         sim, _ = example_roms_simulation
         sim.runtime_code = AdditionalCode(
             location="some/dir", files=["no", "dotin.files", "here"]
@@ -461,7 +457,6 @@ class TestROMSSimulationInitialization:
         - `example_roms_simulation` : A fixture providing an initialized
           `ROMSSimulation` instance.
         """
-
         sim, _ = example_roms_simulation
         assert isinstance(sim.codebases, list)
         assert isinstance(sim.codebases[0], ROMSExternalCodeBase)
@@ -472,7 +467,8 @@ class TestROMSSimulationInitialization:
     def test_forcing_paths(self, example_roms_simulation):
         """Test that the `_forcing_paths` property correctly takes any forcing-related
         InputDatasets associated with the ROMSSimulation and returns a list of paths to
-        the relevant forcing files."""
+        the relevant forcing files.
+        """
         sim, _ = example_roms_simulation
         fake_paths = [
             Path("tidal.nc"),
@@ -552,7 +548,6 @@ class TestROMSSimulationInitialization:
            Mock the output of ROMSRuntimeSettings.from_file to return a basic, mocked
            ROMSRuntimeSettings instance.
         """
-
         sim, _ = example_roms_simulation
 
         # Stop complaints about missing local paths:
@@ -630,7 +625,6 @@ class TestROMSSimulationInitialization:
         example_roms_simulation: ROMSSimulation
            A pytest fixture returning a common, example ROMSSimulation instance.
         """
-
         sim, _ = example_roms_simulation
         with pytest.raises(
             ValueError, match="Cannot access runtime settings without local `.in` file."
@@ -660,7 +654,6 @@ class TestROMSSimulationInitialization:
         - `example_roms_simulation` : A fixture providing an initialized
           `ROMSSimulation` instance.
         """
-
         sim, directory = example_roms_simulation
         mg = sim.model_grid
         ic = sim.initial_conditions
@@ -732,7 +725,6 @@ class TestROMSSimulationInitialization:
         - Checks that `ROMSSimulation` raises a `ValueError` when the provided dates are invalid.
         - Asserts that the error message contains a specific substring identifying the issue.
         """
-
         with pytest.raises(ValueError) as exception_info:
             ROMSSimulation(
                 name="test",
@@ -770,7 +762,6 @@ class TestROMSSimulationInitialization:
         - A warning is logged
         - The input dataset's `start_date` is set to match the simulation's `start_date`.
         """
-
         sim, _ = example_roms_simulation
         caplog.set_level(logging.INFO, logger=sim.log.name)
 
@@ -805,7 +796,6 @@ class TestROMSSimulationInitialization:
         - An appropriate warning message is logged
         - The input dataset's `end_date` is updated to match the simulation's `end_date`.
         """
-
         sim, _ = example_roms_simulation
         caplog.set_level(logging.INFO, logger=sim.log.name)
         sim.river_forcing = ROMSRiverForcing(
@@ -882,7 +872,6 @@ class TestStrAndRepr:
         ----------
         - The string representation matches a predefined string.
         """
-
         sim, directory = example_roms_simulation
 
         mock_settings = ROMSRuntimeSettings(
@@ -948,7 +937,6 @@ Is setup: False"""
         ----------
         - The string representation matches a predefined string.
         """
-
         sim, directory = example_roms_simulation
         expected_repr = f"""\
 ROMSSimulation(
@@ -988,7 +976,6 @@ forcing_corrections = <list of 1 ROMSForcingCorrections instances>
         ----------
         - The output of tree() matches a predefined string
         """
-
         sim, directory = example_roms_simulation
         expected_tree = f"""\
 {directory}
@@ -1054,8 +1041,8 @@ class TestToAndFromDictAndBlueprint:
     def setup_method(self):
         """Sets a common dictionary representation of the ROMSSimulation instance
         associated with the `example_roms_simulation` fixture to be used across tests in
-        this class."""
-
+        this class.
+        """
         self.example_simulation_dict = {
             "name": "ROMSTest",
             "valid_start_date": datetime(2024, 1, 1, 0, 0),
@@ -1129,7 +1116,6 @@ class TestToAndFromDictAndBlueprint:
         ---------------------
         - `example_roms_simulation`: A fixture providing a pre-configured `ROMSSimulation` instance.
         """
-
         sim, directory = example_roms_simulation
         test_dict = sim.to_dict()
 
@@ -1254,7 +1240,6 @@ class TestToAndFromDictAndBlueprint:
         ----------------
         - `example_roms_simulation`: A fixture providing a pre-configured `ROMSSimulation` instance.
         """
-
         sim, directory = example_roms_simulation
         sim_to_dict = sim.to_dict()
         sim_from_dict = sim.from_dict(
@@ -1284,7 +1269,6 @@ class TestToAndFromDictAndBlueprint:
         - `mock_open`: A mock for Python's built-in `open()` function.
         - `mock_yaml_dump`: A mock for `yaml.dump()` to intercept and verify the YAML writing operation.
         """
-
         sim, directory = example_roms_simulation
         mock_file_path = "mock_path.yaml"
 
@@ -1327,7 +1311,6 @@ class TestToAndFromDictAndBlueprint:
          - `mock_path_exists`: Mocks `Path.exists()` to return `True`, ensuring the test bypasses file existence checks.
          - `tmp_path`: A temporary directory provided by `pytest` to simulate the blueprint file's location.
         """
-
         blueprint_path = tmp_path / "roms_blueprint.yaml"
 
         with patch("yaml.safe_load", return_value=self.example_simulation_dict):
@@ -1367,7 +1350,6 @@ class TestToAndFromDictAndBlueprint:
         - `mock_path_exists`: Mocks `Path.exists()` to return `True`, bypassing file existence checks.
         - `tmp_path`: A temporary directory provided by `pytest` to simulate the blueprint's location.
         """
-
         blueprint_path = tmp_path / "roms_blueprint.nc"
 
         with patch("yaml.safe_load", return_value=self.example_simulation_dict):
@@ -1400,7 +1382,6 @@ class TestToAndFromDictAndBlueprint:
         - `mock_requests_get`: Mocks `requests.get()` to return a simulated YAML blueprint response.
         - `tmp_path`: A temporary directory provided by `pytest` to simulate the simulation directory.
         """
-
         mock_response = MagicMock()
         mock_response.text = yaml.dump(self.example_simulation_dict)
         mock_requests_get.return_value = mock_response
@@ -1432,7 +1413,6 @@ class TestToAndFromDictAndBlueprint:
         - `example_roms_simulation`: A fixture providing a sample `ROMSSimulation` instance.
         - `tmp_path`: A temporary directory provided by `pytest` to store the blueprint file.
         """
-
         sim, _ = example_roms_simulation
         output_file = tmp_path / "test.yaml"
         sim.to_blueprint(filename=output_file)
@@ -1539,7 +1519,6 @@ class TestProcessingAndExecution:
         - Ensures `get()` is called twice for compile-time and runtime code.
         - Ensures `get()` is called once per input dataset.
         """
-
         sim, directory = example_roms_simulation
         sim.setup()
         assert mock_handle_config_status.call_count == 2
@@ -1647,7 +1626,6 @@ class TestProcessingAndExecution:
         - Ensures `is_setup` returns `True` only when both runtime and compile-time code exist.
         - Ensures `is_setup` returns `False` when either component is missing.
         """
-
         sim, _ = example_roms_simulation
 
         mock_additionalcode_exists.side_effect = [runtime_exists, compile_exists]
@@ -1779,7 +1757,6 @@ class TestProcessingAndExecution:
         - Ensures the executable path is correctly stored in `exe_path`.
         - Ensures the executable hash is stored in `_exe_hash` after successful compilation.
         """
-
         sim, directory = example_roms_simulation
         build_dir = directory / "ROMS/compile_time_code"
         (build_dir / "Compile").mkdir(exist_ok=True, parents=True)
@@ -1840,7 +1817,6 @@ class TestProcessingAndExecution:
         - Ensures `build` exits early without calling `make compile_clean` or `make`.
         - Ensures an informational message is logged about skipping recompilation.
         """
-
         sim, directory = example_roms_simulation
         caplog.set_level(logging.INFO, logger=sim.log.name)
         build_dir = directory / "ROMS/compile_time_code"
@@ -1893,7 +1869,6 @@ class TestProcessingAndExecution:
         - Ensures `make compile_clean` is called before compilation.
         - Verifies that a `RuntimeError` is raised when `make compile_clean` fails.
         """
-
         sim, directory = example_roms_simulation
         build_dir = directory / "ROMS/compile_time_code"
         (build_dir / "Compile").mkdir(exist_ok=True, parents=True)
@@ -1934,7 +1909,6 @@ class TestProcessingAndExecution:
         - Ensures `make` is called for ROMS compilation.
         - Verifies that a `RuntimeError` is raised when `make` fails.
         """
-
         sim, directory = example_roms_simulation
         build_dir = directory / "ROMS/compile_time_code"
         sim.compile_time_code.working_path = build_dir
@@ -1968,7 +1942,6 @@ class TestProcessingAndExecution:
         ----------
         - Ensures that calling `build` without a build directory raises a `ValueError`.
         """
-
         sim, directory = example_roms_simulation
         with pytest.raises(ValueError, match="Unable to compile ROMSSimulation"):
             sim.build()
@@ -1990,7 +1963,6 @@ class TestProcessingAndExecution:
         - Ensures that `partition()` is called only on datasets that exist locally.
         - Ensures that datasets not found locally are not partitioned.
         """
-
         sim, _ = example_roms_simulation
 
         # Mock some input datasets
@@ -2018,8 +1990,8 @@ class TestProcessingAndExecution:
 
     def test_run_raises_if_no_runtime_code_working_path(self, example_roms_simulation):
         """Confirm that ROMSSimulation.run() raises a FileNotFoundError if
-        ROMSSimulation.runtime_code does not exist locally."""
-
+        ROMSSimulation.runtime_code does not exist locally.
+        """
         sim, _ = example_roms_simulation
         sim.exe_path = Path("madeup.exe")
         with pytest.raises(
@@ -2042,7 +2014,6 @@ class TestProcessingAndExecution:
         ----------
         - Ensures `ValueError` is raised with the expected error message when `exe_path` is `None`.
         """
-
         sim, directory = example_roms_simulation
         with pytest.raises(ValueError, match="unable to find ROMS executable"):
             sim.run()
@@ -2062,7 +2033,6 @@ class TestProcessingAndExecution:
         ----------
         - Ensures `ValueError` is raised with the expected error message when `n_procs_tot` is `None`.
         """
-
         sim, directory = example_roms_simulation
         sim.exe_path = directory / "ROMS/compile_time_code/roms"
         with patch(
@@ -2099,7 +2069,6 @@ class TestProcessingAndExecution:
         - Ensures `LocalProcess.start()` is called.
         - Ensures the returned execution handler matches the mocked `LocalProcess` instance.
         """
-
         sim, directory = example_roms_simulation
 
         # Mock no scheduler
@@ -2170,7 +2139,6 @@ class TestProcessingAndExecution:
         - Ensures the scheduler job's `submit()` method is called.
         - Ensures the returned execution handler matches the created job instance.
         """
-
         sim, directory = example_roms_simulation
         build_dir = directory / "ROMS/compile_time_code"
         sim.runtime_code.working_path = directory / "ROMS/runtime_code/"
@@ -2251,7 +2219,6 @@ class TestProcessingAndExecution:
         - Ensures `create_scheduler_job` is never called if `account_key` is missing.
         - Confirms that the expected `ValueError` is raised with an appropriate message.
         """
-
         sim, directory = example_roms_simulation
         build_dir = directory / "ROMS/compile_time_code"
         sim.runtime_code.working_path = directory / "ROMS/runtime_code/"
@@ -2296,7 +2263,6 @@ class TestProcessingAndExecution:
         - Confirms that calling `post_run` without a prior `run` invocation raises `RuntimeError`.
         - Checks the error message to verify it correctly informs the user of the issue.
         """
-
         sim, _ = example_roms_simulation
         with pytest.raises(
             RuntimeError,
@@ -2324,7 +2290,6 @@ class TestProcessingAndExecution:
           raises `RuntimeError`.
         - Validates that the error message correctly informs the user of the issue.
         """
-
         sim, _ = example_roms_simulation
 
         # Mock `_execution_handler` and set its `status` attribute to something *not* COMPLETED
@@ -2363,7 +2328,6 @@ class TestProcessingAndExecution:
         - Confirms that the partitioned files are moved to `PARTITIONED` after merging.
         - Validates that the `post_run` process completes without errors.
         """
-
         # Setup
         sim, directory = example_roms_simulation
         output_dir = directory / "output"
@@ -2435,7 +2399,6 @@ class TestProcessingAndExecution:
         - Ensures `logger.info()` is called with the expected message.
         - Confirms that `Path.glob` is called once to check for output files.
         """
-
         # Setup
         sim, _ = example_roms_simulation
         sim._execution_handler = MagicMock()
@@ -2479,7 +2442,6 @@ class TestProcessingAndExecution:
         - Ensures `ncjoin` is executed with the correct file pattern.
         - Confirms that a `RuntimeError` is raised when `ncjoin` returns a non-zero exit code.
         """
-
         # Setup
         sim, directory = example_roms_simulation
         output_dir = directory / "output"
@@ -2563,7 +2525,6 @@ class TestROMSSimulationRestart:
         - The new instance's `initial_conditions` attribute is correctly assigned the
           detected restart file.
         """
-
         # Setup mock simulation
         sim, directory = example_roms_simulation
         new_end_date = datetime(2026, 6, 1)
@@ -2605,7 +2566,6 @@ class TestROMSSimulationRestart:
         - The method searches for restart files with the expected filename pattern.
         - A `FileNotFoundError` is raised if no matching restart files are found.
         """
-
         # Setup mock simulation
         sim, directory = example_roms_simulation
         new_end_date = datetime(2026, 6, 1)
@@ -2643,7 +2603,6 @@ class TestROMSSimulationRestart:
         - The method searches for restart files with the expected filename pattern.
         - A `ValueError` is raised if multiple restart files are found.
         """
-
         sim, directory = example_roms_simulation
         restart_dir = directory / "output"
         new_end_date = datetime(2025, 6, 1)

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1323,7 +1323,7 @@ class TestToAndFromDictAndBlueprint:
 
         # Assertions
         assert isinstance(sim, ROMSSimulation)
-        mock_open_file.assert_called_once_with(str(blueprint_path), "r")
+        mock_open_file.assert_called_once_with(str(blueprint_path))
 
     @patch("pathlib.Path.exists", return_value=True)
     @patch(

--- a/cstar/tests/unit_tests/system/test_context_registry.py
+++ b/cstar/tests/unit_tests/system/test_context_registry.py
@@ -74,7 +74,8 @@ def test_context_registry(wrapped_class: type[_SystemContext]) -> None:
 )
 def test_registry_keys(expected_name: str, wrapped_class: type[_SystemContext]) -> None:
     """Verify that the system contexts have the names expected from using
-    HostNameEvaluator for all known systems."""
+    HostNameEvaluator for all known systems.
+    """
     assert expected_name == wrapped_class.name
 
 

--- a/cstar/tests/unit_tests/system/test_context_schedulers.py
+++ b/cstar/tests/unit_tests/system/test_context_schedulers.py
@@ -30,7 +30,8 @@ def test_context_registry(
     exp_queue_names: set[str] | None,
 ) -> None:
     """Verify that the type of scheduler created by each of the known system contexts
-    matches expectations."""
+    matches expectations.
+    """
     scheduler = wrapped_class.create_scheduler()
 
     if exp_sched_type is not None:

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -67,7 +67,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms the correct sequence of subprocess calls for resetting and loading modules.
         """
-
         # Set up the LMOD_SYSHOST environment variable
         with patch.dict(
             "cstar.system.environment.os.environ", {"LMOD_SYSHOST": lmod_syshost}
@@ -113,7 +112,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         lmod_list: Module names to be loaded, based on the system's `.lmod` file.
         """
-
         lmod_file_path = (
             f"{env.package_root}/additional_files/lmod_lists/{env._system_name}.lmod"
         )
@@ -149,7 +147,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms merged environment variables with expected values after expansion.
         """
-
         # Write simulated system .env content to the appropriate location
         system_dotenv_path.write_text(
             "NETCDFHOME=${NETCDF_FORTRANHOME}/\n"
@@ -209,7 +206,6 @@ class TestSetupEnvironmentFromFiles:
         -------
         - Confirms merged environment variables with expected values after expansion.
         """
-
         # Write simulated system .env content to the appropriate location
         exp_system_env = {
             "NETCDFHOME": "${NETCDF_FORTRANHOME}/",
@@ -373,7 +369,6 @@ class TestExceptions:
         - CStarEnvironment.uses_lmod: Patched to simulate environments that use or don’t use Lmod.
         - os.environ: Cleared and patched with specific values for test isolation.
         """
-
         self.subprocess_patcher = patch(
             "cstar.base.utils.subprocess.run",
             return_value=subprocess.CompletedProcess(args="module reset", returncode=0),
@@ -427,7 +422,6 @@ class TestExceptions:
         -------
         - Raises EnvironmentError with a message indicating Lmod modules are not supported on the system.
         """
-
         self.mock_uses_lmod.return_value = False
         with pytest.raises(
             EnvironmentError, match="does not appear to use Linux Environment Modules"
@@ -454,7 +448,6 @@ class TestExceptions:
         - Raises RuntimeError with a message indicating failure of the "module reset" command.
         - subprocess.run is called with the expected command for `module reset`.
         """
-
         mock_subprocess.return_value.returncode = 1  # Simulate failure
         mock_subprocess.return_value.stderr = "Module reset error"
 
@@ -491,7 +484,6 @@ class TestExceptions:
         - Raises RuntimeError with a message indicating failure of the "module load" command.
         - subprocess.run is called with the expected commands `reset` and `load`
         """
-
         # Define side effects for subprocess.run
         side_effects = [
             subprocess.CompletedProcess(

--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -44,7 +44,8 @@ def test_no_lmod_in_env(
     mock_system: mock.MagicMock, mock_machine: mock.MagicMock
 ) -> None:
     """Verify that an environment without lmod environment variables returns a platform-
-    based name."""
+    based name.
+    """
     namer = HostNameEvaluator()
 
     mock_system.assert_called_once()
@@ -103,7 +104,8 @@ def test_partial_lmod_results_in_lmod_name(
     lmod_sysname: str,
 ) -> None:
     """Verify that an environment specifying incomplete lmod variables returns the value
-    that is set."""
+    that is set.
+    """
     with patch.dict(
         os.environ,
         {
@@ -135,8 +137,8 @@ def test_lmod_prioritizes_syshost(
     mock_machine: mock.MagicMock,
 ) -> None:
     """Verify that the an when both LMOD env vars are set, the value from sys host is
-    prioritized as the lmod name."""
-
+    prioritized as the lmod name.
+    """
     namer = HostNameEvaluator()
 
     mock_system.assert_called_once()
@@ -159,8 +161,8 @@ def test_partial_platform_naming(
     machine_name: str,
 ) -> None:
     """Verify that when the system name and machine name are not both found, the
-    platform name is empty."""
-
+    platform name is empty.
+    """
     with (
         patch("platform.system", return_value=system_name),
         patch("platform.machine", return_value=machine_name),
@@ -188,8 +190,8 @@ def test_partial_platform_fallback(
     machine_name: str,
 ) -> None:
     """Verify that when there is no lmod information and the system name and machine
-    name are not both found, accessing the name fails."""
-
+    name are not both found, accessing the name fails.
+    """
     with (
         patch("platform.system", return_value=system_name),
         patch("platform.machine", return_value=machine_name),

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -24,8 +24,6 @@ def mock_environment_vars() -> Generator[None, None, None]:
 
     Configures the environment to simulate execution on Perlmutter.
 
-    Returns
-    -------
     """
     with patch.dict(
         os.environ,

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -189,7 +189,8 @@ class TestScheduler:
 
     def test_scheduler_get_queue(self):
         """Ensure that queues can be retrieved by name, and missing queues raise a
-        ValueError."""
+        ValueError.
+        """
         queue1 = MockQueue(name="general")
         queue2 = MockQueue(name="batch")
         scheduler = SlurmScheduler(
@@ -344,7 +345,6 @@ class TestScheduler:
         -------
         - An appropriate error message is logged
         """
-
         caplog.set_level(logging.DEBUG, logger="cstar.base.utils.log")
 
         mock_subprocess_run.return_value = MagicMock(
@@ -377,7 +377,6 @@ class TestScheduler:
         -------
         - An appropriate error message is logged
         """
-
         caplog.set_level(logging.DEBUG, logger="cstar.base.utils.log")
 
         mock_subprocess_run.return_value = MagicMock(
@@ -427,7 +426,8 @@ class TestScheduler:
 
 class TestStrAndRepr:
     """Unit tests for the __str__ and __repr__ methods of Queue, Scheduler, and their
-    respective subclasses."""
+    respective subclasses.
+    """
 
     def test_slurmqos_str(self):
         """Test __str__ for SlurmQueue."""
@@ -440,9 +440,7 @@ class TestStrAndRepr:
                 return_value="09:00:00",
             ),
         ):
-            expected = (
-                "SlurmQOS:\n" "--------\n" "name: main\n" "max_walltime: 09:00:00\n"
-            )
+            expected = "SlurmQOS:\n--------\nname: main\nmax_walltime: 09:00:00\n"
             assert str(queue) == expected
 
     def test_slurmqos_repr(self):
@@ -463,10 +461,7 @@ class TestStrAndRepr:
             ),
         ):
             expected = (
-                "SlurmPartition:\n"
-                "--------------\n"
-                "name: main\n"
-                "max_walltime: 09:00:00\n"
+                "SlurmPartition:\n--------------\nname: main\nmax_walltime: 09:00:00\n"
             )
             assert str(queue) == expected
 
@@ -479,7 +474,7 @@ class TestStrAndRepr:
     def test_pbsqueue_str(self):
         """Test __str__ for PBSQueue."""
         queue = PBSQueue(name="batch", max_walltime="72:00:00")
-        expected = "PBSQueue:\n" "--------\n" "name: batch\n" "max_walltime: 72:00:00\n"
+        expected = "PBSQueue:\n--------\nname: batch\nmax_walltime: 72:00:00\n"
         assert str(queue) == expected
 
     def test_pbsqueue_repr(self):

--- a/cstar/tests/unit_tests/test_simulation.py
+++ b/cstar/tests/unit_tests/test_simulation.py
@@ -222,7 +222,6 @@ class TestSimulationInitialization:
         ----------
         - The returned value matches the expected `datetime` object or `None`.
         """
-
         sim, _ = example_simulation
         assert sim._parse_date(date=input_date, field_name="test_field") == expected
 
@@ -241,7 +240,6 @@ class TestSimulationInitialization:
         ----------
         - The returned value matches the explicitly provided date.
         """
-
         sim, _ = example_simulation
         assert sim._get_date_or_fallback(
             date="2025-01-01", fallback=datetime(2024, 1, 1), field_name="start_date"
@@ -265,7 +263,6 @@ class TestSimulationInitialization:
         - A warning is logged indicating that the fallback value is being used.
         - The returned value matches the fallback date.
         """
-
         sim, _ = example_simulation
         caplog.set_level(logging.DEBUG, logger=sim.log.name)
 
@@ -288,7 +285,6 @@ class TestSimulationInitialization:
         ----------
         - A `ValueError` is raised with the expected error message.
         """
-
         sim, _ = example_simulation
         with pytest.raises(
             ValueError, match="Neither start_date nor a valid fallback was provided."
@@ -305,7 +301,6 @@ class TestSimulationInitialization:
         ----------------
         - `example_simulation`: Provides a mock `Simulation` instance.
         """
-
         sim, _ = example_simulation
         sim._validate_date_range()  # Should not raise any error
 
@@ -323,7 +318,6 @@ class TestSimulationInitialization:
         ----------
         - A `ValueError` is raised with a message indicating `start_date` is too early.
         """
-
         with pytest.raises(
             ValueError, match="start_date .* is before the earliest valid start date"
         ):
@@ -352,7 +346,6 @@ class TestSimulationInitialization:
         ----------
         - A `ValueError` is raised with a message indicating `end_date` is too late.
         """
-
         with pytest.raises(
             ValueError, match="end_date .* is after the latest valid end date"
         ):
@@ -411,7 +404,6 @@ class TestSimulationInitialization:
         ----------
         - The returned directory path is correctly resolved.
         """
-
         sim, _ = example_simulation
         new_dir = tmp_path / "new_simulation"
 
@@ -465,7 +457,6 @@ class TestSimulationInitialization:
         - `_validate_date_range()` is called once.
         - The `Simulation` instance has correctly set attributes.
         """
-
         with (
             patch.object(
                 MockSimulation, "_validate_simulation_directory"
@@ -513,7 +504,6 @@ class TestSimulationInitialization:
         - The `Simulation` instance's `end_date` is set to `valid_end_date`.
         - A warning is logged indicating that default values are being used.
         """
-
         sim = MockSimulation(
             name="FallbackSim",
             directory=tmp_path,
@@ -547,7 +537,6 @@ class TestSimulationInitialization:
         ----------
           - A warning is logged indicating that date range validation is not possible.
         """
-
         sim = MockSimulation(
             name="FallbackSim",
             codebase=MockExternalCodeBase(),
@@ -631,7 +620,6 @@ Executable path: {sim_dir}"""
         ----------
         - The generated string matches the expected format for `repr()`.
         """
-
         sim, sim_dir = example_simulation
         expected_repr = f"""\
 MockSimulation(
@@ -700,20 +688,19 @@ class TestSimulationPersistence:
         - The restored instance matches the original instance when converted to a dictionary.
         - The serialized version of the restored instance matches the original.
         """
-
         sim, _ = example_simulation
         sim.persist()
         restored_sim = MockSimulation.restore(sim.directory)
 
         # Ensure the restored object has the same attributes
-        assert (
-            restored_sim.to_dict() == sim.to_dict()
-        ), "Restored simulation does not match the original"
+        assert restored_sim.to_dict() == sim.to_dict(), (
+            "Restored simulation does not match the original"
+        )
 
         # Also compare serialized versions
-        assert pickle.dumps(restored_sim) == pickle.dumps(
-            sim
-        ), "Serialized data mismatch after restore"
+        assert pickle.dumps(restored_sim) == pickle.dumps(sim), (
+            "Serialized data mismatch after restore"
+        )
 
     def test_restore_missing_file(self, tmp_path):
         """Test that `restore()` raises an error when the state file is missing.
@@ -750,7 +737,6 @@ class TestSimulationPersistence:
         - A `RuntimeError` is raised with a message indicating that persistence
           is not allowed while a local process is running.
         """
-
         sim, _ = example_simulation
         mock_handler = MagicMock(spec=LocalProcess)
         mock_handler.status = ExecutionStatus.RUNNING
@@ -800,13 +786,12 @@ class TestSimulationRestart:
         - The restarted simulation is an instance of `MockSimulation`.
         - The restarted simulation is a new object and not the same as the original instance.
         """
-
         sim, _ = example_simulation
         new_sim = sim.restart(new_end_date="2026-06-30")
 
-        assert isinstance(
-            new_sim, MockSimulation
-        ), "Restart did not return a new MockSimulation instance"
+        assert isinstance(new_sim, MockSimulation), (
+            "Restart did not return a new MockSimulation instance"
+        )
         assert new_sim is not sim, "Restarted simulation should be a new object"
 
     def test_restart_updates_start_and_end_dates(self, example_simulation):
@@ -825,16 +810,15 @@ class TestSimulationRestart:
         - The restarted simulation's `start_date` matches the original simulation's `end_date`.
         - The restarted simulation's `end_date` matches the provided `new_end_date`.
         """
-
         sim, _ = example_simulation
         new_end_date = datetime(2026, 6, 30)
         new_sim = sim.restart(new_end_date=new_end_date)
-        assert (
-            new_sim.start_date == sim.end_date
-        ), "Restarted simulation start_date is incorrect"
-        assert (
-            new_sim.end_date == new_end_date
-        ), "Restarted simulation end_date does not match input"
+        assert new_sim.start_date == sim.end_date, (
+            "Restarted simulation start_date is incorrect"
+        )
+        assert new_sim.end_date == new_end_date, (
+            "Restarted simulation end_date does not match input"
+        )
 
     def test_restart_preserves_other_attributes(self, example_simulation):
         """Test that `restart()` maintains all attributes except dates and directory.
@@ -852,7 +836,6 @@ class TestSimulationRestart:
         - The `discretization` settings remain identical.
         - `valid_start_date` and `valid_end_date` remain the same.
         """
-
         sim, _ = example_simulation
         new_sim = sim.restart(new_end_date="2026-06-30")
 
@@ -877,14 +860,13 @@ class TestSimulationRestart:
         - The restarted simulation's directory name includes the expected timestamp
           derived from the original simulation's `end_date`.
         """
-
         sim, _ = example_simulation
         new_sim = sim.restart(new_end_date="2026-06-30")
 
         expected_dir_suffix = f"RESTART_{sim.end_date.strftime('%Y%m%d_%H%M%S')}"
-        assert expected_dir_suffix in str(
-            new_sim.directory
-        ), "Restart directory does not include correct timestamp"
+        assert expected_dir_suffix in str(new_sim.directory), (
+            "Restart directory does not include correct timestamp"
+        )
 
     def test_restart_raises_error_on_invalid_new_end_date(self, example_simulation):
         """Test that `restart()` raises an error for an invalid `new_end_date`.
@@ -901,7 +883,6 @@ class TestSimulationRestart:
         - A `ValueError` is raised with a message indicating that `new_end_date`
           must be a `str` or `datetime`.
         """
-
         sim, _ = example_simulation
         with pytest.raises(
             ValueError, match="Expected str or datetime for `new_end_date`"
@@ -923,13 +904,12 @@ class TestSimulationRestart:
         - The restarted simulation's `end_date` is correctly parsed as a `datetime` object.
         - The parsed `end_date` matches the expected `datetime` value.
         """
-
         sim, _ = example_simulation
         new_sim = sim.restart(new_end_date="2026-06-30")
 
-        assert new_sim.end_date == datetime(
-            2026, 6, 30
-        ), "Restarted simulation did not correctly parse string end_date"
+        assert new_sim.end_date == datetime(2026, 6, 30), (
+            "Restarted simulation did not correctly parse string end_date"
+        )
 
 
 def test_to_dict(example_simulation):
@@ -946,7 +926,6 @@ def test_to_dict(example_simulation):
     ----------
     - The values in the dictionary correctly match the `Simulation` instance's attributes.
     """
-
     sim, directory = example_simulation
     test_dict = sim.to_dict()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ test = [
      "pytest>=7.0",
      "roms_tools[dask]==2.6.2"
      ]
-dev =[]
+dev =["ruff"]
 
 [build-system]
 requires = [
@@ -53,15 +53,39 @@ fallback_version = "9999"
 
 # Configuration for mypy type checker
 [tool.mypy]
-ignore_missing_imports = true 
+ignore_missing_imports = true
 exclude = "properties|asv_bench|docs"
 
 # Configuration for ruff linter and formatter
 [tool.ruff]
 fix = true
+show-fixes = true
+line-length = 88
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["I", "F", "E", "W", "D", "UP"] #  "RUF", "UP"]
+ignore = [
+    # will fix eventually
+    "E501",
+    "D205",
+    "D102",
+    "D101",
+    "D400",
+    "D103",
+    "D106",
+    # maybe fix
+    "D100",
+    "D401",
+    "D104", # will this show up in the readthedocs?
+    # won't fix
+    "D105",
+    "D107", # if you're doing wacky init stuff, please document
+
+]#, "D205", "D102", "D100", "D401", "D101", "D105", "D103", "D104"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
 
 [tool.pre-commit]
 config = ".pre-commit-config.yaml"


### PR DESCRIPTION
- Extends existing `ruff` rules from defaults & `I` to include `F, E, W, D, UP`, with 10 ignores to address later (c5d6b8735ec8140a6726486aae8857133e9f7714) 
- Applies this new ruleset and fixes issues (47f7082b55236213d755b25d57c1c4a89df4f4d4) 
- Fixes two syntactic breakages in the unit tests (478ea16b023ba8b79753de54ccc586e0a4f55f81)