### PR TITLE
CSD-128: Fix healthcheck test failure and overly verbose logging

### DIFF
--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -267,7 +267,6 @@ class Service(ABC, LoggingMixin):
 
         last_health_check = time.time()  # timestamp of last health check
         running = True
-        update_delay = 0.0
         hc_elapsed = 0.0
 
         while running:
@@ -279,7 +278,7 @@ class Service(ABC, LoggingMixin):
                 # report large gaps between updates.
                 if hc_elapsed > 3 * config.health_check_frequency:
                     self.log.warning(
-                        f"No health update in last {update_delay:.2f} seconds."
+                        f"No health update in last {hc_elapsed:.2f} seconds."
                     )
 
                 if msg := msg_queue.get_nowait():

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -40,7 +40,13 @@ class ServiceConfiguration(BaseModel):
 
     @computed_field
     def max_health_check_latency(self) -> float:
-        """Get the max latency allowed before missed health checks should be logged."""
+        """Get the max latency allowed before missed health checks should be logged.
+
+        When no healthcheck frequency is supplied, defaults to 1 second.
+        """
+        if self.health_check_frequency == 0:
+            return 1.0
+
         return self.health_check_frequency * self.health_check_log_threshold
 
 

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel, Field
 from cstar.base.log import LoggingMixin
 
 
-# @dc.dataclass
 class ServiceConfiguration(BaseModel):
     """Configuration options for a Service."""
 

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -316,6 +316,9 @@ class Service(ABC, LoggingMixin):
         The health check thread is not blocked by the main thread when service
         operations are blocking.
         """
+        if self._config.health_check_frequency is None:
+            return
+
         if self._config.health_check_frequency >= 0:
             self.log.debug(
                 "Starting healthcheck thread w/frequency: %s.",

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -364,7 +364,7 @@ class Service(ABC, LoggingMixin):
         """
         self._send_terminate_to_hc(reason=reason)
         if self._hc_thread and self._hc_thread.is_alive():
-            self._hc_thread.join()
+            self._hc_thread.join(timeout=1.0)
 
     def _shutdown(self) -> None:
         """Perform a clean shutdown of the service.

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -1,5 +1,4 @@
 import asyncio
-import dataclasses as dc
 import logging
 import signal
 import time
@@ -10,11 +9,13 @@ from queue import Empty
 from threading import Thread
 from types import FrameType
 
+from pydantic import BaseModel, Field
+
 from cstar.base.log import LoggingMixin
 
 
-@dc.dataclass
-class ServiceConfiguration:
+# @dc.dataclass
+class ServiceConfiguration(BaseModel):
     """Configuration options for a Service."""
 
     as_service: bool = False
@@ -24,10 +25,9 @@ class ServiceConfiguration:
     shutdown criteria are met. When `False`, the service completes a single
     pass through the service lifecycle and automatically exits.
     """
-    loop_delay: float = 0
-    """Duration (in seconds) of a forced delay between iterations of the main event
-    loop."""
-    health_check_frequency: float = 0
+    loop_delay: float = Field(0.0, ge=0.0)
+    """Duration (in seconds) of a delay between iterations of the main event loop."""
+    health_check_frequency: float = Field(0.0, ge=0.0)
     """Time (in seconds) between calls to a health check handler.
 
     A value of 0 triggers the health check on every iteration.
@@ -55,10 +55,6 @@ class Service(ABC, LoggingMixin):
         ----------
         config: ServiceConfiguration
             Configuration to modify the behavior of the service.
-
-        Returns
-        -------
-        None
         """
         self._config = config
         """Runtime configuration of the `Service`"""

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -276,7 +276,7 @@ class Service(ABC, LoggingMixin):
                 remaining_wait = max(hcf_remaining, 0)
 
                 # report large gaps between updates.
