### PR TITLE
Fix user-relative directory handling bug

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -128,13 +128,17 @@ class JobFileSystemManager(LoggingMixin):
     """
 
     _INPUT_NAME: t.ClassVar[t.Literal["input"]] = "input"
+    """The name of the subfolder where job inputs will be written."""
     _WORK_NAME: t.ClassVar[t.Literal["work"]] = "work"
+    """The name of the subfolder where job scripts will be written."""
     _TASKS_NAME: t.ClassVar[t.Literal["tasks"]] = "tasks"
+    """The name of the subfolder where job sub-tasks will be executed."""
     _LOGS_NAME: t.ClassVar[t.Literal["logs"]] = "logs"
+    """The name of the subfolder where job logs will be written."""
     _OUTPUT_NAME: t.ClassVar[t.Literal["output"]] = "output"
-
-    root: t.Final[Path]
-    """The root directory of the job. It is provided via user configuration."""
+    """The name of the subfolder where job outputs will be written."""
+    _root: t.Final[Path]
+    """The root directory of the job."""
 
     def __init__(self, root_directory: Path) -> None:
         """Initialize the job file system.
@@ -144,7 +148,7 @@ class JobFileSystemManager(LoggingMixin):
         root_directory : Path
             The root directory that contains all job byproducts.
         """
-        self.root = root_directory
+        self._root = root_directory.expanduser().resolve()
 
     def _dir_set(self) -> set[Path]:
         """Return the complete set of directories for the job.
@@ -160,6 +164,16 @@ class JobFileSystemManager(LoggingMixin):
             self.logs_dir,
             self.output_dir,
         }
+
+    @property
+    def root(self) -> Path:
+        """The root directory containing all job outputs.
+
+        Returns
+        -------
+        Path
+        """
+        return self._root
 
     @property
     def input_dir(self) -> Path:
@@ -219,11 +233,11 @@ class JobFileSystemManager(LoggingMixin):
 
     def __getstate__(self) -> dict[str, str]:
         """Return the state of the object."""
-        return {"root": self.root.as_posix()}
+        return {"_root": self._root.as_posix()}
 
     def __setstate__(self, state: dict[str, str]) -> None:
         """Restore the object from a pickle."""
-        self.__dict__.update({"root": Path(state["root"])})
+        self.__dict__.update({"_root": Path(state["_root"])})
 
 
 class RomsFileSystemManager(JobFileSystemManager):

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -25,6 +25,15 @@ def populated_output_dir(tmp_path: Path) -> tuple[Path, list[Path]]:
     return asset_root, files
 
 
+def test_file_system_root() -> None:
+    """Test that a user path is expanded to an absolute path."""
+    user_path = Path("~/cstar-directory")
+    fsm = JobFileSystemManager(user_path)
+
+    assert fsm.root.is_absolute()
+    assert "~" not in str(fsm.root)
+
+
 def test_file_system_prepare(
     tmp_path: Path,
 ) -> None:
@@ -64,7 +73,7 @@ def test_file_system_clear(
     fs = RomsFileSystemManager(output_dir)
     fs.clear()
 
-    assert all([not f.exists() for f in output_files])
+    assert all(not f.exists() for f in output_files)
 
 
 def test_file_system_pickle_job_fs(tmp_path: Path) -> None:

--- a/docs/releases/v0.2.x.rst
+++ b/docs/releases/v0.2.x.rst
@@ -34,6 +34,7 @@ Bug Fixes
 - Fix indentation creating an unreachable code block in git utils
 - Add conda installation of rsync to environment.yml (fixes bug related to a flag used in newer ucla-roms makefiles that is not available in MacOS's default rsync installation)
 - Reimplement CSTAR_CLOBBER_WORKING_DIR for single-blueprint cases
+- Fix bug handling user-relative paths in `JobFileSystemManager`
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

This PR fixes a defect in the `JobFileSystemManager` causing a subdirectory to be named `~` instead of being expanded

# Bug Fixes

- Fix bug handling user-relative paths in `JobFileSystemManager`

# Review Checklist

- [X] Closes #CSD-570
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`