### PR TITLE
CSD-227: Add short-form arguments for worker script

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -295,12 +295,14 @@ def create_parser() -> argparse.ArgumentParser:
         exit_on_error=True,
     )
     parser.add_argument(
+        "-b",
         "--blueprint-uri",
         type=str,
         required=True,
         help="The URI of a blueprint.",
     )
     parser.add_argument(
+        "-l",
         "--log-level",
         default="INFO",
         type=str,
@@ -317,25 +319,28 @@ def create_parser() -> argparse.ArgumentParser:
         ],
     )
     parser.add_argument(
+        "-o",
         "--output-dir",
         default="~/code/cstar/examples/",
         type=str,
         required=False,
-        help="Local path to write simulation outputs to",
+        help="Local path to write simulation outputs to.",
     )
     parser.add_argument(
+        "-s",
         "--start-date",
         default="2012-01-03 12:00:00",
         type=str,
         required=False,
-        help=(f"The simulation start date, formatted `{DATE_FORMAT}`"),
+        help=(f"Simulation start date, formatted `{DATE_FORMAT}`"),
     )
     parser.add_argument(
+        "-e",
         "--end-date",
         default="2012-01-04 12:00:00",
         type=str,
         required=False,
-        help=(f"The simulation end date, formatted `{DATE_FORMAT}`"),
+        help=(f"Simulation end date, formatted `{DATE_FORMAT}`"),
     )
     return parser
 

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -293,16 +293,15 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run a c-star simulation.",
         exit_on_error=True,
+        allow_abbrev=True,
     )
     parser.add_argument(
-        "-b",
         "--blueprint-uri",
         type=str,
         required=True,
         help="The URI of a blueprint.",
     )
     parser.add_argument(
-        "-l",
         "--log-level",
         default="INFO",
         type=str,
@@ -319,7 +318,6 @@ def create_parser() -> argparse.ArgumentParser:
         ],
     )
     parser.add_argument(
-        "-o",
         "--output-dir",
         default="~/code/cstar/examples/",
         type=str,
@@ -327,7 +325,6 @@ def create_parser() -> argparse.ArgumentParser:
         help="Local path to write simulation outputs to.",
     )
     parser.add_argument(
-        "-s",
         "--start-date",
         default="2012-01-03 12:00:00",
         type=str,
@@ -335,7 +332,6 @@ def create_parser() -> argparse.ArgumentParser:
         help=(f"Simulation start date, formatted `{DATE_FORMAT}`"),
     )
     parser.add_argument(
-        "-e",
         "--end-date",
         default="2012-01-04 12:00:00",
         type=str,

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -293,15 +293,16 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run a c-star simulation.",
         exit_on_error=True,
-        allow_abbrev=True,
     )
     parser.add_argument(
+        "-b",
         "--blueprint-uri",
         type=str,
         required=True,
         help="The URI of a blueprint.",
     )
     parser.add_argument(
+        "-l",
         "--log-level",
         default="INFO",
         type=str,
@@ -318,6 +319,7 @@ def create_parser() -> argparse.ArgumentParser:
         ],
     )
     parser.add_argument(
+        "-o",
         "--output-dir",
         default="~/code/cstar/examples/",
         type=str,
@@ -325,6 +327,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="Local path to write simulation outputs to.",
     )
     parser.add_argument(
+        "-s",
         "--start-date",
         default="2012-01-03 12:00:00",
         type=str,
@@ -332,6 +335,7 @@ def create_parser() -> argparse.ArgumentParser:
         help=(f"Simulation start date, formatted `{DATE_FORMAT}`"),
     )
     parser.add_argument(
+        "-e",
         "--end-date",
         default="2012-01-04 12:00:00",
         type=str,

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -227,11 +227,11 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     ("blueprint_uri", "output_dir", "start_date", "end_date", "log_level"),
     [
         (
-            "--b blueprint1.yaml",
-            "--o output1",
-            "--s 2012-01-01 12:00:00",
-            "--e 2012-02-04 12:00:00",
-            "--l DEBUG",
+            "-b blueprint1.yaml",
+            "-o output1",
+            "-s 2012-01-01 12:00:00",
+            "-e 2012-02-04 12:00:00",
+            "-l DEBUG",
         ),
         (
             "--blueprint-uri blueprint2.yaml",
@@ -248,11 +248,11 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
             "--log-level WARNING",
         ),
         (
-            "--b blueprint1.yaml",
-            "--o output1",
-            "--s 2012-01-01 12:00:00",
-            "--e 2012-02-04 12:00:00",
-            "--l ERROR",
+            "-b blueprint1.yaml",
+            "-o output1",
+            "-s 2012-01-01 12:00:00",
+            "-e 2012-02-04 12:00:00",
+            "-l ERROR",
         ),
     ],
 )

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -43,11 +43,11 @@ def valid_args() -> dict[str, str]:
 def valid_args_short() -> dict[str, str]:
     """Fixture to provide valid arguments for the SimulationRunner."""
     return {
-        "-b": "blueprint.yaml",
-        "-o": "output",
-        "-l": "INFO",
-        "-s": "2012-01-03 12:00:00",
-        "-e": "2012-01-04 12:00:00",
+        "--b": "blueprint.yaml",
+        "--o": "output",
+        "--l": "INFO",
+        "--s": "2012-01-03 12:00:00",
+        "--e": "2012-01-04 12:00:00",
     }
 
 
@@ -136,19 +136,10 @@ def test_create_parser_happy_path() -> None:
     parser = create_parser()
 
     # ruff: noqa: SLF001
-    assert "-b" in parser._option_string_actions
     assert "--blueprint-uri" in parser._option_string_actions
-
-    assert "-o" in parser._option_string_actions
     assert "--output-dir" in parser._option_string_actions
-
-    assert "-l" in parser._option_string_actions
     assert "--log-level" in parser._option_string_actions
-
-    assert "-s" in parser._option_string_actions
     assert "--start-date" in parser._option_string_actions
-
-    assert "-e" in parser._option_string_actions
     assert "--end-date" in parser._option_string_actions
 
 
@@ -177,7 +168,7 @@ def test_parser_good_log_level(
     if "--log-level" in valid_args:
         valid_args["--log-level"] = log_level
     else:
-        valid_args["-l"] = log_level
+        valid_args["--l"] = log_level
 
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
@@ -236,11 +227,11 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     ("blueprint_uri", "output_dir", "start_date", "end_date", "log_level"),
     [
         (
-            "-b blueprint1.yaml",
-            "-o output1",
-            "-s 2012-01-01 12:00:00",
-            "-e 2012-02-04 12:00:00",
-            "-l DEBUG",
+            "--b blueprint1.yaml",
+            "--o output1",
+            "--s 2012-01-01 12:00:00",
+            "--e 2012-02-04 12:00:00",
+            "--l DEBUG",
         ),
         (
             "--blueprint-uri blueprint2.yaml",
@@ -257,11 +248,11 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
             "--log-level WARNING",
         ),
         (
-            "-b blueprint1.yaml",
-            "-o output1",
-            "-s 2012-01-01 12:00:00",
-            "-e 2012-02-04 12:00:00",
-            "-l ERROR",
+            "--b blueprint1.yaml",
+            "--o output1",
+            "--s 2012-01-01 12:00:00",
+            "--e 2012-02-04 12:00:00",
+            "--l ERROR",
         ),
     ],
 )

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -39,6 +39,18 @@ def valid_args() -> dict[str, str]:
     }
 
 
+@pytest.fixture
+def valid_args_short() -> dict[str, str]:
+    """Fixture to provide valid arguments for the SimulationRunner."""
+    return {
+        "-b": "blueprint.yaml",
+        "-o": "output",
+        "-l": "INFO",
+        "-s": "2012-01-03 12:00:00",
+        "-e": "2012-01-04 12:00:00",
+    }
+
+
 def test_create_parser_help() -> None:
     """Verify that a help argument is present in the parser."""
     parser = create_parser()
@@ -124,26 +136,43 @@ def test_create_parser_happy_path() -> None:
     parser = create_parser()
 
     # ruff: noqa: SLF001
+    assert "-b" in parser._option_string_actions
     assert "--blueprint-uri" in parser._option_string_actions
+
+    assert "-o" in parser._option_string_actions
     assert "--output-dir" in parser._option_string_actions
+
+    assert "-l" in parser._option_string_actions
     assert "--log-level" in parser._option_string_actions
+
+    assert "-s" in parser._option_string_actions
     assert "--start-date" in parser._option_string_actions
+
+    assert "-e" in parser._option_string_actions
     assert "--end-date" in parser._option_string_actions
 
 
 @pytest.mark.parametrize(
-    ("log_level", "expected_level"),
+    ("log_level", "expected_level", "args_fixture_name"),
     [
-        ("DEBUG", logging.DEBUG),
-        ("INFO", logging.INFO),
-        ("WARNING", logging.WARNING),
-        ("ERROR", logging.ERROR),
+        ("DEBUG", logging.DEBUG, "valid_args"),
+        ("INFO", logging.INFO, "valid_args"),
+        ("WARNING", logging.WARNING, "valid_args"),
+        ("ERROR", logging.ERROR, "valid_args"),
+        ("DEBUG", logging.DEBUG, "valid_args_short"),
+        ("INFO", logging.INFO, "valid_args_short"),
+        ("WARNING", logging.WARNING, "valid_args_short"),
+        ("ERROR", logging.ERROR, "valid_args_short"),
     ],
 )
 def test_parser_good_log_level(
-    valid_args: dict[str, str], log_level: str, expected_level: int
+    request: pytest.FixtureRequest,
+    log_level: str,
+    expected_level: int,
+    args_fixture_name: str,
 ) -> None:
     """Verify that a log level is parsed correctly."""
+    valid_args: dict[str, str] = request.getfixturevalue(args_fixture_name)
     valid_args = valid_args.copy()
     valid_args["--log-level"] = log_level
 

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -43,11 +43,11 @@ def valid_args() -> dict[str, str]:
 def valid_args_short() -> dict[str, str]:
     """Fixture to provide valid arguments for the SimulationRunner."""
     return {
-        "--b": "blueprint.yaml",
-        "--o": "output",
-        "--l": "INFO",
-        "--s": "2012-01-03 12:00:00",
-        "--e": "2012-01-04 12:00:00",
+        "-b": "blueprint.yaml",
+        "-o": "output",
+        "-l": "INFO",
+        "-s": "2012-01-03 12:00:00",
+        "-e": "2012-01-04 12:00:00",
     }
 
 
@@ -168,7 +168,7 @@ def test_parser_good_log_level(
     if "--log-level" in valid_args:
         valid_args["--log-level"] = log_level
     else:
-        valid_args["--l"] = log_level
+        valid_args["-l"] = log_level
 
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -174,7 +174,10 @@ def test_parser_good_log_level(
     """Verify that a log level is parsed correctly."""
     valid_args: dict[str, str] = request.getfixturevalue(args_fixture_name)
     valid_args = valid_args.copy()
-    valid_args["--log-level"] = log_level
+    if "--log-level" in valid_args:
+        valid_args["--log-level"] = log_level
+    else:
+        valid_args["-l"] = log_level
 
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
@@ -230,25 +233,35 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("blueprint_uri", "output_dir", "start_date", "end_date"),
+    ("blueprint_uri", "output_dir", "start_date", "end_date", "log_level"),
     [
         (
-            "blueprint1.yaml",
-            "output1",
-            "2012-01-01 12:00:00",
-            "2012-02-04 12:00:00",
+            "-b blueprint1.yaml",
+            "-o output1",
+            "-s 2012-01-01 12:00:00",
+            "-e 2012-02-04 12:00:00",
+            "-l DEBUG",
         ),
         (
-            "blueprint2.yaml",
-            "output2",
-            "2020-02-01 00:00:00",
-            "2020-03-02 00:00:00",
+            "--blueprint-uri blueprint2.yaml",
+            "--output-dir output2",
+            "--start-date 2020-02-01 00:00:00",
+            "--end-date 2020-03-02 00:00:00",
+            "--log-level INFO",
         ),
         (
-            "blueprint3.yaml",
-            "output3",
-            "2021-03-01 08:30:00",
-            "2021-04-16 09:30:00",
+            "--blueprint-uri blueprint3.yaml",
+            "--output-dir output3",
+            "--start-date 2021-03-01 08:30:00",
+            "--end-date 2021-04-16 09:30:00",
+            "--log-level WARNING",
+        ),
+        (
+            "-b blueprint1.yaml",
+            "-o output1",
+            "-s 2012-01-01 12:00:00",
+            "-e 2012-02-04 12:00:00",
+            "-l ERROR",
         ),
     ],
 )
@@ -257,22 +270,29 @@ def test_get_service_config(
     output_dir: str,
     start_date: str,
     end_date: str,
+    log_level: str,
 ) -> None:
     """Verify that the expected values are set on the service config."""
+    arg_b, val_b = blueprint_uri.split(" ", maxsplit=1)
+    arg_o, val_o = output_dir.split(" ", maxsplit=1)
+    arg_s, val_s = start_date.split(" ", maxsplit=1)
+    arg_e, val_e = end_date.split(" ", maxsplit=1)
+    arg_l, val_l = log_level.split(" ", maxsplit=1)
+
     parser = create_parser()
     parsed_args = parser.parse_args(
         [
-            "--blueprint-uri",
-            blueprint_uri,
-            "--output-dir",
-            output_dir,
-            "--log-level",
-            "INFO",
-            "--start-date",
-            start_date,
-            "--end-date",
-            end_date,
-        ]
+            arg_b,
+            val_b,
+            arg_o,
+            val_o,
+            arg_l,
+            val_l,
+            arg_s,
+            val_s,
+            arg_e,
+            val_e,
+        ],
     )
 
     config = get_service_config(parsed_args)


### PR DESCRIPTION
Add args and tests for single character "short" arguments as complement to full argument.


`python worker.py -o /out/dir -b /in/blueprint.yml -l /out/logs -s 01-01-2010 -e 01-01-2011`

is verified as equivalent to:

`python worker.py --output-dir /out/dir -blueprint-uri /in/blueprint.yml --log-level /out/logs --start-date 01-01-2010 --end-date 01-01-2011`

### Checklist

- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage