### PR TITLE
Fix CI (codecov and docs build failures)

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -51,9 +51,12 @@ jobs:
         shell: micromamba-shell {0}                
         run: |
           coverage report -m ; coverage xml
-
+        with:
+          fail_ci_if_error: false
+          
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -50,10 +50,9 @@ jobs:
       - name: Get coverage report
         shell: micromamba-shell {0}                
         run: |
-          coverage report -m ; coverage xml
-        with:
-          fail_ci_if_error: false
-          
+          coverage report -m || true ; coverage xml || true
+
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -18,7 +18,7 @@ jobs:
           micromamba-version: 'latest'
           environment-file: ci/environment.yml
           create-args: |
-            python=${{ matrix.python-version }}
+            python=3.12
       - name: Install C-Star
         shell: micromamba-shell {0}
         run: |

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -50,9 +50,12 @@ jobs:
         shell: micromamba-shell {0}                
         run: |
           coverage report -m ; coverage xml
+        with:
+          fail_ci_if_error: false
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -49,9 +49,7 @@ jobs:
       - name: Get coverage report
         shell: micromamba-shell {0}                
         run: |
-          coverage report -m ; coverage xml
-        with:
-          fail_ci_if_error: false
+          coverage report -m || true ; coverage xml || true
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,7 +2,7 @@ name: cstar_env
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python>=3.10,<3.14
   - numpy
   - roms-tools
   - compilers

--- a/ci/environment_hpc.yml
+++ b/ci/environment_hpc.yml
@@ -2,7 +2,7 @@ name: cstar_env
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10
+  - python>=3.10,<3.14
   - numpy
   - xarray
   - roms-tools


### PR DESCRIPTION
Thanks to @NoraLoose for already fixing the codecov failures in roms-tools and paving the way.

Additionally, I'm pinning the docs build to use python 3.12 for now. It actually didn't have a matrix defined and wasn't pinning a python version at all, which is why if was getting 3.14 (which fails).