### PR TITLE
Rename and relocate run-id env var

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -3,6 +3,7 @@ import sys
 import types
 import typing as t
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -136,6 +137,11 @@ def nprocs_factory() -> str:
     return str((os.cpu_count() or 3) // 3)
 
 
+def generate_run_id() -> str:
+    """Generate a unique run identifier based on the current time."""
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
 ENV_CSTAR_LOG_LEVEL: t.Annotated[
     t.Literal["CSTAR_LOG_LEVEL"],
     EnvVar(
@@ -250,8 +256,7 @@ ENV_CSTAR_RUNID: t.Annotated[
     EnvVar(
         description="Unique run identifier used by the orchestrator.",
         group=_GROUP_SIM,
-        default="",
-        # default_factory=lambda _: generate_run_id(),
+        default_factory=lambda _: generate_run_id(),
     ),
 ] = "CSTAR_RUNID"
 """Environment variable containing a unique run identifier used by the orchestrator."""

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -245,6 +245,17 @@ ENV_CSTAR_STATE_HOME: t.Annotated[
 ] = "CSTAR_STATE_HOME"
 """Environment variable used to override the home directory for C-Star state storage."""
 
+ENV_CSTAR_RUNID: t.Annotated[
+    t.Literal["CSTAR_RUNID"],
+    EnvVar(
+        description="Unique run identifier used by the orchestrator.",
+        group=_GROUP_SIM,
+        default="",
+        # default_factory=lambda _: generate_run_id(),
+    ),
+] = "CSTAR_RUNID"
+"""Environment variable containing a unique run identifier used by the orchestrator."""
+
 
 def discover_env_vars(
     modules: list[types.ModuleType],

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from prefect import task
 from prefect.context import TaskRunContext
 
-from cstar.base.env import get_env_item
+from cstar.base.env import ENV_CSTAR_RUNID, get_env_item
 from cstar.base.log import get_logger
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionStatus
@@ -23,7 +23,6 @@ from cstar.orchestration.orchestration import (
 )
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
-    ENV_CSTAR_ORCH_RUNID,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
     ENV_CSTAR_SLURM_QUEUE,
@@ -47,7 +46,7 @@ def cache_key_func(context: TaskRunContext, params: dict[str, t.Any]) -> str:
     str
         The cache key for the current context.
     """
-    run_id = os.getenv(ENV_CSTAR_ORCH_RUNID)
+    run_id = os.getenv(ENV_CSTAR_RUNID)
     cache_key = f"{run_id}_{params['step'].name}_{context.task.name}"
 
     log.debug("Cache check: %s", cache_key)

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 import typing as t
 from abc import ABC
 from copy import deepcopy
@@ -24,9 +23,9 @@ from pydantic import (
 )
 from pytimeparse import parse
 
-from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.utils import slugify
-from cstar.execution.file_system import RomsFileSystemManager
+from cstar.execution.file_system import DirectoryManager, RomsFileSystemManager
+from cstar.orchestration.utils import get_run_id
 
 RequiredString: t.TypeAlias = t.Annotated[
     str,
@@ -503,9 +502,8 @@ class Step(BaseModel):
         Path
             The path to the step working directory.
         """
-        run_dir = os.environ[ENV_CSTAR_RUNID]
-        step_dir = self.safe_name
-        return Path(run_dir) / step_dir
+        root_dir = DirectoryManager.data_home()
+        return Path(root_dir) / get_run_id() / self.safe_name
 
     def file_system(self, bp: RomsMarblBlueprint) -> RomsFileSystemManager:
         """The directories used by this step.

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import typing as t
 from abc import ABC
 from copy import deepcopy
@@ -23,9 +24,9 @@ from pydantic import (
 )
 from pytimeparse import parse
 
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.utils import slugify
 from cstar.execution.file_system import RomsFileSystemManager
-from cstar.orchestration.utils import get_run_id
 
 RequiredString: t.TypeAlias = t.Annotated[
     str,
@@ -502,7 +503,7 @@ class Step(BaseModel):
         Path
             The path to the step working directory.
         """
-        run_dir = get_run_id()
+        run_dir = os.environ[ENV_CSTAR_RUNID]
         step_dir = self.safe_name
         return Path(run_dir) / step_dir
 

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -503,7 +503,7 @@ class Step(BaseModel):
             The path to the step working directory.
         """
         root_dir = DirectoryManager.data_home()
-        return Path(root_dir) / get_run_id() / self.safe_name
+        return root_dir / get_run_id() / self.safe_name
 
     def file_system(self, bp: RomsMarblBlueprint) -> RomsFileSystemManager:
         """The directories used by this step.

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -6,15 +6,12 @@ from pathlib import Path
 
 import networkx as nx
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME, get_env_item
+from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID, get_env_item
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import slugify
 from cstar.orchestration.models import Step, Workplan
-from cstar.orchestration.utils import (
-    ENV_CSTAR_ORCH_REQD_ENV,
-    ENV_CSTAR_ORCH_RUNID,
-)
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
 
 KEY_STATUS: t.Literal["status"] = "status"
 KEY_STEP: t.Literal["step"] = "step"
@@ -653,7 +650,7 @@ def check_environment() -> None:
         If required environment variables are missing or empty.
     """
     required_config = get_env_item(ENV_CSTAR_ORCH_REQD_ENV).value
-    required_vars: set[str] = {ENV_CSTAR_ORCH_RUNID}
+    required_vars: set[str] = {ENV_CSTAR_RUNID}
     required_vars.update({x.strip() for x in required_config.split(",") if x})
 
     for key in required_vars:
@@ -678,4 +675,4 @@ def configure_environment(
         os.environ[ENV_CSTAR_DATA_HOME] = output_dir.expanduser().resolve().as_posix()
 
     if run_id:
-        os.environ[ENV_CSTAR_ORCH_RUNID] = slugify(run_id)
+        os.environ[ENV_CSTAR_RUNID] = slugify(run_id)

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -1,16 +1,9 @@
-import os
 import typing as t
-from datetime import datetime, timezone
 
 from cstar.base.env import EnvVar
 
 _GROUP_ORCH: t.Final[str] = "Orchestration"
 _GROUP_DEV: t.Final[str] = "Developer Only"
-
-
-def generate_run_id() -> str:
-    """Generate a unique run identifier based on the current time."""
-    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
 
 ENV_CSTAR_ORCH_DELAYS: t.Annotated[
@@ -43,16 +36,6 @@ ENV_CSTAR_CMD_CONVERTER_OVERRIDE: t.Annotated[
 ] = "CSTAR_CMD_CONVERTER_OVERRIDE"
 """Environment variable containing an overridden mapping key to apply when
 converting applications into CLI commands."""
-
-ENV_CSTAR_ORCH_RUNID: t.Annotated[
-    t.Literal["CSTAR_RUNID"],
-    EnvVar(
-        description="Unique run identifier used by the orchestrator.",
-        group=_GROUP_DEV,
-        default_factory=lambda _: generate_run_id(),
-    ),
-] = "CSTAR_RUNID"
-"""Environment variable containing a unique run identifier used by the orchestrator."""
 
 ENV_CSTAR_SLURM_ACCOUNT: t.Annotated[
     t.Literal["CSTAR_SLURM_ACCOUNT"],
@@ -93,15 +76,3 @@ ENV_CSTAR_ORCH_REQD_ENV: t.Annotated[
     ),
 ] = "CSTAR_ORCH_REQD_ENV"
 """A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
-
-
-def get_run_id() -> str:
-    """Retrieve the current run-id.
-
-    Generate a new run-id if not found in the environment.
-
-    Returns
-    -------
-    str
-    """
-    return os.getenv(ENV_CSTAR_ORCH_RUNID, generate_run_id())

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -1,6 +1,7 @@
+import os
 import typing as t
 
-from cstar.base.env import EnvVar
+from cstar.base.env import ENV_CSTAR_RUNID, EnvVar, generate_run_id
 
 _GROUP_ORCH: t.Final[str] = "Orchestration"
 _GROUP_DEV: t.Final[str] = "Developer Only"
@@ -76,3 +77,17 @@ ENV_CSTAR_ORCH_REQD_ENV: t.Annotated[
     ),
 ] = "CSTAR_ORCH_REQD_ENV"
 """A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
+
+"""A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
+
+
+def get_run_id() -> str:
+    """Retrieve the current run-id.
+
+    Generate a new run-id if not found in the environment.
+
+    Returns
+    -------
+    str
+    """
+    return os.getenv(ENV_CSTAR_RUNID, generate_run_id())

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -78,8 +78,6 @@ ENV_CSTAR_ORCH_REQD_ENV: t.Annotated[
 ] = "CSTAR_ORCH_REQD_ENV"
 """A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
 
-"""A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
-
 
 def get_run_id() -> str:
     """Retrieve the current run-id.

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -20,12 +20,8 @@ from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
     ENV_CSTAR_SLURM_QUEUE,
+    get_run_id,
 )
-
-
-def generate_run_id() -> str:
-    """Generate a unique run identifier based on the current time."""
-    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
 
 @pytest.mark.asyncio
@@ -279,7 +275,7 @@ async def test_prepare_composed_dag(
         )
 
         configure_environment(output_dir, run_id)
-        run_id = generate_run_id()
+        run_id = get_run_id()
         output_dir = DirectoryManager.data_home()
         check_environment()
         wp, wp_path = await prepare_workplan(generated_wp_path, output_dir, run_id)

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_STATE_HOME, FLAG_ON
+from cstar.base.env import ENV_CSTAR_RUNID, ENV_CSTAR_STATE_HOME, FLAG_ON
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.cli.workplan.compose import WorkplanTemplate, compose
 from cstar.execution.file_system import DirectoryManager
@@ -16,13 +16,16 @@ from cstar.orchestration.serialization import deserialize, serialize
 from cstar.orchestration.transforms import SplitFrequency, WorkplanTransformer
 from cstar.orchestration.utils import (
     ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
-    ENV_CSTAR_ORCH_RUNID,
     ENV_CSTAR_ORCH_TRX_FREQ,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
     ENV_CSTAR_SLURM_QUEUE,
-    get_run_id,
 )
+
+
+def generate_run_id() -> str:
+    """Generate a unique run identifier based on the current time."""
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
 
 @pytest.mark.asyncio
@@ -197,7 +200,7 @@ async def test_build_and_run_dag_env(
         ENV_CSTAR_SLURM_ACCOUNT: "xyz",
         ENV_CSTAR_SLURM_QUEUE: "wholenode",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:5:00",
-        ENV_CSTAR_ORCH_RUNID: run_id,
+        ENV_CSTAR_RUNID: run_id,
     }
 
     # get rid of one required env var.
@@ -276,7 +279,7 @@ async def test_prepare_composed_dag(
         )
 
         configure_environment(output_dir, run_id)
-        run_id = get_run_id()
+        run_id = generate_run_id()
         output_dir = DirectoryManager.data_home()
         check_environment()
         wp, wp_path = await prepare_workplan(generated_wp_path, output_dir, run_id)

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -8,7 +8,7 @@ from unittest import mock
 import networkx as nx
 import pytest
 
-from cstar.base.env import FLAG_ON
+from cstar.base.env import ENV_CSTAR_RUNID, FLAG_ON
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
@@ -26,7 +26,6 @@ from cstar.orchestration.transforms import (
     WorkplanTransformer,
     get_time_slices,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_RUNID
 
 
 @pytest.fixture
@@ -319,7 +318,7 @@ def test_workplan_transformation(diamond_workplan: Workplan) -> None:
         mock.patch.dict(
             os.environ,
             {
-                ENV_CSTAR_ORCH_RUNID: str(uuid.uuid4()),
+                ENV_CSTAR_RUNID: str(uuid.uuid4()),
                 ENV_FF_ORCH_TRX_TIMESPLIT: FLAG_ON,
             },
         ),

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME
 from cstar.orchestration.models import Application, Step, Workplan
 from cstar.orchestration.transforms import (
@@ -13,7 +14,6 @@ from cstar.orchestration.transforms import (
     get_time_slices,
     get_transforms,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_RUNID
 
 
 @pytest.fixture
@@ -121,7 +121,7 @@ def test_splitter(single_step_workplan: Workplan) -> None:
 
     step = single_step_workplan.steps[0]
 
-    with mock.patch.dict(os.environ, {ENV_CSTAR_ORCH_RUNID: "12345"}, clear=True):
+    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: "12345"}, clear=True):
         transformed_steps = list(transform(step))
 
     # one step transforms into 12 monthly steps

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Workplan
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.transforms import (
@@ -12,7 +13,6 @@ from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
     get_transforms,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_RUNID
 
 
 @pytest.fixture
@@ -151,7 +151,7 @@ def test_override_transform(
     transform = OverrideTransform()
     step = step_overiding_wp.steps[0]
 
-    with mock.patch.dict(os.environ, {ENV_CSTAR_ORCH_RUNID: "12345"}, clear=True):
+    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: "12345"}, clear=True):
         steps = transform(step)
 
     transformed = list(steps)[0]
@@ -212,7 +212,7 @@ def test_override_transform_system_precedence(
     transform = OverrideTransform(sys_overrides=system_od_override)
     step = step_overiding_wp.steps[0]
 
-    with mock.patch.dict(os.environ, {ENV_CSTAR_ORCH_RUNID: "12345"}, clear=True):
+    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: "12345"}, clear=True):
         steps = transform(step)
 
     transformed = list(steps)[0]


### PR DESCRIPTION
# Summary

This PR relocates and renames `ENV_CSTAR_ORCH_RUNID` to avoid circular dependencies when using the run id in preparation for CSD-535.

# Miscellaneous

- Rename constant and move from `cstar.orchestration.utils` to `cstar.base.env`
- Update all references to the variable

- [X] Tests passing
