### PR TITLE
update to roms-tools 3.1.2

### DIFF
--- a/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml
@@ -10,8 +10,8 @@ marbl_codebase:
   checkout_target: 'marbl0.45.0'
 runtime_code:
   location: '<additional_code_location>'
-  checkout_target: '7fdf8ea2225d55e9b98b5d4d0e7adbff961c9940'
-  subdir: 'additional_code/ROMS/namelists'
+  checkout_target: 'roms_tools_3_1_2'
+  subdir: 'additional_code/ROMS/runtime_code'
   files:
     - "roms.in"
     - "marbl_in"
@@ -19,8 +19,8 @@ runtime_code:
     - "marbl_diagnostic_output_list"
 compile_time_code:
   location: '<additional_code_location>'
-  checkout_target: '7fdf8ea2225d55e9b98b5d4d0e7adbff961c9940'
-  subdir: 'additional_code/ROMS/source_mods'
+  checkout_target: 'roms_tools_3_1_2'
+  subdir: 'additional_code/ROMS/compile_time_code'
   files:
     - "bgc.opt"
     - "bulk_frc.opt"
@@ -36,20 +36,20 @@ discretization:
   time_step: 60
 model_grid:
   location: '<input_datasets_location>/roms_grd.nc'
-  file_hash: 'cd8c8901a44eaaf30e3f4532ae34e039ee35b59ce3683b37597bd71feb18f51b'
+  file_hash: '73a15442870db4c22a626c19ec6764d2cd1214bb15795c46983ec0f3030aea5c'
 initial_conditions:
   location: '<input_datasets_location>/roms_ini.nc'
-  file_hash: '049eb5a966e20e90e270557386d414def168017f2bdcf726ebc455b979728e1c'
+  file_hash: '5f37c42b538dfe9963a6dd9e6887b9aaf537562eda086d2f2538a2e70d7f3606'
 tidal_forcing:
   location: '<input_datasets_location>/roms_tides.nc'
-  file_hash: '62125b05ca140667e472e223795b1254751eca4923bb6502c11b9835f2539910'
+  file_hash: '2db437f0cdaadec0e9eaa15f00cb077f1b2b384dc1abe5c8ec2d38f07a3418c0'
 boundary_forcing:
   - location: '<input_datasets_location>/roms_bry.nc'
-    file_hash: '5dff15e078bf075aed78d7b54b5d9be2c536a0d4f4daa29e5091b2d3076d0fb3'
+    file_hash: '5946f6aba0093a1123aa9f247a6f78270fa05228e5e33c56053a6efada2be0a0'
   - location: '<input_datasets_location>/roms_bry_bgc.nc'
-    file_hash: 'e9b25ab60c7631a61868015a0ef2cb10a5098cfb795275ebce1f851187e429e4'
+    file_hash: 'd3bdf070100e9ed3ddca15ca37cd3c6ecbae93b9425aa5bafb4b37418efae43c'
 surface_forcing:
   - location: '<input_datasets_location>/roms_frc.nc'
-    file_hash: '2479c18308367216fba78b1ff887792315535518faa3a29d1e2f4f280beb2b4e'
+    file_hash: '096f0b19aa27e99a92ac2b76b534e59051f76846b62dc7d41c607da2a2517e16'
   - location: '<input_datasets_location>/roms_frc_bgc.nc'
-    file_hash: '41ac621adece1883a553214f875f3dcad1e37ded9baacc8a130b918d2b874c65'
+    file_hash: '142b19c66f9e37d3c24a858424ad01b3448b563c89f0fecaabc398c88458b0de'

--- a/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml
@@ -9,8 +9,8 @@ marbl_codebase:
   checkout_target: 'marbl0.45.0'
 runtime_code:
   location: '<additional_code_location>'
-  checkout_target: '7fdf8ea2225d55e9b98b5d4d0e7adbff961c9940'
-  subdir: 'additional_code/ROMS/namelists'
+  checkout_target: 'roms_tools_3_1_2'
+  subdir: 'additional_code/ROMS/runtime_code'
   files:
     - "roms.in"
     - "marbl_in"
@@ -18,8 +18,8 @@ runtime_code:
     - "marbl_diagnostic_output_list"
 compile_time_code:
   location: '<additional_code_location>'
-  checkout_target: '7fdf8ea2225d55e9b98b5d4d0e7adbff961c9940'
-  subdir: 'additional_code/ROMS/source_mods'
+  checkout_target: 'roms_tools_3_1_2'
+  subdir: 'additional_code/ROMS/compile_time_code'
   files:
     - "bgc.opt"
     - "bulk_frc.opt"

