### PR TITLE
Update disclaimer language date to 2026

### DIFF
--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -3,4 +3,4 @@
 >
 > The [python API](https://c-star.readthedocs.io/en/latest/api.html) is not yet stable, and some aspects of the schema for the [blueprint](https://c-star.readthedocs.io/en/latest/terminology.html#term-blueprint) will likely evolve. 
 > Therefore whilst you are welcome to try out using the package, we cannot yet guarantee backwards compatibility. 
-> We expect to reach a more stable version in Q1 2025.
+> We expect to reach a more stable version in 2026.


### PR DESCRIPTION
Quick fix to outdated disclaimer language.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation