### PR TITLE
Fix incorrect path to joined outputs

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -145,7 +145,7 @@ class RomsFileSystemManager(JobFileSystemManager):
     @property
     def joined_output_dir(self) -> Path:
         """The directory for de-partitioned outputs."""
-        return self.root / self._JOINED_OUTPUT_NAME
+        return self.output_dir / self._JOINED_OUTPUT_NAME
 
     def codebase_subdir(self, key: str) -> Path:
         """Return a codebase subdirectory path.


### PR DESCRIPTION
# Fix incorrect path to joined outputs

This PR fixes a copypasta error resulting in the outputs from `ncjoin` being placed in the incorrect output directory.


# Changes

- Update `RomsFileSystemManager` to use `self.output_path` when calculating the joined output path

