### PR TITLE
Refine docs

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -202,10 +202,6 @@ CLI
 
 Use the `run` command from the `cstar CLI` to execute a blueprint.
 
-.. code-block:: console
-
-    cstar blueprint run my_blueprint.yaml
-
 
 .. tab-set::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ A key strength of C-Star lies in its ability to run regional simulations using a
     :caption: Getting Started
 
     Installing C-Star <installation>
+    configuration
 
 .. toctree::
     :maxdepth: 1
@@ -31,8 +32,7 @@ A key strength of C-Star lies in its ability to run regional simulations using a
 
     blueprints
     workplans
-    configuration
-   
+
 .. toctree::
     :maxdepth: 1
     :caption: Deployment


### PR DESCRIPTION
Two small and easy docs changes:
* move Configuration page up higher (as previously discussed)
* remove a duplicate example for `blueprint cli run`