-                if hc_elapsed > 3 * config.health_check_frequency:
+                if hc_elapsed > 10 * config.health_check_frequency:
                     self.log.warning(
                         f"No health update in last {hc_elapsed:.2f} seconds."
                     )

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -389,8 +389,8 @@ class Service(ABC, LoggingMixin):
         """
         try:
             running = True
-            self._start_healthcheck()
             self._on_start()
+            self._start_healthcheck()
         except Exception:
             self.log.exception("Unable to start service.")
             running = False

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -382,7 +382,6 @@ async def test_event_hc_term(max_duration: float, frequency: float) -> None:
 @pytest.mark.parametrize(
     ("loop_delay", "loop_count"),
     [
-        (0.05, 10),
         (0.05, 20),
         (0.1, 10),
     ],

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -184,7 +184,7 @@ async def run_a_fail_on_shutdown_printer() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [1, 10, 1000])
+@pytest.mark.parametrize("loop_count", [1, 10, 100])
 async def test_event_loop_shutdown(loop_count: int) -> None:
     """Verify that _on_iteration repeats until _can_shutdown returns True."""
     service = PrintingService(max_iterations=loop_count, hc_freq=1.0)
@@ -199,7 +199,7 @@ async def test_event_loop_shutdown(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [0, 10, 100, 1000])
+@pytest.mark.parametrize("loop_count", [0, 10, 50, 100])
 async def test_event_loop_task_service(loop_count: int) -> None:
     """Verify that  using as_service=False executes _on_iteration 1x."""
     with PrintingService(
@@ -224,7 +224,7 @@ async def test_event_loop_task_service(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [10, 100, 1000])
+@pytest.mark.parametrize("loop_count", [10, 40, 100])
 async def test_event_loop_hc_start(loop_count: int) -> None:
     """Verify aspects of the health-check startup.
 
@@ -254,7 +254,7 @@ async def test_event_loop_hc_start(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [10, 100, 1000])
+@pytest.mark.parametrize("loop_count", [10, 30, 100])
 async def test_event_loop_hc_freq(loop_count: int) -> None:
     """Verify that the health check occurs at the correct frequency.
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -533,10 +533,10 @@ async def test_user_unhandled_exceptions(user_hook_name: str) -> None:
     """
     # Configured to run for 3 seconds but it should blow up immediately.
     service = PrintingService(
+        # run as service to avoid shutting down before delay is invoke
         as_service=True,
-        hc_freq=0.1,
-        max_duration=3,
-        delay=0.1,
+        max_iterations=2,
+        delay=0.01,
     )
     # Any exception raised in user code should not propagate here.
     with (

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -329,7 +329,7 @@ async def test_event_loop_hc_freq(loop_count: int) -> None:
     # Configure the health check to update every event loop iteration
     with PrintingService(max_iterations=loop_count, hc_freq=0) as service:
         service._start_healthcheck()  # noqa: SLF001
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.1)
 
         # Confirm the HC thread and queue are created
         assert service.is_healthcheck_running
@@ -501,7 +501,7 @@ async def test_signal_handling(fail_on_shutdown: bool) -> None:  # noqa: FBT001
         # clearly cause it to exit early.
         process = mp.Process(target=printer_fn)
         process.start()
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
 
         term_at = time.time()
         process.terminate()  # Send a signal to terminate the service

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -156,13 +156,7 @@ class PrintingService(Service):
                 "Exception occurred in service context: %s",
                 exc_value,
             )
-        self._send_terminate_to_hc("context manager exit")
-        if self.test_queue is not None:
-            self.test_queue.close()
-            self.test_queue.join_thread()
-        if self._hc_thread is not None:
-            self._send_terminate_to_hc("context manager exit")
-            self._hc_thread.join()
+        self._shutdown()
 
 
 async def run_a_printer() -> None:

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -187,7 +187,7 @@ async def run_a_fail_on_shutdown_printer() -> None:
 @pytest.mark.parametrize("loop_count", [1, 10, 100])
 async def test_event_loop_shutdown(loop_count: int) -> None:
     """Verify that _on_iteration repeats until _can_shutdown returns True."""
