### PR TITLE
two bug fixes

### DIFF
--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -43,7 +43,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
 
         # Compile NHMG library
         _run_cmd(
-            f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
+            f"make all COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=roms_root / "Work",
             msg_pre="Compiling NHMG library...",
             msg_err="Error when compiling ROMS' NHMG library.",

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -41,15 +41,6 @@ class ROMSExternalCodeBase(ExternalCodeBase):
             "PATH", f"{roms_root / 'Tools-Roms'}:{os.environ.get('PATH')}"
         )
 
-        # Compile NHMG library
-        _run_cmd(
-            f"make all COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=roms_root / "Work",
-            msg_pre="Compiling NHMG library...",
-            msg_err="Error when compiling ROMS' NHMG library.",
-            raise_on_error=True,
-        )
-
         # Compile Tools-Roms
         _run_cmd(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -89,7 +89,7 @@ class ROMSInputDataset(InputDataset, ABC):
                     "Cannot use hash verification with partitioned source files"
                 )
             n_source_partitions = self.source_np_xi * self.source_np_eta  # type: ignore[operator]
-            ndigits = len(str(n_source_partitions))
+            ndigits = len(str(n_source_partitions - 1))
             locations = []
             for i in range(n_source_partitions):
                 old_suffix = f".{0:0{ndigits}d}.nc"
@@ -332,7 +332,7 @@ class ROMSInputDataset(InputDataset, ABC):
         expects to see `my_grid.nc`
         """
         if self.partitioning is not None:
-            ndigits = len(str(self.partitioning.np_xi * self.partitioning.np_eta))
+            ndigits = len(str(self.partitioning.np_xi * self.partitioning.np_eta - 1))
             zero_str = "." + "0" * ndigits + ".nc"
             zero_files = [f for f in self.partitioning.files if zero_str in str(f)]
             return [Path(str(f).replace(zero_str, ".nc")) for f in zero_files]

--- a/cstar/tests/integration_tests/blueprints/blueprint_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/blueprint_template.yaml
@@ -9,7 +9,7 @@ valid_end_date: 2012-12-31 12:00:00
 code:
   roms:
     location: https://github.com/CWorthy-ocean/ucla-roms.git
-    commit: e5e3658ac42b9a19b74bd4ba11d6f6536bdae2e9
+    commit: 7864087ff12742b7890b9bbe4c96ffa8526871f8
     documentation: cworthy fork
   marbl:
     location: https://github.com/marbl-ecosys/MARBL.git

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -76,7 +76,6 @@ class TestROMSExternalCodeBaseConfigure:
         ) as mock_run_cmd:
             mock_run_cmd.side_effect = [
                 mock.Mock(returncode=0),  # first call
-                mock.Mock(returncode=0),  # second call
             ]
             recb._configure()
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -93,36 +93,6 @@ class TestROMSExternalCodeBaseConfigure:
         )
 
     @mock.patch("cstar.base.utils.subprocess.run")
-    def test_make_nhmg_failure(
-        self,
-        mock_subprocess,
-        romsexternalcodebase_staged,
-    ):
-        """Test that the _configure method raises an error when 'NHMG/make' fails."""
-        mock_subprocess.side_effect = [
-            subprocess.CompletedProcess(
-                args=["make nhmg"],
-                returncode=1,
-                stdout="",
-                stderr="Mocked ROMS Compilation Failure",
-            ),
-        ]
-        recb = romsexternalcodebase_staged
-
-        # Test
-        with (
-            pytest.raises(
-                RuntimeError,
-                match=(
-                    "Error when compiling ROMS' NHMG library. Return Code: `1`. STDERR:\n"
-                    "Mocked ROMS Compilation Failure"
-                ),
-            ),
-        ):
-            recb._configure()
-        assert mock_subprocess.call_count == 1
-
-    @mock.patch("cstar.base.utils.subprocess.run")
     def test_make_tools_failure(
         self,
         mock_subprocess,
@@ -130,9 +100,6 @@ class TestROMSExternalCodeBaseConfigure:
     ):
         """Test that the _configure method raises an error when 'Tools-Roms/make' fails."""
         mock_subprocess.side_effect = [
-            subprocess.CompletedProcess(
-                args=["make nhmg"], returncode=0, stdout="", stderr=""
-            ),
             subprocess.CompletedProcess(
                 args=["make Tools-Roms"],
                 returncode=1,
@@ -151,7 +118,7 @@ class TestROMSExternalCodeBaseConfigure:
             ),
         ):
             recb._configure()
-        assert mock_subprocess.call_count == 2
+        assert mock_subprocess.call_count == 1
 
     def test_is_configured_when_configured(
         self,

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -85,10 +85,11 @@ class TestROMSExternalCodeBaseConfigure:
             assert os.environ[recb.root_env_var] == str(recb.working_copy.path)
 
         mock_run_cmd.assert_any_call(
-            f"make nhmg COMPILER={cstar_sysmgr.environment.compiler}",
-            cwd=roms_path / "Work",
-            msg_pre="Compiling NHMG library...",
-            msg_err="Error when compiling ROMS' NHMG library.",
+            f"make COMPILER={cstar_sysmgr.environment.compiler}",
+            cwd=roms_path / "Tools-Roms",
+            msg_pre="Compiling Tools-Roms package for UCLA ROMS...",
+            msg_post="Compiled Tools-Roms",
+            msg_err="Error when compiling Tools-Roms.",
             raise_on_error=True,
         )
 


### PR DESCRIPTION
Two small bug fixes are in this PR.

1) the `make` command when building NHMG in ROMS is fixed (previous error is below)
2) when cstar looks for partitioned files, it looked for the wrong number of digits in the files if the number of partitions equaled to 10^x (for x>=1). (previous error also below)

**Previous error for `make`:**
<img width="1640" height="1696" alt="image" src="https://github.com/user-attachments/assets/8cb2f14b-7ce8-40d8-ab91-9331105f8472" />

**Previous error for handling partitioned files:**
<img width="964" height="950" alt="image" src="https://github.com/user-attachments/assets/d7bdfe5f-0bb9-4fe4-bd5d-b44a6126cb8c" />


- [ ] Closes #xxxx
- [x] Tests passing
- [ ] Changes are documented in `docs/releases.rst`