### PR TITLE
Log automatic job cancellations

### DIFF
--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -614,6 +614,7 @@ class Orchestrator(LoggingMixin):
             cancellations = {
                 v for v in kvp.values() if v and Status.is_running(v.status)
             }
+            self.log.exception("A task has failed unexpectedly")
 
         await self._cancel(cancellations)
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -627,9 +627,13 @@ class Orchestrator(LoggingMixin):
         cancellations : Iterable[Task]
             The tasks to be cancelled.
         """
-        tasks = [asyncio.Task(self.launcher.cancel(task)) for task in cancellations]
-        results = await asyncio.gather(*tasks, return_exceptions=False)
+        cancel_requests = [
+            asyncio.Task(self.launcher.cancel(task)) for task in cancellations
+        ]
+        results = await asyncio.gather(*cancel_requests, return_exceptions=False)
         for task in results:
+            msg = f"The orchestrator requested cancellation of task: {task.step.name}"
+            self.log.warning(msg)
             self.planner.store(task.step.name, KEY_STATUS, task.status)
 
 


### PR DESCRIPTION
# Log automatic job cancellations

The orchestrator currently checks for any failed or cancelled jobs, then silently cancels any remaining jobs. This is confusing for a user reviewing logs.

## Changes

- Log at the point of task failure causing task cancellations.
- Log all task cancellations once they have been submitted to the scheduler.


## Review checklist

- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage