### PR TITLE
Slurm improvements

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -666,8 +666,9 @@ class SlurmJob(SchedulerJob):
         ) in self.scheduler.other_scheduler_directives.items():
             scheduler_script += f"\n#SBATCH {key} {value}"
 
+        scheduler_script += "\n\nset -e"
         # Add roms command to scheduler script
-        scheduler_script += f"\n\n{self.commands}"
+        scheduler_script += f"\n{self.commands}"
         return scheduler_script
 
     def submit(self) -> int | None:

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -703,7 +703,9 @@ class SlurmJob(SchedulerJob):
         }
 
         deps = ":".join(str(d) for d in self.depends_on)
-        dep_clause = f" --dependency=afterok:{deps}" if deps else ""
+        dep_clause = (
+            f" --dependency=afterok:{deps} --kill-on-invalid-dep=yes" if deps else ""
+        )
 
         cmd = f"sbatch{dep_clause} {self.script_path}"
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1521,6 +1521,7 @@ class ROMSSimulation(Simulation):
             f"{final_runtime_settings_file}"
         )
 
+        self.log.info(f"Running {roms_exec_cmd}")
         # If this simulation is already in a scheduler job, don't create a new one, just run it locally.
         if (
             cstar_sysmgr.scheduler is not None

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -123,8 +123,9 @@ class TestSlurmJob:
             "#SBATCH --export=ALL\n"
             "#SBATCH --mail-type=ALL\n"
             "#SBATCH --time=01:00:00\n"
-            "#SBATCH -mock_directive mock_value\n"
-            "\necho Hello, World"
+            "#SBATCH -mock_directive mock_value\n\n"
+            "set -e\n"
+            "echo Hello, World"
         )
 
         assert job.script.strip() == expected_script.strip(), (
@@ -184,8 +185,9 @@ class TestSlurmJob:
             "#SBATCH --export=ALL\n"
             "#SBATCH --mail-type=ALL\n"
             "#SBATCH --time=01:00:00\n"
-            "#SBATCH -mock_directive mock_value\n"
-            "\necho Hello, World"
+            "#SBATCH -mock_directive mock_value\n\n"
+            "set -e\n"
+            "echo Hello, World"
         )
 
         assert job.script.strip() == expected_script.strip(), (


### PR DESCRIPTION
Small PR with a few slurm/sbatch related changes:
* Add `--kill-on-invalid-dep=yes` so that if a job's dependency fails, slurm kills the dependent job instead of it staying in pending forever.
* Add `set -e` to the sbatch script. The FD team found this was needed on Anvil to tell batch to exit properly if ROMS had an error. I _think_ this isn't strictly needed since we already wrap the ROMS execution in python subprocesses and our python script should exit cleanly when appropriate, but I also had a few cases where things timed out and I don't know for sure if this would have helped or if it was a different issue. I think it also doesn't hurt to add it?