--- a/cstar/tests/integration_tests/config.py
+++ b/cstar/tests/integration_tests/config.py
@@ -38,7 +38,7 @@ TEST_CONFIG = {
     "test_case_remote_with_netcdf_datasets": {
         "template_blueprint_path": f"{TEST_DIRECTORY}/integration_tests/blueprints/cstar_blueprint_with_netcdf_datasets_template.yaml",
         "strs_to_replace": {
-            "<input_datasets_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/raw/main/input_datasets/ROMS",
+            "<input_datasets_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/raw/roms_tools_3_1_2/input_datasets/ROMS",
             "<additional_code_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case.git",
         },
     },
@@ -46,7 +46,7 @@ TEST_CONFIG = {
     "test_case_remote_with_yaml_datasets": {
         "template_blueprint_path": f"{TEST_DIRECTORY}/integration_tests/blueprints/cstar_blueprint_with_yaml_datasets_template.yaml",
         "strs_to_replace": {
-            "<input_datasets_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/raw/main/roms_tools_yaml_files",
+            "<input_datasets_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/raw/roms_tools_3_1_2/roms_tools_yaml_files",
             "<additional_code_location>": "https://github.com/CWorthy-ocean/cstar_blueprint_test_case.git",
         },
     },

--- a/cstar/tests/integration_tests/fixtures.py
+++ b/cstar/tests/integration_tests/fixtures.py
@@ -69,13 +69,19 @@ def fetch_roms_tools_source_data(request, log) -> Callable[[str | Path], None]:
             registry={
                 "GLORYS_NA_2012.nc": "b862add892f5d6e0d670c8f7fa698f4af5290ac87077ca812a6795e120d0ca8c",
                 "ERA5_NA_2012.nc": "d07fa7450869dfd3aec54411777a5f7de3cb3ec21492eec36f4980e220c51757",
-                "TPXO_global_test_data.nc": "457bfe87a7b247ec6e04e3c7d3e741ccf223020c41593f8ae33a14f2b5255e60",
+                "global_grid_tpxo10.v2.nc": "26eb97cd135cd6f2b4e894c5f11bf7f860ff19cec8dbaa9190e37d30ee6e744e",
+                "global_h_tpxo10.v2.nc": "ef60fae6d52fa514dcc59a737435d74aa798dc114b57f01b123aa39dbaffc592",
+                "global_u_tpxo10.v2.nc": "022e57e6287e51f52eb1e5296614b1086e0e22ecd0bd57c9fd8d0e155babf5c3",
+                # "TPXO_global_test_data.nc": "457bfe87a7b247ec6e04e3c7d3e741ccf223020c41593f8ae33a14f2b5255e60",
                 "CESM_BGC_2012.nc": "e374d5df3c1be742d564fd26fd861c2d40af73be50a432c51d258171d5638eb6",
                 "CESM_BGC_SURFACE_2012.nc": "3c4d156adca97909d0fac36bf50b99583ab37d8020d7a3e8511e92abf2331b38",
             },
         )
         pup_test_data.fetch("GLORYS_NA_2012.nc")
-        pup_test_data.fetch("TPXO_global_test_data.nc")
+        # pup_test_data.fetch("TPXO_global_test_data.nc")
+        pup_test_data.fetch("global_grid_tpxo10.v2.nc")
+        pup_test_data.fetch("global_h_tpxo10.v2.nc")
+        pup_test_data.fetch("global_u_tpxo10.v2.nc")
         pup_test_data.fetch("ERA5_NA_2012.nc")
         pup_test_data.fetch("CESM_BGC_2012.nc")
         pup_test_data.fetch("CESM_BGC_SURFACE_2012.nc")
@@ -125,7 +131,7 @@ def fetch_remote_test_case_data() -> Callable[[], None]:
         test_case_repo_url = (
             "https://github.com/CWorthy-ocean/cstar_blueprint_test_case/"
         )
-        checkout_target = "7fdf8ea2225d55e9b98b5d4d0e7adbff961c9940"
+        checkout_target = "roms_tools_3_1_2"
 
         # Construct the URL of this commit as a zip archive:
         archive_url = f"{test_case_repo_url.rstrip('/')}/archive/{checkout_target}.zip"
@@ -133,7 +139,7 @@ def fetch_remote_test_case_data() -> Callable[[], None]:
         # Download the zip with pooch
         zip_path = pooch.retrieve(
             url=archive_url,
-            known_hash="74126fce593fa86aa09937a9eb89b75f64517c341b899821bb6b07fbb579cc58",
+            known_hash="ea5d149975622bde9aefe4af32e078969b5e68e4bf08efd85d562799aa3e5500",
             fname=f"{checkout_target}.zip",  # Name of the cached file
             path=CSTAR_TEST_DATA_DIRECTORY,  # Set the cache directory (customize as needed)
         )

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -135,8 +135,8 @@ class TestFetchData:
         )
 
         expected_files = [
-            "additional_code/ROMS/namelists/roms.in",
-            "additional_code/ROMS/source_mods/Makefile",
+            "additional_code/ROMS/runtime_code/roms.in",
+            "additional_code/ROMS/compile_time_code/Makefile",
             "input_datasets/ROMS/roms_bry.nc",
             "input_datasets/ROMS/roms_frc.nc",
             "roms_tools_yaml_files/roms_bry.yaml",

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -101,6 +101,9 @@ class TestFetchData:
             "GLORYS_NA_2012.nc",
             "ERA5_NA_2012.nc",
             "TPXO_global_test_data.nc",
+            "global_grid_tpxo10.v2.nc",
+            "global_h_tpxo10.v2.nc",
+            "global_u_tpxo10.v2.nc",
             "CESM_BGC_2012.nc",
             "CESM_BGC_SURFACE_2012.nc",
         ]

--- a/cstar/tests/integration_tests/test_fixtures.py
+++ b/cstar/tests/integration_tests/test_fixtures.py
@@ -100,7 +100,6 @@ class TestFetchData:
         expected_files = [
             "GLORYS_NA_2012.nc",
             "ERA5_NA_2012.nc",
-            "TPXO_global_test_data.nc",
             "global_grid_tpxo10.v2.nc",
             "global_h_tpxo10.v2.nc",
             "global_u_tpxo10.v2.nc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,14 @@ dependencies = [
     "PyYAML==6.0.2",
     "pydantic>=2.11",
     "pooch>=1.8.1",
-    "roms_tools[dask]==2.6.2"
+    "roms_tools[dask]==3.1.2"
 ]
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 
 [project.optional-dependencies]
 test = [
      "pytest>=7.0",
-     "roms_tools[dask]==2.6.2"
+     "roms_tools[dask]==3.1.2"
      ]
 dev =["ruff"]
 


### PR DESCRIPTION
Sets the required version at 3.1.2 (pinned) and updates the test case to ensure compatibility
- [x] Closes #330 

