### PR TITLE
Fix posix-path conversion bug for remote blueprints (CSD-535)

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -365,7 +365,7 @@ def additional_files_dir() -> Path:
     return Path(__file__).parent.parent / "additional_files"
 
 
-def copy_local(url: str) -> Path:
+def copy_local(url: str, directory: Path) -> Path:
     """Copy a remote resource to a local file.
 
     Returns
@@ -383,7 +383,7 @@ def copy_local(url: str) -> Path:
         msg = f"Unable to retrieve file from: {url}"
         raise FileNotFoundError(msg)
 
-    local_path = Path(resource_name)
+    local_path = directory / resource_name
     local_path.write_text(get_request.text)
 
     return local_path.expanduser().resolve()

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -5,8 +5,10 @@ import re
 import subprocess
 import typing as t
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import dateutil
+from requests import request
 
 from cstar.base.log import get_logger
 
@@ -361,3 +363,27 @@ def additional_files_dir() -> Path:
     Path
     """
     return Path(__file__).parent.parent / "additional_files"
+
+
+def copy_local(url: str) -> Path:
+    """Copy a remote resource to a local file.
+
+    Returns
+    -------
+    Path
+        The local path where the remote resource was copied
+    """
+    parsed_url = urlsplit(url)
+    resource_path = Path(parsed_url.path)
+    resource_name = resource_path.name
+    http_ok: t.Final[int] = 200
+
+    get_request = request("GET", url, timeout=2.0)
+    if get_request.status_code != http_ok:
+        msg = f"Unable to retrieve file from: {url}"
+        raise FileNotFoundError(msg)
+
+    local_path = Path(resource_name)
+    local_path.write_text(get_request.text)
+
+    return local_path.expanduser().resolve()

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -5,10 +5,8 @@ import re
 import subprocess
 import typing as t
 from pathlib import Path
-from urllib.parse import urlsplit
 
 import dateutil
-from requests import request
 
 from cstar.base.log import get_logger
 
@@ -363,27 +361,3 @@ def additional_files_dir() -> Path:
     Path
     """
     return Path(__file__).parent.parent / "additional_files"
-
-
-def copy_local(url: str, directory: Path) -> Path:
-    """Copy a remote resource to a local file.
-
-    Returns
-    -------
-    Path
-        The local path where the remote resource was copied
-    """
-    parsed_url = urlsplit(url)
-    resource_path = Path(parsed_url.path)
-    resource_name = resource_path.name
-    http_ok: t.Final[int] = 200
-
-    get_request = request("GET", url, timeout=2.0)
-    if get_request.status_code != http_ok:
-        msg = f"Unable to retrieve file from: {url}"
-        raise FileNotFoundError(msg)
-
-    local_path = directory / resource_name
-    local_path.write_text(get_request.text)
-
-    return local_path.expanduser().resolve()

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -1,8 +1,10 @@
 import typing as t
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import typer
 
+from cstar.base.utils import copy_local
 from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.serialization import deserialize
 
@@ -11,7 +13,7 @@ app = typer.Typer()
 
 @app.command()
 def check(
-    path: t.Annotated[Path, typer.Argument(help="Path to a blueprint file.")],
+    path: t.Annotated[str, typer.Argument(help="Path to a blueprint file.")],
 ) -> bool:
     """Perform content validation on a user-supplied blueprint.
 
@@ -20,13 +22,22 @@ def check(
     bool
         `True` if valid
     """
+    is_remote = path.startswith("http")
+    bp: RomsMarblBlueprint | None = None
+    bp_path: Path | None = None
+
     try:
-        _ = deserialize(path, RomsMarblBlueprint)
-        print("The blueprint is valid")
-        return True
-    except FileNotFoundError:
-        print(f"Blueprint not found at path: {path}")
+        with TemporaryDirectory() as tmp_dir:
+            bp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
+            bp = deserialize(bp_path, RomsMarblBlueprint)
     except ValueError as ex:
         print(f"The blueprint is invalid: {ex}")
+    except FileNotFoundError:
+        print(f"Blueprint not found at path: {path}")
+    else:
+        print("The blueprint is valid")
+    finally:
+        if is_remote and bp_path and bp_path.exists():
+            bp_path.unlink()
 
-    return False
+    return bp is not None

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -1,10 +1,8 @@
 import typing as t
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import typer
 
-from cstar.base.utils import copy_local
+from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.serialization import deserialize
 
@@ -22,13 +20,10 @@ def check(
     bool
         `True` if valid
     """
-    is_remote = path.startswith("http")
     bp: RomsMarblBlueprint | None = None
-    bp_path: Path | None = None
 
     try:
-        with TemporaryDirectory() as tmp_dir:
-            bp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
+        with local_copy(path) as bp_path:
             bp = deserialize(bp_path, RomsMarblBlueprint)
     except ValueError as ex:
         print(f"The blueprint is invalid: {ex}")
@@ -36,8 +31,5 @@ def check(
         print(f"Blueprint not found at path: {path}")
     else:
         print("The blueprint is valid")
-    finally:
-        if is_remote and bp_path and bp_path.exists():
-            bp_path.unlink()
 
     return bp is not None

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -1,6 +1,5 @@
 import asyncio
 import typing as t
-from pathlib import Path
 
 import typer
 
@@ -20,7 +19,8 @@ app = typer.Typer()
 @app.command()
 def run(
     path: t.Annotated[
-        Path, typer.Argument(help="The path to the blueprint to execute")
+        str,
+        typer.Argument(help="The path to the blueprint to execute"),
     ],
     stage: t.Annotated[
         list[SimulationStages] | None,
@@ -37,7 +37,7 @@ def run(
     print("Executing blueprint in a worker service")
     job_cfg = get_job_config()
     service_cfg = get_service_config(get_env_item(ENV_CSTAR_LOG_LEVEL).value)
-    request = get_request(path.as_posix(), stage)
+    request = get_request(path, stage)
 
     rc = asyncio.run(execute_runner(job_cfg, service_cfg, request))
 

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -1,10 +1,8 @@
 import typing as t
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import typer
 
-from cstar.base.utils import copy_local
+from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import deserialize
 
@@ -22,13 +20,10 @@ def check(
     bool
         `True` if valid
     """
-    is_remote = path.startswith("http")
     wp: Workplan | None = None
-    wp_path: Path | None = None
 
     try:
-        with TemporaryDirectory() as tmp_dir:
-            wp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
+        with local_copy(path) as wp_path:
             wp = deserialize(wp_path, Workplan)
     except ValueError as ex:
         print(f"The workplan is invalid: {ex}")

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -1,8 +1,10 @@
 import typing as t
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import typer
 
+from cstar.base.utils import copy_local
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import deserialize
 
@@ -11,7 +13,7 @@ app = typer.Typer()
 
 @app.command()
 def check(
-    path: t.Annotated[Path, typer.Argument(help="Path to the workplan")],
+    path: t.Annotated[str, typer.Argument(help="Path to the workplan")],
 ) -> bool:
     """Perform content validation on the workplan supplied by the user.
 
@@ -20,13 +22,19 @@ def check(
     bool
         `True` if valid
     """
+    is_remote = path.startswith("http")
+    wp: Workplan | None = None
+    wp_path: Path | None = None
+
     try:
-        _ = deserialize(path, Workplan)
-        print("The workplan is valid")
-        return True
-    except FileNotFoundError:
-        print(f"Workplan not found at path: {path}")
+        with TemporaryDirectory() as tmp_dir:
+            wp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
+            wp = deserialize(wp_path, Workplan)
     except ValueError as ex:
         print(f"The workplan is invalid: {ex}")
+    except FileNotFoundError:
+        print(f"Workplan not found at path: {path}")
+    else:
+        print("The workplan is valid")
 
-    return False
+    return wp is not None

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -1,9 +1,11 @@
 import asyncio
 import typing as t
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import typer
 
+from cstar.base.utils import copy_local
 from cstar.cli.workplan.check import check
 from cstar.orchestration.dag_runner import build_and_run_dag
 
@@ -12,7 +14,7 @@ app = typer.Typer()
 
 @app.command()
 def run(
-    path: t.Annotated[Path, typer.Argument(help="Path to a workplan file.")],
+    path: t.Annotated[str, typer.Argument(help="Path to a workplan file.")],
     run_id: t.Annotated[
         str,
         typer.Option(help="The unique identifier for an execution of the workplan."),
@@ -31,9 +33,13 @@ def run(
     if not check(path):
         return
 
+    is_remote = path.startswith("http")
+
     try:
-        output_path = Path(output_dir) if output_dir else None
-        asyncio.run(build_and_run_dag(path, run_id, output_path))
+        with TemporaryDirectory() as tmp_dir:
+            wp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
+            output_path = Path(output_dir) if output_dir else None
+            asyncio.run(build_and_run_dag(wp_path, run_id, output_path))
         print("Workplan run has completed.")
     except Exception as ex:
         print(f"Workplan run has completed unsuccessfully: {ex!r}")

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -1,12 +1,11 @@
 import asyncio
 import typing as t
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import typer
 
-from cstar.base.utils import copy_local
 from cstar.cli.workplan.check import check
+from cstar.execution.file_system import local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
 
 app = typer.Typer()
@@ -33,12 +32,10 @@ def run(
     if not check(path):
         return
 
-    is_remote = path.startswith("http")
+    output_path = Path(output_dir) if output_dir else None
 
     try:
-        with TemporaryDirectory() as tmp_dir:
-            wp_path = copy_local(path, Path(tmp_dir)) if is_remote else Path(path)
-            output_path = Path(output_dir) if output_dir else None
+        with local_copy(path) as wp_path:
             asyncio.run(build_and_run_dag(wp_path, run_id, output_path))
         print("Workplan run has completed.")
     except Exception as ex:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -4,7 +4,6 @@ import sys
 import textwrap
 import typing as t
 from collections import defaultdict
-from pathlib import Path
 
 from cstar.base.log import get_logger
 from cstar.orchestration.models import Application, Step
@@ -44,8 +43,8 @@ def convert_roms_step_to_command(step: Step) -> str:
     str
         The complete CLI command.
     """
-    bp_path = Path(step.blueprint_path).as_posix()
-    return f"{sys.executable} -m cstar.entrypoint.worker.worker -b {bp_path}"
+    worker_module = "cstar.entrypoint.worker.worker"
+    return f"{sys.executable} -m {worker_module}  -b {step.blueprint_path}"
 
 
 def convert_step_to_placeholder(step: Step) -> str:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,6 +1,5 @@
 import os
 import typing as t
-from pathlib import Path
 
 from prefect import task
 from prefect.context import TaskRunContext
@@ -134,8 +133,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             A ProcessHandle identifying the newly submitted job.
         """
         job_name = step.safe_name
-        bp_path = Path(step.blueprint_path)
-        bp = deserialize(bp_path, RomsMarblBlueprint)
+        bp = deserialize(step.blueprint_path, RomsMarblBlueprint)
         job_dep_ids = [d.pid for d in dependencies]
 
         step_converter = get_command_mapping(

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
@@ -20,7 +20,7 @@ def test_blueprint_check_file_dne(
     """
     blueprint_path = tmp_path / "blueprint-dne.yml"
 
-    check(blueprint_path)
+    check(blueprint_path.as_posix())
 
     assert "not found" in capsys.readouterr().out
 
@@ -41,7 +41,7 @@ def test_blueprint_check_file_no_content(
     blueprint_path = tmp_path / "empty_blueprint.yml"
     blueprint_path.touch()
 
-    check(blueprint_path)
+    check(blueprint_path.as_posix())
 
     assert "is invalid" in capsys.readouterr().out
 
@@ -67,7 +67,7 @@ def test_blueprint_check_file_bad_content(
     blueprint_path = tmp_path / "invalid_blueprint.yml"
     blueprint_path.write_text(content)
 
-    check(blueprint_path)
+    check(blueprint_path.as_posix())
 
     assert "is invalid" in capsys.readouterr().out
 
@@ -102,7 +102,7 @@ def test_blueprint_valid_input(
     """
     blueprint_path = package_path / repo_relative_path
 
-    check(Path(blueprint_path))
+    check(blueprint_path.as_posix())
 
     assert "is valid" in capsys.readouterr().out, (
         f"`{blueprint_path}` does not contain a valid blueprint"
@@ -179,7 +179,7 @@ def test_blueprint_incomplete_input(
     bp_path = tmp_path / "bp.yaml"
     bp_path.write_text("\n".join(remaining_content))
 
-    check(bp_path)
+    check(bp_path.as_posix())
 
     err_msg = f"{bp_path} should not pass validation"
     assert "is invalid" in capsys.readouterr().out, err_msg
@@ -241,7 +241,43 @@ def test_blueprint_optional_input(
     bp_path = tmp_path / "bp.yaml"
     bp_path.write_text("\n".join(remaining_content))
 
-    check(bp_path)
+    check(bp_path.as_posix())
 
     err_msg = f"{bp_path} should not pass validation"
     assert "is valid" in capsys.readouterr().out, err_msg
+
+
+def test_blueprint_check_remote_blueprint_dne(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote blueprint is handled properly and the
+    blueprint is not executed if the URL is invalid.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint-X.yaml"
+
+    check(bp_path)
+
+    assert "not found" in capsys.readouterr().out
+
+
+def test_blueprint_check_remote_blueprint(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote blueprint is handled properly and the
+    blueprint is executed.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+
+    check(bp_path)
+
+    assert "is valid" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
@@ -265,8 +265,16 @@ def test_blueprint_check_remote_blueprint_dne(
     assert "not found" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    "bp_uri",
+    [
+        "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml",
+        "HTTPS://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml",
+    ],
+)
 def test_blueprint_check_remote_blueprint(
     capsys: pytest.CaptureFixture,
+    bp_uri: str,
 ) -> None:
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is executed.
@@ -275,9 +283,9 @@ def test_blueprint_check_remote_blueprint(
     ----------
     capsys : pytest.CaptureFixture
         Used to verify outputs from the CLI
+    bp_uri : str
+        A working URL referencing a valid blueprint
     """
-    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
-
-    check(bp_path)
+    check(bp_uri)
 
     assert "is valid" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -19,8 +20,49 @@ def test_blueprint_run_file_dne(
     tmp_path : Path
         Temporary directory to read/write test inputs and outputs
     """
-    wp_path = tmp_path / "blueprint-dne.yml"
+    bp_path = tmp_path / "blueprint-dne.yml"
 
-    run(wp_path)
+    run(bp_path.as_posix())
 
     assert "not found" in capsys.readouterr().out
+
+
+def test_blueprint_run_remote_blueprint_dne(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote blueprint is handled properly and the
+    blueprint is not executed if the URL is invalid.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint-X.yaml"
+
+    run(bp_path)
+
+    assert "not found" in capsys.readouterr().out
+
+
+def test_blueprint_run_remote_blueprint(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote blueprint is handled properly and the
+    blueprint is executed.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+
+    with mock.patch(
+        "cstar.cli.blueprint.run.execute_runner",
+        return_value=0,
+    ) as mock_exec:
+        run(bp_path)
+
+    assert "is valid" in capsys.readouterr().out
+    mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
@@ -32,7 +32,7 @@ def test_cli_workplan_check_action_tpl(
     wp_path = tmp_path / template_file
     wp_path.write_text(template_path.read_text())
 
-    check(wp_path)
+    check(wp_path.as_posix())
     captured = capsys.readouterr().out
     assert " valid" in captured
 
@@ -54,7 +54,7 @@ def test_cli_workplan_check_dne(
     """
     wp_path = tmp_path / "workplan-dne.yaml"
 
-    check(wp_path)
+    check(wp_path.as_posix())
     captured = capsys.readouterr().out
     assert " not found" in captured
 
@@ -75,7 +75,7 @@ def test_cli_workplan_check_file_no_content(
     wp_path = tmp_path / "empty_workplan.yml"
     wp_path.touch()
 
-    check(wp_path)
+    check(wp_path.as_posix())
 
     assert "is invalid" in capsys.readouterr().out
 
@@ -101,7 +101,7 @@ def test_cli_workplan_check_file_bad_content(
     wp_path = tmp_path / "invalid_workplan.yml"
     wp_path.write_text(content)
 
-    check(wp_path)
+    check(wp_path.as_posix())
 
     assert "is invalid" in capsys.readouterr().out
 
@@ -134,7 +134,7 @@ def test_cli_workplan_check_valid_input(
     """
     wp_path = package_path / repo_relative_path
 
-    check(Path(wp_path))
+    check(wp_path.as_posix())
 
     msg = f"`{wp_path}` does not contain a valid workplan"
     assert "is valid" in capsys.readouterr().out, msg
@@ -197,12 +197,12 @@ def test_workplan_incomplete_input(
         if end_removal is None or end_removal in line:
             cutting = False
 
-    bp_path = tmp_path / "bp.yaml"
-    bp_path.write_text("\n".join(remaining_content))
+    wp_path = tmp_path / "wp.yaml"
+    wp_path.write_text("\n".join(remaining_content))
 
-    check(bp_path)
+    check(wp_path.as_posix())
 
-    err_msg = f"{bp_path} should not pass validation"
+    err_msg = f"{wp_path} should not pass validation"
     assert "is invalid" in capsys.readouterr().out, err_msg
 
 
@@ -267,10 +267,46 @@ def test_workplan_optional_input(
         if end_removal is None or end_removal in line:
             cutting = False
 
-    bp_path = tmp_path / "bp.yaml"
-    bp_path.write_text("\n".join(remaining_content))
+    wp_path = tmp_path / "bp.yaml"
+    wp_path.write_text("\n".join(remaining_content))
 
-    check(bp_path)
+    check(wp_path.as_posix())
 
-    err_msg = f"{bp_path} should not pass validation"
+    err_msg = f"{wp_path} should not pass validation"
     assert "is valid" in capsys.readouterr().out, err_msg
+
+
+def test_workplan_check_remote_workplan_dne(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote workplan is handled properly and the
+    workplan is not executed if the URL is invalid.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml_XXX"
+
+    check(wp_path)
+
+    assert "not found" in capsys.readouterr().out
+
+
+def test_workplan_check_remote_workplan(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote workplan is handled properly and the
+    workplan is executed.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
+
+    check(wp_path)
+
+    assert "is valid" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
@@ -294,8 +294,16 @@ def test_workplan_check_remote_workplan_dne(
     assert "not found" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    "wp_uri",
+    [
+        "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml",
+        "HTTPS://raw.githubusercontent.com/cworthy-ocean/c-star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml",
+    ],
+)
 def test_workplan_check_remote_workplan(
     capsys: pytest.CaptureFixture,
+    wp_uri: str,
 ) -> None:
     """Verify that a URL to a remote workplan is handled properly and the
     workplan is executed.
@@ -304,9 +312,9 @@ def test_workplan_check_remote_workplan(
     ----------
     capsys : pytest.CaptureFixture
         Used to verify outputs from the CLI
+    wp_uri : str
+        A working URL referencing a valid workplan
     """
-    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
-
-    check(wp_path)
+    check(wp_uri)
 
     assert "is valid" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -45,8 +45,16 @@ def test_workplan_run_remote_workplan_dne(
     assert "not found" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    "wp_uri",
+    [
+        "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml",
+        "HTTPS://raw.githubusercontent.com/cworthy-ocean/c-star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml",
+    ],
+)
 def test_workplan_run_remote_workplan(
     capsys: pytest.CaptureFixture,
+    wp_uri: str,
 ) -> None:
     """Verify that a URL to a remote workplan is handled properly and the
     workplan is executed.
@@ -55,14 +63,14 @@ def test_workplan_run_remote_workplan(
     ----------
     capsys : pytest.CaptureFixture
         Used to verify outputs from the CLI
+    wp_uri : str
+        A working URL referencing a valid workplan
     """
-    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
-
     with mock.patch(
         "cstar.cli.workplan.run.build_and_run_dag",
         return_value=0,
     ) as mock_exec:
-        run(wp_path, "12345")
+        run(wp_uri, "12345")
 
     assert "is valid" in capsys.readouterr().out
     mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -21,6 +22,47 @@ def test_workplan_run_file_dne(
     """
     wp_path = tmp_path / "workplan-dne.yml"
 
-    run(wp_path, "test-run-id")
+    run(wp_path.as_posix(), "test-run-id")
 
     assert "not found" in capsys.readouterr().out
+
+
+def test_workplan_run_remote_workplan_dne(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote workplan is handled properly and the
+    workplan is not executed if the URL is invalid.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml_XXX"
+
+    run(wp_path, "my-run-id")
+
+    assert "not found" in capsys.readouterr().out
+
+
+def test_workplan_run_remote_workplan(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a URL to a remote workplan is handled properly and the
+    workplan is executed.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    """
+    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
+
+    with mock.patch(
+        "cstar.cli.workplan.run.build_and_run_dag",
+        return_value=0,
+    ) as mock_exec:
+        run(wp_path, "12345")
+
+    assert "is valid" in capsys.readouterr().out
+    mock_exec.assert_called_once()

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -30,6 +30,7 @@ Bug Fixes
 - Fix failure to override output directories for orchestrated blueprints
 - Fix defect where steps defined before dependencies were not mapped correctly after time-splitting
 - Fix unhandled exceptions in `cstar [blueprint|workplan] check` with invalid paths
+- Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run` 
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

Update the `cstar blueprint run` CLI command to fix a defect where remote blueprint URI's are incorrectly converted to posix paths.

# Change List

- Avoid use of `Path.as_posix()` for conversion of CLI argument to string

# Bug Fixes

- Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run` 

# Review Checklist

- [X] Closes #CSD-535
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`