### PR TITLE
Patch fixture for ROMSSimulation.__init__

### DIFF
--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,10 +1,8 @@
 import logging
 import pathlib
-from collections.abc import Generator
 from pathlib import Path
 from unittest import mock
 
-import numpy as np
 import pytest
 
 from cstar.base import AdditionalCode, Discretization
@@ -17,21 +15,9 @@ from cstar.io.source_data import SourceData, _SourceInspector
 from cstar.io.staged_data import StagedData
 from cstar.io.stager import Stager
 from cstar.marbl import MARBLExternalCodeBase
-from cstar.roms import ROMSDiscretization, ROMSExternalCodeBase, ROMSSimulation
-from cstar.roms.input_dataset import (
-    ROMSBoundaryForcing,
-    ROMSForcingCorrections,
-    ROMSInitialConditions,
-    ROMSModelGrid,
-    ROMSRiverForcing,
-    ROMSSurfaceForcing,
-    ROMSTidalForcing,
-)
-from cstar.roms.runtime_settings import ROMSRuntimeSettings
 from cstar.tests.unit_tests.fake_abc_subclasses import (
     FakeExternalCodeBase,
     FakeInputDataset,
-    FakeROMSInputDataset,
     StubSimulation,
 )
 
@@ -247,24 +233,6 @@ def fake_externalcodebase(mock_sourcedata_remote_repo):
     yield fecb
     patch_source_data.stop()
 
-
-@pytest.fixture
-def fake_romsexternalcodebase(mock_sourcedata_remote_repo):
-    """Pytest fixutre that provides an instance of the ROMSExternalCodeBase class
-    with a mocked SourceData instance.
-    """
-    source_data = mock_sourcedata_remote_repo(
-        location="https://github.com/roms/repo.git", identifier="roms_branch"
-    )
-    patch_source_data = mock.patch(
-        "cstar.base.external_codebase.SourceData", return_value=source_data
-    )
-    patch_source_data.start()
-    recb = ROMSExternalCodeBase()
-    recb._source = source_data
-    yield recb
-    patch_source_data.stop()
-
     # patch_source_data.stop()
 
 
@@ -287,68 +255,6 @@ def fake_marblexternalcodebase(mock_sourcedata_remote_repo):
     mecb._source = source_data
     yield mecb
     patch_source_data.stop()
-
-
-################################################################################
-# ROMSRuntimeSettings
-################################################################################
-@pytest.fixture
-def fake_romsruntimesettings():
-    """Fixture providing a `ROMSRuntimeSettings` instance for testing.
-
-    The example instance corresponds to the file `fixtures/example_runtime_settings.in`
-    in order to test the `ROMSRuntimeSettings.to_file` and `from_file` methods.
-
-    Paths do not correspond to real files.
-
-    Yields
-    ------
-    ROMSRuntimeSettings
-       The example ROMSRuntimeSettings instance
-    """
-    yield ROMSRuntimeSettings(
-        title="Example runtime settings",
-        time_stepping={"ntimes": 360, "dt": 60, "ndtfast": 60, "ninfo": 1},
-        bottom_drag={
-            "rdrg": 0.0e-4,
-            "rdrg2": 1e-3,
-            "zob": 1e-2,
-            "cdb_min": 1e-4,
-            "cdb_max": 1e-2,
-        },
-        initial={"nrrec": 1, "ininame": Path("input_datasets/roms_ini.nc")},
-        forcing={
-            "filenames": [
-                Path("input_datasets/roms_frc.nc"),
-                Path("input_datasets/roms_frc_bgc.nc"),
-                Path("input_datasets/roms_bry.nc"),
-                Path("input_datasets/roms_bry_bgc.nc"),
-            ]
-        },
-        output_root_name="ROMS_test",
-        s_coord={"theta_s": 5.0, "theta_b": 2.0, "tcline": 300.0},
-        rho0=1000.0,
-        lin_rho_eos={"Tcoef": 0.2, "T0": 1.0, "Scoef": 0.822, "S0": 1.0},
-        marbl_biogeochemistry={
-            "marbl_namelist_fname": Path("marbl_in"),
-            "marbl_tracer_list_fname": Path("marbl_tracer_list_fname"),
-            "marbl_diag_list_fname": Path("marbl_diagnostic_output_list"),
-        },
-        lateral_visc=0.0,
-        gamma2=1.0,
-        tracer_diff2=[
-            0.0,
-        ]
-        * 38,
-        vertical_mixing={"Akv_bak": 0, "Akt_bak": np.zeros(37)},
-        my_bak_mixing={"Akq_bak": 1.0e-5, "q2nu2": 0.0, "q2nu4": 0.0},
-        sss_correction=7.777,
-        sst_correction=10.0,
-        ubind=0.1,
-        v_sponge=0.0,
-        grid=Path("input_datasets/roms_grd.nc"),
-        climatology=Path("climfile2.nc"),
-    )
 
 
 ################################################################################