-    service = PrintingService(max_iterations=loop_count, hc_freq=1.0)
+    service = PrintingService(max_iterations=loop_count, hc_freq=0.1)
 
     # Service should run until `loop_count` is exceeded
     assert not service.can_shutdown
@@ -411,7 +411,7 @@ async def test_delay(loop_delay: float, loop_count: int) -> None:
         # Confirm the delay plus "other time" combine to a total runtime over
         # the minimum possible time, but don't let them vastly exceed min.
 
-        upper_bound = 1.2 * expected_duration
+        upper_bound = 1.5 * expected_duration
 
         assert expected_duration <= elapsed
         assert elapsed <= upper_bound

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -362,7 +362,7 @@ async def test_event_hc_term(max_duration: float, frequency: float) -> None:
         service._start_healthcheck()  # noqa: SLF001
         await asyncio.sleep(0.1)
         service._send_terminate_to_hc("test_event_hc_term")  # noqa: SLF001
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
 
         assert not service.is_healthcheck_running
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -189,6 +189,7 @@ async def run_a_fail_on_shutdown_printer() -> None:
     await service.execute()
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "value",
     [
@@ -204,6 +205,7 @@ async def test_config_check_delay(value: float) -> None:
     assert ps
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "value",
     [
@@ -218,6 +220,7 @@ async def test_config_check_delay_out_of_range(value: float) -> None:
         _ = PrintingService(delay=value)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "value",
     [
@@ -233,6 +236,7 @@ async def test_config_check_hcfreq(value: float) -> None:
     assert ps
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "value",
     [

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -42,8 +42,8 @@ class PrintingService(Service):
 
         super().__init__(config)
         self._do_shutdown = False
-        self.max_iter = max_iterations
-        self.max_duration = max_duration
+        self.max_iter = abs(max_iterations)
+        self.max_duration = abs(max_duration)
         self.start_time = 0.0
         self.test_queue: mp.Queue = mp.Queue()
         self.metrics: dict[str, int] = defaultdict(lambda: 0)

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -471,8 +471,8 @@ async def test_delay(loop_delay: float, loop_count: int) -> None:
         summary = service.summarize(finalize=True)
         assert summary["_on_delay"] >= n_loops
 
-        # Confirm the delay plus "other time" combine to a total runtime over
-        # the minimum possible time, but don't let them vastly exceed min.
+        # Confirm the cumulative delay to the total runtime is over the minimum
+        # possible time, while allowing for compute overhead of processes/threads
 
         upper_bound = 1.3 * expected_duration
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -410,7 +410,7 @@ async def test_delay(loop_delay: float, loop_count: int) -> None:
         # Confirm the delay plus "other time" combine to a total runtime over
         # the minimum possible time, but don't let them vastly exceed min.
 
-        upper_bound = 1.5 * expected_duration
+        upper_bound = 1.3 * expected_duration
 
         assert expected_duration <= elapsed
         assert elapsed <= upper_bound

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -146,9 +146,9 @@ class PrintingService(Service):
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[types.TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
     ) -> None:
         """Context manager exit point."""
         if exc_type is not None:

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -5,7 +5,6 @@ import queue
 import time
 import types
 from collections import defaultdict
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -490,7 +489,7 @@ async def test_signal_handling(fail_on_shutdown: bool) -> None:  # noqa: FBT001
     If the service is configured to fail on shutdown, the signal handler must gracefully
     handle the failure without crashing.
     """
-    process: Optional[mp.Process] = None
+    process: mp.Process | None = None
 
     try:
         printer_fn = run_a_fail_on_shutdown_printer

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -474,7 +474,7 @@ async def test_delay(loop_delay: float, loop_count: int) -> None:
         # Confirm the cumulative delay to the total runtime is over the minimum
         # possible time, while allowing for compute overhead of processes/threads
 
-        upper_bound = 1.3 * expected_duration
+        upper_bound = 1.4 * expected_duration
 
         assert expected_duration <= elapsed
         assert elapsed <= upper_bound

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -36,6 +36,7 @@ class PrintingService(Service):
             loop_delay=delay,
             health_check_frequency=hc_freq,
             log_level=logging.DEBUG,
+            health_check_log_threshold=20,
             name="PrintingService",
         )
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -520,7 +520,7 @@ async def test_signal_handling(fail_on_shutdown: bool) -> None:  # noqa: FBT001
         "_on_iteration",
         "_on_iteration_complete",
         "_on_shutdown",
-        "_on_health_check",  # done in 2nd thread, mock fails to patch
+        "_start_healthcheck",
         "_on_delay",
         "_can_shutdown",
     ],

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -26,7 +26,7 @@ class PrintingService(Service):
         *,
         max_iterations: int = 0,
         as_service: bool = True,
-        hc_freq: float = 1,
+        hc_freq: float | None = None,
         max_duration: float = 0.0,
         delay: float = 0.0,
     ) -> None:
@@ -251,7 +251,7 @@ async def test_config_check_hcfreq_out_of_range(value: float) -> None:
 @pytest.mark.parametrize("loop_count", [1, 10, 100])
 async def test_event_loop_shutdown(loop_count: int) -> None:
     """Verify that _on_iteration repeats until _can_shutdown returns True."""
-    service = PrintingService(max_iterations=loop_count, hc_freq=0.1)
+    service = PrintingService(max_iterations=loop_count)
 
     # Service should run until `loop_count` is exceeded
     assert not service.can_shutdown
@@ -269,7 +269,6 @@ async def test_event_loop_task_service(loop_count: int) -> None:
     with PrintingService(
         max_iterations=loop_count,
         as_service=False,
-        hc_freq=1.0,
     ) as service:
         mock_on_iter = mock.MagicMock()
         mock.patch.object(service, "_on_iteration", mock_on_iter)

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -110,7 +110,7 @@ def sim_runner(
 
     service_config = ServiceConfiguration(
         as_service=False,
-        health_check_frequency=1,
+        health_check_frequency=0,
         log_level=logging.DEBUG,
         name="test_simulation_runner",
     )
@@ -409,7 +409,7 @@ def test_start_runner(
 
     service_config = ServiceConfiguration(
         as_service=False,
-        health_check_frequency=1,
+        health_check_frequency=0,
         log_level=logging.DEBUG,
         name="test_start_runner",
     )

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -110,7 +110,7 @@ def sim_runner(
 
     service_config = ServiceConfiguration(
         as_service=False,
-        health_check_frequency=-1,
+        health_check_frequency=1,
         log_level=logging.DEBUG,
         name="test_simulation_runner",
     )
@@ -409,7 +409,7 @@ def test_start_runner(
 
     service_config = ServiceConfiguration(
         as_service=False,
-        health_check_frequency=-1,
+        health_check_frequency=1,
         log_level=logging.DEBUG,
         name="test_start_runner",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ include-package-data = true
 norecursedirs = [".tox", ".git", "__pycache__", ".#*", "*~"]
 log_cli_format = "%(asctime)s | %(levelname)s | %(name)s::%(funcName)s:%(lineno)d: %(message)s"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 
 # Use addopts to ignore specific files and directories


### PR DESCRIPTION
Enhances the testing code for the `Service` class. 

- Improves the reliability of inputs by ensuring invalid values cannot be set (e.g. negative values for the loop limiter).
- Move the logging threshold to configuration to simplify configuring thresholds.
- Reduce unnecessary `sleep` calls in tests
- Reduce iteration counts on health check tests
- Start health check after `_on_start` completes to reduce health check logging

- [x] Closes [CSD-128](https://cworthy.atlassian.net/browse/CSD-128)
- [x] Tests added
- [x] Tests passing

[CSD-128]: https://cworthy.atlassian.net/browse/CSD-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