### PR TITLE
CSD-225: Fix worker startup bug

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -7,7 +7,7 @@ import pathlib
 import shutil
 import sys
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Final, override
 
 from cstar.base.exceptions import BlueprintError, CstarError
 from cstar.base.log import get_logger
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 WORKER_LOG_FILE_TPL = "cstar-worker.{0}.log"
 JOBFILE_DATE_FORMAT = "%Y%m%d_%H%M%S"
+LOGS_DIRECTORY: Final[str] = "logs"
 
 
 def _generate_job_name() -> str:
@@ -132,7 +133,7 @@ class SimulationRunner(Service):
         """
         # ensure that log files don't cause startup to fail.
         outputs = next(
-            (p for p in self._output_root.glob("*") if "logs" not in str(p)),
+            (p for p in self._output_root.glob("*") if LOGS_DIRECTORY not in str(p)),
             None,
         )
 
@@ -459,7 +460,7 @@ async def main(raw_args: list[str]) -> int:
 
     log_file = (
         blueprint_req.output_dir
-        / "logs"
+        / LOGS_DIRECTORY
         / WORKER_LOG_FILE_TPL.format(datetime.now(timezone.utc))
     )
     log = get_logger(__name__, level=service_cfg.log_level, filename=log_file)

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -140,13 +140,15 @@ class SimulationRunner(Service):
         # leftover external code folder causes non-empty repo errors; remove.
         externals_path = cstar_sysmgr.environment.package_root / "externals"
         if externals_path.exists():
-            self.log.debug(f"Removing existing externals dir: {externals_path}")
+            msg = f"Removing existing externals dir: {externals_path}"
+            self.log.debug(msg)
             shutil.rmtree(externals_path)
         externals_path.mkdir(parents=True, exist_ok=False)
 
         # create a clean location to write outputs.
         if not self._output_dir.exists():
-            self.log.debug(f"Creating clean output dir: {self._output_dir}")
+            msg = f"Creating clean output dir: {self._output_dir}"
+            self.log.debug(msg)
             self._output_dir.mkdir(parents=True, exist_ok=True)
 
     def _log_disposition(self) -> None:

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -19,9 +19,9 @@ from cstar.system.manager import cstar_sysmgr
 if TYPE_CHECKING:
     from cstar import Simulation
 
-DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-WORKER_LOG_FILE_TPL = "cstar-worker.{0}.log"
-JOBFILE_DATE_FORMAT = "%Y%m%d_%H%M%S"
+DATE_FORMAT: Final[str] = "%Y-%m-%d %H:%M:%S"
+WORKER_LOG_FILE_TPL: Final[str] = "cstar-worker.{0}.log"
+JOBFILE_DATE_FORMAT: Final[str] = "%Y%m%d_%H%M%S"
 LOGS_DIRECTORY: Final[str] = "logs"
 
 

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -131,7 +131,10 @@ class SimulationRunner(Service):
             If the output directory exists and contains
         """
         # ensure that log files don't cause startup to fail.
-        outputs = (p for p in self._output_root.glob("*") if "logs" not in str(p))
+        outputs = next(
+            (p for p in self._output_root.glob("*") if "logs" not in str(p)),
+            None,
+        )
 
         if self._output_root.exists() and outputs:
             msg = f"Output directory {self._output_root} is not empty."

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -130,12 +130,12 @@ class SimulationRunner(Service):
         ValueError
             If the output directory exists and contains
         """
-        # a leftover root_dir may have files in it, breaking download; warn.
-        if (
-            self._output_root.exists()
-            and next(self._output_root.glob("*"), None) is not None
-        ):
-            raise ValueError(f"Output directory {self._output_root} is not empty.")
+        # ensure that log files don't cause startup to fail.
+        outputs = (p for p in self._output_root.glob("*") if "logs" not in str(p))
+
+        if self._output_root.exists() and outputs:
+            msg = f"Output directory {self._output_root} is not empty."
+            raise ValueError(msg)
 
         # leftover external code folder causes non-empty repo errors; remove.
         externals_path = cstar_sysmgr.environment.package_root / "externals"

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -461,6 +461,46 @@ def test_runner_directory_check(
         sim_runner._prepare_file_system()
 
 
+def test_runner_directory_check_ignore_logs(
+    tmp_path: Path,
+    sim_runner: SimulationRunner,
+    dotenv_path: Path,
+) -> None:
+    """Test the simulation runner's file system preparation.
+
+    Verify that the worker ignores a populated output directory if it only
+    contains log files.
+
+    Parameters
+    ----------
+    sim_runner: SimulationRunner
+        An instance of SimulationRunner to be used for the test.
+    tmp_path : Path
+        A temporary path to store simulation output and logs
+    dotenv_path : Path
+        Path to a temporary location to
+    """
+    output_dir = tmp_path / "output"
+
+    # populate the directories that should be cleaned-up
+    dotenv_path.parent.mkdir(parents=True, exist_ok=True)
+    dotenv_path.touch()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = output_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=False)
+
+    # A file in the logs directory should be ignored
+    (logs_dir / "any-name.txt").touch()
+
+    with mock.patch(
+        "cstar.system.environment.CStarEnvironment.user_env_path",
+        new_callable=mock.PropertyMock,
+        return_value=dotenv_path,
+    ):
+        sim_runner._prepare_file_system()
+
+
 def test_runner_directory_prep(
     tmp_path: Path,
     sim_runner: SimulationRunner,


### PR DESCRIPTION
Fixes a defect where the worker log level may cause startup to fail.

- Ignore any files in the `logs` subdirectory.


### Checklist

- [x] Closes #CSD-225
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
