### PR TITLE
Consolidate dev dependencies in `pyproject.toml`

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-      - name: Install specific pre-commit version
-        run: pip install pre-commit==3.8.0
+      - uses: actions/setup-python@v5
+      - name: Install package and development dependencies
+        run: pip install .[dev]
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
         name: mypy
         entry: mypy
         language: system
+        types: [python]
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        additional_dependencies: [
-          "types-requests",
-          "types-python-dateutil",
-          "types-PyYAML",
-          "types-pytz",
-          "pydantic",
-        ]        
+        additional_dependencies: []        
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,12 @@ repos:
         args: ["--fix"]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies: []        
+        name: mypy
+        entry: mypy
+        language: system
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -147,7 +147,7 @@ class CStarEnvironment:
         expanded_vars = {}
         for key, value in env_vars.items():
             # Use os.path.expandvars to expand ${VAR} and $VAR syntax
-            expanded_value = os.path.expandvars(value)
+            expanded_value = os.path.expandvars(value) if value else ""
             expanded_vars[key] = expanded_value
 
         os.environ.update(expanded_vars)

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import pytest
 
-import cstar
 from cstar.roms.simulation import ROMSSimulation
 from cstar.tests.integration_tests.config import TEST_CONFIG
 
@@ -53,8 +52,8 @@ class TestCStar:
             mock.patch(
                 "cstar.system.environment.CStarEnvironment.lmod_path", mock_lmod_path
             ),
-            mock.patch.object(
-                cstar.system.environment.CStarEnvironment, "package_root", new=ext_root
+            mock.patch(
+                "cstar.system.environment.CStarEnvironment.package_root", new=ext_root
             ),
         ):
             if "local" in test_config_key:

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -69,7 +69,7 @@ class TestMARBLExternalCodeBaseConfigure:
         """Test that the _configure method succeeds when subprocess calls succeed."""
         mecb = marblexternalcodebase_staged
         # marbl_path = tmp_path
-        with mock.patch.object(MARBLExternalCodeBase, "_run_cmd") as mock_run_cmd:
+        with mock.patch("cstar.marbl.external_codebase._run_cmd") as mock_run_cmd:
             mock_run_cmd.return_value.returncode = 0
             mecb._configure()
 

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -5,7 +5,6 @@ import unittest.mock as mock
 
 import pytest
 
-import cstar
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 
@@ -70,9 +69,7 @@ class TestMARBLExternalCodeBaseConfigure:
         """Test that the _configure method succeeds when subprocess calls succeed."""
         mecb = marblexternalcodebase_staged
         # marbl_path = tmp_path
-        with mock.patch.object(
-            cstar.marbl.external_codebase, "_run_cmd"
-        ) as mock_run_cmd:
+        with mock.patch.object(MARBLExternalCodeBase, "_run_cmd") as mock_run_cmd:
             mock_run_cmd.return_value.returncode = 0
             mecb._configure()
 

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -5,7 +5,6 @@ import unittest.mock as mock
 
 import pytest
 
-import cstar
 from cstar.roms.external_codebase import ROMSExternalCodeBase
 from cstar.system.manager import cstar_sysmgr
 
@@ -71,9 +70,7 @@ class TestROMSExternalCodeBaseConfigure:
     ):
         """Test that the _configure method succeeds when subprocess calls succeed."""
         recb = romsexternalcodebase_staged
-        with mock.patch.object(
-            cstar.roms.external_codebase, "_run_cmd"
-        ) as mock_run_cmd:
+        with mock.patch.object(ROMSExternalCodeBase, "_run_cmd") as mock_run_cmd:
             mock_run_cmd.side_effect = [
                 mock.Mock(returncode=0),  # first call
                 mock.Mock(returncode=0),  # second call

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -70,7 +70,7 @@ class TestROMSExternalCodeBaseConfigure:
     ):
         """Test that the _configure method succeeds when subprocess calls succeed."""
         recb = romsexternalcodebase_staged
-        with mock.patch.object(ROMSExternalCodeBase, "_run_cmd") as mock_run_cmd:
+        with mock.patch("cstar.roms.external_codebase._run_cmd") as mock_run_cmd:
             mock_run_cmd.side_effect = [
                 mock.Mock(returncode=0),  # first call
                 mock.Mock(returncode=0),  # second call

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -6,11 +6,10 @@ from unittest.mock import Mock, PropertyMock, call, mock_open, patch
 
 import pytest
 
-import cstar
 from cstar.system.environment import CStarEnvironment
 
 
-class MockEnvironment(cstar.system.environment.CStarEnvironment):
+class MockEnvironment(CStarEnvironment):
     def __init__(
         self,
         system_name="mock_system",
@@ -41,7 +40,7 @@ class TestSetupEnvironmentFromFiles:
     @pytest.mark.parametrize("lmod_syshost", ["perlmutter", "derecho", "expanse"])
     @patch("cstar.base.utils.subprocess.run")
     @patch.object(
-        cstar.system.environment.CStarEnvironment,
+        CStarEnvironment,
         "uses_lmod",
         new_callable=PropertyMock,
         return_value=True,
@@ -152,9 +151,7 @@ class TestSetupEnvironmentFromFiles:
 
         # Patch the root path and expanduser to point to our temporary files
         with (
-            patch.object(
-                cstar.system.environment.CStarEnvironment, "package_root", new=tmp_path
-            ),
+            patch.object(CStarEnvironment, "package_root", new=tmp_path),
         ):
             # Instantiate the environment to trigger loading the environment variables
             env = MockEnvironment()

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -225,7 +225,7 @@ class TestScheduler:
         )
 
     def test_slurmscheduler_global_max_cpus_per_node_failure(
-        self, mock_subprocess_run, caplog: pytest.CaptureFixture
+        self, mock_subprocess_run, caplog: pytest.LogCaptureFixture
     ):
         """Validate SlurmScheduler handles subprocess failures when querying CPUs.
 
@@ -278,7 +278,7 @@ class TestScheduler:
         )
 
     def test_slurmscheduler_global_max_mem_per_node_gb_failure(
-        self, mock_subprocess_run, caplog: pytest.CaptureFixture
+        self, mock_subprocess_run, caplog: pytest.LogCaptureFixture
     ):
         """Validate SlurmScheduler handles subprocess failures when querying memory.
 
@@ -328,7 +328,7 @@ class TestScheduler:
         )
 
     def test_pbsscheduler_global_max_cpus_per_node_failure(
-        self, mock_subprocess_run, caplog: pytest.CaptureFixture
+        self, mock_subprocess_run, caplog: pytest.LogCaptureFixture
     ):
         """Validate PBSScheduler handles subprocess failures when querying CPUs.
 
@@ -360,7 +360,7 @@ class TestScheduler:
         assert "STDERR:\nError querying CPUs" in captured
 
     def test_pbsscheduler_global_max_mem_per_node_gb_failure(
-        self, mock_subprocess_run, caplog: pytest.CaptureFixture
+        self, mock_subprocess_run, caplog: pytest.LogCaptureFixture
     ):
         """Validate PBSScheduler handles subprocess failures when querying memory.
 

--- a/examples/cstar_example.py
+++ b/examples/cstar_example.py
@@ -6,11 +6,8 @@ For more details, see ../README.md or cstar_example_notebook.ipynb
 import cstar
 import os
 
-roms_marbl_case = cstar.Case.from_blueprint(
+roms_marbl_case = cstar.Simulation.from_blueprint(
     blueprint="cstar_blueprint_yaml_test.yaml",
-    caseroot="roms_marbl_example_case/",
-    start_date="20120103 12:00:00",
-    end_date="20120103 18:00:00",
 )
 
 ## In a python session, execute:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 [project.optional-dependencies]
 dev = [
     "coverage>=7.13",
-    "isort>=7.0.0",
     "mypy>=1.16.1",
     "pre-commit==3.8.0",
     "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,16 @@ keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 [project.optional-dependencies]
 dev = [
     "coverage>=7.13",
+    "isort>=7.0.0",
+    "mypy>=1.16.1",
     "pre-commit==3.8.0",
-    "ruff",
+    "ruff>=0.12.2",
     "pytest>=7.0",
     "pytest-asyncio>=1.3.0",
+    "types-python-dateutil>=2.9.0",
+    "types-pytz>=2025.2.0",
+    "types-PyYAML>=6.0.12",
+    "types-requests>2.32.4",
 ]
 docs = [
     "nbsphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "pooch>=1.8.1",
     "prefect>=3.6.1",
     "pydantic>=2.12",
     "python-dateutil>=2.8.2",
@@ -42,6 +41,7 @@ keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 dev = [
     "coverage>=7.13",
     "mypy>=1.16.1",
+    "pooch>=1.8.1",
     "pre-commit==3.8.0",
     "pytest>=7.0",
     "pytest-asyncio>=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "python-dateutil>=2.8.2",
-    "python-dotenv",
-    "PyYAML==6.0.2",
-    "pydantic>=2.12",
-    "pytimeparse>=1.1.8",
     "pooch>=1.8.1",
     "prefect>=3.6.1",
+    "pydantic>=2.12",
+    "python-dateutil>=2.8.2",
+    "pytimeparse>=1.1.8",
+    "python-dotenv",
+    "PyYAML==6.0.2",
     "roms_tools[dask]>=3.4.0,<4",
     "typer>=0.17.5",
 ]
@@ -44,9 +44,9 @@ dev = [
     "isort>=7.0.0",
     "mypy>=1.16.1",
     "pre-commit==3.8.0",
-    "ruff>=0.12.2",
     "pytest>=7.0",
     "pytest-asyncio>=1.3.0",
+    "ruff>=0.12.2",
     "types-python-dateutil>=2.9.0",
     "types-pytz>=2025.2.0",
     "types-PyYAML>=6.0.12",


### PR DESCRIPTION
# Consolidate dev dependencies in `pyproject.toml`

This PR moves additional dependencies used by `pre-commit` into the 'dev' optional dependency group in `pyproject.toml`, with the following goals:

- ensure that `pyproject.toml` is the single source of truth for project wide dependency management.
- ensure that developers do not need to manually install type stubs for full IDE support
- enables manual execution of `mypy` without invoking pre-commit

## Change list

1. Move additional dependencies from `.pre-commit-config.yaml` into `pyproject.toml`
2. Alphabetize depdendencies in `pyproject.toml`
3. Update github action to use local dependencies
4. Mitigate previously existing minor typing issues

## Check list:

- [x] Tests passing