### PR TITLE
Update/edit Csd 538

### DIFF
--- a/cstar/io/stager.py
+++ b/cstar/io/stager.py
@@ -129,6 +129,8 @@ class RemoteRepositoryStager(Stager):
             The local directory in which to stage the repository
         """
         retrieved_path = self.source.retriever.save(target_dir=target_dir)
+        retriever = cast(RemoteRepositoryRetriever, self.source.retriever)
+        retriever.checkout(target_dir=target_dir)
         return StagedRepository(source=self.source, path=retrieved_path)
 
 

--- a/cstar/tests/unit_tests/io/test_retriever.py
+++ b/cstar/tests/unit_tests/io/test_retriever.py
@@ -157,11 +157,10 @@ class TestRemoteRepositoryRetriever:
             r.read()
 
     def test_save_clones_and_checkouts(self, tmp_path, mocksourcedata_remote_repo):
-        """Tests that RemoteRepositoryRetriever.save() clones the repo and checks out the target."""
+        """Test that RemoteRepositoryRetriever.save() clones the repo."""
         source = mocksourcedata_remote_repo()
         with (
             mock.patch("cstar.io.retriever._clone") as mock_clone,
-            mock.patch("cstar.io.retriever._checkout") as mock_checkout,
         ):
             r = retriever.RemoteRepositoryRetriever(source)
             result = r._save(tmp_path)
@@ -169,11 +168,7 @@ class TestRemoteRepositoryRetriever:
         mock_clone.assert_called_once_with(
             source_repo=source.location, local_path=tmp_path
         )
-        mock_checkout.assert_called_once_with(
-            source_repo=source.location,
-            local_path=tmp_path,
-            checkout_target="test_target",
-        )
+
         assert result == tmp_path
 
     def test_save_raises_if_dir_not_empty(self, tmp_path, mocksourcedata_remote_repo):


### PR DESCRIPTION
I took a look at #422 (even though it's in draft). Here are a few edits:
* also call checkout from RemoteRepositoryStager
* edit tests to pass

Some things to note with this fix (I don't think any of them are problematic, but good to make sure it's intended):
* Previously, the `Retriever` was responsible for getting _and checking out_ a repository. Now the checkout responsibility is in the `Stager`.
* Thus, adjusted the retriever test to not expect a checkout
* Adjusted the cached stager test to not expect the files in the cache are the same as the target (since only the target gets checked out)