### PR TITLE
CSD-101 - Mitigate nullable type and __init__-based member declaration mypy errors

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -296,7 +296,8 @@ class ROMSSimulation(Simulation):
 
         Returns
         -------
-        str : The file path
+        str or None :
+            The `.in` file path
 
         Raises
         ------

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -3,7 +3,7 @@ import pickle
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 
 import dateutil
 
@@ -13,8 +13,10 @@ from cstar.base.log import LoggingMixin
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.execution.local_process import LocalProcess
 
+_TDiscretization = TypeVar("_TDiscretization", bound=Discretization)
 
-class Simulation(ABC, LoggingMixin):
+
+class Simulation(Generic[_TDiscretization], ABC, LoggingMixin):
     """An abstract base class representing a C-Star simulation.
 
     Attributes
@@ -86,14 +88,14 @@ class Simulation(ABC, LoggingMixin):
     """Runtime configuration files."""
     compile_time_code: AdditionalCode | None
     """Additional source code modifications and compile-time configuration files."""
-    discretization: "Discretization"
+    discretization: _TDiscretization
     """Numerical discretization parameters for this simulation."""
 
     def __init__(
         self,
         name: str,
         directory: str | Path,
-        discretization: "Discretization",
+        discretization: _TDiscretization,
         runtime_code: Optional["AdditionalCode"] = None,
         compile_time_code: Optional["AdditionalCode"] = None,
         codebase: Optional["ExternalCodeBase"] = None,


### PR DESCRIPTION
Qualify of life type-hinting improvements to fix some issues encountered when consuming `Simulation` classes from the worker.

- Shift member variable declarations out of `__init__` so they are discoverable
- Wrap conditionals around use of nullable fields
- Convert `discretization` field to generic parameter  

### Simulation.discretization shadowing

<img width="904" height="299" alt="image" src="https://github.com/user-attachments/assets/9f484aca-2eab-437c-9265-fe385cff01d2" />

### Simulation.runtime_code shadowing

<img width="904" height="299" alt="image" src="https://github.com/user-attachments/assets/6c0ab427-18e6-47d1-8121-a37cf560c4cd" />

### Checklist

- [x] Tests passing