### PR TITLE
Set partitioning attribute if source is partitioned

### DIFF
--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -97,8 +97,8 @@ class ROMSInputDataset(InputDataset, ABC):
                 locations.append(location.replace(old_suffix, new_suffix))
             self.partitioned_source = SourceDataCollection.from_locations(locations)
             self.partitioning = ROMSPartitioning(
-                np_xi=source_np_xi,
-                np_eta=source_np_eta,
+                np_xi=self.source_np_xi,  # type: ignore[arg-type]
+                np_eta=self.source_np_eta,  # type: ignore[arg-type]
                 files=[Path(p) for p in self.partitioned_source.locations],
             )
         self._working_copy = None

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -96,6 +96,11 @@ class ROMSInputDataset(InputDataset, ABC):
                 new_suffix = f".{i:0{ndigits}d}.nc"
                 locations.append(location.replace(old_suffix, new_suffix))
             self.partitioned_source = SourceDataCollection.from_locations(locations)
+            self.partitioning = ROMSPartitioning(
+                np_xi=source_np_xi,
+                np_eta=source_np_eta,
+                files=[Path(p) for p in self.partitioned_source.locations],
+            )
         self._working_copy = None
         self.validate()
 

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -96,6 +96,7 @@ class ROMSInputDataset(InputDataset, ABC):
                 new_suffix = f".{i:0{ndigits}d}.nc"
                 locations.append(location.replace(old_suffix, new_suffix))
             self.partitioned_source = SourceDataCollection.from_locations(locations)
+            # muting the linter because we only enter this block if np_xi and np_eta are not None
             self.partitioning = ROMSPartitioning(
                 np_xi=self.source_np_xi,  # type: ignore[arg-type]
                 np_eta=self.source_np_eta,  # type: ignore[arg-type]
@@ -107,7 +108,7 @@ class ROMSInputDataset(InputDataset, ABC):
     @property
     def source_partitioning(self) -> tuple[int, int] | None:
         if (self.source_np_xi is not None) and (self.source_np_eta is not None):
-            return (self.source_np_xi, self.source_np_eta)
+            return self.source_np_xi, self.source_np_eta
         return None
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
I was getting an error where C-Star was trying to re-partition input files that were already partitioned. I think this was introduced with the input dataset refactor. This fix sets the older `partitioning` attribute if the newer`source_partitioning` is defined, and therefore ensures that the `partition()` method exits immediately. I'm not sure if there is an intended difference between the two partitioning-related properties or if they're duplicative; we can refactor later if one or the other should be pruned out.