### PR TITLE
Fix retriever test bugs and improve type-hints

### DIFF
--- a/cstar/tests/unit_tests/io/test_retriever.py
+++ b/cstar/tests/unit_tests/io/test_retriever.py
@@ -1,3 +1,5 @@
+import typing as t
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -5,6 +7,16 @@ import pytest
 from cstar.base.utils import _get_sha256_hash
 from cstar.io import retriever
 from cstar.io.constants import SourceClassification
+from cstar.io.source_data import SourceData
+
+
+class SourceDataFactory(t.Protocol):
+    def __call__(
+        self,
+        classification: SourceClassification | None = None,
+        location: str | Path | None = None,
+        identifier: str | None = None,
+    ) -> SourceData: ...
 
 
 class DummyRetriever(retriever.Retriever):
@@ -12,23 +24,29 @@ class DummyRetriever(retriever.Retriever):
 
     _classification = SourceClassification.LOCAL_TEXT_FILE
 
-    def read(self):
+    def read(self) -> bytes:
         return b""
 
-    def _save(self, target_dir):
+    def _save(self, target_dir: Path) -> Path:
         return target_dir / "out"
 
 
 class TestRegistry:
-    def test_register_and_get_retriever(self, mocksourcedata_local_text_file):
+    def test_register_and_get_retriever(
+        self,
+        mocksourcedata_local_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that a new retriever can be registered and fetched from the register"""
-        temp_registry = {}
+        temp_registry: dict[str, type[retriever.Retriever]] = {}
         with mock.patch("cstar.io.retriever._registry", temp_registry):
             retriever.register_retriever(DummyRetriever)
             r = retriever.get_retriever(mocksourcedata_local_text_file())
             assert isinstance(r, DummyRetriever)
 
-    def test_get_retriever_not_registered(self, mocksourcedata_factory):
+    def test_get_retriever_not_registered(
+        self,
+        mocksourcedata_factory: SourceDataFactory,
+    ) -> None:
         """Tests that getting an unregistered retriever raises a ValueError"""
         sourcedata = mocksourcedata_factory(
             classification=SourceClassification.LOCAL_DIRECTORY,
@@ -40,29 +58,36 @@ class TestRegistry:
 
 class TestRetrieverABC:
     def test_save_creates_dir_and_calls_subclass_save(
-        self, tmp_path, mocksourcedata_local_text_file
-    ):
+        self,
+        tmp_path: Path,
+        mocksourcedata_local_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that parent class save ensures validity before calling subclass save()"""
-        r = DummyRetriever(mocksourcedata_local_text_file)
+        r = DummyRetriever(mocksourcedata_local_text_file())
         result = r.save(tmp_path / "newdir")
         assert result == tmp_path / "newdir/out", (
             f"EXPECTED {tmp_path / 'newdir/out'} \nGOT {result}"
         )
 
     def test_save_raises_if_not_directory(
-        self, tmp_path, mocksourcedata_local_text_file
-    ):
+        self,
+        tmp_path: Path,
+        mocksourcedata_local_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that parent class save raises if target_dir is not a dir"""
         file_path = tmp_path / "afile"
         file_path.write_text("x")
 
-        r = retriever.LocalFileRetriever(mocksourcedata_local_text_file)
+        r = retriever.LocalFileRetriever(mocksourcedata_local_text_file())
         with pytest.raises(ValueError):
             r.save(file_path)
 
 
 class TestRemoteFileRetriever:
-    def test_read_returns_content(self, mocksourcedata_remote_text_file):
+    def test_read_returns_content(
+        self,
+        mocksourcedata_remote_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that RemoteFileRetriever.read returns expected bytes"""
         fake_response = mock.Mock()
         fake_response.content = b"abc"
@@ -75,7 +100,11 @@ class TestRemoteFileRetriever:
 
 
 class TestRemoteTextFileRetriever:
-    def test_save_writes_file(self, tmp_path, mocksourcedata_remote_text_file):
+    def test_save_writes_file(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that RemoteTextFileRetriever.save takes `read` output and saves it to file"""
         fake_data = b"hello world"
 
@@ -84,7 +113,7 @@ class TestRemoteTextFileRetriever:
             retriever.RemoteTextFileRetriever, "read", return_value=fake_data
         ) as mock_read:
             r = retriever.RemoteTextFileRetriever(
-                source=mocksourcedata_remote_text_file()
+                source=mocksourcedata_remote_text_file(),
             )
             result = r._save(tmp_path)
 
@@ -97,7 +126,11 @@ class TestRemoteTextFileRetriever:
 
 
 class TestRemoteBinaryFileRetriever:
-    def test_save_writes_file(self, tmp_path, mocksourcedata_remote_file):
+    def test_save_writes_file(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_file: SourceDataFactory,
+    ) -> None:
         """Tests that RemoteBinaryFileRetriever.save iterates over chunks and updates file correctly."""
         fake_chunk = b"abc"
         source = mocksourcedata_remote_file()
@@ -114,7 +147,11 @@ class TestRemoteBinaryFileRetriever:
         assert path.exists()
         assert path.read_bytes() == fake_chunk
 
-    def test_save_raises_on_hash_mismatch(self, tmp_path, mocksourcedata_remote_file):
+    def test_save_raises_on_hash_mismatch(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_file: SourceDataFactory,
+    ) -> None:
         """Tests that RemoteBinaryFileRetriever.save raises if the final calculated hash does not match `identifier`"""
         source = mocksourcedata_remote_file()
         fake_chunk = b"abc"
@@ -131,7 +168,11 @@ class TestRemoteBinaryFileRetriever:
 
 
 class TestLocalFileRetriever:
-    def test_read_and_save(self, tmp_path, mocksourcedata_local_text_file):
+    def test_read_and_save(
+        self,
+        tmp_path: Path,
+        mocksourcedata_local_text_file: SourceDataFactory,
+    ) -> None:
         """Tests that LocalFileRetriever.read and .save read and copy files, respectively"""
         test_file = tmp_path / "f.txt"
         source = mocksourcedata_local_text_file(location=test_file)
@@ -149,14 +190,18 @@ class TestLocalFileRetriever:
 
 
 class TestRemoteRepositoryRetriever:
-    def test_read_raises(self, mocksourcedata_remote_repo):
+    def test_read_raises(self, mocksourcedata_remote_repo: SourceDataFactory) -> None:
         """Tests that RemoteRepositoryRetriever.read raises a NotImplementedError"""
         source = mocksourcedata_remote_repo()
         r = retriever.RemoteRepositoryRetriever(source)
         with pytest.raises(NotImplementedError):
             r.read()
 
-    def test_save_clones_and_checkouts(self, tmp_path, mocksourcedata_remote_repo):
+    def test_save_clones_and_checkouts(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_repo: SourceDataFactory,
+    ) -> None:
         """Test that RemoteRepositoryRetriever.save() clones the repo."""
         source = mocksourcedata_remote_repo()
         with (
@@ -171,7 +216,11 @@ class TestRemoteRepositoryRetriever:
 
         assert result == tmp_path
 
-    def test_save_raises_if_dir_not_empty(self, tmp_path, mocksourcedata_remote_repo):
+    def test_save_raises_if_dir_not_empty(
+        self,
+        tmp_path: Path,
+        mocksourcedata_remote_repo: SourceDataFactory,
+    ) -> None:
         """Tests that RemoteRepositoryRetriever.save raises a ValueError if target_dir is not empty."""
         source = mocksourcedata_remote_repo()
         (tmp_path / "afile").write_text("x")


### PR DESCRIPTION
## Summary

A defect was identified in `test_save_creates_dir_and_calls_subclass_save` and `test_save_raises_if_not_directory` where the mock is used incorrectly. Instead of passing the `SourceData` object to retreivers, the factory-function that produces it is passed.

This PR fixes the two incorrectly passed test parameters and adds additional type-hints to ensure it does not recur.

## Changes

1. Add type-hints as-needed to `test_retriever.py`
2. Fix passing factory function to `retriever.__init__` in 2 tests

## Review Checklist

- [X] Tests passing