### PR TITLE
Fix failure to include run-id in output paths when transforms are disabled

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -459,6 +459,7 @@ async def execute_runner(
     log.debug(f"Job config: {job_cfg}")
     log.debug(f"Simulation runner service config: {service_cfg}")
     log.debug(f"Simulation request: {request}")
+    log.debug(f"os.environ: {os.environ}")
 
     try:
         configure_environment(log)

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -170,14 +170,11 @@ async def prepare_workplan(
     wp_orig = await asyncio.to_thread(deserialize, wp_path, Workplan)
     run_root_dir = output_dir / run_id
 
-    if is_feature_enabled("ORCH_TRANSFORM_AUTO"):
-        transformer = WorkplanTransformer(wp_orig, RomsMarblTimeSplitter())
-        wp = transformer.apply()
+    transformer = WorkplanTransformer(wp_orig, RomsMarblTimeSplitter())
+    wp = transformer.apply()
 
-        if transformer.is_modified:
-            log.info("A time-split workplan will be executed.")
-    else:
-        wp = wp_orig
+    if transformer.is_modified:
+        log.info("A time-split workplan will be executed.")
 
     # make a copy of the original and modified blueprint in the output directory
     persist_orig = WorkplanTransformer.derived_path(

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from itertools import cycle
 from pathlib import Path
 
-from cstar.base.feature import is_feature_enabled
 from cstar.base.log import get_logger
 from cstar.base.utils import get_output_dir
 from cstar.orchestration.launch.slurm import SlurmLauncher

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from pathlib import Path
 
 from cstar.base.feature import is_feature_enabled
+from cstar.base.log import LoggingMixin
 from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME, deep_merge, slugify
 from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import (
@@ -172,7 +173,7 @@ def get_time_slices(
     return time_slices
 
 
-class WorkplanTransformer:
+class WorkplanTransformer(LoggingMixin):
     """Transform a workplan by applying transforms to its steps."""
 
     original: Workplan
@@ -282,6 +283,9 @@ class WorkplanTransformer:
                     tweak.depends_on.append(transformed_steps[-1].name)
 
                 steps.extend(transformed_steps)
+                    
+            if self.is_modified:
+                self.log.info("A time-split workplan will be returned.")
 
         if is_feature_enabled("CSTAR_FF_ORCH_TRANSFORM_OVR"):
             override_transform = OverrideTransform()

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -290,7 +290,9 @@ class WorkplanTransformer(LoggingMixin):
             overrides = step.blueprint_overrides
             if "runtime_params" not in overrides:
                 step.blueprint_overrides["runtime_params"] = {}
-            runtime_params = t.cast(dict[str, str | Path], overrides.get("runtime_params", {}))
+            runtime_params = t.cast(
+                dict[str, Path], overrides.get("runtime_params", {})
+            )
             if "output_dir" not in runtime_params:
                 runtime_params["output_dir"] = step.working_dir(bp)
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -258,6 +258,27 @@ class WorkplanTransformer(LoggingMixin):
 
         return directory / filename
 
+    def _ensure_unique_paths(self, steps: list[Step]) -> None:
+        """Modify any steps that do not include the unique run-id in their
+        output directory.
+
+        Parameters
+        ----------
+        steps : list[Step]
+            The steps to be modified.
+        """
+        # HACK: force-update the step output directories to avoid collisions
+        for step in steps:
+            bp = deserialize(step.blueprint_path, RomsMarblBlueprint)
+            overrides = step.blueprint_overrides
+            if "runtime_params" not in overrides:
+                step.blueprint_overrides["runtime_params"] = {}
+            runtime_params = t.cast(
+                dict[str, Path], overrides.get("runtime_params", {})
+            )
+            if "output_dir" not in runtime_params:
+                runtime_params["output_dir"] = step.working_dir(bp)
+
     def apply(self) -> Workplan:
         """Create a new workplan with appropriate transforms applied.
 
@@ -284,17 +305,7 @@ class WorkplanTransformer(LoggingMixin):
 
                 steps.extend(transformed_steps)
 
-        # HACK: force-update the step output directories to avoid collisions
-        for step in self.original.steps:
-            bp = deserialize(step.blueprint_path, RomsMarblBlueprint)
-            overrides = step.blueprint_overrides
-            if "runtime_params" not in overrides:
-                step.blueprint_overrides["runtime_params"] = {}
-            runtime_params = t.cast(
-                dict[str, Path], overrides.get("runtime_params", {})
-            )
-            if "output_dir" not in runtime_params:
-                runtime_params["output_dir"] = step.working_dir(bp)
+        self._ensure_unique_paths(steps)  # HACK: remove when possible
 
         if is_feature_enabled("CSTAR_FF_ORCH_TRANSFORM_OVR"):
             override_transform = OverrideTransform()


### PR DESCRIPTION
Fix a bug where the `output_dir` does not include the `run-id` unless the time-splitting transform is applied. 

- [X] Tests passing
- [X] Full type hint coverage
