### PR TITLE
Remove user env file

### DIFF
--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from cstar.base.external_codebase import ExternalCodeBase
@@ -37,7 +38,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         roms_root = self.working_copy.path
         cstar_sysmgr.environment.set_env_var(self.root_env_var, str(roms_root))
         cstar_sysmgr.environment.set_env_var(
-            "PATH", f"${{PATH}}:{roms_root / 'Tools-Roms'}"
+            "PATH", f"{os.environ.get('PATH')}:{roms_root / 'Tools-Roms'}"
         )
 
         # Compile NHMG library

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -38,7 +38,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         roms_root = self.working_copy.path
         cstar_sysmgr.environment.set_env_var(self.root_env_var, str(roms_root))
         cstar_sysmgr.environment.set_env_var(
-            "PATH", f"{os.environ.get('PATH')}:{roms_root / 'Tools-Roms'}"
+            "PATH", f"{roms_root / 'Tools-Roms'}:{os.environ.get('PATH')}"
         )
 
         # Compile NHMG library

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -307,6 +307,8 @@ class CStarEnvironment:
     def set_env_var(key: str, value: str) -> None:
         """Set value of an environment variable.
 
+        TODO: Remove unless new functionality is needed here.
+
         Note: after removing the persisted user_env file, this method seems silly. Leaving it for the moment,
         just so we don't have to update everywhere that uses it, and because we may want some other behavior
         around config files or logging to be happening here in the future.

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -303,9 +303,13 @@ class CStarEnvironment:
         for mod in lmod_list:
             self._call_lmod(f"load {mod}")
 
-    def set_env_var(self, key: str, value: str) -> None:
-        """Set value of an environment variable and store it in the user environment
-        file.
+    @staticmethod
+    def set_env_var(key: str, value: str) -> None:
+        """Set value of an environment variable.
+
+        Note: after removing the persisted user_env file, this method seems silly. Leaving it for the moment,
+        just so we don't have to update everywhere that uses it, and because we may want some other behavior
+        around config files or logging to be happening here in the future.
 
         Parameters
         ----------
@@ -315,4 +319,3 @@ class CStarEnvironment:
             The value to set for the environment variable.
         """
         os.environ[key] = value
-        self._env_vars = self._load_env()

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -74,7 +74,7 @@ class CStarEnvironment:
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
         self._PACKAGE_ROOT: Path = self._find_package_root()
-        self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
+        # self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
         self._env_vars = self._load_env()
 
         if self.uses_lmod:
@@ -207,16 +207,16 @@ class CStarEnvironment:
         """
         return (platform.system() == "Linux") and ("LMOD_CMD" in list(os.environ))
 
-    @property
-    def user_env_path(self) -> Path:
-        """Identify the expected path to a .env file for the current user.
+    # @property
+    # def user_env_path(self) -> Path:
+    #     """Identify the expected path to a .env file for the current user.
 
-        Returns
-        -------
-        Path
-            The path to the `.env` file.
-        """
-        return self._CSTAR_USER_ENV_PATH
+    #     Returns
+    #     -------
+    #     Path
+    #         The path to the `.env` file.
+    #     """
+    #     return self._CSTAR_USER_ENV_PATH
 
     @property
     def system_env_path(self) -> Path:
@@ -329,5 +329,6 @@ class CStarEnvironment:
         value : str
             The value to set for the environment variable.
         """
-        set_key(self.user_env_path, key, value)
+        # set_key(self.user_env_path, key, value)
+        os.environ[key] = value
         self._env_vars = self._load_env()

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -3,7 +3,7 @@ import os
 import platform
 from pathlib import Path
 
-from dotenv import dotenv_values, set_key
+from dotenv import dotenv_values
 
 from cstar.base.utils import _run_cmd
 
@@ -74,7 +74,6 @@ class CStarEnvironment:
         self._mpi_exec_prefix = mpi_exec_prefix
         self._compiler = compiler
         self._PACKAGE_ROOT: Path = self._find_package_root()
-        # self._CSTAR_USER_ENV_PATH = Path("~/.cstar.env").expanduser()
         self._env_vars = self._load_env()
 
         if self.uses_lmod:
@@ -135,8 +134,6 @@ class CStarEnvironment:
             The variables that were loaded
         """
         env_vars = dotenv_values(self.system_env_path)
-        user_env_vars = dotenv_values(self.user_env_path)
-        env_vars.update(user_env_vars)
 
         env_vars = {k: v for k, v in env_vars.items() if v is not None}
         os.environ.update(env_vars)
@@ -194,7 +191,6 @@ class CStarEnvironment:
         """
         return self._PACKAGE_ROOT
 
-    # Environment management related
     @property
     def uses_lmod(self) -> bool:
         """Checks if the system uses Linux Environment Modules (Lmod) based on OS type
