### PR TITLE
Blueprint, rsync updates, silence omp warning

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - netCDF4
   - pip
   - ipykernel
+  - rsync
   # only needed for building docs
   - pandoc

--- a/cstar/__init__.py
+++ b/cstar/__init__.py
@@ -2,7 +2,13 @@
 # Build module environment at import time
 # NOTE: need to set ROMS_ROOT,MARBL_ROOT,CSTAR_ROOT,CSTAR_SYSTEM, and maybe modify PATH on conda install
 
+import os
 from importlib.metadata import version as _version
+
+# silence numba-based OMP warning:
+# OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.
+# see https://github.com/numba/numba/issues/5275
+os.environ["KMP_WARNINGS"] = "off"
 
 from cstar.simulation import Simulation
 

--- a/cstar/tests/integration_tests/blueprints/blueprint_complete.yaml
+++ b/cstar/tests/integration_tests/blueprints/blueprint_complete.yaml
@@ -1,5 +1,5 @@
-name: roms_marbl_example_new_bp
-description: this is to test the new blueprint schema, here's "a few" weird characters.
+name: roms_marbl_example_wales_new_bp
+description: toy domain near wales, for fast laptop/CI runs
 application: roms_marbl
 state: draft
 valid_start_date: 2012-01-01 00:00:00
@@ -24,12 +24,12 @@ code:
         - marbl_in
         - marbl_tracer_output_list
         - marbl_diagnostic_output_list
-      directory: roms_runtime_code
+      directory: wales-toy-domain/roms_runtime_code
   compile_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
     branch: main
     filter:
-      directory: roms_compile_time_code
+      directory: wales-toy-domain/roms_compile_time_code
       files:
       - bgc.opt
       - bulk_frc.opt
@@ -44,33 +44,33 @@ code:
 grid:
   documentation: my favorite grid
   data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_grd.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_grd.nc
       hash: 41397c80fd00536dc414f6b8039b08fbe5d9f234aec66c3fc9b5a8e13353502a
 
 
 initial_conditions:
   data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_ini.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_ini.nc
       hash: c8eda3bab223d8f247055da5afe6a69234833733c75cba7dc6b5a85b06263d52
 
 forcing:
   tidal:
     data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_tides.nc
+      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_tides.nc
         hash: 9466a6cacf33f3b3cbfaa87044c70cc8ef12e963f42ce3e72e30b564541afef1
   surface:
     documentation: best forcing ever
     locked: true
     data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_frc.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_frc.nc
       hash: b9d1884c5175c8e690ad372d0585583ccaa04baa35bb1e8f3c0d2f2b37666829
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_frc_bgc.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_frc_bgc.nc
       hash: f78fce51e2178adcd128ea8d92bf091a450e4245dcb023027faae8e2d3963e72
   boundary:
     data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_bry.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry.nc
       hash: 3b51a46b1bd50d8a0e7c7f96c7b153c9d2c7fb26a8e9d97ce957d43210944909
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/netcdf_inputs/input_datasets_netcdf/roms_bry_bgc.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry_bgc.nc
       hash: 366af33acf309c7644fab8f7bd5385c99123634c82d5c15f09d2033ec7103a6e
 
 partitioning:

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -29,6 +29,7 @@ Bug Fixes
 
 - Fix path concatenation bug resulting in invalid source data paths
 - Fix indentation creating an unreachable code block in git utils
+- Add conda installation of rsync to environment.yml (fixes bug related to a flag used in newer ucla-roms makefiles that is not available in MacOS's default rsync installation)
 
 Improvements
 ~~~~~~~~~~~~
@@ -41,6 +42,8 @@ Miscellaneous
 ~~~~~~~~~~~~~
 
 - Additional details added in docstrings
+- Silence OMP warning originating from numba
+- Modify a blueprint in the tests directory for a refactored layout in the remote data repository
 
 ---
 


### PR DESCRIPTION
A few small updates:
- Silence OMP warning originating from numba
- Modify a blueprint in the tests directory for a refactored layout in the remote data repository
- Add conda installation of rsync to environment.yml (fixes bug related to a flag used in newer ucla-roms makefiles that is not available in MacOS's default rsync installation)

- [x] Tests passing
- [x] Changes are documented in `docs/releases.rst`