### PR TITLE
Reduce magic string usage

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -44,6 +44,47 @@ DEFAULT_STATE_HOME: t.Final[str] = "~/.local/state"
 SCRATCH_DIRS: t.Final[list[str]] = ["SCRATCH", "SCRATCH_DIR", "LOCAL_SCRATCH"]
 """Common env var names identifying scratch paths on HPC systems, in order of precedence."""
 
+ENV_CSTAR_OUTDIR: t.Literal["CSTAR_OUTDIR"] = "CSTAR_OUTDIR"
+"""Environment variable containing a path to the root output directory."""
+
+ENV_FF_ORCH_TRX_TIMESPLIT: t.Final[str] = "CSTAR_FF_ORCH_TRX_TIMESPLIT"
+"""Enable automatic time-splitting of simulations."""
+
+ENV_FF_ORCH_TRX_OVERRIDE: t.Final[str] = "CSTAR_FF_ORCH_TRX_OVERRIDE"
+"""Enable automatic overrides to blueprints contained in a workplan."""
+
+ENV_FF_CLI_ENV_SHOW: t.Final[str] = "CSTAR_FF_CLI_ENV_SHOW"
+"""Enable CLI for displaying environment configuration."""
+
+ENV_FF_CLI_TEMPLATE_CREATE: t.Final[str] = "CSTAR_FF_CLI_TEMPLATE_CREATE"
+"""Enable CLI for creating blueprints and workplans from standard templates."""
+
+ENV_FF_CLI_WORKPLAN_GEN: t.Final[str] = "CSTAR_FF_CLI_WORKPLAN_GEN"
+"""Enable CLI for generating a workplan from a directory of blueprints."""
+
+ENV_FF_CLI_WORKPLAN_PLAN: t.Final[str] = "CSTAR_FF_CLI_WORKPLAN_PLAN"
+"""Enable CLI for generating the execution plan of a workplan."""
+
+ENV_FF_CLI_WORKPLAN_STATUS: t.Final[str] = "CSTAR_FF_CLI_WORKPLAN_STATUS"
+"""Enable CLI for retrieving status about a workplan run."""
+
+ENV_FF_CLI_WORKPLAN_COMPOSE: t.Final[str] = "CSTAR_FF_CLI_WORKPLAN_COMPOSE"
+"""Enable CLI for composing a workplan from pre-existing blueprints."""
+
+
+def get_ff_descriptions() -> dict[str, str]:
+    """Return user-friendly mapping of key-to-decription for all available feature flags."""
+    return {
+        ENV_FF_ORCH_TRX_TIMESPLIT: "Enable automatic time-splitting of simulations.",
+        ENV_FF_ORCH_TRX_OVERRIDE: "Enable automatic overrides to blueprints contained in a workplan.",
+        ENV_FF_CLI_ENV_SHOW: "Enable CLI for displaying environment configuration.",
+        ENV_FF_CLI_TEMPLATE_CREATE: "Enable CLI for creating blueprints and workplans from standard templates.",
+        ENV_FF_CLI_WORKPLAN_GEN: "Enable CLI for generating a workplan from a directory of blueprints.",
+        ENV_FF_CLI_WORKPLAN_PLAN: "Enable CLI for generating the execution plan of a workplan.",
+        ENV_FF_CLI_WORKPLAN_STATUS: "Enable CLI for retrieving status about a workplan run.",
+        ENV_FF_CLI_WORKPLAN_COMPOSE: "Enable CLI for composing a workplan from pre-existing blueprints.",
+    }
+
 
 def coerce_datetime(datetime: str | dt.datetime) -> dt.datetime:
     """Coerces datetime-like input to a datetime instance.

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -44,12 +44,6 @@ DEFAULT_STATE_HOME: t.Final[str] = "~/.local/state"
 SCRATCH_DIRS: t.Final[list[str]] = ["SCRATCH", "SCRATCH_DIR", "LOCAL_SCRATCH"]
 """Common env var names identifying scratch paths on HPC systems, in order of precedence."""
 
-ENV_CSTAR_OUTDIR: t.Literal["CSTAR_OUTDIR"] = "CSTAR_OUTDIR"
-"""Environment variable containing a path to the root output directory (user override)."""
-
-ENV_CSTAR_CACHEDIR: t.Literal["CSTAR_CACHEDIR"] = "CSTAR_CACHEDIR"
-"""Environment variable containing a path to the asset cache directory (user override)."""
-
 
 def coerce_datetime(datetime: str | dt.datetime) -> dt.datetime:
     """Coerces datetime-like input to a datetime instance.

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 import typing as t
 from abc import ABC
 from copy import deepcopy
@@ -26,7 +25,7 @@ from pytimeparse import parse
 
 from cstar.base.utils import slugify
 from cstar.execution.file_system import DirectoryManager, RomsFileSystemManager
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_RUNID
+from cstar.orchestration.utils import get_run_id
 
 RequiredString: t.TypeAlias = t.Annotated[
     str,
@@ -503,7 +502,7 @@ class Step(BaseModel):
         # TODO: consider removing this completely and ONLY storing relative paths
         out_dir = DirectoryManager.state_home()
 
-        run_dir = os.environ[ENV_CSTAR_ORCH_RUNID]
+        run_dir = get_run_id()
         step_dir = self.safe_name
         return Path(out_dir) / run_dir / step_dir
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 from cstar.base.feature import is_feature_enabled
 from cstar.base.log import LoggingMixin
-from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME, deep_merge, slugify
+from cstar.base.utils import (
+    DEFAULT_OUTPUT_ROOT_NAME,
+    ENV_FF_ORCH_TRX_OVERRIDE,
+    ENV_FF_ORCH_TRX_TIMESPLIT,
+    deep_merge,
+    slugify,
+)
 from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import (
     Application,
@@ -291,7 +297,7 @@ class WorkplanTransformer(LoggingMixin):
 
         steps = list(self.original.steps)
 
-        if is_feature_enabled("CSTAR_FF_ORCH_TRANSFORM_AUTO"):
+        if is_feature_enabled(ENV_FF_ORCH_TRX_TIMESPLIT):
             steps = []
 
             for step in self.original.steps:
@@ -307,7 +313,7 @@ class WorkplanTransformer(LoggingMixin):
 
         self._ensure_unique_paths(steps)  # HACK: remove when possible
 
-        if is_feature_enabled("CSTAR_FF_ORCH_TRANSFORM_OVR"):
+        if is_feature_enabled(ENV_FF_ORCH_TRX_OVERRIDE):
             override_transform = OverrideTransform()
 
             for i, step in enumerate(steps):

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -5,14 +5,15 @@ from unittest import mock
 
 import pytest
 
-from cstar.base.utils import ENV_CSTAR_STATE_HOME
+from cstar.base.feature import FF_ON
+from cstar.base.utils import ENV_CSTAR_STATE_HOME, ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.cli.workplan.compose import WorkplanTemplate, compose
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.dag_runner import build_and_run_dag, prepare_workplan
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Workplan
 from cstar.orchestration.orchestration import check_environment, configure_environment
 from cstar.orchestration.serialization import deserialize, serialize
-from cstar.orchestration.transforms import WorkplanTransformer
+from cstar.orchestration.transforms import SplitFrequency, WorkplanTransformer
 from cstar.orchestration.utils import (
     ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
     ENV_CSTAR_ORCH_RUNID,
@@ -249,8 +250,8 @@ async def test_prepare_composed_dag(
         ENV_CSTAR_SLURM_ACCOUNT: "xyz",
         ENV_CSTAR_SLURM_QUEUE: "wholenode",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:5:00",
-        "CSTAR_FF_ORCH_TRANSFORM_AUTO": "1",
-        ENV_CSTAR_ORCH_TRX_FREQ: "monthly",
+        ENV_FF_ORCH_TRX_TIMESPLIT: FF_ON,
+        ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
     }
 
     def _raise_ex(*args, **kwargs):
@@ -326,8 +327,8 @@ async def test_run_composed_dag(
         ENV_CSTAR_SLURM_ACCOUNT: "ees250129",
         ENV_CSTAR_SLURM_QUEUE: "wholenode",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:5:00",
-        "CSTAR_FF_ORCH_TRANSFORM_AUTO": "1",
-        ENV_CSTAR_ORCH_TRX_FREQ: "monthly",
+        ENV_FF_ORCH_TRX_TIMESPLIT: FF_ON,
+        ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
         ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
     }
 

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+import uuid
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -7,6 +8,8 @@ from unittest import mock
 import networkx as nx
 import pytest
 
+from cstar.base.feature import FF_ON
+from cstar.base.utils import ENV_FF_ORCH_TRX_OVERRIDE, ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 from cstar.orchestration.orchestration import (
@@ -23,6 +26,7 @@ from cstar.orchestration.transforms import (
     WorkplanTransformer,
     get_time_slices,
 )
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_RUNID
 
 
 @pytest.fixture
@@ -315,9 +319,9 @@ def test_workplan_transformation(diamond_workplan: Workplan) -> None:
         mock.patch.dict(
             os.environ,
             {
-                "CSTAR_RUNID": "12345",
-                "CSTAR_FF_ORCH_TRANSFORM_AUTO": "1",
-                "CSTAR_FF_ORCH_TRANSFORM_OVR": "1",
+                ENV_CSTAR_ORCH_RUNID: str(uuid.uuid4()),
+                ENV_FF_ORCH_TRX_TIMESPLIT: FF_ON,
+                ENV_FF_ORCH_TRX_OVERRIDE: FF_ON,
             },
         ),
     ):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,7 +132,12 @@ Feature flags enable unsupported, experimental features in C-Star. They are subj
 |                              |                       | `cstar workplan       |
 |                              |                       | status` command.      |
 +------------------------------+-----------------------+-----------------------+
-| CSTAR_FF_ORCH_TRANSFORM_AUTO | 0                     | If 1, enable the      |
+| CSTAR_FF_ORCH_TRX_OVERRIDE   | 0                     | If 1, enable auto-    |
+|                              |                       | matic overrides to    |
+|                              |                       | blueprints contained  |
+|                              |                       | in a workplan.        |
++------------------------------+-----------------------+-----------------------+
+| CSTAR_FF_ORCH_TRX_TIMESPLIT  | 0                     | If 1, enable the      |
 |                              |                       | time-splitting of     |
 |                              |                       | simulations when run  |
 |                              |                       | by the orchestrator.  |

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -38,6 +38,7 @@ Improvements
 - Avoid automatic failures by retrying failed git clone operations
 - Add informational logging when tasks fail and additional tasks are cancelled
 - Update default log format to include file name and line number
+- Add constants for the set of available feature flags
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Reduce Magic String Usage

This PR reduces usage of magic strings by using or creating additional constants. I was inspired by the need to update the `configuration.rst` docs and am moving toward being able to generate this automatically.

## Change list

1. Create constants for feature flags
2. Use FF constants where hardcoded strings were previously used

## Review Checklist

- [X] Tests passing
- [X] Full type hint coverage