### PR TITLE
Unit test fixture cleanup II.

### DIFF
--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -7,25 +7,14 @@ from unittest import mock
 import numpy as np
 import pytest
 
-from cstar.base import AdditionalCode, Discretization
+from cstar.base import AdditionalCode, Discretization, ExternalCodeBase, InputDataset
 from cstar.base.datasource import DataSource
 from cstar.base.log import get_logger
 from cstar.marbl import MARBLExternalCodeBase
-from cstar.roms import ROMSDiscretization, ROMSExternalCodeBase, ROMSSimulation
-from cstar.roms.input_dataset import (
-    ROMSBoundaryForcing,
-    ROMSForcingCorrections,
-    ROMSInitialConditions,
-    ROMSModelGrid,
-    ROMSRiverForcing,
-    ROMSSurfaceForcing,
-    ROMSTidalForcing,
-)
 from cstar.roms.runtime_settings import ROMSRuntimeSettings
 from cstar.tests.unit_tests.fake_abc_subclasses import (
     FakeExternalCodeBase,
     FakeInputDataset,
-    FakeROMSInputDataset,
     StubSimulation,
 )
 
@@ -35,7 +24,7 @@ from cstar.tests.unit_tests.fake_abc_subclasses import (
 
 
 @pytest.fixture
-def fake_additionalcode_remote():
+def fake_additionalcode_remote() -> AdditionalCode:
     """Pytest fixture that provides an instance of the AdditionalCode class representing
     a remote repository.
 
@@ -64,7 +53,7 @@ def fake_additionalcode_remote():
 
 
 @pytest.fixture
-def fake_additionalcode_local():
+def fake_additionalcode_local() -> AdditionalCode:
     """Pytest fixture that provides an instance of the AdditionalCode class representing
     code located on the local filesystem.
 
@@ -93,8 +82,12 @@ def fake_additionalcode_local():
 ################################################################################
 # ExternalCodeBase
 ################################################################################
+
+
 @pytest.fixture
-def fake_externalcodebase(log: logging.Logger):
+def fake_externalcodebase(
+    log: logging.Logger,
+) -> Generator[ExternalCodeBase, None, None]:
     """Yields a fake codebase (instance of FakeExternalCodeBase) for
     use in testing.
     """
@@ -104,6 +97,21 @@ def fake_externalcodebase(log: logging.Logger):
         return_value="test123",
     ):
         yield FakeExternalCodeBase()
+
+
+@pytest.fixture
+def fake_marblexternalcodebase(
+    log: logging.Logger,
+) -> Generator[MARBLExternalCodeBase, None, None]:
+    """Fixture providing a `MARBLExternalCodeBase` instance for testing."""
+    # Correctly patch the imported _get_hash_from_checkout_target in the ExternalCodeBase's module
+    with mock.patch(
+        "cstar.base.external_codebase._get_hash_from_checkout_target",
+        return_value="test123",
+    ):
+        yield MARBLExternalCodeBase(
+            source_repo="https://marbl.com/repo.git", checkout_target="v1"
+        )
 
 
 ################################################################################
@@ -174,7 +182,7 @@ def fake_romsruntimesettings():
 
 
 @pytest.fixture
-def fake_inputdataset_local():
+def fake_inputdataset_local() -> Generator[InputDataset, None, None]:
     """Fixture to provide a mock local InputDataset instance.
 
     This fixture patches properties of the DataSource class to simulate a local dataset,
@@ -215,7 +223,7 @@ def fake_inputdataset_local():
 
 
 @pytest.fixture
-def fake_inputdataset_remote():
+def fake_inputdataset_remote() -> Generator[InputDataset, None, None]:
     """Fixture to provide a mock remote InputDataset instance.
 
     This fixture patches properties of the DataSource class to simulate a remote dataset,
@@ -261,127 +269,12 @@ def fake_inputdataset_remote():
 
 
 ################################################################################
-# ROMSInputDataset
-################################################################################
-
-
-@pytest.fixture
-def fake_romsinputdataset_netcdf_local():
-    """Fixture to provide a ROMSInputDataset with a local NetCDF source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'path'
-    - DataSource.source_type: Property mocked as 'netcdf'
-    - DataSource.basename: Property mocked as 'local_file.nc'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local NetCDF file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-    ):
-        mock_location_type.return_value = "path"
-        mock_source_type.return_value = "netcdf"
-
-        dataset = FakeROMSInputDataset(
-            location="some/local/source/path/local_file.nc",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-@pytest.fixture
-def fake_romsinputdataset_yaml_local():
-    """Fixture to provide a ROMSInputDataset with a local YAML source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'path'
-    - DataSource.source_type: Property mocked as 'yaml'
-    - DataSource.basename: Property mocked as 'local_file.yaml'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-        mock.patch.object(
-            DataSource, "basename", new_callable=mock.PropertyMock
-        ) as mock_basename,
-    ):
-        mock_location_type.return_value = "path"
-        mock_source_type.return_value = "yaml"
-        mock_basename.return_value = "local_file.yaml"
-
-        dataset = FakeROMSInputDataset(
-            location="some/local/source/path/local_file.yaml",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-@pytest.fixture
-def fake_romsinputdataset_yaml_remote():
-    """Fixture to provide a ROMSInputDataset with a remote YAML source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'url'
-    - DataSource.source_type: Property mocked as 'yaml'
-    - DataSource.basename: Property mocked as 'remote_file.yaml'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-        mock.patch.object(
-            DataSource, "basename", new_callable=mock.PropertyMock
-        ) as mock_basename,
-    ):
-        mock_location_type.return_value = "url"
-        mock_source_type.return_value = "yaml"
-        mock_basename.return_value = "remote_file.yaml"
-
-        dataset = FakeROMSInputDataset(
-            location="https://dodgyfakeyamlfiles.ru/all/remote_file.yaml",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-################################################################################
 # Simulation
 ################################################################################
 
 
 @pytest.fixture
-def stub_simulation(tmp_path):
+def stub_simulation(fake_externalcodebase, tmp_path) -> StubSimulation:
     """Fixture providing a `StubSimulation` instance for testing.
 
     This fixture sets up a minimal `StubSimulation` instance with a mock external
@@ -416,94 +309,11 @@ def stub_simulation(tmp_path):
         valid_start_date="2024-01-01",
         valid_end_date="2026-01-01",
     )
-    yield sim
+    return sim
 
 
 ################################################################################
 # ROMSSimulation
-################################################################################
-
-
-@pytest.fixture
-def fake_romssimulation(
-    tmp_path,
-) -> Generator[ROMSSimulation, None, None]:
-    """Fixture providing a `ROMSSimulation` instance for testing.
-
-    This fixture initializes a `ROMSSimulation` with a comprehensive configuration,
-    including discretization settings, mock external ROMS and MARBL codebases.
-    runtime and compile-time code, and multiple input datasets (grid, initial
-    conditions, tidal forcing, boundary forcing, and surface forcing). The
-    temporary directory (`tmp_path`) is used as the working directory.
-
-    Yields
-    ------
-    tuple[ROMSSimulation, Path]
-        A tuple containing:
-        - `ROMSSimulation` instance with fully configured attributes.
-        - The temporary directory where the simulation is stored.
-    """
-    directory = tmp_path
-    sim = ROMSSimulation(
-        name="ROMSTest",
-        directory=directory,
-        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
-        codebase=ROMSExternalCodeBase(
-            source_repo="http://my.code/repo.git", checkout_target="dev"
-        ),
-        runtime_code=AdditionalCode(
-            location=directory.parent,
-            subdir="subdir/",
-            checkout_target="main",
-            files=[
-                "file1",
-                "file2.in",
-                "marbl_in",
-                "marbl_tracer_output_list",
-                "marbl_diagnostic_output_list",
-            ],
-        ),
-        compile_time_code=AdditionalCode(
-            location=directory.parent,
-            subdir="subdir/",
-            checkout_target="main",
-            files=["file1.h", "file2.opt"],
-        ),
-        start_date="2025-01-01",
-        end_date="2025-12-31",
-        valid_start_date="2024-01-01",
-        valid_end_date="2026-01-01",
-        marbl_codebase=MARBLExternalCodeBase(
-            source_repo="http://marbl.com/repo.git", checkout_target="v1"
-        ),
-        model_grid=ROMSModelGrid(location="http://my.files/grid.nc", file_hash="123"),
-        initial_conditions=ROMSInitialConditions(
-            location="http://my.files/initial.nc", file_hash="234"
-        ),
-        tidal_forcing=ROMSTidalForcing(
-            location="http://my.files/tidal.nc", file_hash="345"
-        ),
-        river_forcing=ROMSRiverForcing(
-            location="http://my.files/river.nc", file_hash="543"
-        ),
-        boundary_forcing=[
-            ROMSBoundaryForcing(
-                location="http://my.files/boundary.nc", file_hash="456"
-            ),
-        ],
-        surface_forcing=[
-            ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567"),
-        ],
-        forcing_corrections=[
-            ROMSForcingCorrections(
-                location="http://my.files/sw_corr.nc", file_hash="890"
-            ),
-        ],
-    )
-
-    yield sim  # Ensures pytest can handle resource cleanup if needed
-
-
 ################################################################################
 
 