@@ -206,17 +202,6 @@ class CStarEnvironment:
             True if the OS is Linux and `LMOD_DIR` is present in environment variables.
         """
         return (platform.system() == "Linux") and ("LMOD_CMD" in list(os.environ))
-
-    # @property
-    # def user_env_path(self) -> Path:
-    #     """Identify the expected path to a .env file for the current user.
-
-    #     Returns
-    #     -------
-    #     Path
-    #         The path to the `.env` file.
-    #     """
-    #     return self._CSTAR_USER_ENV_PATH
 
     @property
     def system_env_path(self) -> Path:
@@ -329,6 +314,5 @@ class CStarEnvironment:
         value : str
             The value to set for the environment variable.
         """
-        # set_key(self.user_env_path, key, value)
         os.environ[key] = value
         self._env_vars = self._load_env()

--- a/cstar/tests/conftest.py
+++ b/cstar/tests/conftest.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -29,14 +28,3 @@ def mock_user_env_name() -> str:
         The name of the .env file
     """
     return ".mock.env"
-
-
-@pytest.fixture(autouse=True)
-def never_touch_user_env(tmp_path: Path, mock_user_env_name: str):
-    """Autouse fixture to always replace user env path with a temp path"""
-    with patch(
-        "cstar.system.environment.CStarEnvironment.user_env_path",
-        new_callable=PropertyMock,
-        return_value=tmp_path / mock_user_env_name,
-    ):
-        yield

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -788,25 +788,6 @@ def mock_path_resolve():
         yield mock_resolve
 
 
-@pytest.fixture
-def dotenv_path(tmp_path: Path, mock_user_env_name: str) -> Path:
-    """Return a complete path to a temporary user .env file.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        The path to a temporary location to write the env file
-    mock_user_env_name : str
-        The name of the file that will be written
-
-    Returns
-    -------
-    Path
-        The complete path to the config file
-    """
-    return tmp_path / mock_user_env_name
-
-
 def _write_custom_env(path: Path, variables: dict[str, str]) -> None:
     """Populate a .env configuration file.
 
@@ -843,25 +824,6 @@ def custom_system_env(
         A function that will write a new env config file.
     """
     return functools.partial(_write_custom_env, system_dotenv_path)
-
-
-@pytest.fixture
-def custom_user_env(
-    dotenv_path: Path,
-) -> Callable[[dict[str, str]], None]:
-    """Return a function to populate a mocked user environment config file.
-
-    Parameters
-    ----------
-    dotenv_path: Path
-        The path to a temporary location to write the env file
-
-    Returns
-    -------
-    Callable[[dict[str, str]], None]
-        A function that will write a new env config file.
-    """
-    return functools.partial(_write_custom_env, dotenv_path)
 
 
 @pytest.fixture(scope="session")

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -364,7 +364,6 @@ def test_start_runner(
 def test_runner_directory_check(
     tmp_path: Path,
     sim_runner: SimulationRunner,
-    dotenv_path: Path,
 ) -> None:
     """Test the simulation runner's file system preparation.
 
@@ -377,8 +376,6 @@ def test_runner_directory_check(
         An instance of SimulationRunner to be used for the test.
     tmp_path : Path
         A temporary path to store simulation output and logs
-    dotenv_path : Path
-        Path to a temporary location to
     """
     sim_runner._output_dir.mkdir(parents=True, exist_ok=True)
     (sim_runner._output_dir / "somefile.txt").touch()
@@ -392,7 +389,6 @@ def test_runner_directory_check(
 def test_runner_directory_check_ignore_logs(
     tmp_path: Path,
     sim_runner: SimulationRunner,
-    dotenv_path: Path,
 ) -> None:
     """Test the simulation runner's file system preparation.
 
@@ -405,14 +401,8 @@ def test_runner_directory_check_ignore_logs(
         An instance of SimulationRunner to be used for the test.
     tmp_path : Path
         A temporary path to store simulation output and logs
-    dotenv_path : Path
-        Path to a temporary location to
     """
     output_dir = tmp_path / "output"
-
-    # populate the directories that should be cleaned-up
-    dotenv_path.parent.mkdir(parents=True, exist_ok=True)
-    dotenv_path.touch()
 
     output_dir.mkdir(parents=True, exist_ok=True)
     logs_dir = output_dir / "logs"
@@ -421,18 +411,12 @@ def test_runner_directory_check_ignore_logs(
     # A file in the logs directory should be ignored
     (logs_dir / "any-name.txt").touch()
 
-    with mock.patch(
-        "cstar.system.environment.CStarEnvironment.user_env_path",
-        new_callable=mock.PropertyMock,
-        return_value=dotenv_path,
-    ):
-        sim_runner._prepare_file_system()
+    sim_runner._prepare_file_system()
 
 
 def test_runner_directory_prep(
     tmp_path: Path,
     sim_runner: SimulationRunner,
-    dotenv_path: Path,
 ) -> None:
     """Test the simulation runner's file system preparation.
 
@@ -444,22 +428,14 @@ def test_runner_directory_prep(
         An instance of SimulationRunner to be used for the test.
     tmp_path : Path
         A temporary path to store simulation output and logs
-    dotenv_path : Path
-        Path to a temporary location to
+
     """
     output_dir = tmp_path / "output"
-
-    # populate the directories that should be cleaned-up
-    dotenv_path.parent.mkdir(parents=True, exist_ok=True)
-    dotenv_path.touch()
 
     # an empty output dir should be ok
     output_dir.mkdir(parents=True, exist_ok=True)
 
     sim_runner._prepare_file_system()
-
-    # Confirm a user env file is not removed
-    assert dotenv_path.exists()
 
     # Confirm the output directory is created...
     assert sim_runner._output_dir.exists()

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -1,8 +1,8 @@
+import os
 import pathlib
 import subprocess
 import unittest.mock as mock
 
-import dotenv
 import pytest
 
 import cstar
@@ -65,7 +65,6 @@ class TestMARBLExternalCodeBaseConfigure:
     def test_configure_success(
         self,
         marblexternalcodebase_staged,
-        dotenv_path: pathlib.Path,
         marbl_path: pathlib.Path,
     ):
         """Test that the _configure method succeeds when subprocess calls succeed."""
@@ -78,7 +77,7 @@ class TestMARBLExternalCodeBaseConfigure:
             mecb._configure()
 
         ## Check that environment was updated correctly
-        actual_value = dotenv.get_key(dotenv_path, mecb.root_env_var)
+        actual_value = os.getenv(mecb.root_env_var)
         assert actual_value == str(mecb.working_copy.path)
 
         mock_run_cmd.assert_called_once_with(
@@ -96,7 +95,6 @@ class TestMARBLExternalCodeBaseConfigure:
         mock_subprocess,
         marblexternalcodebase_staged,
         tmp_path,
-        dotenv_path,
     ):
         """Test that the _configure method raises an error when 'make' fails."""
         mock_subprocess.side_effect = [
@@ -123,7 +121,6 @@ class TestMARBLExternalCodeBaseConfigure:
         self,
         marblexternalcodebase_staged,
         tmp_path,
-        dotenv_path,
     ):
         """Tests that the `is_configured` property is True when all conditions met.
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -3,7 +3,6 @@ import pathlib
 import subprocess
 import unittest.mock as mock
 
-import dotenv
 import pytest
 
 import cstar
@@ -68,7 +67,6 @@ class TestROMSExternalCodeBaseConfigure:
     def test_configure_success(
         self,
         romsexternalcodebase_staged,
-        dotenv_path: pathlib.Path,
         roms_path: pathlib.Path,
     ):
         """Test that the _configure method succeeds when subprocess calls succeed."""
@@ -84,10 +82,7 @@ class TestROMSExternalCodeBaseConfigure:
 
             # Assertions:
             ## Check environment variables
-            dotenv.load_dotenv(dotenv_path, override=True)
             assert os.environ[recb.root_env_var] == str(recb.working_copy.path)
-            dotenv_var = dotenv.get_key(dotenv_path, recb.root_env_var)
-            assert dotenv_var == str(recb.working_copy.path)
 
         mock_run_cmd.assert_any_call(
             f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
@@ -102,7 +97,6 @@ class TestROMSExternalCodeBaseConfigure:
         self,
         mock_subprocess,
         romsexternalcodebase_staged,
-        dotenv_path,
     ):
         """Test that the _configure method raises an error when 'NHMG/make' fails."""
         mock_subprocess.side_effect = [
@@ -133,7 +127,6 @@ class TestROMSExternalCodeBaseConfigure:
         self,
         mock_subprocess,
         romsexternalcodebase_staged,
-        dotenv_path,
     ):
         """Test that the _configure method raises an error when 'Tools-Roms/make' fails."""
         mock_subprocess.side_effect = [
@@ -164,7 +157,6 @@ class TestROMSExternalCodeBaseConfigure:
         self,
         romsexternalcodebase_staged,
         roms_path,
-        dotenv_path,
     ):
         """Tests that the `is_configured` property returns True when all conditions met:
 


### PR DESCRIPTION
Per discussion, these sorts of variables should really be set in blueprints or via other mechanisms in the future. For now, we are having lots of trouble with simultaneous runs writing/reading from the same user env location.