@@ -444,121 +350,6 @@ def fake_inputdataset_remote():
 
 
 ################################################################################
-# ROMSInputDataset
-################################################################################
-
-
-@pytest.fixture
-def fake_romsinputdataset_netcdf_local():
-    """Fixture to provide a ROMSInputDataset with a local NetCDF source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'path'
-    - DataSource.source_type: Property mocked as 'netcdf'
-    - DataSource.basename: Property mocked as 'local_file.nc'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local NetCDF file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-    ):
-        mock_location_type.return_value = "path"
-        mock_source_type.return_value = "netcdf"
-
-        dataset = FakeROMSInputDataset(
-            location="some/local/source/path/local_file.nc",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-@pytest.fixture
-def fake_romsinputdataset_yaml_local():
-    """Fixture to provide a ROMSInputDataset with a local YAML source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'path'
-    - DataSource.source_type: Property mocked as 'yaml'
-    - DataSource.basename: Property mocked as 'local_file.yaml'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-        mock.patch.object(
-            DataSource, "basename", new_callable=mock.PropertyMock
-        ) as mock_basename,
-    ):
-        mock_location_type.return_value = "path"
-        mock_source_type.return_value = "yaml"
-        mock_basename.return_value = "local_file.yaml"
-
-        dataset = FakeROMSInputDataset(
-            location="some/local/source/path/local_file.yaml",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-@pytest.fixture
-def fake_romsinputdataset_yaml_remote():
-    """Fixture to provide a ROMSInputDataset with a remote YAML source.
-
-    Mocks:
-    ------
-    - DataSource.location_type: Property mocked as 'url'
-    - DataSource.source_type: Property mocked as 'yaml'
-    - DataSource.basename: Property mocked as 'remote_file.yaml'
-
-    Yields:
-    -------
-        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
-    """
-    with (
-        mock.patch.object(
-            DataSource, "location_type", new_callable=mock.PropertyMock
-        ) as mock_location_type,
-        mock.patch.object(
-            DataSource, "source_type", new_callable=mock.PropertyMock
-        ) as mock_source_type,
-        mock.patch.object(
-            DataSource, "basename", new_callable=mock.PropertyMock
-        ) as mock_basename,
-    ):
-        mock_location_type.return_value = "url"
-        mock_source_type.return_value = "yaml"
-        mock_basename.return_value = "remote_file.yaml"
-
-        dataset = FakeROMSInputDataset(
-            location="https://dodgyfakeyamlfiles.ru/all/remote_file.yaml",
-            start_date="2024-10-22 12:34:56",
-            end_date="2024-12-31 23:59:59",
-        )
-
-        yield dataset
-
-
-################################################################################
 # Simulation
 ################################################################################
 
@@ -600,96 +391,6 @@ def stub_simulation(fake_externalcodebase, tmp_path):
         valid_end_date="2026-01-01",
     )
     yield sim
