### PR TITLE
Orchestration

### DIFF
--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -113,7 +113,7 @@ class ForcingConfiguration(ConfiguredBaseModel):
 
     corrections: Dataset | None = Field(default=None, validate_default=False)
     """Wind or other forcing corrections."""
-
+print("ForcingConfiguration") 
 
 class CodeRepository(DocLocMixin, ConfiguredBaseModel):
     """Reference to a remote code repository with optional path filtering
@@ -123,10 +123,10 @@ class CodeRepository(DocLocMixin, ConfiguredBaseModel):
     location: HttpUrl | str
     """Location of the remote code repository."""
 
-    commit: str = Field(default="", min_length=1, validate_default=False)
+    commit: str = Field(default="", validate_default=False)
     """A specific commit to be used."""
 
-    branch: str = Field(default="", min_length=1, validate_default=False)
+    branch: str = Field(default="", validate_default=False)
     """A specific branch to be used."""
 
     filter: PathFilter | None = Field(default=None, validate_default=False)

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -114,6 +114,7 @@ class ForcingConfiguration(ConfiguredBaseModel):
     corrections: Dataset | None = Field(default=None, validate_default=False)
     """Wind or other forcing corrections."""
 
+
 class CodeRepository(DocLocMixin, ConfiguredBaseModel):
     """Reference to a remote code repository with optional path filtering
     and point-in-time specification.

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -113,7 +113,6 @@ class ForcingConfiguration(ConfiguredBaseModel):
 
     corrections: Dataset | None = Field(default=None, validate_default=False)
     """Wind or other forcing corrections."""
-print("ForcingConfiguration") 
 
 class CodeRepository(DocLocMixin, ConfiguredBaseModel):
     """Reference to a remote code repository with optional path filtering


### PR DESCRIPTION
The `CodeRepository` was internally inconsistent, require either `branch` or `commit`, not both — but each also having a minimum length of 1. This PR fixes that issue.