### PR TITLE
Mitigate linter warnings

### DIFF
--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -32,7 +32,7 @@ def run(
         asyncio.run(build_and_run_dag(path, run_id, output_path))
         print("Workplan run has completed.")
     except Exception as ex:
-        print(f"Workplan run has completed unsuccessfully: {ex}")
+        print(f"Workplan run has completed unsuccessfully: {ex!r}")
 
 
 if __name__ == "__main__":

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from prefect import task
 from prefect.context import TaskRunContext
 
-from cstar.base.utils import _run_cmd
+from cstar.base.log import get_logger
+from cstar.base.utils import _run_cmd, get_env_item
 from cstar.execution.handler import ExecutionStatus
 from cstar.execution.scheduler_job import (
     create_scheduler_job,
@@ -24,10 +25,13 @@ from cstar.orchestration.orchestration import (
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
     ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
+    ENV_CSTAR_ORCH_RUNID,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
     ENV_CSTAR_SLURM_QUEUE,
 )
+
+log = get_logger(__name__)
 
 
 def cache_key_func(context: TaskRunContext, params: dict[str, t.Any]) -> str:
@@ -45,8 +49,10 @@ def cache_key_func(context: TaskRunContext, params: dict[str, t.Any]) -> str:
     str
         The cache key for the current context.
     """
-    cache_key = f"{os.getenv('CSTAR_RUNID')}_{params['step'].name}_{context.task.name}"
-    print(f"Cache check: {cache_key}")
+    run_id = os.getenv(ENV_CSTAR_ORCH_RUNID)
+    cache_key = f"{run_id}_{params['step'].name}_{context.task.name}"
+
+    log.debug("Cache check: %s", cache_key)
     return cache_key
 
 
@@ -64,7 +70,7 @@ class SlurmHandle(ProcessHandle):
         job_id : str
             The SLURM_JOB_ID identifying a job.
         job_name : str or None
-            The job name assigend to the job.
+            The job name assigned to the job.
         """
         super().__init__(pid=job_id)
         self.job_name = job_name
@@ -151,7 +157,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         str
             The queue to use for SLURM jobs.
         """
-        return os.getenv(ENV_CSTAR_SLURM_QUEUE) or ""
+        return get_env_item(ENV_CSTAR_SLURM_QUEUE).value
 
     @staticmethod
     def configured_walltime() -> str:
@@ -164,7 +170,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         str
             The max-walltime to use for SLURM jobs.
         """
-        return os.getenv(ENV_CSTAR_SLURM_MAX_WALLTIME) or ""
+        return get_env_item(ENV_CSTAR_SLURM_MAX_WALLTIME).value
 
     @staticmethod
     def configured_account() -> str:
@@ -177,12 +183,12 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         str
             The account to use for SLURM jobs.
         """
-        return os.getenv(ENV_CSTAR_SLURM_ACCOUNT) or ""
+        return get_env_item(ENV_CSTAR_SLURM_ACCOUNT).value
 
     @task(persist_result=True, cache_key_fn=cache_key_func)
     @staticmethod
     async def _submit(step: Step, dependencies: list[SlurmHandle]) -> SlurmHandle:
-        """Submit a step to SLURM as a new batch allocation.
+        """Submit a step as a new batch allocation.
 
         Parameters
         ----------
@@ -235,16 +241,17 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         )
 
         short_command = command.replace("\n", "")[:40]  # shorten and omit newlines
-        print(f"Submitting command `{short_command}...` for step `{step.name}`.")
+
+        msg = f"Submitting command `{short_command}...` for step `{step.name}`."
+        log.debug(msg)
         job.submit()
 
         if job.id:
-            print(f"Submission of `{step.name}` created Job ID `{job.id}`")
-            handle = SlurmHandle(job_id=str(job.id), job_name=job_name)
-            return handle
+            log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
+            return SlurmHandle(job_id=str(job.id), job_name=job_name)
 
-        print(f"Job submission for step `{step.name}` failed: {job}")
-        raise RuntimeError(f"Unable to retrieve scheduled job ID for: {step.name}")
+        msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"
+        raise RuntimeError(msg)
 
     @staticmethod
     async def _status(step: Step, handle: SlurmHandle) -> ExecutionStatus:
@@ -262,11 +269,10 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         ExecutionStatus
             The current status of the step.
         """
-        status = ExecutionStatus.UNKNOWN
-
-        print(f"requesting status of job {handle.pid} for step {step.name}")
         status = get_status_of_slurm_job(handle.pid)
-        print(f"status of job {handle.pid} is {status} for step {step.name}")
+
+        msg = f"Status of job {handle.pid} is {status} for step {step.name}"
+        log.debug(msg)
 
         return status
 
@@ -314,22 +320,23 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The current status of the item.
         """
         handle = item.handle if isinstance(item, Task) else item
-        slurm_status = await SlurmLauncher._status(step, handle)
+        exec_status = await SlurmLauncher._status(step, handle)
 
-        print(f"SLURM job `{handle.pid}` status is `{slurm_status}`")
+        msg = f"SLURM job `{handle.pid}` status is `{exec_status}`"
+        log.debug(msg)
 
-        if slurm_status in [
+        if exec_status in [
             ExecutionStatus.PENDING,
             ExecutionStatus.RUNNING,
             ExecutionStatus.ENDING,
             ExecutionStatus.HELD,
         ]:
             return Status.Running
-        if slurm_status in [ExecutionStatus.COMPLETED]:
+        if exec_status == ExecutionStatus.COMPLETED:
             return Status.Done
-        if slurm_status in [ExecutionStatus.CANCELLED]:
+        if exec_status == ExecutionStatus.CANCELLED:
             return Status.Cancelled
-        if slurm_status in [ExecutionStatus.FAILED]:
+        if exec_status == ExecutionStatus.FAILED:
             return Status.Failed
 
         return Status.Unsubmitted
@@ -360,6 +367,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             )
             item.status = Status.Cancelled
         except RuntimeError:
-            print(f"Unable to cancel the task `{handle.pid}`")
+            log.exception("Unable to cancel the task `%s`", handle.pid)
 
         return item

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -188,7 +188,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
     @task(persist_result=True, cache_key_fn=cache_key_func)
     @staticmethod
     async def _submit(step: Step, dependencies: list[SlurmHandle]) -> SlurmHandle:
-        """Submit a step as a new batch allocation.
+        """Submit a step to SLURM as a new batch allocation.
 
         Parameters
         ----------

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -661,7 +661,7 @@ def check_environment() -> None:
     for key in required_vars:
         if not os.getenv(key, ""):
             msg = f"Missing required environment variable: {key}"
-            raise KeyError(msg)
+            raise ValueError(msg)
 
 
 def configure_environment(

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -82,7 +82,7 @@ class Status(IntEnum):
         return status in {Status.Done, Status.Cancelled, Status.Failed}
 
     @classmethod
-    def is_failure(cls, status) -> bool:
+    def is_failure(cls, status: "Status") -> bool:
         """Return `True` if a status is in the set of terminal statuses.
 
         Paramters
@@ -97,7 +97,7 @@ class Status(IntEnum):
         return status in {Status.Cancelled, Status.Failed}
 
     @classmethod
-    def is_running(cls, status) -> bool:
+    def is_running(cls, status: "Status") -> bool:
         """Return `True` if a status is in the set of in-progress statuses.
 
         Paramters
@@ -660,9 +660,8 @@ def check_environment() -> None:
 
     for key in required_vars:
         if not os.getenv(key, ""):
-            raise ValueError(
-                f"Unable to run workplan. `{key}` not found in environment."
-            )
+            msg = f"Missing required environment variable: {key}"
+            raise KeyError(msg)
 
 
 def configure_environment(


### PR DESCRIPTION
## Summary

This PR contains quality-of-life improvements associated with CSD-353. There are no behavioral changes.

## Change List

1. Remove commented-out code blocks
2. Mitigate warnings
   - calling `subprocess.run` without explicit `Check`
   - missing timezone specification
   - long messages provided directly to log/exceptions 
3. Use env var constants in place of magic strings
4. Add missing type-hints
5. Fix typo
6. Avoid specifying alternative ENV var defaults
7. Use logging instead of `print`
8. Replace `in <single-item collection>` with equality checks

## Review Checklist

- [X] Tests passing
- [X] Full type hint coverage