### PR TITLE
Fix string concatenation of path segments with leading/trailing slashes

### DIFF
--- a/cstar/io/source_data.py
+++ b/cstar/io/source_data.py
@@ -405,7 +405,7 @@ class SourceDataCollection:
                 )
             case SourceClassification.LOCAL_DIRECTORY:
                 return cls.from_locations(
-                    locations=[f"{common_location}/{subdir}/{f}" for f in files]
+                    locations=[f"{Path(common_location) / subdir / f}" for f in files]
                 )
             case _:
                 raise ValueError(


### PR DESCRIPTION
# Fix path concatenation bug

The `SourceDataCollection.from_common_location` method exhibits a bug when paths passed from blueprints contain trailing slashes. 

The string concatenation results in paths with duped slashes.

## Changes

- Update the concatenation code to use `pathlib.Path` to automatically handle slashes.

## Review Checklist

- [x] Tests passing