-
-
-################################################################################
-# ROMSSimulation
-################################################################################
-
-
-@pytest.fixture
-def fake_romssimulation(
-    fake_marblexternalcodebase,
-    fake_romsexternalcodebase,
-    tmp_path,
-) -> Generator[ROMSSimulation, None, None]:
-    """Fixture providing a `ROMSSimulation` instance for testing.
-
-    This fixture initializes a `ROMSSimulation` with a comprehensive configuration,
-    including discretization settings, mock external ROMS and MARBL codebases.
-    runtime and compile-time code, and multiple input datasets (grid, initial
-    conditions, tidal forcing, boundary forcing, and surface forcing). The
-    temporary directory (`tmp_path`) is used as the working directory.
-
-    Yields
-    ------
-    tuple[ROMSSimulation, Path]
-        A tuple containing:
-        - `ROMSSimulation` instance with fully configured attributes.
-        - The temporary directory where the simulation is stored.
-    """
-    print(fake_romsexternalcodebase.source)
-    directory = tmp_path
-    sim = ROMSSimulation(
-        name="ROMSTest",
-        directory=directory,
-        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
-        codebase=fake_romsexternalcodebase,
-        # codebase=ROMSExternalCodeBase(
-        #     source_repo="http://my.code/repo.git", checkout_target="dev"
-        # ),
-        runtime_code=AdditionalCode(
-            location=directory.parent,
-            subdir="subdir/",
-            checkout_target="main",
-            files=[
-                "file1",
-                "file2.in",
-                "marbl_in",
-                "marbl_tracer_output_list",
-                "marbl_diagnostic_output_list",
-            ],
-        ),
-        compile_time_code=AdditionalCode(
-            location=directory.parent,
-            subdir="subdir/",
-            checkout_target="main",
-            files=["file1.h", "file2.opt"],
-        ),
-        start_date="2025-01-01",
-        end_date="2025-12-31",
-        valid_start_date="2024-01-01",
-        valid_end_date="2026-01-01",
-        # marbl_codebase=MARBLExternalCodeBase(
-        #     source_repo="http://marbl.com/repo.git", checkout_target="v1"
-        # ),
-        marbl_codebase=fake_marblexternalcodebase,
-        model_grid=ROMSModelGrid(location="http://my.files/grid.nc", file_hash="123"),
-        initial_conditions=ROMSInitialConditions(
-            location="http://my.files/initial.nc", file_hash="234"
-        ),
-        tidal_forcing=ROMSTidalForcing(
-            location="http://my.files/tidal.nc", file_hash="345"
-        ),
-        river_forcing=ROMSRiverForcing(
-            location="http://my.files/river.nc", file_hash="543"
-        ),
-        boundary_forcing=[
-            ROMSBoundaryForcing(
-                location="http://my.files/boundary.nc", file_hash="456"
-            ),
-        ],
-        surface_forcing=[
-            ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567"),
-        ],
-        forcing_corrections=[
-            ROMSForcingCorrections(
-                location="http://my.files/sw_corr.nc", file_hash="890"
-            ),
-        ],
-    )
-
-    yield sim  # Ensures pytest can handle resource cleanup if needed
 
 
 ################################################################################

--- a/cstar/tests/unit_tests/roms/conftest.py
+++ b/cstar/tests/unit_tests/roms/conftest.py
@@ -1,0 +1,434 @@
+from collections.abc import Generator
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from cstar.base import AdditionalCode
+from cstar.base.datasource import DataSource
+from cstar.roms import ROMSDiscretization, ROMSExternalCodeBase, ROMSSimulation
+from cstar.roms.input_dataset import (
+    ROMSBoundaryForcing,
+    ROMSForcingCorrections,
+    ROMSInitialConditions,
+    ROMSModelGrid,
+    ROMSRiverForcing,
+    ROMSSurfaceForcing,
+    ROMSTidalForcing,
+)
+from cstar.roms.runtime_settings import ROMSRuntimeSettings
+from cstar.tests.unit_tests.fake_abc_subclasses import (
+    FakeROMSInputDataset,
+)
+
+
+@pytest.fixture
+def fake_romsexternalcodebase(mock_sourcedata_remote_repo):
+    """Pytest fixutre that provides an instance of the ROMSExternalCodeBase class
+    with a mocked SourceData instance.
+    """
+    source_data = mock_sourcedata_remote_repo(
+        location="https://github.com/roms/repo.git", identifier="roms_branch"
+    )
+    patch_source_data = mock.patch(
+        "cstar.base.external_codebase.SourceData", return_value=source_data
+    )
+    patch_source_data.start()
+    recb = ROMSExternalCodeBase()
+    recb._source = source_data
+    yield recb
+    patch_source_data.stop()
+
+
+################################################################################
+# ROMSRuntimeSettings
+################################################################################
+@pytest.fixture
+def fake_romsruntimesettings():
+    """Fixture providing a `ROMSRuntimeSettings` instance for testing.
+
+    The example instance corresponds to the file `fixtures/example_runtime_settings.in`
+    in order to test the `ROMSRuntimeSettings.to_file` and `from_file` methods.
+
+    Paths do not correspond to real files.
+
+    Yields
+    ------
+    ROMSRuntimeSettings
+       The example ROMSRuntimeSettings instance
+    """
+    yield ROMSRuntimeSettings(
+        title="Example runtime settings",
+        time_stepping={"ntimes": 360, "dt": 60, "ndtfast": 60, "ninfo": 1},
+        bottom_drag={
+            "rdrg": 0.0e-4,
+            "rdrg2": 1e-3,
+            "zob": 1e-2,
+            "cdb_min": 1e-4,
+            "cdb_max": 1e-2,
+        },
+        initial={"nrrec": 1, "ininame": Path("input_datasets/roms_ini.nc")},
+        forcing={
+            "filenames": [
+                Path("input_datasets/roms_frc.nc"),
+                Path("input_datasets/roms_frc_bgc.nc"),
+                Path("input_datasets/roms_bry.nc"),
+                Path("input_datasets/roms_bry_bgc.nc"),
+            ]
+        },
+        output_root_name="ROMS_test",
+        s_coord={"theta_s": 5.0, "theta_b": 2.0, "tcline": 300.0},
+        rho0=1000.0,
+        lin_rho_eos={"Tcoef": 0.2, "T0": 1.0, "Scoef": 0.822, "S0": 1.0},
+        marbl_biogeochemistry={
+            "marbl_namelist_fname": Path("marbl_in"),
+            "marbl_tracer_list_fname": Path("marbl_tracer_list_fname"),
+            "marbl_diag_list_fname": Path("marbl_diagnostic_output_list"),
+        },
+        lateral_visc=0.0,
+        gamma2=1.0,
+        tracer_diff2=[
+            0.0,
+        ]
+        * 38,
+        vertical_mixing={"Akv_bak": 0, "Akt_bak": np.zeros(37)},
+        my_bak_mixing={"Akq_bak": 1.0e-5, "q2nu2": 0.0, "q2nu4": 0.0},
+        sss_correction=7.777,
+        sst_correction=10.0,
+        ubind=0.1,
+        v_sponge=0.0,
+        grid=Path("input_datasets/roms_grd.nc"),
+        climatology=Path("climfile2.nc"),
+    )
+
+
+################################################################################
+# Runtime and compile-time code
+################################################################################
+@pytest.fixture
+def fake_roms_runtime_code(tmp_path):
+    directory = tmp_path
+    rc = AdditionalCode(
+        location=directory.parent,
+        subdir="subdir/",
+        checkout_target="main",
+        files=[
+            "file1",
+            "file2.in",
+            "marbl_in",
+            "marbl_tracer_output_list",
+            "marbl_diagnostic_output_list",
+        ],
+    )
+    return rc
+
+
+@pytest.fixture
+def fake_roms_compile_time_code(tmp_path):
+    directory = tmp_path
+    cc = AdditionalCode(
+        location=directory.parent,
+        subdir="subdir/",
+        checkout_target="main",
+        files=["file1.h", "file2.opt"],
+    )
+    return cc
+
+
+################################################################################
+# ROMSInputDataset
+################################################################################
+@pytest.fixture
+def fake_romsinputdataset_netcdf_local():
+    """Fixture to provide a ROMSInputDataset with a local NetCDF source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'path'
+    - DataSource.source_type: Property mocked as 'netcdf'
+    - DataSource.basename: Property mocked as 'local_file.nc'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local NetCDF file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+    ):
+        mock_location_type.return_value = "path"
+        mock_source_type.return_value = "netcdf"
+
+        dataset = FakeROMSInputDataset(
+            location="some/local/source/path/local_file.nc",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_romsinputdataset_yaml_local():
+    """Fixture to provide a ROMSInputDataset with a local YAML source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'path'
+    - DataSource.source_type: Property mocked as 'yaml'
+    - DataSource.basename: Property mocked as 'local_file.yaml'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+        mock.patch.object(
+            DataSource, "basename", new_callable=mock.PropertyMock
+        ) as mock_basename,
+    ):
+        mock_location_type.return_value = "path"
+        mock_source_type.return_value = "yaml"
+        mock_basename.return_value = "local_file.yaml"
+
+        dataset = FakeROMSInputDataset(
+            location="some/local/source/path/local_file.yaml",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_romsinputdataset_yaml_remote():
+    """Fixture to provide a ROMSInputDataset with a remote YAML source.
+
+    Mocks:
+    ------
+    - DataSource.location_type: Property mocked as 'url'
+    - DataSource.source_type: Property mocked as 'yaml'
+    - DataSource.basename: Property mocked as 'remote_file.yaml'
+
+    Yields:
+    -------
+        FakeROMSInputDataset: A mock dataset pointing to a local YAML file.
+    """
+    with (
+        mock.patch.object(
+            DataSource, "location_type", new_callable=mock.PropertyMock
+        ) as mock_location_type,
+        mock.patch.object(
+            DataSource, "source_type", new_callable=mock.PropertyMock
+        ) as mock_source_type,
+        mock.patch.object(
+            DataSource, "basename", new_callable=mock.PropertyMock
+        ) as mock_basename,
+    ):
+        mock_location_type.return_value = "url"
+        mock_source_type.return_value = "yaml"
+        mock_basename.return_value = "remote_file.yaml"
+
+        dataset = FakeROMSInputDataset(
+            location="https://dodgyfakeyamlfiles.ru/all/remote_file.yaml",
+            start_date="2024-10-22 12:34:56",
+            end_date="2024-12-31 23:59:59",
+        )
+
+        yield dataset
+
+
+@pytest.fixture
+def fake_model_grid():
+    return ROMSModelGrid(location="http://my.files/grid.nc", file_hash="123")
+
+
+@pytest.fixture
+def fake_initial_conditions():
+    return ROMSInitialConditions(location="http://my.files/initial.nc", file_hash="234")
+
+
+@pytest.fixture
+def fake_tidal_forcing():
+    return ROMSTidalForcing(location="http://my.files/tidal.nc", file_hash="345")
+
+
+@pytest.fixture
+def fake_river_forcing():
+    return ROMSRiverForcing(location="http://my.files/river.nc", file_hash="543")
+
+
+@pytest.fixture
+def fake_boundary_forcing():
+    return ROMSBoundaryForcing(location="http://my.files/boundary.nc", file_hash="456")
+
+
+@pytest.fixture
+def fake_surface_forcing():
+    return ROMSSurfaceForcing(location="http://my.files/surface.nc", file_hash="567")
+
+
+@pytest.fixture
+def fake_forcing_corrections():
+    return ROMSForcingCorrections(
+        location="http://my.files/sw_corr.nc", file_hash="890"
+    )
+
+
+################################################################################
+# ROMSSimulation
+################################################################################
+
+
+@pytest.fixture
+def fake_romssimulation(
+    fake_marblexternalcodebase,
+    fake_romsexternalcodebase,
+    fake_roms_runtime_code,
+    fake_roms_compile_time_code,
+    fake_model_grid,
+    fake_initial_conditions,
+    fake_tidal_forcing,
+    fake_river_forcing,
+    fake_boundary_forcing,
+    fake_surface_forcing,
+    fake_forcing_corrections,
+    tmp_path,
+) -> Generator[ROMSSimulation, None, None]:
+    """Fixture providing a `ROMSSimulation` instance for testing.
+
+    This fixture initializes a `ROMSSimulation` with a comprehensive configuration,
+    including discretization settings, mock external ROMS and MARBL codebases.
+    runtime and compile-time code, and multiple input datasets (grid, initial
+    conditions, tidal forcing, boundary forcing, and surface forcing). The
+    temporary directory (`tmp_path`) is used as the working directory.
+
+    Yields
+    ------
+    tuple[ROMSSimulation, Path]
+        A tuple containing:
+        - `ROMSSimulation` instance with fully configured attributes.
+        - The temporary directory where the simulation is stored.
+    """
+    print(fake_romsexternalcodebase.source)
+    directory = tmp_path
+    sim = ROMSSimulation(
+        name="ROMSTest",
+        directory=directory,
+        discretization=ROMSDiscretization(time_step=60, n_procs_x=2, n_procs_y=3),
+        codebase=fake_romsexternalcodebase,
+        runtime_code=fake_roms_runtime_code,
+        compile_time_code=fake_roms_compile_time_code,
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        valid_start_date="2024-01-01",
+        valid_end_date="2026-01-01",
+        # marbl_codebase=MARBLExternalCodeBase(
+        #     source_repo="http://marbl.com/repo.git", checkout_target="v1"
+        # ),
+        marbl_codebase=fake_marblexternalcodebase,
+        model_grid=fake_model_grid,
+        initial_conditions=fake_initial_conditions,
+        tidal_forcing=fake_tidal_forcing,
+        river_forcing=fake_river_forcing,
+        boundary_forcing=[
+            fake_boundary_forcing,
+        ],
+        surface_forcing=[
+            fake_surface_forcing,
+        ],
+        forcing_corrections=[
+            fake_forcing_corrections,
+        ],
+    )
+
+    yield sim  # Ensures pytest can handle resource cleanup if needed
+
+
+@pytest.fixture
+def fake_romssimulation_dict(fake_romssimulation):
+    sim = fake_romssimulation
+    return_dict = {
+        "name": sim.name,
+        "valid_start_date": sim.valid_start_date,
+        "valid_end_date": sim.valid_end_date,
+        "codebase": {
+            "source_repo": sim.codebase.source.location,
+            "checkout_target": sim.codebase.source.checkout_target,
+        },
+        "discretization": {
+            "time_step": sim.discretization.time_step,
+            "n_procs_x": sim.discretization.n_procs_x,
+            "n_procs_y": sim.discretization.n_procs_y,
+        },
+        "runtime_code": {
+            "location": sim.runtime_code.source.location,
+            "subdir": sim.runtime_code.subdir,
+            "checkout_target": sim.runtime_code.checkout_target,
+            "files": sim.runtime_code.files,
+        },
+        "compile_time_code": {
+            "location": sim.compile_time_code.source.location,
+            "subdir": sim.compile_time_code.subdir,
+            "checkout_target": sim.compile_time_code.checkout_target,
+            "files": sim.compile_time_code.files,
+        },
+        "marbl_codebase": {
+            "source_repo": sim.marbl_codebase.source.location,
+            "checkout_target": sim.marbl_codebase.source.checkout_target,
+        },
+        "model_grid": {
+            "location": sim.model_grid.source.location,
+            "file_hash": sim.model_grid.source.file_hash,
+        },
+        "initial_conditions": {
+            "location": sim.initial_conditions.source.location,
+            "file_hash": sim.initial_conditions.source.file_hash,
+        },
+        "tidal_forcing": {
+            "location": sim.tidal_forcing.source.location,
+            "file_hash": sim.tidal_forcing.source.file_hash,
+        },
+        "river_forcing": {
+            "location": sim.river_forcing.source.location,
+            "file_hash": sim.river_forcing.source.file_hash,
+        },
+        "surface_forcing": [
+            {
+                "location": sim.surface_forcing[0].source.location,
+                "file_hash": sim.surface_forcing[0].source.file_hash,
+            }
+        ],
+        "boundary_forcing": [
+            {
+                "location": sim.boundary_forcing[0].source.location,
+                "file_hash": sim.boundary_forcing[0].source.file_hash,
+            },
+        ],
+        "forcing_corrections": [
+            {
+                "location": sim.forcing_corrections[0].source.location,
+                "file_hash": sim.forcing_corrections[0].source.file_hash,
+            }
+        ],
+    }
+    return return_dict
+
+
+@pytest.fixture
+def fake_romssimulation_dict_no_forcing_lists(fake_romssimulation_dict):
+    sim_dict = fake_romssimulation_dict
+    for k in ["surface_forcing", "boundary_forcing", "forcing_corrections"]:
+        sim_dict[k] = sim_dict[k][0]
+    return sim_dict

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -947,67 +947,7 @@ class TestToAndFromDictAndBlueprint:
         reconstructed with `from_blueprint()` retains all properties.
     """
 
-    def setup_method(self):
-        """Sets a common dictionary representation of the ROMSSimulation instance
-        associated with the `fake_romssimulation` fixture to be used across tests in
-        this class.
-        """
-        self.example_simulation_dict = {
-            "name": "ROMSTest",
-            "valid_start_date": datetime(2024, 1, 1, 0, 0),
-            "valid_end_date": datetime(2026, 1, 1, 0, 0),
-            "codebase": {
-                "source_repo": "https://github.com/roms/repo.git",
-                "checkout_target": "roms_branch",
-            },
-            "discretization": {"time_step": 60, "n_procs_x": 2, "n_procs_y": 3},
-            "runtime_code": {
-                "location": "some/dir",
-                "subdir": "subdir/",
-                "checkout_target": "main",
-                "files": [
-                    "file1",
-                    "file2.in",
-                    "marbl_in",
-                    "marbl_tracer_output_list",
-                    "marbl_diagnostic_output_list",
-                ],
-            },
-            "compile_time_code": {
-                "location": "some/dir",
-                "subdir": "subdir/",
-                "checkout_target": "main",
-                "files": ["file1.h", "file2.opt"],
-            },
-            "marbl_codebase": {
-                "source_repo": "https://marbl.com/repo.git",
-                "checkout_target": "v1",
-            },
-            "model_grid": {"location": "http://my.files/grid.nc", "file_hash": "123"},
-            "initial_conditions": {
-                "location": "http://my.files/initial.nc",
-                "file_hash": "234",
-            },
-            "tidal_forcing": {
-                "location": "http://my.files/tidal.nc",
-                "file_hash": "345",
-            },
-            "river_forcing": {
-                "location": "http://my.files/river.nc",
-                "file_hash": "543",
-            },
-            "surface_forcing": [
-                {"location": "http://my.files/surface.nc", "file_hash": "567"}
-            ],
-            "boundary_forcing": [
-                {"location": "http://my.files/boundary.nc", "file_hash": "456"},
-            ],
-            "forcing_corrections": [
-                {"location": "http://my.files/sw_corr.nc", "file_hash": "890"}
-            ],
-        }
-
-    def test_to_dict(self, fake_romssimulation):
+    def test_to_dict(self, fake_romssimulation, fake_romssimulation_dict):
         """Tests that `to_dict()` correctly represents a `ROMSSimulation` instance in a
         dictionary.
 
@@ -1026,30 +966,23 @@ class TestToAndFromDictAndBlueprint:
         - `fake_romssimulation`: A fixture providing a pre-configured `ROMSSimulation` instance.
         """
         sim = fake_romssimulation
-        test_dict = sim.to_dict()
+        tested_dict = sim.to_dict()
+        target_dict = fake_romssimulation_dict
 
-        assert (
-            test_dict["marbl_codebase"]
-            == self.example_simulation_dict["marbl_codebase"]
+        assert tested_dict.get("marbl_codebase") == target_dict.get("marbl_codebase")
+        assert tested_dict.get("model_grid") == target_dict.get("model_grid")
+        assert tested_dict.get("initial_conditions") == target_dict.get(
+            "initial_conditions"
         )
-        assert test_dict["model_grid"] == self.example_simulation_dict["model_grid"]
-        assert (
-            test_dict["initial_conditions"]
-            == self.example_simulation_dict["initial_conditions"]
+        assert tested_dict.get("tidal_forcing") == target_dict.get("tidal_forcing")
+        assert tested_dict.get("boundary_forcing") == target_dict.get(
+            "boundary_forcing"
         )
-        assert (
-            test_dict["tidal_forcing"] == self.example_simulation_dict["tidal_forcing"]
-        )
-        assert (
-            test_dict["boundary_forcing"]
-            == self.example_simulation_dict["boundary_forcing"]
-        )
-        assert (
-            test_dict["surface_forcing"]
-            == self.example_simulation_dict["surface_forcing"]
-        )
+        assert tested_dict.get("surface_forcing") == target_dict.get("surface_forcing")
 
-    def test_from_dict(self, fake_romssimulation, mock_source_data_factory):
+    def test_from_dict(
+        self, fake_romssimulation, fake_romssimulation_dict, mock_source_data_factory
+    ):
         """Tests that `from_dict()` correctly reconstructs a `ROMSSimulation` instance.
 
         This test verifies that calling `from_dict()` with a valid simulation dictionary
@@ -1067,7 +1000,7 @@ class TestToAndFromDictAndBlueprint:
         - mock_source_data_factory: A fixture to return a custom mocked SourceData instance
         """
         sim = fake_romssimulation
-        sim_dict = self.example_simulation_dict
+        sim_dict = fake_romssimulation_dict
 
         marbl_codebase_sourcedata = mock_source_data_factory(
             classification=SourceClassification.REMOTE_REPOSITORY,
@@ -1104,7 +1037,10 @@ class TestToAndFromDictAndBlueprint:
             # as an attribute on SourceData anyway.  Perhaps that should not be the case.
 
     def test_from_dict_with_single_forcing_entries(
-        self, mock_source_data_factory, tmp_path
+        self,
+        fake_romssimulation_dict_no_forcing_lists,
+        mock_source_data_factory,
+        tmp_path,
     ):
         """Tests that `from_dict()` works with single surface and boundary forcing or
         forcing correction entries.
@@ -1128,19 +1064,7 @@ class TestToAndFromDictAndBlueprint:
         - mock_source_data_factory: A fixture to return a custom mocked SourceData instance
         - `tmp_path`: A pytest fixture providing a temporary directory for testing.
         """
-        sim_dict = self.example_simulation_dict.copy()
-        sim_dict["surface_forcing"] = {
-            "location": "http://my.files/surface.nc",
-            "file_hash": "567",
-        }
-        sim_dict["boundary_forcing"] = {
-            "location": "http://my.files/boundary.nc",
-            "file_hash": "456",
-        }
-        sim_dict["forcing_corrections"] = {
-            "location": "http://my.files/sw_corr.nc",
-            "file_hash": "345",
-        }
+        sim_dict = fake_romssimulation_dict_no_forcing_lists
         marbl_codebase_sourcedata = mock_source_data_factory(
             classification=SourceClassification.REMOTE_REPOSITORY,
             location=sim_dict["marbl_codebase"]["source_repo"],
@@ -1177,7 +1101,7 @@ class TestToAndFromDictAndBlueprint:
         assert (
             sim.forcing_corrections[0].source.location == "http://my.files/sw_corr.nc"
         )
-        assert sim.forcing_corrections[0].source.file_hash == "345"
+        assert sim.forcing_corrections[0].source.file_hash == "890"
 
     def test_dict_roundtrip(self, fake_romssimulation, mock_source_data_factory):
         """Tests that `to_dict()` and `from_dict()` produce consistent results.
@@ -1257,7 +1181,12 @@ class TestToAndFromDictAndBlueprint:
     @patch("pathlib.Path.exists", return_value=True)
     @patch("builtins.open", new_callable=mock_open)
     def test_from_blueprint_valid_file(
-        self, mock_open_file, mock_path_exists, tmp_path, mock_source_data_factory
+        self,
+        mock_open_file,
+        mock_path_exists,
+        tmp_path,
+        mock_source_data_factory,
+        fake_romssimulation_dict,
     ):
         """Tests that `from_blueprint()` correctly loads a `ROMSSimulation` from a valid
         YAML file.
@@ -1276,7 +1205,7 @@ class TestToAndFromDictAndBlueprint:
          - `mock_path_exists`: Mocks `Path.exists()` to return `True`, ensuring the test bypasses file existence checks.
          - `tmp_path`: A temporary directory provided by `pytest` to simulate the blueprint file's location.
         """
-        sim_dict = self.example_simulation_dict
+        sim_dict = fake_romssimulation_dict
         blueprint_path = tmp_path / "roms_blueprint.yaml"
         marbl_codebase_sourcedata = mock_source_data_factory(
             classification=SourceClassification.REMOTE_REPOSITORY,
@@ -1325,7 +1254,7 @@ class TestToAndFromDictAndBlueprint:
         read_data="name: TestROMS\ndiscretization:\n  time_step: 60",
     )
     def test_from_blueprint_invalid_filetype(
-        self, mock_open_file, mock_path_exists, tmp_path
+        self, mock_open_file, mock_path_exists, tmp_path, fake_romssimulation_dict
     ):
         """Tests that `from_blueprint()` raises a `ValueError` when given a non-YAML
         file.
@@ -1345,7 +1274,7 @@ class TestToAndFromDictAndBlueprint:
         """
         blueprint_path = tmp_path / "roms_blueprint.nc"
 
-        with patch("yaml.safe_load", return_value=self.example_simulation_dict):
+        with patch("yaml.safe_load", return_value=fake_romssimulation_dict):
             with pytest.raises(
                 ValueError, match="C-Star expects blueprint in '.yaml' format"
             ):
@@ -1359,7 +1288,12 @@ class TestToAndFromDictAndBlueprint:
     @patch("requests.get")
     @patch("pathlib.Path.exists", return_value=True)
     def test_from_blueprint_url(
-        self, mock_path_exists, mock_requests_get, mock_source_data_factory, tmp_path
+        self,
+        mock_path_exists,
+        mock_requests_get,
+        mock_source_data_factory,
+        fake_romssimulation_dict,
+        tmp_path,
     ):
         """Tests that `from_blueprint()` correctly loads a `ROMSSimulation` from a URL.
 
@@ -1378,7 +1312,7 @@ class TestToAndFromDictAndBlueprint:
         - mock_source_data_factory: A fixture to return a custom mocked SourceData instance
         - `tmp_path`: A temporary directory provided by `pytest` to simulate the simulation directory.
         """
-        sim_dict = self.example_simulation_dict
+        sim_dict = fake_romssimulation_dict
         mock_response = MagicMock()
         mock_response.text = yaml.dump(sim_dict)
         mock_requests_get.return_value = mock_response
@@ -1418,7 +1352,11 @@ class TestToAndFromDictAndBlueprint:
         mock_requests_get.assert_called_once()
 
     def test_blueprint_roundtrip(
-        self, fake_romssimulation, mock_source_data_factory, tmp_path
+        self,
+        fake_romssimulation,
+        fake_romssimulation_dict,
+        mock_source_data_factory,
+        tmp_path,
     ):
         """Tests that a `ROMSSimulation` can be serialized to a YAML blueprint and
         reconstructed correctly using `from_blueprint()`.
@@ -1439,7 +1377,7 @@ class TestToAndFromDictAndBlueprint:
         sim = fake_romssimulation
         output_file = tmp_path / "test.yaml"
         sim.to_blueprint(filename=output_file)
-        sim_dict = self.example_simulation_dict
+        sim_dict = fake_romssimulation_dict
         marbl_codebase_sourcedata = mock_source_data_factory(
             classification=SourceClassification.REMOTE_REPOSITORY,
             location=sim_dict["marbl_codebase"]["source_repo"],


### PR DESCRIPTION
This PR creates a new fixture `patch_romssimulation_init_sourcedata` that returns a context manager patching any `SourceData` instances necessary to create a `ROMSSimulation` instance inside a test, for example in `test_from_blueprint_url`. 

This already drops 132 lines of repeated `mock.patch` calls in `test_roms_simulation.py` that were made necessary by the `io` implementation on `ExternalCodeBase` and would continue sprawling as `io` reaches more parts of the code.

It also tidies up some remaining missing typehints.