### PR TITLE
Enable execution of local runner with non-test application mapping

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -31,7 +31,7 @@ class EnvItem(EnvVar):
 
     @property
     def value(self) -> str:
-        if env_value := os.getenv(self.name, ""):
+        if (env_value := os.getenv(self.name)) is not None:
             return env_value
 
         if self.default_factory and (factory_default := self.default_factory(self)):

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -90,22 +90,25 @@ def get_env_item(var_name: str, prefix: str = "ENV_") -> EnvItem:
     env_item: EnvItem
         The metadata associated with the environment variable
     """
-    hints = t.get_type_hints(sys.modules[__name__], include_extras=True)
-
+    constant_mods = [__name__, "cstar.orchestration.utils", "cstar.base.feature"]
     constant_name = f"{prefix}{var_name}"
-    if hint := hints.get(constant_name, None):
-        metadata = getattr(hint, "__metadata__", None)
-        if not metadata:
-            return EnvItem(
-                description="unknown",
-                group=_GROUP_UNK,
-                default="unknown",
-                name=var_name,
-            )
 
-        meta = metadata[0]
-        if isinstance(meta, EnvVar):
-            return EnvItem.from_env_var(meta, var_name)
+    for module_name in constant_mods:
+        hints = t.get_type_hints(sys.modules[module_name], include_extras=True)
+
+        if hint := hints.get(constant_name, None):
+            metadata = getattr(hint, "__metadata__", None)
+            if not metadata:
+                return EnvItem(
+                    description="unknown",
+                    group=_GROUP_UNK,
+                    default="unknown",
+                    name=var_name,
+                )
+
+            meta = metadata[0]
+            if isinstance(meta, EnvVar):
+                return EnvItem.from_env_var(meta, var_name)
 
     msg = f"No environment variable metadata found for: {constant_name}"
     raise ValueError(msg)

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -4,12 +4,14 @@ import hashlib
 import re
 import subprocess
 import typing as t
-from os import PathLike
 from pathlib import Path
 
 import dateutil
 
 from cstar.base.log import get_logger
+
+if t.TYPE_CHECKING:
+    from os import PathLike
 
 log = get_logger(__name__)
 

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -200,18 +200,22 @@ class JobFileSystemManager(LoggingMixin):
 
     def clear(self) -> None:
         """Ensure the job's working directories are empty."""
-        if self.root.exists():
-            self.log.debug(f"Emptying working directories for job `{self.root.name}`")
+        if not self.root.exists():
+            return
 
-            for directory in [
-                self.input_dir,
-                self.work_dir,
-                self.tasks_dir,
-                self.logs_dir,
-                self.output_dir,
-            ]:
+        msg = f"Emptying working directories for job `{self.root.name}`"
+        self.log.debug(msg)
+
+        for directory in [
+            self.input_dir,
+            self.work_dir,
+            self.tasks_dir,
+            self.logs_dir,
+            self.output_dir,
+        ]:
+            if directory.exists():
                 shutil.rmtree(directory)
-                directory.mkdir(parents=True)
+            directory.mkdir(parents=True)
 
     def __getstate__(self) -> dict[str, str]:
         """Return the state of the object."""
@@ -284,10 +288,14 @@ class RomsFileSystemManager(JobFileSystemManager):
 
     def clear(self) -> None:
         """Ensure the job's working directories are empty."""
-        if self.root.exists():
-            self.log.warning(f"Clearing existing job directory: {self.root}")
-            super().clear()
+        super().clear()
 
-            for directory in [self.joined_output_dir]:
+        for directory in [
+            self.compile_time_code_dir,
+            self.runtime_code_dir,
+            self.input_datasets_dir,
+            self._codebases_dir,
+            self.joined_output_dir,
+        ]:
+            if directory.exists():
                 shutil.rmtree(directory)
-                directory.mkdir(parents=True)

