### PR TITLE
Pass `include_coarse_dims=False` if `roms_tools.partion_netcdf` fails

### DIFF
--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -221,10 +221,17 @@ class ROMSInputDataset(InputDataset, ABC):
 
             for idfile in files:
                 self.log.info(f"Partitioning {idfile} into ({np_xi},{np_eta})")
-                new_parted_files.extend(
-                    roms_tools.partition_netcdf(idfile, np_xi=np_xi, np_eta=np_eta, 
-                    include_coarse_dims=False)
-                )
+                try:
+                    result = roms_tools.partition_netcdf(
+                        idfile, np_xi=np_xi, np_eta=np_eta)
+                except Exception:
+                    try:
+                        result = roms_tools.partition_netcdf(
+                            idfile, np_xi=np_xi, np_eta=np_eta,
+                            include_coarse_dims=False)
+                    except Exception:
+                        raise
+                new_parted_files.extend(result)
 
             return [f.resolve() for f in new_parted_files]
 

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -222,7 +222,8 @@ class ROMSInputDataset(InputDataset, ABC):
             for idfile in files:
                 self.log.info(f"Partitioning {idfile} into ({np_xi},{np_eta})")
                 new_parted_files.extend(
-                    roms_tools.partition_netcdf(idfile, np_xi=np_xi, np_eta=np_eta)
+                    roms_tools.partition_netcdf(idfile, np_xi=np_xi, np_eta=np_eta, 
+                    include_coarse_dims=False)
                 )
 
             return [f.resolve() for f in new_parted_files]


### PR DESCRIPTION
This puts the call to `roms_tools.partition_netcdf` in a try/except block:
1. try without using `include_coarse_dims`
2. if that fails, use `include_coarse_dims=False`
3. if that fails, abort