--- a/cstar/tests/unit_tests/roms/conftest.py
+++ b/cstar/tests/unit_tests/roms/conftest.py
@@ -1,0 +1,443 @@
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from cstar.base import AdditionalCode
+from cstar.base.datasource import DataSource
+from cstar.roms import ROMSDiscretization, ROMSExternalCodeBase, ROMSSimulation
+from cstar.roms.input_dataset import (
+    ROMSBoundaryForcing,
+    ROMSForcingCorrections,
+    ROMSInitialConditions,
+    ROMSInputDataset,
+    ROMSModelGrid,
+    ROMSRiverForcing,
+    ROMSSurfaceForcing,
+    ROMSTidalForcing,
+)
+from cstar.roms.runtime_settings import ROMSRuntimeSettings
+from cstar.tests.unit_tests.fake_abc_subclasses import (
+    FakeROMSInputDataset,
+)
+
+
+@pytest.fixture
+def fake_romsexternalcodebase() -> Generator[ROMSExternalCodeBase, None, None]:
+    """Provides a `ROMSExternalCodeBase` instance with fake values for testing."""
+    with mock.patch(
+        "cstar.base.external_codebase._get_hash_from_checkout_target",
+        return_value="test123",
+    ):
+        yield ROMSExternalCodeBase(
+            source_repo="https://github.com/roms/repo.git",
+            checkout_target="roms_branch",
+        )
+
+
+################################################################################
+# ROMSRuntimeSettings
+################################################################################
+@pytest.fixture
+def fake_romsruntimesettings() -> ROMSRuntimeSettings:
+    """Fixture providing a `ROMSRuntimeSettings` instance for testing.
+
+    The example instance corresponds to the file `fixtures/example_runtime_settings.in`
+    in order to test the `ROMSRuntimeSettings.to_file` and `from_file` methods.
+
+    Paths do not correspond to real files.
+
+    Returns
+    -------
+    ROMSRuntimeSettings
+       The example ROMSRuntimeSettings instance
+    """
+    return ROMSRuntimeSettings(
+        title="Example runtime settings",
+        time_stepping={"ntimes": 360, "dt": 60, "ndtfast": 60, "ninfo": 1},
+        bottom_drag={
+            "rdrg": 0.0e-4,
+            "rdrg2": 1e-3,
+            "zob": 1e-2,
+            "cdb_min": 1e-4,
+            "cdb_max": 1e-2,
+        },
+        initial={"nrrec": 1, "ininame": Path("input_datasets/roms_ini.nc")},
+        forcing={
+            "filenames": [
+                Path("input_datasets/roms_frc.nc"),
+                Path("input_datasets/roms_frc_bgc.nc"),
+                Path("input_datasets/roms_bry.nc"),
+                Path("input_datasets/roms_bry_bgc.nc"),
+            ]
+        },
+        output_root_name="ROMS_test",
+        s_coord={"theta_s": 5.0, "theta_b": 2.0, "tcline": 300.0},
+        rho0=1000.0,
+        lin_rho_eos={"Tcoef": 0.2, "T0": 1.0, "Scoef": 0.822, "S0": 1.0},
+        marbl_biogeochemistry={
+            "marbl_namelist_fname": Path("marbl_in"),
+            "marbl_tracer_list_fname": Path("marbl_tracer_list_fname"),
+            "marbl_diag_list_fname": Path("marbl_diagnostic_output_list"),
+        },
+        lateral_visc=0.0,
+        gamma2=1.0,
+        tracer_diff2=[
+            0.0,
+        ]
+        * 38,
+        vertical_mixing={"Akv_bak": 0, "Akt_bak": np.zeros(37)},
+        my_bak_mixing={"Akq_bak": 1.0e-5, "q2nu2": 0.0, "q2nu4": 0.0},
+        sss_correction=7.777,
+        sst_correction=10.0,
+        ubind=0.1,
+        v_sponge=0.0,
+        grid=Path("input_datasets/roms_grd.nc"),
+        climatology=Path("climfile2.nc"),
+    )
+
+
+################################################################################
+# Runtime and compile-time code
+################################################################################
+@pytest.fixture
+def fake_roms_runtime_code(tmp_path) -> AdditionalCode:
+    """Provides an example of ROMSSimulation.runtime_code with fake values for testing"""
+    directory = tmp_path
+    rc = AdditionalCode(
+        location=directory.parent,
+        subdir="subdir/",
+        checkout_target="main",
+        files=[
+            "file1",
+            "file2.in",
+            "marbl_in",
+            "marbl_tracer_output_list",
+            "marbl_diagnostic_output_list",
+        ],
+    )
+    return rc
+
+
+@pytest.fixture
+def fake_roms_compile_time_code(tmp_path) -> AdditionalCode:
+    """Provides an example of ROMSSimulation.compile_time_code with fake values for testing"""
+    directory = tmp_path
+    cc = AdditionalCode(
+        location=directory.parent,
+        subdir="subdir/",
+        checkout_target="main",
+        files=["file1.h", "file2.opt"],
+    )
+    return cc
+
+
+################################################################################
+# ROMSInputDataset
+################################################################################
+@pytest.fixture
+def fake_romsinputdataset_netcdf_local() -> Generator[ROMSInputDataset, None, None]:
+    """Fixture to provide a ROMSInputDataset with a local NetCDF source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'path'
+    - DataSource.source_type: Property mocked as 'netcdf'
+    - DataSource.basename: Property mocked as 'local_file.nc'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local NetCDF file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+    ):
+        mock_location_type.return_value = "path"
+        mock_source_type.return_value = "netcdf"
+
+        dataset = FakeROMSInputDataset(
+            location="some/local/source/path/local_file.nc",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_romsinputdataset_yaml_local() -> Generator[ROMSInputDataset, None, None]:
+    """Fixture to provide a ROMSInputDataset with a local YAML source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'path'
+    - DataSource.source_type: Property mocked as 'yaml'
+    - DataSource.basename: Property mocked as 'local_file.yaml'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+        mock.patch.object(
+            DataSource, "basename", new_callable=mock.PropertyMock
+        ) as mock_basename,
+    ):
+        mock_location_type.return_value = "path"
+        mock_source_type.return_value = "yaml"
+        mock_basename.return_value = "local_file.yaml"
+
+        dataset = FakeROMSInputDataset(
+            location="some/local/source/path/local_file.yaml",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_romsinputdataset_yaml_remote() -> Generator[ROMSInputDataset, None, None]:
+    """Fixture to provide a ROMSInputDataset with a remote YAML source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'url'
+    - DataSource.source_type: Property mocked as 'yaml'
+    - DataSource.basename: Property mocked as 'remote_file.yaml'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+        mock.patch.object(
+            DataSource, "basename", new_callable=mock.PropertyMock
+        ) as mock_basename,
+    ):
+        mock_location_type.return_value = "url"
+        mock_source_type.return_value = "yaml"
+        mock_basename.return_value = "remote_file.yaml"
+
+        dataset = FakeROMSInputDataset(
+            location="https://dodgyfakeyamlfiles.ru/all/remote_file.yaml",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_model_grid() -> ROMSModelGrid:
+    """Provides a ROMSModelGrid instance with fake attrs for testing"""
+    return ROMSModelGrid(location="http://my.files/grid.nc", file_hash="123")
+
+
+@pytest.fixture
+def fake_initial_conditions() -> ROMSInitialConditions:
+    """Provides a ROMSInitialConditions instance with fake attrs for testing"""
+    return ROMSInitialConditions(location="http://my.files/initial.nc", file_hash="234")
+
+
+@pytest.fixture
+def fake_tidal_forcing() -> ROMSTidalForcing:
+    """Provides a ROMSTidalForcing instance with fake attrs for testing"""
+    return ROMSTidalForcing(location="http://my.files/tidal.nc", file_hash="345")
+
+
+@pytest.fixture
+def fake_river_forcing() -> ROMSRiverForcing:
+    """Provides a ROMSRiverForcing instance with fake attrs for testing"""
+    return ROMSRiverForcing(location="http://my.files/river.nc", file_hash="543")
+
+
+@pytest.fixture
+def fake_boundary_forcing() -> ROMSBoundaryForcing:
+    """Provides a ROMSBoundaryForcing instance with fake attrs for testing"""
+    return ROMSBoundaryForcing(location="http://my.files/boundary.nc", file_hash="456")
+
+
+@pytest.fixture
+def fake_surface_forcing() -> ROMSSurfaceForcing:
+    """Provides a ROMSSurfaceForcing instance with fake attrs for testing"""
+    return ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567")
+
+
+@pytest.fixture
+def fake_forcing_corrections() -> ROMSForcingCorrections:
+    """Provides a ROMSForcingCorrections  instance with fake attrs for testing"""
+    return ROMSForcingCorrections(
+        location="http://my.files/sw_corr.nc", file_hash="890"
+    )
+
+
+################################################################################
+# ROMSSimulation
+################################################################################
+
+
+@pytest.fixture
+def fake_romssimulation(
+    fake_marblexternalcodebase,
+    fake_romsexternalcodebase,
+    fake_roms_runtime_code,
+    fake_roms_compile_time_code,
+    fake_model_grid,
+    fake_initial_conditions,
+    fake_tidal_forcing,
+    fake_river_forcing,
+    fake_boundary_forcing,
+    fake_surface_forcing,
+    fake_forcing_corrections,
+    tmp_path,
+) -> ROMSSimulation:
+    """Fixture providing a `ROMSSimulation` instance for testing.
+
+    This fixture initializes a `ROMSSimulation` with a comprehensive configuration,
+    including discretization settings, mock external ROMS and MARBL codebases.
+    runtime and compile-time code, and multiple input datasets (grid, initial
+    conditions, tidal forcing, boundary forcing, and surface forcing). The
+    temporary directory (`tmp_path`) is used as the working directory.
+
+    Yields
+    ------
+    tuple[ROMSSimulation, Path]
+        A tuple containing:
+        - `ROMSSimulation` instance with fully configured attributes.
+        - The temporary directory where the simulation is stored.
+    """
+    directory = tmp_path
+    sim = ROMSSimulation(
+        name="ROMSTest",
+        directory=directory,
+        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
+        codebase=fake_romsexternalcodebase,
+        runtime_code=fake_roms_runtime_code,
+        compile_time_code=fake_roms_compile_time_code,
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        valid_start_date="2024-01-01",
+        valid_end_date="2026-01-01",
+        marbl_codebase=fake_marblexternalcodebase,
+        model_grid=fake_model_grid,
+        initial_conditions=fake_initial_conditions,
+        tidal_forcing=fake_tidal_forcing,
+        river_forcing=fake_river_forcing,
+        boundary_forcing=[
+            fake_boundary_forcing,
+        ],
+        surface_forcing=[
+            fake_surface_forcing,
+        ],
+        forcing_corrections=[
+            fake_forcing_corrections,
+        ],
+    )
+
+    return sim
+
+
+@pytest.fixture
+def fake_romssimulation_dict(fake_romssimulation) -> dict[str, Any]:
+    """Fixture returning the dictionary associated with the `fake_romssimulation` fixture.
+
+    Used for independently testing to/from_dict methods.
+    """
+    sim = fake_romssimulation
+    return_dict = {
+        "name": sim.name,
+        "valid_start_date": sim.valid_start_date,
+        "valid_end_date": sim.valid_end_date,
+        "codebase": {
+            "source_repo": sim.codebase.source_repo,
+            "checkout_target": sim.codebase.checkout_target,
+        },
+        "discretization": {
+            "time_step": sim.discretization.time_step,
+            "n_procs_x": sim.discretization.n_procs_x,
+            "n_procs_y": sim.discretization.n_procs_y,
+        },
+        "runtime_code": {
+            "location": sim.runtime_code.source.location,
+            "subdir": sim.runtime_code.subdir,
+            "checkout_target": sim.runtime_code.checkout_target,
+            "files": sim.runtime_code.files,
+        },
+        "compile_time_code": {
+            "location": sim.compile_time_code.source.location,
+            "subdir": sim.compile_time_code.subdir,
+            "checkout_target": sim.compile_time_code.checkout_target,
+            "files": sim.compile_time_code.files,
+        },
+        "marbl_codebase": {
+            "source_repo": sim.marbl_codebase.source_repo,
+            "checkout_target": sim.marbl_codebase.checkout_target,
+        },
+        "model_grid": {
+            "location": sim.model_grid.source.location,
+            "file_hash": sim.model_grid.source.file_hash,
+        },
+        "initial_conditions": {
+            "location": sim.initial_conditions.source.location,
+            "file_hash": sim.initial_conditions.source.file_hash,
+        },
+        "tidal_forcing": {
+            "location": sim.tidal_forcing.source.location,
+            "file_hash": sim.tidal_forcing.source.file_hash,
+        },
+        "river_forcing": {
+            "location": sim.river_forcing.source.location,
+            "file_hash": sim.river_forcing.source.file_hash,
+        },
+        "surface_forcing": [
+            {
+                "location": sim.surface_forcing[0].source.location,
+                "file_hash": sim.surface_forcing[0].source.file_hash,
+            }
+        ],
+        "boundary_forcing": [
+            {
+                "location": sim.boundary_forcing[0].source.location,
+                "file_hash": sim.boundary_forcing[0].source.file_hash,
+            },
+        ],
+        "forcing_corrections": [
+            {
+                "location": sim.forcing_corrections[0].source.location,
+                "file_hash": sim.forcing_corrections[0].source.file_hash,
+            }
+        ],
+    }
+    return return_dict
+
+
+@pytest.fixture
+def fake_romssimulation_dict_no_forcing_lists(
+    fake_romssimulation_dict,
+) -> dict[str, Any]:
+    """As fake_romssimulation_dict, but without list values for certain forcing types."""
+    sim_dict = fake_romssimulation_dict
+    for k in ["surface_forcing", "boundary_forcing", "forcing_corrections"]:
+        sim_dict[k] = sim_dict[k][0]
+    return sim_dict

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -88,8 +88,8 @@ class TestROMSSimulationInitialization:
             "n_procs_y": 3,
         }
 
-        assert sim.codebase.source_repo == "http://my.code/repo.git"
-        assert sim.codebase.checkout_target == "dev"
+        assert sim.codebase.source_repo == "https://github.com/roms/repo.git"
+        assert sim.codebase.checkout_target == "roms_branch"
         assert sim.runtime_code.source.location == str(sim.directory.parent)
         assert sim.runtime_code.subdir == "subdir/"
         assert sim.runtime_code.checkout_target == "main"
@@ -105,7 +105,7 @@ class TestROMSSimulationInitialization:
         assert sim.compile_time_code.checkout_target == "main"
         assert sim.compile_time_code.files == ["file1.h", "file2.opt"]
 
-        assert sim.marbl_codebase.source_repo == "http://marbl.com/repo.git"
+        assert sim.marbl_codebase.source_repo == "https://marbl.com/repo.git"
         assert sim.marbl_codebase.checkout_target == "v1"
 
         assert sim.start_date == datetime(2025, 1, 1)
@@ -951,67 +951,7 @@ class TestToAndFromDictAndBlueprint:
         reconstructed with `from_blueprint()` retains all properties.
     """
 
-    def setup_method(self):
-        """Sets a common dictionary representation of the ROMSSimulation instance
-        associated with the `fake_romssimulation` fixture to be used across tests in
-        this class.
-        """
-        self.example_simulation_dict = {
-            "name": "ROMSTest",
-            "valid_start_date": datetime(2024, 1, 1, 0, 0),
-            "valid_end_date": datetime(2026, 1, 1, 0, 0),
-            "codebase": {
-                "source_repo": "http://my.code/repo.git",
-                "checkout_target": "dev",
-            },
-            "discretization": {"time_step": 60, "n_procs_x": 2, "n_procs_y": 3},
-            "runtime_code": {
-                "location": "some/dir",
-                "subdir": "subdir/",
-                "checkout_target": "main",
-                "files": [
-                    "file1",
-                    "file2.in",
-                    "marbl_in",
-                    "marbl_tracer_output_list",
-                    "marbl_diagnostic_output_list",
-                ],
-            },
-            "compile_time_code": {
-                "location": "some/dir",
-                "subdir": "subdir/",
-                "checkout_target": "main",
-                "files": ["file1.h", "file2.opt"],
-            },
-            "marbl_codebase": {
-                "source_repo": "http://marbl.com/repo.git",
-                "checkout_target": "v1",
-            },
-            "model_grid": {"location": "http://my.files/grid.nc", "file_hash": "123"},
-            "initial_conditions": {
-                "location": "http://my.files/initial.nc",
-                "file_hash": "234",
-            },
-            "tidal_forcing": {
-                "location": "http://my.files/tidal.nc",
-                "file_hash": "345",
-            },
-            "river_forcing": {
-                "location": "http://my.files/river.nc",
-                "file_hash": "543",
-            },
-            "surface_forcing": [
-                {"location": "http://my.files/surface.nc", "file_hash": "567"}
-            ],
-            "boundary_forcing": [
-                {"location": "http://my.files/boundary.nc", "file_hash": "456"},
-            ],
-            "forcing_corrections": [
-                {"location": "http://my.files/sw_corr.nc", "file_hash": "890"}
-            ],
-        }
-
-    def test_to_dict(self, fake_romssimulation):
+    def test_to_dict(self, fake_romssimulation, fake_romssimulation_dict):
         """Tests that `to_dict()` correctly represents a `ROMSSimulation` instance in a
         dictionary.
 
@@ -1030,30 +970,25 @@ class TestToAndFromDictAndBlueprint:
         - `fake_romssimulation`: A fixture providing a pre-configured `ROMSSimulation` instance.
         """
         sim = fake_romssimulation
-        test_dict = sim.to_dict()
+        tested_dict = sim.to_dict()
+        target_dict = fake_romssimulation_dict
 
-        assert (
-            test_dict["marbl_codebase"]
-            == self.example_simulation_dict["marbl_codebase"]
+        assert tested_dict.get("marbl_codebase") == target_dict.get("marbl_codebase")
+        assert tested_dict.get("model_grid") == target_dict.get("model_grid")
+        assert tested_dict.get("initial_conditions") == target_dict.get(
+            "initial_conditions"
         )
-        assert test_dict["model_grid"] == self.example_simulation_dict["model_grid"]
-        assert (
-            test_dict["initial_conditions"]
-            == self.example_simulation_dict["initial_conditions"]
+        assert tested_dict.get("tidal_forcing") == target_dict.get("tidal_forcing")
+        assert tested_dict.get("boundary_forcing") == target_dict.get(
+            "boundary_forcing"
         )
-        assert (
-            test_dict["tidal_forcing"] == self.example_simulation_dict["tidal_forcing"]
-        )
-        assert (
-            test_dict["boundary_forcing"]
-            == self.example_simulation_dict["boundary_forcing"]
-        )
-        assert (
-            test_dict["surface_forcing"]
-            == self.example_simulation_dict["surface_forcing"]
-        )
+        assert tested_dict.get("surface_forcing") == target_dict.get("surface_forcing")
 
-    def test_from_dict(self, fake_romssimulation):
+    def test_from_dict(
+        self,
+        fake_romssimulation,
+        fake_romssimulation_dict,
+    ):
         """Tests that `from_dict()` correctly reconstructs a `ROMSSimulation` instance.
 
         This test verifies that calling `from_dict()` with a valid simulation dictionary
@@ -1069,9 +1004,8 @@ class TestToAndFromDictAndBlueprint:
         - `fake_romssimulation`: A fixture providing a pre-configured `ROMSSimulation` instance.
         """
         sim = fake_romssimulation
-        sim_dict = self.example_simulation_dict
-        sim_dict["runtime_code"]["location"] = sim.directory.parent
-        sim_dict["compile_time_code"]["location"] = sim.directory.parent
+        sim_dict = fake_romssimulation_dict
+
         sim2 = ROMSSimulation.from_dict(
             sim_dict,
             directory=sim.directory,
@@ -1081,7 +1015,13 @@ class TestToAndFromDictAndBlueprint:
 
         assert pickle.dumps(sim2) == pickle.dumps(sim), "Instances are not identical"
 
-    def test_from_dict_with_single_forcing_entries(self, tmp_path):
+        assert sim2.to_dict() == sim_dict
+
+    def test_from_dict_with_single_forcing_entries(
+        self,
+        fake_romssimulation_dict_no_forcing_lists,
+        tmp_path,
+    ):
         """Tests that `from_dict()` works with single surface and boundary forcing or
         forcing correction entries.
 
@@ -1103,19 +1043,7 @@ class TestToAndFromDictAndBlueprint:
         ----------------
         - `tmp_path`: A pytest fixture providing a temporary directory for testing.
         """
-        sim_dict = self.example_simulation_dict.copy()
-        sim_dict["surface_forcing"] = {
-            "location": "http://my.files/surface.nc",
-            "file_hash": "567",
-        }
-        sim_dict["boundary_forcing"] = {
-            "location": "http://my.files/boundary.nc",
-            "file_hash": "456",
-        }
-        sim_dict["forcing_corrections"] = {
-            "location": "http://my.files/sw_corr.nc",
-            "file_hash": "345",
-        }
+        sim_dict = fake_romssimulation_dict_no_forcing_lists
 
         sim = ROMSSimulation.from_dict(
             sim_dict, directory=tmp_path, start_date="2024-01-01", end_date="2024-01-02"
@@ -1136,7 +1064,7 @@ class TestToAndFromDictAndBlueprint:
         assert (
             sim.forcing_corrections[0].source.location == "http://my.files/sw_corr.nc"
         )
-        assert sim.forcing_corrections[0].source.file_hash == "345"
+        assert sim.forcing_corrections[0].source.file_hash == "890"
 
     def test_dict_roundtrip(self, fake_romssimulation):
         """Tests that `to_dict()` and `from_dict()` produce consistent results.
@@ -1205,7 +1133,7 @@ class TestToAndFromDictAndBlueprint:
         read_data="name: TestROMS\ndiscretization:\n  time_step: 60",
     )
     def test_from_blueprint_valid_file(
-        self, mock_open_file, mock_path_exists, tmp_path
+        self, mock_open_file, mock_path_exists, tmp_path, fake_romssimulation_dict
     ):
         """Tests that `from_blueprint()` correctly loads a `ROMSSimulation` from a valid
         YAML file.
@@ -1224,9 +1152,11 @@ class TestToAndFromDictAndBlueprint:
          - `mock_path_exists`: Mocks `Path.exists()` to return `True`, ensuring the test bypasses file existence checks.
          - `tmp_path`: A temporary directory provided by `pytest` to simulate the blueprint file's location.
         """
+        sim_dict = fake_romssimulation_dict
         blueprint_path = tmp_path / "roms_blueprint.yaml"
-
-        with patch("yaml.safe_load", return_value=self.example_simulation_dict):
+        with (
+            patch("yaml.safe_load", return_value=sim_dict),
+        ):
             sim = ROMSSimulation.from_blueprint(
                 blueprint=str(blueprint_path),
                 directory=tmp_path,
@@ -1245,7 +1175,7 @@ class TestToAndFromDictAndBlueprint:
         read_data="name: TestROMS\ndiscretization:\n  time_step: 60",
     )
     def test_from_blueprint_invalid_filetype(
-        self, mock_open_file, mock_path_exists, tmp_path
+        self, mock_open_file, mock_path_exists, tmp_path, fake_romssimulation_dict
     ):
         """Tests that `from_blueprint()` raises a `ValueError` when given a non-YAML
         file.
@@ -1265,7 +1195,7 @@ class TestToAndFromDictAndBlueprint:
         """
         blueprint_path = tmp_path / "roms_blueprint.nc"
 
-        with patch("yaml.safe_load", return_value=self.example_simulation_dict):
+        with patch("yaml.safe_load", return_value=fake_romssimulation_dict):
             with pytest.raises(
                 ValueError, match="C-Star expects blueprint in '.yaml' format"
             ):
@@ -1278,7 +1208,9 @@ class TestToAndFromDictAndBlueprint:
 
     @patch("requests.get")
     @patch("pathlib.Path.exists", return_value=True)
-    def test_from_blueprint_url(self, mock_path_exists, mock_requests_get, tmp_path):
+    def test_from_blueprint_url(
+        self, mock_path_exists, mock_requests_get, tmp_path, fake_romssimulation_dict
+    ):
         """Tests that `from_blueprint()` correctly loads a `ROMSSimulation` from a URL.
 
         This test ensures that when given a valid URL to a YAML blueprint file,
@@ -1295,8 +1227,9 @@ class TestToAndFromDictAndBlueprint:
         - `mock_requests_get`: Mocks `requests.get()` to return a simulated YAML blueprint response.
         - `tmp_path`: A temporary directory provided by `pytest` to simulate the simulation directory.
         """
+        sim_dict = fake_romssimulation_dict
         mock_response = MagicMock()
-        mock_response.text = yaml.dump(self.example_simulation_dict)
+        mock_response.text = yaml.dump(sim_dict)
         mock_requests_get.return_value = mock_response
         blueprint_path = "http://sketchyamlfiles4u.ru/roms_blueprint.yaml"
 


### PR DESCRIPTION
This follows #336 and further modularises the unit tests. ROMS fixtures are now moved to `roms/conftest.py`.

More importantly, fixtures that return fake/mock instances of more complex classes like `ROMSSimulation` are built up from similar fixtures covering lower level classes. 

For example, every assignment in the below fixture (from before) creates an instance of some class in C-Star. Aside from being messy and fragile, the changes coming in the `io` refactor mean that `__init__` calls on most classes will do a lot more work, much of which needs to be patched:

```python
@pytest.fixture
def fake_romssimulation(
    tmp_path,
) -> Generator[ROMSSimulation, None, None]:
    """Fixture providing a `ROMSSimulation` instance for testing....
    """
    directory = tmp_path
    sim = ROMSSimulation(
        name="ROMSTest",
        directory=directory,
        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
        codebase=ROMSExternalCodeBase(
            source_repo="http://my.code/repo.git", checkout_target="dev"
        ),
        runtime_code=AdditionalCode(
            location=directory.parent,
            subdir="subdir/",
            checkout_target="main",
            files=[
                "file1",
                "file2.in",
                "marbl_in",
                "marbl_tracer_output_list",
                "marbl_diagnostic_output_list",
            ],
        ),
        compile_time_code=AdditionalCode(
            location=directory.parent,
            subdir="subdir/",
            checkout_target="main",
            files=["file1.h", "file2.opt"],
        ),
        start_date="2025-01-01",
        end_date="2025-12-31",
        valid_start_date="2024-01-01",
        valid_end_date="2026-01-01",
        marbl_codebase=MARBLExternalCodeBase(
            source_repo="http://marbl.com/repo.git", checkout_target="v1"
        ),
        model_grid=ROMSModelGrid(location="http://my.files/grid.nc", file_hash="123"),
        initial_conditions=ROMSInitialConditions(
            location="http://my.files/initial.nc", file_hash="234"
        ),
        tidal_forcing=ROMSTidalForcing(
            location="http://my.files/tidal.nc", file_hash="345"
        ),
        river_forcing=ROMSRiverForcing(
            location="http://my.files/river.nc", file_hash="543"
        ),
        boundary_forcing=[
            ROMSBoundaryForcing(
                location="http://my.files/boundary.nc", file_hash="456"
            ),
        ],
        surface_forcing=[
            ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567"),
        ],
        forcing_corrections=[
            ROMSForcingCorrections(
                location="http://my.files/sw_corr.nc", file_hash="890"
            ),
        ],
    )

    yield sim 

```

Following the PR:

```python
@pytest.fixture
def fake_romssimulation(
    fake_marblexternalcodebase,
    fake_romsexternalcodebase,
    fake_roms_runtime_code,
    fake_roms_compile_time_code,
    fake_model_grid,
    fake_initial_conditions,
    fake_tidal_forcing,
    fake_river_forcing,
    fake_boundary_forcing,
    fake_surface_forcing,
    fake_forcing_corrections,
    tmp_path,
) -> ROMSSimulation:
    """Fixture providing a `ROMSSimulation` instance for testing...
    """
    directory = tmp_path
    sim = ROMSSimulation(
        name="ROMSTest",
        directory=directory,
        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
        codebase=fake_romsexternalcodebase,
        runtime_code=fake_roms_runtime_code,
        compile_time_code=fake_roms_compile_time_code,
        start_date="2025-01-01",
        end_date="2025-12-31",
        valid_start_date="2024-01-01",
        valid_end_date="2026-01-01",
        marbl_codebase=fake_marblexternalcodebase,
        model_grid=fake_model_grid,
        initial_conditions=fake_initial_conditions,
        tidal_forcing=fake_tidal_forcing,
        river_forcing=fake_river_forcing,
        boundary_forcing=[
            fake_boundary_forcing,
        ],
        surface_forcing=[
            fake_surface_forcing,
        ],
        forcing_corrections=[
            fake_forcing_corrections,
        ],
    )

    return sim
```
now all these `__init__` calls on lower level classes happen in dedicated fixtures, which can manage their own patches and cleanup. 

Another advantage is that there is a single source of truth for "fake" values, which are now consistent throughout. Previously, for example, a dictionary representation of the fake ROMS simulation just sort of lived as an attr of a test class, and had to be updated manually if the fake changed. It is now created by a fixture, based on the values of the corresponding ROMSSimulation instance. There should be no more duplicates like this that have to be updated by hand following this PR. 

Lastly it adds docstrings and typehints that were missing from #336 