### PR TITLE
Fix unintended checkout on cached remote repository

### DIFF
--- a/cstar/io/retriever.py
+++ b/cstar/io/retriever.py
@@ -308,6 +308,21 @@ class RemoteRepositoryRetriever(Retriever):
                 f"All clone attempts have failed for: {self.source.location}"
             )
 
+        return target_dir
+
+    def checkout(self, target_dir: Path) -> Path:
+        """Perform a checkout on the repository cloned to `target_dir`.
+
+        Parameters
+        ----------
+        target_dir : pathlib.Path
+            The directory where this repository has been cloned
+
+        Returns
+        -------
+        pathlib.Path
+            The path to the local clone of the repository
+        """
         if self.source.checkout_target:
             _checkout(
                 source_repo=self.source.location,

--- a/cstar/io/stager.py
+++ b/cstar/io/stager.py
@@ -1,13 +1,15 @@
-import shutil
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
+from cstar.base.utils import _run_cmd
 from cstar.execution.file_system import DirectoryManager
+from cstar.io.retriever import RemoteRepositoryRetriever
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from cstar.io.source_data import SourceData
+
 from cstar.base.utils import slugify
 from cstar.io.constants import SourceClassification
 from cstar.io.staged_data import StagedFile, StagedRepository
@@ -155,7 +157,12 @@ class CachedRemoteRepositoryStager(Stager):
         else:
             self.source.retriever.refresh(target_dir=cache_path)
 
-        shutil.copytree(cache_path, target_dir, symlinks=True, dirs_exist_ok=True)
+        if target_dir.exists():
+            target_dir.rmdir()
+
+        _run_cmd(f"cp -av {cache_path}/ {target_dir}")
+        remote = cast("RemoteRepositoryRetriever", self.source.retriever)
+        remote.checkout(target_dir=target_dir)
 
         return StagedRepository(source=self.source, path=target_dir)
 

--- a/cstar/io/stager.py
+++ b/cstar/io/stager.py
@@ -129,7 +129,7 @@ class RemoteRepositoryStager(Stager):
             The local directory in which to stage the repository
         """
         retrieved_path = self.source.retriever.save(target_dir=target_dir)
-        retriever = cast(RemoteRepositoryRetriever, self.source.retriever)
+        retriever = cast("RemoteRepositoryRetriever", self.source.retriever)
         retriever.checkout(target_dir=target_dir)
         return StagedRepository(source=self.source, path=retrieved_path)
 

--- a/cstar/io/stager.py
+++ b/cstar/io/stager.py
@@ -129,6 +129,8 @@ class RemoteRepositoryStager(Stager):
             The local directory in which to stage the repository
         """
         retrieved_path = self.source.retriever.save(target_dir=target_dir)
+        retriever = cast(RemoteRepositoryRetriever, self.source.retriever)
+        retriever.checkout(target_dir=target_dir)
         return StagedRepository(source=self.source, path=retrieved_path)
 
 

--- a/cstar/tests/unit_tests/io/test_retriever.py
+++ b/cstar/tests/unit_tests/io/test_retriever.py
@@ -157,11 +157,10 @@ class TestRemoteRepositoryRetriever:
             r.read()
 
     def test_save_clones_and_checkouts(self, tmp_path, mocksourcedata_remote_repo):
-        """Tests that RemoteRepositoryRetriever.save() clones the repo and checks out the target."""
+        """Test that RemoteRepositoryRetriever.save() clones the repo."""
         source = mocksourcedata_remote_repo()
         with (
             mock.patch("cstar.io.retriever._clone") as mock_clone,
-            mock.patch("cstar.io.retriever._checkout") as mock_checkout,
         ):
             r = retriever.RemoteRepositoryRetriever(source)
             result = r._save(tmp_path)
@@ -169,11 +168,7 @@ class TestRemoteRepositoryRetriever:
         mock_clone.assert_called_once_with(
             source_repo=source.location, local_path=tmp_path
         )
-        mock_checkout.assert_called_once_with(
-            source_repo=source.location,
-            local_path=tmp_path,
-            checkout_target="test_target",
-        )
+
         assert result == tmp_path
 
     def test_save_raises_if_dir_not_empty(self, tmp_path, mocksourcedata_remote_repo):

--- a/cstar/tests/unit_tests/io/test_stager.py
+++ b/cstar/tests/unit_tests/io/test_stager.py
@@ -168,3 +168,95 @@ class TestStagerSubclasses:
         fake_retriever.save.assert_called_once_with(target_dir=tmp_path)
         mock_staged_repo.assert_called_once_with(source=source, path=fake_path)
         assert result is mock_staged_repo.return_value
+
+    def test_cached_remote_repository_stager_writes_to_cache(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_repo: SourceDataFactory,
+    ) -> None:
+        """Tests that CachedRemoteRepositoryStager.stage caches the retrieved repository
+        in the correct path.
+        """
+        source = mocksourcedata_remote_repo()
+        repo_name = "repo"
+        fake_path = tmp_path / repo_name
+        fake_cache_path = tmp_path / "cache" / repo_name
+        fake_retriever = mock.Mock()
+        fake_retriever.save.return_value = fake_cache_path
+
+        with (
+            mock.patch.object(
+                type(source),
+                "retriever",
+                new_callable=mock.PropertyMock,
+            ) as mock_ret,
+            mock.patch("cstar.io.stager.StagedRepository") as mock_staged_repo,
+            mock.patch("cstar.io.stager._run_cmd") as mock_run_cmd,
+            mock.patch(
+                "cstar.io.stager.CachedRemoteRepositoryStager._get_cache_path",
+            ) as mock_get_cache_path,
+        ):
+            mock_get_cache_path.return_value = fake_cache_path
+            mock_run_cmd.return_value = ""
+            mock_ret.return_value = fake_retriever
+            s = stager.CachedRemoteRepositoryStager(source)
+
+            result = s.stage(fake_path)
+
+        # confirm repo is put into cache
+        fake_retriever.save.assert_called_once_with(target_dir=fake_cache_path)
+
+        # confirm the content is copied from the cache to the target
+        mock_run_cmd.assert_called_once_with(f"cp -av {fake_cache_path}/ {fake_path}")
+
+        # confirm the result is a new path and the cached location is not leaked
+        mock_staged_repo.assert_called_once_with(source=source, path=fake_path)
+        assert result is mock_staged_repo.return_value
+
+    def test_cached_remote_repository_stager_reads_from_cache(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_repo: SourceDataFactory,
+    ) -> None:
+        """Tests that CachedRemoteRepositoryStager.stage returns fresh content from
+        the cache if the remote repository has been previously staged.
+        """
+        source = mocksourcedata_remote_repo()
+        repo_name = "repo"
+        fake_path = tmp_path / repo_name
+
+        fake_cache_path = tmp_path / "cache" / repo_name
+        fake_cache_path.mkdir(parents=True, exist_ok=False)
+        fake_content_path = fake_cache_path / "foo.txt"
+        fake_content_path.touch()  # trick stager into believing content is cached.
+
+        fake_retriever = mock.Mock()
+        fake_retriever.save.return_value = fake_cache_path
+
+        with (
+            mock.patch.object(
+                type(source),
+                "retriever",
+                new_callable=mock.PropertyMock,
+            ) as mock_ret,
+            mock.patch("cstar.io.stager.StagedRepository"),  # avoid validation
+            mock.patch("cstar.io.stager._run_cmd") as mock_run_cmd,
+            mock.patch(
+                "cstar.io.stager.CachedRemoteRepositoryStager._get_cache_path",
+            ) as mock_get_cache_path,
+        ):
+            mock_get_cache_path.return_value = fake_cache_path
+            mock_run_cmd.return_value = ""
+            mock_ret.return_value = fake_retriever
+            s = stager.CachedRemoteRepositoryStager(source)
+
+            _ = s.stage(fake_path)
+
+        # confirm repo is not retrieved
+        fake_retriever.save.assert_not_called()
+
+        # confirm cached repo is updated with latest changes
+        fake_retriever.refresh.assert_called_once_with(target_dir=fake_cache_path)
+
+        # confirm the correct hash/branch is checked out from the copy (not cache)
+        fake_retriever.checkout.assert_called_once_with(target_dir=fake_path)


### PR DESCRIPTION
## Summary

This PR fixes an error that occurs when using the `CachedRemoteRepositoryRetriever`.

There are two underlying issues:

1. A checkout was performed on the cache
2. Copied symlinks pointed to the cache directory


## Change List

1. Split clone && checkout behavior in remote repository retriever
2. Execute checkout on copied repository
3. Ensure cache content (not folder) is copied to target dir 

## Review Checklist

- [X] Closes #CSD-538
- [X] Tests passing
- [X] Full type hint coverage