--- a/cstar/io/retriever.py
+++ b/cstar/io/retriever.py
@@ -77,9 +77,8 @@ class Retriever(ABC, LoggingMixin):
         """
         if target_dir.exists():
             if not target_dir.is_dir():
-                raise ValueError(
-                    f"Cannot save to target_dir={target_dir} (not a directory)"
-                )
+                msg = f"Cannot save to target_dir={target_dir} (not a directory)"
+                raise ValueError(msg)
         else:
             target_dir.mkdir(parents=True)
 

--- a/cstar/io/retriever.py
+++ b/cstar/io/retriever.py
@@ -83,9 +83,11 @@ class Retriever(ABC, LoggingMixin):
         else:
             target_dir.mkdir(parents=True)
 
-        self.log.debug(f"Saving source `{self.source}` to: {target_dir}")
-        savepath = self._save(target_dir=target_dir)
-        return savepath
+        loc, has = self.source.location, self.source.checkout_hash
+        msg = f"Saving source `{loc}{f'@{has}' if has else ''}` to `{target_dir}`"
+        self.log.debug(msg)
+
+        return self._save(target_dir=target_dir)
 
     @abstractmethod
     def _save(self, target_dir: Path) -> Path:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -1,0 +1,117 @@
+import os
+import random
+import sys
+import textwrap
+import typing as t
+from collections import defaultdict
+from pathlib import Path
+
+from cstar.base.log import get_logger
+from cstar.orchestration.models import Application, Step
+from cstar.orchestration.orchestration import Launcher
+from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
+
+log = get_logger(__name__)
+
+StepToCommandConversionFn: t.TypeAlias = t.Callable[[Step], str]
+"""Convert a `Step` into a command to be executed.
+
+Parameters
+----------
+step : Step
+    The step to be converted.
+
+Returns
+-------
+str
+    The complete CLI command.
+"""
+
+
+def convert_roms_step_to_command(step: Step) -> str:
+    """Convert a `Step` into a command to be executed.
+
+    This function converts ROMS/ROMS-MARBL applications into a command triggering
+    a C-Star worker to run a simulation.
+
+    Parameters
+    ----------
+    step : Step
+        The step to be converted.
+
+    Returns
+    -------
+    str
+        The complete CLI command.
+    """
+    bp_path = Path(step.blueprint_path).as_posix()
+    return f"{sys.executable} -m cstar.entrypoint.worker.worker -b {bp_path}"
+
+
+def convert_step_to_placeholder(step: Step) -> str:
+    """Convert a `Step` into a command to be executed.
+
+    This function converts applications into mocks by starting a process that
+    executes a blocking sleep.
+
+    Parameters
+    ----------
+    step : Step
+        The step to be converted.
+
+    Returns
+    -------
+    str
+        The complete CLI command.
+    """
+    sleep_time = random.randint(1, 10)
+    return textwrap.dedent(f"""\
+        # this is a mock application script that produces verifiable output
+        echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";
+        sleep {sleep_time};
+        echo "{step.name} completed at $(date "+%Y-%m-%d %H:%M:%S")";
+        """)
+
+
+app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
+    Application.ROMS_MARBL.value: convert_roms_step_to_command,
+    "sleep": convert_step_to_placeholder,
+}
+"""Map application types to a function that converts a step to a CLI command."""
+
+launcher_aware_app_to_cmd_map: dict[
+    type[Launcher],
+    dict[str, StepToCommandConversionFn],
+] = defaultdict(
+    lambda: {
+        Application.SLEEP.value: convert_step_to_placeholder,
+        Application.ROMS_MARBL.value: convert_roms_step_to_command,
+    },
+)
+
+
+def register_command_mapping(
+    application: Application,
+    launcher: type[Launcher],
+    mapping_func: StepToCommandConversionFn,
+) -> None:
+    launcher_map = launcher_aware_app_to_cmd_map[launcher]
+    launcher_map[application] = mapping_func
+
+
+def get_command_mapping(
+    application: Application,
+    launcher: type[Launcher],
+) -> StepToCommandConversionFn:
+    launcher_map = launcher_aware_app_to_cmd_map[launcher]
+    step_converter = launcher_map[application.value]
+
+    if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
+        converter = app_to_cmd_map[converter_override]
+        msg = f"Overriding step converter `{step_converter}` with `{converter}` for `{application}` commands."
+        step_converter = converter
+    else:
+        msg = f"Using `{step_converter}` for `{application}` commands."
+
+    log.debug(msg)
+    return step_converter

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -73,12 +73,6 @@ def convert_step_to_placeholder(step: Step) -> str:
         """)
 
 
