### PR TITLE
Promote blueprint overrides feature to always on

### DIFF
--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -89,16 +89,6 @@ ENV_FF_ORCH_TRX_TIMESPLIT: t.Annotated[
 ] = "CSTAR_FF_ORCH_TRX_TIMESPLIT"
 """Enable automatic time-splitting of simulations."""
 
-ENV_FF_ORCH_TRX_OVERRIDE: t.Annotated[
-    t.Literal["CSTAR_FF_ORCH_TRX_OVERRIDE"],
-    EnvVar(
-        "Enable automatic overrides to blueprints contained in a workplan.",
-        _GROUP_FF,
-        default=FLAG_OFF,
-    ),
-] = "CSTAR_FF_ORCH_TRX_OVERRIDE"
-"""Enable automatic overrides to blueprints contained in a workplan."""
-
 
 def is_feature_enabled(flag: str) -> bool:
     """Determine if an environment variable for a feature is set.

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -6,7 +6,6 @@ from enum import StrEnum
 from pathlib import Path
 
 from cstar.base.feature import (
-    ENV_FF_ORCH_TRX_OVERRIDE,
     ENV_FF_ORCH_TRX_TIMESPLIT,
     is_feature_enabled,
 )
@@ -313,12 +312,11 @@ class WorkplanTransformer(LoggingMixin):
 
                 steps.extend(transformed_steps)
 
-        if is_feature_enabled(ENV_FF_ORCH_TRX_OVERRIDE):
-            override_transform = OverrideTransform()
+        override_transform = OverrideTransform()
 
-            for i, step in enumerate(steps):
-                overridden_step_result = list(override_transform(step))
-                steps[i] = overridden_step_result[0]
+        for i, step in enumerate(steps):
+            overridden_step_result = list(override_transform(step))
+            steps[i] = overridden_step_result[0]
 
         wp_attrs = self.original.model_dump()
         wp_attrs.update(

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -9,10 +9,7 @@ import networkx as nx
 import pytest
 
 from cstar.base.env import FLAG_ON
-from cstar.base.feature import (
-    ENV_FF_ORCH_TRX_OVERRIDE,
-    ENV_FF_ORCH_TRX_TIMESPLIT,
-)
+from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 from cstar.orchestration.orchestration import (
@@ -324,7 +321,6 @@ def test_workplan_transformation(diamond_workplan: Workplan) -> None:
             {
                 ENV_CSTAR_ORCH_RUNID: str(uuid.uuid4()),
                 ENV_FF_ORCH_TRX_TIMESPLIT: FLAG_ON,
-                ENV_FF_ORCH_TRX_OVERRIDE: FLAG_ON,
             },
         ),
     ):

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -14,6 +14,7 @@ Breaking Changes
 
 - Environment variables ``CSTAR_HOME`` and ``CSTAR_OUTDIR`` are deprecated in favor of ``CSTAR_CONFIG_HOME`` and ``CSTAR_STATE_HOME``
 - Relocated command conversion functions from `cstar.orchestration.launch.slurm` to `cstar.orchestration.converter`
+- Promote blueprint overrides to always-on, deprecate and remove feature flag ``CSTAR_FF_ORCH_TRX_OVERRIDE``
 
 New features
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

This pull request deprecates the feature flag `CSTAR_FF_ORCH_TRX_OVERRIDE`. 

# Breaking Changes

- The flag constant is removed

# Improvements

- Remove `if is_feature_enabled("CSTAR_FF_ORCH_TRX_OVERRIDE")` to always enable overrides.

# Review Checklist

- [X] Closes #CSD-569
- [X] Tests added
- [X] Tests passing
- [X] Changes are documented in `docs/releases.rst`