### PR TITLE
Add function to clear the working directory before launching a job

### DIFF
--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import typing as t
 from pathlib import Path
@@ -124,6 +125,16 @@ app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
 """Map application types to a function that converts a step to a CLI command."""
 
 
+def clear_working_dir(step: Step):
+    # TODO this is temporary only, for my sanity
+    _bp = deserialize(Path(step.blueprint), RomsMarblBlueprint)
+    out_path = _bp.runtime_params.output_dir
+    print(f"clearing {out_path}")
+    shutil.rmtree(out_path / "ROMS", ignore_errors=True)
+    shutil.rmtree(out_path / "output", ignore_errors=True)
+    shutil.rmtree(out_path / "JOINED_OUTPUT", ignore_errors=True)
+
+
 class SlurmLauncher(Launcher[SlurmHandle]):
     """A launcher that executes steps in a SLURM-enabled cluster."""
 
@@ -149,6 +160,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         bp = deserialize(bp_path, RomsMarblBlueprint)
         job_dep_ids = [d.pid for d in dependencies]
 
+        clear_working_dir(step)
         step_converter = app_to_cmd_map[step.application]
         if converter_override := os.getenv("CSTAR_CMD_CONVERTER_OVERRIDE", ""):
             print(

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -149,7 +149,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         bp = deserialize(bp_path, RomsMarblBlueprint)
         job_dep_ids = [d.pid for d in dependencies]
 
-        clear_working_dir(step)
+        clear_working_dir(bp.runtime_params.output_dir)
 
         step_converter = app_to_cmd_map[step.application]
         if converter_override := os.getenv("CSTAR_CMD_CONVERTER_OVERRIDE", ""):

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -1,4 +1,10 @@
+import os
 import re
+import shutil
+from pathlib import Path
+
+from cstar.orchestration.models import RomsMarblBlueprint, Step
+from cstar.orchestration.serialization import deserialize
 
 
 def slugify(source: str) -> str:
@@ -18,3 +24,23 @@ def slugify(source: str) -> str:
         raise ValueError
 
     return re.sub(r"\s+", "-", source.casefold())
+
+
+def clear_working_dir(step: Step) -> None:
+    """Clear the working directory for a step if CSTAR_CLOBBER_WORKING_DIR is set.
+
+    Parameters
+    ----------
+    step: the step who's working directory should be cleared
+
+    Returns
+    -------
+    None
+    """
+    if os.getenv("CSTAR_CLOBBER_WORKING_DIR") == "1":
+        _bp = deserialize(Path(step.blueprint), RomsMarblBlueprint)
+        out_path = _bp.runtime_params.output_dir
+        print(f"clearing {out_path}")
+        shutil.rmtree(out_path / "ROMS", ignore_errors=True)
+        shutil.rmtree(out_path / "output", ignore_errors=True)
+        shutil.rmtree(out_path / "JOINED_OUTPUT", ignore_errors=True)

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -3,9 +3,6 @@ import re
 import shutil
 from pathlib import Path
 
-from cstar.orchestration.models import RomsMarblBlueprint, Step
-from cstar.orchestration.serialization import deserialize
-
 
 def slugify(source: str) -> str:
     """Convert a source string into a URL-safe slug.
@@ -26,21 +23,19 @@ def slugify(source: str) -> str:
     return re.sub(r"\s+", "-", source.casefold())
 
 
-def clear_working_dir(step: Step) -> None:
-    """Clear the working directory for a step if CSTAR_CLOBBER_WORKING_DIR is set.
+def clear_working_dir(path: Path) -> None:
+    """Clear specific paths under the working directory if CSTAR_CLOBBER_WORKING_DIR is set.
 
     Parameters
     ----------
-    step: the step who's working directory should be cleared
+    path: the working directory to be cleared
 
     Returns
     -------
     None
     """
     if os.getenv("CSTAR_CLOBBER_WORKING_DIR") == "1":
-        _bp = deserialize(Path(step.blueprint), RomsMarblBlueprint)
-        out_path = _bp.runtime_params.output_dir
-        print(f"clearing {out_path}")
-        shutil.rmtree(out_path / "ROMS", ignore_errors=True)
-        shutil.rmtree(out_path / "output", ignore_errors=True)
-        shutil.rmtree(out_path / "JOINED_OUTPUT", ignore_errors=True)
+        print(f"clearing {path}")
+        shutil.rmtree(path / "ROMS", ignore_errors=True)
+        shutil.rmtree(path / "output", ignore_errors=True)
+        shutil.rmtree(path / "JOINED_OUTPUT", ignore_errors=True)

--- a/cstar/tests/unit_tests/orchestration/test_utils.py
+++ b/cstar/tests/unit_tests/orchestration/test_utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,21 +21,12 @@ def populated_output_dir(tmp_path: Path) -> tuple[Path, list[Path]]:
     return output_dir, files
 
 
-@pytest.fixture
-def mocked_bp_with_output_dir(populated_output_dir) -> MagicMock:
-    mock = MagicMock()
-    mock.runtime_params = MagicMock()
-    mock.runtime_params.output_dir, _ = populated_output_dir
-    return mock
-
-
 @pytest.mark.parametrize(
     "env_value,cleared", (("1", True), ("0", False), (None, False))
 )
 def test_clear_working_directory_env_setting(
     env_value: str | None,
     cleared: bool,
-    mocked_bp_with_output_dir: MagicMock,
     monkeypatch,
     populated_output_dir: tuple[Path, list[Path]],
 ):
@@ -48,28 +38,22 @@ def test_clear_working_directory_env_setting(
     ----------
     env_value: value to set our magic env-var to
     cleared: whether the directory should be cleared or not
-    mocked_bp_with_output_dir: mocked RomsMarblBlueprint with output_dir pointing to our tmp path
     monkeypatch: pytest util for setting env-vars in tests
     populated_output_dir: fixture providing tmp_path and fake files
 
     """
     output_dir, output_files = populated_output_dir
-    with patch(
-        "cstar.orchestration.utils.deserialize", return_value=mocked_bp_with_output_dir
-    ):
-        if env_value is not None:
-            monkeypatch.setenv("CSTAR_CLOBBER_WORKING_DIR", env_value)
-        else:
-            monkeypatch.delenv("CSTAR_CLOBBER_WORKING_DIR", raising=False)
 
-        dummy_step = MagicMock()
-        dummy_step.blueprint = "doesn't matter"
+    if env_value is not None:
+        monkeypatch.setenv("CSTAR_CLOBBER_WORKING_DIR", env_value)
+    else:
+        monkeypatch.delenv("CSTAR_CLOBBER_WORKING_DIR", raising=False)
 
-        clear_working_dir(dummy_step)
-        if cleared:
-            assert all([not f.exists() for f in output_files])
-            assert all([not f.parent.exists() for f in output_files])
+    clear_working_dir(output_dir)
+    if cleared:
+        assert all([not f.exists() for f in output_files])
+        assert all([not f.parent.exists() for f in output_files])
 
-        else:
-            assert output_dir.exists()
-            assert all([f.exists for f in output_files])
+    else:
+        assert output_dir.exists()
+        assert all([f.exists for f in output_files])

--- a/cstar/tests/unit_tests/orchestration/test_utils.py
+++ b/cstar/tests/unit_tests/orchestration/test_utils.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cstar.orchestration.utils import clear_working_dir
+
+
+@pytest.fixture
+def populated_output_dir(tmp_path: Path) -> tuple[Path, list[Path]]:
+    output_dir = tmp_path / "my_output_dir"
+    files = [
+        (output_dir / "ROMS" / "some_file"),
+        (output_dir / "output" / "some_file"),
+        (output_dir / "JOINED_OUTPUT" / "some_file"),
+    ]
+
+    for f in files:
+        f.parent.mkdir(parents=True)
+        f.touch()
+
+    return output_dir, files
+
+
+@pytest.fixture
+def mocked_bp_with_output_dir(populated_output_dir) -> MagicMock:
+    mock = MagicMock()
+    mock.runtime_params = MagicMock()
+    mock.runtime_params.output_dir, _ = populated_output_dir
+    return mock
+
+
+@pytest.mark.parametrize(
+    "env_value,cleared", (("1", True), ("0", False), (None, False))
+)
+def test_clear_working_directory_env_setting(
+    env_value: str | None,
+    cleared: bool,
+    mocked_bp_with_output_dir: MagicMock,
+    monkeypatch,
+    populated_output_dir: tuple[Path, list[Path]],
+):
+    """
+    Test that clear_working_dir correctly clears the working directory if CSTAR_CLOBBER_WORKING_DIR is set to 1, and
+    doesn't clear it if set to 0 or unset.
+
+    Parameters
+    ----------
+    env_value: value to set our magic env-var to
+    cleared: whether the directory should be cleared or not
+    mocked_bp_with_output_dir: mocked RomsMarblBlueprint with output_dir pointing to our tmp path
+    monkeypatch: pytest util for setting env-vars in tests
+    populated_output_dir: fixture providing tmp_path and fake files
+
+    """
+    output_dir, output_files = populated_output_dir
+    with patch(
+        "cstar.orchestration.utils.deserialize", return_value=mocked_bp_with_output_dir
+    ):
+        if env_value is not None:
+            monkeypatch.setenv("CSTAR_CLOBBER_WORKING_DIR", env_value)
+        else:
+            monkeypatch.delenv("CSTAR_CLOBBER_WORKING_DIR", raising=False)
+
+        dummy_step = MagicMock()
+        dummy_step.blueprint = "doesn't matter"
+
+        clear_working_dir(dummy_step)
+        if cleared:
+            assert all([not f.exists() for f in output_files])
+            assert all([not f.parent.exists() for f in output_files])
+
+        else:
+            assert output_dir.exists()
+            assert all([f.exists for f in output_files])


### PR DESCRIPTION
* Added function that clears problematic directories (e.g. ones that will make RomsSimulation crash if they are already populated) ahead of launching a job in slurm. As I write that, maybe we want this functionality somewhere more general, but that location is working for me for now
* Put this functionality behind an opt-in env-var. I'm going to set this in my bash profile, but probably best to not accidentally delete things for some new user. If/when we get to the point of fully owning the paths for every run, we might reconsider making it default behavior.
* Added unit test to ensure behavior respects env-var 