### PR TITLE
Ensure override transform is always applied

### DIFF
--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -312,7 +312,10 @@ def test_workplan_transformation(diamond_workplan: Workplan) -> None:
 
     transformer = WorkplanTransformer(diamond_workplan, RomsMarblTimeSplitter())
     with (
-        mock.patch.dict(os.environ, {"CSTAR_FF_ORCH_TRANSFORM_AUTO": "1"}),
+        mock.patch.dict(
+            os.environ,
+            {"CSTAR_FF_ORCH_TRANSFORM_AUTO": "1", "CSTAR_FF_ORCH_TRANSFORM_OVR": "1"},
+        ),
     ):
         transformed = transformer.apply()
 


### PR DESCRIPTION
Fix bug where overrides from steps were not applied unless time-splitting was enabled

- [X] Closes #CSD-404
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
