### PR TITLE
Vertical mixing fix

### DIFF
--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -422,7 +422,9 @@ class VerticalMixing(ROMSRuntimeSettingsSection):
     @classmethod
     def fill_tracers(cls, value):
         list_len = len(value)
-        if (num_missing := MIN_NUM_TRACERS - list_len) > 0:
+        if (num_missing := MIN_NUM_TRACERS - list_len) and all(
+            [v == 0 for v in value]
+        ) > 0:
             value.extend([0] * num_missing)
         return value
 

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -14,6 +14,7 @@ from pydantic import (
     ModelWrapValidatorHandler,
     TypeAdapter,
     ValidationError,
+    field_validator,
     model_serializer,
     model_validator,
 )
@@ -33,6 +34,9 @@ CUSTOM_ALIAS_LOOKUP = {
     "my_bak_mixing": "MY_bak_mixing",
     "initial_conditions": "initial",
 }
+
+MIN_NUM_TRACERS = 37
+"""Vertical mixing requires enough values for all tracers or it raises an error."""
 
 
 def _format_float(val: float) -> str:
@@ -413,6 +417,14 @@ class Forcing(ROMSRuntimeSettingsSection):
 class VerticalMixing(ROMSRuntimeSettingsSection):
     Akv_bak: float
     Akt_bak: list[float]
+
+    @field_validator("Akt_bak", mode="after")
+    @classmethod
+    def fill_tracers(cls, value):
+        list_len = len(value)
+        if (num_missing := MIN_NUM_TRACERS - list_len) > 0:
+            value.extend([0] * num_missing)
+        return value
 
 
 class MARBLBiogeochemistry(ROMSRuntimeSettingsSection):

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -420,7 +420,21 @@ class VerticalMixing(ROMSRuntimeSettingsSection):
 
     @field_validator("Akt_bak", mode="after")
     @classmethod
-    def fill_tracers(cls, value):
+    def zero_fill_tracers(cls, value: list[float]):
+        """
+        If the list of vertical mixing for tracers is all zeros, make sure it has enough zeros such that
+        ROMS can read a zero for every tracer (otherwise it will crash). If any values are non-zero, we can't
+        make any assumptions about which tracers the user is trying to assign, so don't do any modification and
+        let ROMS use it or fail as appropriate.
+
+        Parameters
+        ----------
+        value: the field value after running through initial pydantic validation
+
+        Returns
+        -------
+        modified field value
+        """
         list_len = len(value)
         if (num_missing := MIN_NUM_TRACERS - list_len) and all(
             [v == 0 for v in value]

--- a/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
+++ b/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
@@ -604,9 +604,25 @@ class TestROMSRuntimeSettings:
         with pytest.raises(ValueError, match="Required field missing from file."):
             ROMSRuntimeSettings.from_file(modified_file)
 
+    def test_from_file_fills_vertical_mixing_list(
+        self, tmp_path: Path, romsruntimesettings
+    ) -> None:
+        modified_file = tmp_path / "modified_example_settings.in"
+        shutil.copy2(
+            Path(__file__).parent / "fixtures/example_runtime_settings.in",
+            modified_file,
+        )
+        _replace_text_in_file(
+            modified_file,
+            "0.    0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.",
+            "0.    0. 0. 0.",
+        )
+        tested_settings = ROMSRuntimeSettings.from_file(modified_file)
+        assert tested_settings.vertical_mixing == romsruntimesettings.vertical_mixing
+
     def test_file_roundtrip(self, romsruntimesettings, tmp_path):
         """Tests that the `to_file`/`from_file` roundtrip results in a functionally
-        indentical ROMSRuntimeSettings instance.
+        identical ROMSRuntimeSettings instance.
 
         Mocks and Fixtures
         ------------------


### PR DESCRIPTION
When we read in the ROMS runtime settings, if the tracer vertical mixing list is all zeros but too short, pad it with more zeros. If any of the values are non-zero, don't change anything, and leave it up to the user to fix the file if they don't have enough values (which will cause ROMS to barf).

This is a convenience feature for people who are using older roms.in files, or want want to use the background vertical mixing parameter but not the tracer ones (and maybe don't put enough zeros in the list). There are a lot of smarter ways we could probably do this (checking .opt files for the real number of tracers) but this at least makes our current codebase and test files play nicely with the latest commits on main for ucla-roms.