### PR TITLE
CSD-44 Minor Hotfixes

### DIFF
--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import typer
 
 from cstar.entrypoint.worker.worker import (
+    SimulationStages,
     execute_runner,
     get_job_config,
     get_request,
@@ -20,12 +21,19 @@ def run(
     path: t.Annotated[
         Path, typer.Argument(help="The path to the blueprint to execute")
     ],
+    stage: t.Annotated[
+        list[SimulationStages] | None,
+        typer.Option(
+            help="The stages to execute. If not specified, all stages will be executed.",
+            case_sensitive=False,
+        ),
+    ] = None,
 ) -> None:
     """Execute a blueprint in a local worker service."""
     print("Executing blueprint in a worker service")
     job_cfg = get_job_config()
     service_cfg = get_service_config(logging.DEBUG)
-    request = get_request(path.as_posix())
+    request = get_request(path.as_posix(), stage)
 
     rc = asyncio.run(execute_runner(job_cfg, service_cfg, request))
 

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -24,7 +24,6 @@ from cstar.orchestration.transforms import (
 )
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS, get_run_id
 
-WorkplanTemplate: t.TypeAlias = t.Literal["single_step", "linear", "fanout", "parallel"]
 log = get_logger(__name__)
 
 

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -527,24 +527,8 @@ class ChildStep(Step):
     work_dir: Path
     """The path to the working directory of the step."""
 
+    @t.override
     def working_dir(self, bp: RomsMarblBlueprint) -> Path:
-        """The step-relative directory for writing outputs.
-
-        Precedence:
-        1. Overrides provided via a workplan always overwrite blueprint-supplied paths.
-        2. The system may override with a path from the environment variables.
-        3. The output path from the blueprint runtime parameters is used.
-
-        Parameters
-        ----------
-        bp : RomsMarblBlueprint
-            The blueprint instance loaded by the step
-
-        Returns
-        -------
-        Path
-            The path to the step working directory.
-        """
         return self.work_dir
 
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -219,7 +219,7 @@ class WorkplanTransformer:
     def derived_path(
         source: Path,
         target_dir: Path | None = None,
-        suffix: str = "_trx",
+        suffix: str = DERIVED_PATH_SUFFIX,
         extension: str | None = None,
     ) -> Path:
         """Generate a new path name derived from the source path.

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -580,10 +580,6 @@ class Simulation(ABC, LoggingMixin):
         with open(cls.state_file_from(directory), "rb") as state_file:
             simulation: Simulation = pickle.load(state_file)
 
-        # manually add fs manager because persist deletes the attribute.
-        simulation._fs_manager = simulation._get_filesystem_manager(
-            simulation.directory
-        )
         return simulation
 
     @abstractmethod


### PR DESCRIPTION
This PR mitigates some minor issues introduced in CSD-44.

Change-list:
- Remove a `TypeAlias` declaration that was relocated without removal from original location.
- Remove unnecessary block in state-file pickling
- Remove a docstring duplicating the content of a base-class method
- Use a pre-existing constant instead of a magic string
- Add a missing parameter to the _run-blueprint_ CLI command

Check list:

- [x] Tests passing
- [x] Full type hint coverage