-app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
-    Application.ROMS_MARBL.value: convert_roms_step_to_command,
-    "sleep": convert_step_to_placeholder,
-}
-"""Map application types to a function that converts a step to a CLI command."""
-
 launcher_aware_app_to_cmd_map: dict[
     type[Launcher],
     dict[str, StepToCommandConversionFn],
@@ -88,6 +82,7 @@ launcher_aware_app_to_cmd_map: dict[
         Application.ROMS_MARBL.value: convert_roms_step_to_command,
     },
 )
+"""Map application types to a function that converts a step to a CLI command."""
 
 
 def register_command_mapping(
@@ -107,7 +102,11 @@ def get_command_mapping(
     step_converter = launcher_map[application.value]
 
     if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
-        converter = app_to_cmd_map[converter_override]
+        if converter_override not in launcher_map:
+            msg = f"Override in env var `{ENV_CSTAR_CMD_CONVERTER_OVERRIDE}` has invalid value: {converter_override}"
+            raise ValueError(msg)
+
+        converter = launcher_map[converter_override]
         msg = f"Overriding step converter `{step_converter}` with `{converter}` for `{application}` commands."
         step_converter = converter
     else:

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -11,6 +11,7 @@ from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import (
+    Launcher,
     Orchestrator,
     Planner,
     RunMode,
@@ -215,6 +216,7 @@ async def build_and_run_dag(
     configure_environment(output_dir, run_id)
     output_dir = DirectoryManager.data_home()
 
+    launcher: Launcher | None = None
     if cstar_sysmgr.scheduler:
         launcher = SlurmLauncher()
     else:

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from cstar.base.log import get_logger
 from cstar.execution.file_system import DirectoryManager
+from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import (
@@ -21,7 +22,8 @@ from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
     WorkplanTransformer,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS, get_run_id
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS
+from cstar.system.manager import cstar_sysmgr
 
 log = get_logger(__name__)
 
@@ -211,15 +213,12 @@ async def build_and_run_dag(
         were applied.
     """
     configure_environment(output_dir, run_id)
-    run_id = get_run_id()
     output_dir = DirectoryManager.data_home()
     check_environment()
     wp, wp_path = await prepare_workplan(wp_path, output_dir, run_id)
 
     planner = Planner(workplan=wp)
-    # from cstar.orchestration.launch.local import LocalLauncher
-    # launcher: Launcher = LocalLauncher()
-    launcher = SlurmLauncher()
+    launcher = SlurmLauncher() if cstar_sysmgr.scheduler else LocalLauncher()
     orchestrator = Orchestrator(planner, launcher)
 
     # schedule the tasks without waiting for completion

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import random
 from multiprocessing import Process as MpProcess
 from subprocess import run as sprun
 
@@ -9,7 +8,8 @@ from psutil import Process as PsProcess
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.utils import slugify
-from cstar.orchestration.models import Step
+from cstar.orchestration.converter.converter import get_command_mapping
+from cstar.orchestration.models import Application, Step
 from cstar.orchestration.orchestration import (
     Launcher,
     ProcessHandle,
@@ -90,14 +90,17 @@ class LocalLauncher(Launcher[LocalHandle]):
         LocalHandle | None
             A ProcessHandle identifying the newly submitted job.
         """
-        cmd = ["sleep", str(random.randint(1, 4))]
-        print(f"Creating local process from cmd: {' '.join(cmd)}")
+        step_converter = get_command_mapping(
+            Application(step.application),
+            LocalLauncher,
+        )
+        cmd = step_converter(step)
 
         try:
             mp_process = MpProcess(
                 target=run_as_process,
                 name=slugify(step.name),
-                args=(step, cmd),
+                args=(step, cmd.split()),
                 daemon=True,
             )
             mp_process.start()

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -189,7 +189,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
     @task(persist_result=True, cache_key_fn=cache_key_func)
     @staticmethod
     async def _submit(step: Step, dependencies: list[SlurmHandle]) -> SlurmHandle:
-        """Submit a step as a new batch allocation.
+        """Submit a step to SLURM as a new batch allocation.
 
         Parameters
         ----------

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,7 +1,4 @@
 import os
-import random
-import sys
-import textwrap
 import typing as t
 from pathlib import Path
 
@@ -16,6 +13,7 @@ from cstar.execution.scheduler_job import (
     create_scheduler_job,
     get_status_of_slurm_job,
 )
+from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step
 from cstar.orchestration.orchestration import (
     Launcher,
@@ -25,7 +23,6 @@ from cstar.orchestration.orchestration import (
 )
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
-    ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
     ENV_CSTAR_ORCH_RUNID,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -75,73 +72,6 @@ class SlurmHandle(ProcessHandle):
         """
         super().__init__(pid=job_id)
         self.job_name = job_name
-
-
-StepToCommandConversionFn: t.TypeAlias = t.Callable[[Step], str]
-"""Convert a `Step` into a command to be executed.
-
-Parameters
-----------
-step : Step
-    The step to be converted.
-
-Returns
--------
-str
-    The complete CLI command.
-"""
-
-
-def convert_roms_step_to_command(step: Step) -> str:
-    """Convert a `Step` into a command to be executed.
-
-    This function converts ROMS/ROMS-MARBL applications into a command triggering
-    a C-Star worker to run a simulation.
-
-    Parameters
-    ----------
-    step : Step
-        The step to be converted.
-
-    Returns
-    -------
-    str
-        The complete CLI command.
-    """
-    bp_path = Path(step.blueprint_path).as_posix()
-    return f"{sys.executable} -m cstar.entrypoint.worker.worker -b {bp_path}"
-
-
-def convert_step_to_placeholder(step: Step) -> str:
-    """Convert a `Step` into a command to be executed.
-
-    This function converts applications into mocks by starting a process that
-    executes a blocking sleep.
-
-    Parameters
-    ----------
-    step : Step
-        The step to be converted.
-
-    Returns
-    -------
-    str
-        The complete CLI command.
-    """
-    sleep_time = random.randint(1, 10)
-    return textwrap.dedent(f"""\
-        # this is a mock application script that produces verifiable output
-        echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";
-        sleep {sleep_time};
-        echo "{step.name} completed at $(date "+%Y-%m-%d %H:%M:%S")";
-        """)
-
-
-app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
-    Application.ROMS_MARBL.value: convert_roms_step_to_command,
-    "sleep": convert_step_to_placeholder,
-}
-"""Map application types to a function that converts a step to a CLI command."""
 
 
 class SlurmLauncher(Launcher[SlurmHandle]):
@@ -210,10 +140,10 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         step_fs = step.file_system(bp)
 
-        step_converter = app_to_cmd_map[step.application]
-        if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
-            step_converter = app_to_cmd_map[converter_override]
-        print(f"Using `{step_converter.__name__}` for `{step.application}` commands.")
+        step_converter = get_command_mapping(
+            Application(step.application),
+            SlurmLauncher,
+        )
 
         script_path = step_fs.work_dir / "script.sh"
         output_file = step_fs.logs_dir / f"{job_name}.out"

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -189,7 +189,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
     @task(persist_result=True, cache_key_fn=cache_key_func)
     @staticmethod
     async def _submit(step: Step, dependencies: list[SlurmHandle]) -> SlurmHandle:
-        """Submit a step to SLURM as a new batch allocation.
+        """Submit a step as a new batch allocation.
 
         Parameters
         ----------

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -302,6 +302,15 @@ class RuntimeParameterSet(ParameterSet):
 
         return self
 
+    @field_validator("output_dir", mode="after")
+    @classmethod
+    def _resolve_out_dir(
+        cls,
+        value: Path,
+        _info: ValidationInfo,
+    ) -> Path:
+        return value.expanduser().resolve()
+
 
 class PartitioningParameterSet(ParameterSet):
     """Parameters for the partitioning of the model."""

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 import networkx as nx
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME
+from cstar.base.env import ENV_CSTAR_DATA_HOME, get_env_item
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import slugify
 from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.utils import (
-    ENV_CSTAR_ENV_REQD_CONFIG,
+    ENV_CSTAR_ORCH_REQD_ENV,
     ENV_CSTAR_ORCH_RUNID,
 )
 
@@ -652,7 +652,7 @@ def check_environment() -> None:
     ValueError
         If required environment variables are missing or empty.
     """
-    required_config = os.getenv(ENV_CSTAR_ENV_REQD_CONFIG, "")
+    required_config = get_env_item(ENV_CSTAR_ORCH_REQD_ENV).value
     required_vars: set[str] = {ENV_CSTAR_ORCH_RUNID}
     required_vars.update({x.strip() for x in required_config.split(",") if x})
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -6,15 +6,14 @@ from pathlib import Path
 
 import networkx as nx
 
-from cstar.base.env import ENV_CSTAR_STATE_HOME
+from cstar.base.env import ENV_CSTAR_DATA_HOME
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import slugify
 from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.utils import (
+    ENV_CSTAR_ENV_REQD_CONFIG,
     ENV_CSTAR_ORCH_RUNID,
-    ENV_CSTAR_SLURM_ACCOUNT,
-    ENV_CSTAR_SLURM_QUEUE,
 )
 
 KEY_STATUS: t.Literal["status"] = "status"
@@ -653,11 +652,9 @@ def check_environment() -> None:
     ValueError
         If required environment variables are missing or empty.
     """
-    required_vars = (
-        ENV_CSTAR_SLURM_ACCOUNT,
-        ENV_CSTAR_SLURM_QUEUE,
-        ENV_CSTAR_ORCH_RUNID,
-    )
+    required_config = os.getenv(ENV_CSTAR_ENV_REQD_CONFIG, "")
+    required_vars: set[str] = {ENV_CSTAR_ORCH_RUNID}
+    required_vars.update({x.strip() for x in required_config.split(",") if x})
 
     for key in required_vars:
         if not os.getenv(key, ""):
@@ -678,7 +675,7 @@ def configure_environment(
         The unique identifier for an execution of the workplan.
     """
     if output_dir:
-        os.environ[ENV_CSTAR_STATE_HOME] = output_dir.expanduser().resolve().as_posix()
+        os.environ[ENV_CSTAR_DATA_HOME] = output_dir.expanduser().resolve().as_posix()
 
     if run_id:
         os.environ[ENV_CSTAR_ORCH_RUNID] = slugify(run_id)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -313,8 +313,6 @@ class WorkplanTransformer(LoggingMixin):
 
                 steps.extend(transformed_steps)
 
-        self._ensure_unique_paths(steps)  # HACK: remove when possible
-
         if is_feature_enabled(ENV_FF_ORCH_TRX_OVERRIDE):
             override_transform = OverrideTransform()
 

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -84,14 +84,14 @@ ENV_CSTAR_SLURM_QUEUE: t.Annotated[
 ] = "CSTAR_SLURM_QUEUE"
 """Environment variable containing the SLURM priority (queue) used by the SLURM scheduler."""
 
-ENV_CSTAR_ENV_REQD_CONFIG: t.Annotated[
-    t.Literal["CSTAR_ENV_REQD_CONFIG"],
+ENV_CSTAR_ORCH_REQD_ENV: t.Annotated[
+    t.Literal["CSTAR_ORCH_REQD_ENV"],
     EnvVar(
         "A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?).",
         _GROUP_ORCH,
-        "",
+        "CSTAR_SLURM_ACCOUNT,CSTAR_SLURM_QUEUE",
     ),
-] = "CSTAR_ENV_REQD_CONFIG"
+] = "CSTAR_ORCH_REQD_ENV"
 """A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
 
 

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -84,6 +84,16 @@ ENV_CSTAR_SLURM_QUEUE: t.Annotated[
 ] = "CSTAR_SLURM_QUEUE"
 """Environment variable containing the SLURM priority (queue) used by the SLURM scheduler."""
 
+ENV_CSTAR_ENV_REQD_CONFIG: t.Annotated[
+    t.Literal["CSTAR_ENV_REQD_CONFIG"],
+    EnvVar(
+        "A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?).",
+        _GROUP_ORCH,
+        "",
+    ),
+] = "CSTAR_ENV_REQD_CONFIG"
+"""A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
+
 
 def get_run_id() -> str:
     """Retrieve the current run-id.

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -187,6 +187,11 @@ async def test_build_and_run_dag_env(
     run_id = "my-run"
 
     mock_process = mock.AsyncMock()
+
+    # mock the sys manager to engage the checks for Slurm env-vars
+    mock_sys_manager = mock.Mock()
+    mock_sys_manager.scheduler = mock.Mock()
+
     mock_env = {
         ENV_CSTAR_STATE_HOME: output_override_dir.as_posix(),
         ENV_CSTAR_SLURM_ACCOUNT: "xyz",
@@ -200,6 +205,7 @@ async def test_build_and_run_dag_env(
 
     with (
         mock.patch("cstar.orchestration.dag_runner.process_plan", mock_process),
+        mock.patch("cstar.orchestration.dag_runner.cstar_sysmgr", mock_sys_manager),
         mock.patch.dict(os.environ, mock_env, clear=True),
         pytest.raises(ValueError) as ex,
     ):

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -1,0 +1,191 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from cstar.orchestration.converter.converter import (
+    get_command_mapping,
+    launcher_aware_app_to_cmd_map,
+    register_command_mapping,
+)
+from cstar.orchestration.launch.local import LocalLauncher
+from cstar.orchestration.launch.slurm import SlurmLauncher
+from cstar.orchestration.models import Application, Step
+from cstar.orchestration.orchestration import Launcher
+from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
+
+
+def custom_map_function(step: Step) -> str:
+    """A custom step mapping function for testing purposes."""
+    return f"UNIT-TEST-MAPPING: {step.name}"
+
+
+@pytest.mark.parametrize(
+    ("target_application", "launcher_type"),
+    [
+        (Application.ROMS_MARBL, LocalLauncher),
+        (Application.ROMS_MARBL, SlurmLauncher),
+        (Application.SLEEP, LocalLauncher),
+        (Application.SLEEP, SlurmLauncher),
+    ],
+)
+def test_converter_defaults(
+    tmp_path: Path,
+    target_application: Application,
+    launcher_type: type[Launcher],
+) -> None:
+    """Verify that the registration of a converter is not required for the default apps.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs.
+    target_application: Application
+        The application type to locate a mapping for
+    launcher_type: type[Launcher]
+        The type of launcher that will consume the command
+    """
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_path.touch()
+
+    step = Step(
+        name="test step",
+        application=target_application.value,
+        blueprint=bp_path,
+    )
+
+    mapped_fn = get_command_mapping(target_application, launcher_type)
+
+    # confirm a mapping function was returned
+    assert mapped_fn(step)
+
+
+@pytest.mark.parametrize(
+    ("target_application", "launcher_type"),
+    [
+        (Application.ROMS_MARBL, LocalLauncher),
+        (Application.ROMS_MARBL, SlurmLauncher),
+        (Application.SLEEP, LocalLauncher),
+        (Application.SLEEP, SlurmLauncher),
+    ],
+)
+def test_converter_registration(
+    tmp_path: Path,
+    target_application: Application,
+    launcher_type: type[Launcher],
+) -> None:
+    """Verify that the registration of a converter is not required for the default apps.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs
+    target_application: Application
+        The application type to locate a mapping for
+    launcher_type: type[Launcher]
+        The type of launcher that will consume the command
+    """
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_path.touch()
+
+    step = Step(
+        name="test step",
+        application=target_application.value,
+        blueprint=bp_path,
+    )
+
+    # ensure registration doesn't persist after test completes.
+    with mock.patch.dict(launcher_aware_app_to_cmd_map[launcher_type], {}):
+        original_fn = get_command_mapping(target_application, launcher_type)
+
+        register_command_mapping(target_application, launcher_type, custom_map_function)
+
+        mapped_fn = get_command_mapping(target_application, launcher_type)
+
+    # confirm the function is a mapping function
+    assert mapped_fn(step)
+
+    # confirm the newly registered function was returned
+    assert mapped_fn != original_fn
+    assert mapped_fn == custom_map_function
+
+
+@pytest.mark.parametrize(
+    ("target_application", "launcher_type"),
+    [
+        (Application.ROMS_MARBL, LocalLauncher),
+        (Application.ROMS_MARBL, SlurmLauncher),
+        (Application.SLEEP, LocalLauncher),
+        (Application.SLEEP, SlurmLauncher),
+    ],
+)
+def test_converter_override_invalid(
+    tmp_path: Path,
+    target_application: Application,
+    launcher_type: type[Launcher],
+) -> None:
+    """Verify that an invalid converter override results in an error.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs
+    target_application: Application
+        The application type to locate a mapping for
+    launcher_type: type[Launcher]
+        The type of launcher that will consume the command
+    """
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_path.touch()
+
+    with (
+        mock.patch.dict(os.environ, {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "DNE-key"}),
+        pytest.raises(ValueError) as error,
+    ):
+        _ = get_command_mapping(target_application, launcher_type)
+
+    assert ENV_CSTAR_CMD_CONVERTER_OVERRIDE in str(error)
+
+
+@pytest.mark.parametrize(
+    ("target_application", "overridden_target", "launcher_type"),
+    [
+        (Application.ROMS_MARBL, Application.SLEEP, LocalLauncher),
+        (Application.ROMS_MARBL, Application.SLEEP, SlurmLauncher),
+        (Application.SLEEP, Application.ROMS_MARBL, LocalLauncher),
+        (Application.SLEEP, Application.ROMS_MARBL, SlurmLauncher),
+    ],
+)
+def test_converter_override_capability(
+    tmp_path: Path,
+    target_application: Application,
+    overridden_target: Application,
+    launcher_type: type[Launcher],
+) -> None:
+    """Verify that the the override specified in an environment variable takes precedence
+    over defaults.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs
+    target_application: Application
+        The application type to locate a mapping for
+    target_application: Application
+        The application type to locate a mapping for
+    launcher_type: type[Launcher]
+        The type of launcher that will consume the command
+    """
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_path.touch()
+
+    original_fn = get_command_mapping(target_application, launcher_type)
+
+    with mock.patch.dict(
+        os.environ,
+        {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: overridden_target.value},
+    ):
+        overridden_fn = get_command_mapping(target_application, launcher_type)
+
+    assert original_fn != overridden_fn

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -13,6 +13,7 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 - Environment variables ``CSTAR_HOME`` and ``CSTAR_OUTDIR`` are deprecated in favor of ``CSTAR_CONFIG_HOME`` and ``CSTAR_STATE_HOME``
+- Relocated command conversion functions from `cstar.orchestration.launch.slurm` to `cstar.orchestration.converter`
 
 New features
 ~~~~~~~~~~~~

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -42,6 +42,7 @@ Improvements
 - Add constants for the set of available feature flags
 - Implement CSTAR_LOG_LEVEL env-var
 - Automatically retry partitioning without coarse dims if it fails when they are included
+- Enable orchestrated simulation execution using the local runner
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR fixes the hardcoded application configuration of the initial orchestrator release.

## New Features

1. Avoid hardcoded "required environment variables" specific to `SLURM`
2. Implement conditional launcher instantiation using platform information

## Bug Fixes

1. Fix bug writing to incorrect output directory
2. Remove problematic retrieval of run-id
3. Fix bug executing incorrect command format
4. Remove hack/fix causing bug with relative directories

## Miscellaneous

1. Fix formatting issue breaking build

## Review Checklist

- [X] Closes #CSD-353
- [X] Tests passing
- [X] Changes are documented in `docs/releases.rst`
