### PR TITLE
CSD-181: Parameterize ROMS source artifact

### DIFF
--- a/ci/containers/roms/Containerfile
+++ b/ci/containers/roms/Containerfile
@@ -8,7 +8,8 @@ ARG SRC_DIR="/install"
 ARG INSTALL_BASE_DIR=/opt
 ENV ROMS_ROOT=$INSTALL_BASE_DIR/ucla-roms 
 ENV ROMS_PATH=$ROMS_ROOT/Tools-Roms
-ARG REPO_ROMS="https://github.com/dafyddstephenson/ucla-roms/archive/refs/heads/update_makefiles.tar.gz"
+ARG TARGET_BRANCH="main"
+ARG REPO_ROMS="https://github.com/CWorthy-ocean/ucla-roms/archive/refs/heads/$TARGET_BRANCH.tar.gz"
 ENV ROMS_PROFILE="/etc/profile.d/ucla-roms.sh"
 
 WORKDIR "$SRC_DIR"
@@ -19,9 +20,9 @@ RUN echo "export ROMS_ROOT=$ROMS_ROOT" >> $ROMS_PROFILE && \
 
 RUN . /etc/profile && \
     wget -q "$REPO_ROMS" && \
-    tar xvf update_makefiles.tar.gz && \
-    mv ucla-roms-update_makefiles "$ROMS_ROOT" && \
-    rm update_makefiles.tar.gz
+    tar xvf "$TARGET_BRANCH.tar.gz" && \
+    mv "ucla-roms-$TARGET_BRANCH" "$ROMS_ROOT" && \
+    rm "$TARGET_BRANCH.tar.gz"
 
 RUN . /etc/profile && \
     cd "$ROMS_ROOT/Work" && \
@@ -38,4 +39,3 @@ RUN chmod +x /entrypoint.sh
 
 CMD []
 ENTRYPOINT ["/entrypoint.sh"]
-


### PR DESCRIPTION
This change modifies the ROMS `containerfile`. It contains the following changes:

- Use the c-star ucla-roms fork as the default source repository
- Fix bug in partially-parameterized artifact handling


### Checklist

- [x] Closes #CSD-181
