### PR TITLE
Fix uncaught exceptions when validating via CLI

### DIFF
--- a/cstar/additional_files/templates/wp/workplan.yaml
+++ b/cstar/additional_files/templates/wp/workplan.yaml
@@ -40,7 +40,7 @@ steps:
           num_nodes: 4
     - name: Aggregate Results
       application: sleep
-      depends_on: ["Ensemble X", "Ensembly Y"]
+      depends_on: ["Ensemble X", "Ensemble Y"]
       blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
       blueprint_overrides: {}
       workflow_overrides:

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -17,5 +17,7 @@ def check(
     try:
         _ = deserialize(path, RomsMarblBlueprint)
         print("The blueprint is valid")
+    except FileNotFoundError:
+        print(f"Blueprint not found at path: {path}")
     except ValueError as ex:
         print(f"The blueprint is invalid: {ex}")

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -12,12 +12,21 @@ app = typer.Typer()
 @app.command()
 def check(
     path: t.Annotated[Path, typer.Argument(help="Path to a blueprint file.")],
-) -> None:
-    """Perform content validation on a user-supplied blueprint."""
+) -> bool:
+    """Perform content validation on a user-supplied blueprint.
+
+    Returns
+    -------
+    bool
+        `True` if valid
+    """
     try:
         _ = deserialize(path, RomsMarblBlueprint)
         print("The blueprint is valid")
+        return True
     except FileNotFoundError:
         print(f"Blueprint not found at path: {path}")
     except ValueError as ex:
         print(f"The blueprint is invalid: {ex}")
+
+    return False

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import typer
 
 from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
+from cstar.cli.blueprint.check import check
 from cstar.entrypoint.worker.worker import (
     SimulationStages,
     execute_runner,
@@ -30,6 +31,9 @@ def run(
     ] = None,
 ) -> None:
     """Execute a blueprint in a local worker service."""
+    if not check(path):
+        return
+
     print("Executing blueprint in a worker service")
     job_cfg = get_job_config()
     service_cfg = get_service_config(get_env_item(ENV_CSTAR_LOG_LEVEL).value)

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -17,5 +17,7 @@ def check(
     try:
         _ = deserialize(path, Workplan)
         print("The workplan is valid")
+    except FileNotFoundError:
+        print(f"Workplan not found at path: {path}")
     except ValueError as ex:
         print(f"The workplan is invalid: {ex}")

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -12,12 +12,21 @@ app = typer.Typer()
 @app.command()
 def check(
     path: t.Annotated[Path, typer.Argument(help="Path to the workplan")],
-) -> None:
-    """Perform content validation on the workplan supplied by the user."""
+) -> bool:
+    """Perform content validation on the workplan supplied by the user.
+
+    Returns
+    -------
+    bool
+        `True` if valid
+    """
     try:
         _ = deserialize(path, Workplan)
         print("The workplan is valid")
+        return True
     except FileNotFoundError:
         print(f"Workplan not found at path: {path}")
     except ValueError as ex:
         print(f"The workplan is invalid: {ex}")
+
+    return False

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import typer
 
+from cstar.cli.workplan.check import check
 from cstar.orchestration.dag_runner import build_and_run_dag
 
 app = typer.Typer()
@@ -27,6 +28,9 @@ def run(
 
     Specify a previously used run_id option to re-start a prior run.
     """
+    if not check(path):
+        return
+
     try:
         output_path = Path(output_dir) if output_dir else None
         asyncio.run(build_and_run_dag(path, run_id, output_path))

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -498,7 +498,6 @@ class Workplan(BaseModel):
     """A user-friendly description of the workplan."""
 
     steps: t.Sequence[SerializeAsAny[Step]] = Field(
-        default_factory=list,
         min_length=1,
         frozen=True,
     )

--- a/cstar/tests/conftest.py
+++ b/cstar/tests/conftest.py
@@ -6,14 +6,25 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def tests_path() -> Path:
+def package_path() -> Path:
+    """Fixture that returns the path to the repository root directory.
+
+    Returns
+    -------
+    Path
+    """
+    return Path(__file__).parent.parent.parent
+
+
+@pytest.fixture(scope="session")
+def tests_path(package_path: Path) -> Path:
     """Fixture that returns the path to the directory containing C-Star tests.
 
     Returns
     -------
     Path
     """
-    return Path(__file__).parent
+    return package_path / "cstar" / "tests"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
@@ -1,0 +1,247 @@
+from pathlib import Path
+
+import pytest
+
+from cstar.cli.blueprint.check import check
+
+
+def test_blueprint_check_file_dne(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Verify that a path to a non-existent blueprint fails a validity check.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    blueprint_path = tmp_path / "blueprint-dne.yml"
+
+    check(blueprint_path)
+
+    assert "not found" in capsys.readouterr().out
+
+
+def test_blueprint_check_file_no_content(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Verify that an empty blueprint file fails a validity check.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    blueprint_path = tmp_path / "empty_blueprint.yml"
+    blueprint_path.touch()
+
+    check(blueprint_path)
+
+    assert "is invalid" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "content",
+    [" ", "", "\n", '{"foo": "bar"}'],
+)
+def test_blueprint_check_file_bad_content(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+    content: str,
+) -> None:
+    """Verify that an empty blueprint fails a validity check.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    blueprint_path = tmp_path / "invalid_blueprint.yml"
+    blueprint_path.write_text(content)
+
+    check(blueprint_path)
+
+    assert "is invalid" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "repo_relative_path",
+    [
+        Path("cstar/tests/integration_tests/blueprints/blueprint_template.yaml"),
+        Path("cstar/tests/integration_tests/blueprints/blueprint_complete.yaml"),
+        Path("docs/tutorials/wales_toy_blueprint.yaml"),
+        Path("docs/tutorials/wio_toy_blueprint.yaml"),
+    ],
+)
+def test_blueprint_valid_input(
+    capsys: pytest.CaptureFixture,
+    repo_relative_path: Path,
+    package_path: Path,
+) -> None:
+    """Verify that a valid blueprint passes the CLI check.
+
+    NOTE: This test also serves a practical purpose of confirming the continued
+    validity of tutorial and sample blueprints.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    repo_relative_path : Path
+        Relative path to a blueprint within the c-star repo
+    package_path : Path
+        Absolute path to the c-star package on disk
+    """
+    blueprint_path = package_path / repo_relative_path
+
+    check(Path(blueprint_path))
+
+    assert "is valid" in capsys.readouterr().out, (
+        f"`{blueprint_path}` does not contain a valid blueprint"
+    )
+
+
+@pytest.mark.parametrize(
+    ("start_removal", "end_removal"),
+    [
+        ("name:", None),
+        ("description:", None),
+        ("valid_start_date:", None),
+        ("valid_end_date:", None),
+        ("code:", "grid:"),
+        ("grid:", "initial_conditions:"),
+        ("initial_conditions:", "forcing"),
+        ("forcing:", "partitioning"),
+        ("partitioning:", "model_params:"),
+        ("model_params:", "runtime_params:"),
+        ("runtime_params:", "<EOF>"),
+        ("run_time:", "compile_time:"),
+        ("compile_time:", "grid:"),
+        ("location:", None),
+        ("branch", None),
+        ("roms:", "marbl:"),
+        ("directory:", None),
+    ],
+)
+def test_blueprint_incomplete_input(
+    capsys: pytest.CaptureFixture,
+    start_removal: str,
+    end_removal: str,
+    tests_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Verify that an incomplete blueprint fails the CLI check.
+
+    Starts with a sample blueprint and removes a piece of required information in each test.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    start_removal : Path
+        A string that will trigger content skipping to begin when building a test blueprint
+    end_removal : Path
+       A string that will trigger content skipping to end when building a test blueprint
+    tests_path : Path
+        Path to the c-star tests directory
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    blueprint_path = tests_path / "integration_tests/blueprints/blueprint_complete.yaml"
+
+    content = blueprint_path.read_text().splitlines()
+    remaining_content = []
+    cutting = False
+    cut_once = False
+
+    for line in content:
+        if start_removal in line and not cut_once:
+            cutting = True
+            cut_once = True
+        elif end_removal and end_removal in line:
+            cutting = False
+
+        if not cutting:
+            remaining_content.append(line)
+
+        if end_removal is None or end_removal in line:
+            cutting = False
+            remaining_content.append(line)
+
+    bp_path = tmp_path / "bp.yaml"
+    bp_path.write_text("\n".join(remaining_content))
+
+    check(bp_path)
+
+    err_msg = f"{bp_path} should not pass validation"
+    assert "is invalid" in capsys.readouterr().out, err_msg
+
+
+@pytest.mark.parametrize(
+    ("start_removal", "end_removal"),
+    [
+        ("application:", None),
+        ("state:", None),
+        ("filter:", "compile_time"),
+        ("files:", "directory:"),
+    ],
+)
+def test_blueprint_optional_input(
+    capsys: pytest.CaptureFixture,
+    start_removal: str,
+    end_removal: str,
+    tests_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Verify that an incomplete blueprint passes the CLI check if the missing information
+    is not required.
+
+    Starts with a sample blueprint and removes a piece of optional information in each test.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    start_removal : Path
+        A string that will trigger content skipping to begin when building a test blueprint
+    end_removal : Path
+       A string that will trigger content skipping to end when building a test blueprint
+    tests_path : Path
+        Path to the c-star tests directory
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    blueprint_path = tests_path / "integration_tests/blueprints/blueprint_complete.yaml"
+
+    content = blueprint_path.read_text().splitlines()
+    remaining_content = []
+    cutting, cut_once = False, False
+
+    for line in content:
+        if start_removal in line and not cut_once:
+            cutting = True
+            cut_once = True
+        elif end_removal and end_removal in line:
+            cutting = False
+
+        if not cutting:
+            remaining_content.append(line)
+
+        if end_removal is None or end_removal in line:
+            cutting = False
+
+    bp_path = tmp_path / "bp.yaml"
+    bp_path.write_text("\n".join(remaining_content))
+
+    check(bp_path)
+
+    err_msg = f"{bp_path} should not pass validation"
+    assert "is valid" in capsys.readouterr().out, err_msg

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from cstar.cli.blueprint.run import run
+
+
+def test_blueprint_run_file_dne(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Verify that a path to a non-existent blueprint fails to be started due
+    to validation.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    wp_path = tmp_path / "blueprint-dne.yml"
+
+    run(wp_path)
+
+    assert "not found" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_check.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_check.py
@@ -35,3 +35,242 @@ def test_cli_workplan_check_action_tpl(
     check(wp_path)
     captured = capsys.readouterr().out
     assert " valid" in captured
+
+
+def test_cli_workplan_check_dne(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that an invalid path fails a validity check.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    workplan_name : str
+        The name of a workplan template to use for workplan creation
+    wp_templates_dir : Path
+        Fixture returning the path to the directory containing workplan template files
+    """
+    wp_path = tmp_path / "workplan-dne.yaml"
+
+    check(wp_path)
+    captured = capsys.readouterr().out
+    assert " not found" in captured
+
+
+def test_cli_workplan_check_file_no_content(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Verify that an empty workplan file fails a validity check.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    wp_path = tmp_path / "empty_workplan.yml"
+    wp_path.touch()
+
+    check(wp_path)
+
+    assert "is invalid" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "content",
+    [" ", "", "\n", '{"foo": "bar"}', "name: Sample Workplan\n"],
+)
+def test_cli_workplan_check_file_bad_content(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+    content: str,
+) -> None:
+    """Verify that an invalid/malformed workplan fails a validity check.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    wp_path = tmp_path / "invalid_workplan.yml"
+    wp_path.write_text(content)
+
+    check(wp_path)
+
+    assert "is invalid" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "repo_relative_path",
+    [
+        Path("docs/tutorials/workplan_laptop_example.yaml"),
+        Path("cstar/additional_files/templates/wp/workplan.yaml"),
+    ],
+)
+def test_cli_workplan_check_valid_input(
+    capsys: pytest.CaptureFixture,
+    repo_relative_path: Path,
+    package_path: Path,
+) -> None:
+    """Verify that a valid workplan passes the CLI check.
+
+    NOTE: This test also serves a practical purpose of confirming the continued
+    validity of tutorial and sample workplans.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    repo_relative_path : Path
+        Relative path to a workplan within the c-star repo
+    package_path : Path
+        Absolute path to the c-star package on disk
+    """
+    wp_path = package_path / repo_relative_path
+
+    check(Path(wp_path))
+
+    msg = f"`{wp_path}` does not contain a valid workplan"
+    assert "is valid" in capsys.readouterr().out, msg
+
+
+@pytest.mark.parametrize(
+    ("start_removal", "end_removal"),
+    [
+        ("name:", None),
+        ("description:", None),
+        ("steps:", "<EOF>"),
+        ("Prepare", "Ensemble X"),
+        ("Ensemble X", "Ensemble Y"),
+        ("Ensemble Y", "Aggregate"),
+        ("blueprint:", None),
+        ("segment_length:", None),
+    ],
+)
+def test_workplan_incomplete_input(
+    capsys: pytest.CaptureFixture,
+    start_removal: str,
+    end_removal: str,
+    tmp_path: Path,
+    package_path: Path,
+) -> None:
+    """Verify that an incomplete workplan fails the CLI check.
+
+    Starts with a sample workplan and removes a piece of required information in each test.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    start_removal : Path
+        A string that will trigger content skipping to begin when building a test workplan
+    end_removal : Path
+       A string that will trigger content skipping to end when building a test workplan
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    package_path : Path
+        Absolute path to the c-star package on disk
+    """
+    wp_path = package_path / "cstar/additional_files/templates/wp/workplan.yaml"
+
+    content = wp_path.read_text().splitlines()
+    remaining_content = []
+    cutting = False
+    cut_once = False
+
+    for line in content:
+        if start_removal in line and not cut_once:
+            cutting = True
+            cut_once = True
+        elif end_removal and end_removal in line:
+            cutting = False
+
+        if not cutting:
+            remaining_content.append(line)
+
+        if end_removal is None or end_removal in line:
+            cutting = False
+
+    bp_path = tmp_path / "bp.yaml"
+    bp_path.write_text("\n".join(remaining_content))
+
+    check(bp_path)
+
+    err_msg = f"{bp_path} should not pass validation"
+    assert "is invalid" in capsys.readouterr().out, err_msg
+
+
+@pytest.mark.parametrize(
+    ("start_removal", "end_removal"),
+    [
+        ("state:", None),
+        ("compute_environment:", "runtime_vars:"),
+        ("num_nodes:", None),
+        ("num_cpus_per_process:", None),
+        ("runtime_vars:", None),
+        ("Aggregate", None),
+        ("workflow_overrides:", "compute_overrides:"),
+        ("compute_overrides:", "name:"),
+        ("walltime", None),
+        ("          num_nodes:", None),
+        ("blueprint_overrides:", "workflow_overrides"),
+        ("depends_on:", "blueprint"),
+    ],
+)
+def test_workplan_optional_input(
+    capsys: pytest.CaptureFixture,
+    start_removal: str,
+    end_removal: str | None,
+    tmp_path: Path,
+    package_path: Path,
+) -> None:
+    """Verify that an incomplete workplan fails the CLI check.
+
+    Starts with a sample workplan and removes a piece of required information in each test.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    start_removal : Path
+        A string that will trigger content skipping to begin when building a test workplan
+    end_removal : Path
+       A string that will trigger content skipping to end when building a test workplan
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    package_path : Path
+        Absolute path to the c-star package on disk
+    """
+    wp_path = package_path / "cstar/additional_files/templates/wp/workplan.yaml"
+
+    content = wp_path.read_text().splitlines()
+    remaining_content = []
+    cutting = False
+    cut_once = False
+
+    for line in content:
+        if start_removal in line and not cut_once:
+            cutting = True
+            cut_once = True
+        elif end_removal and end_removal in line:
+            cutting = False
+
+        if not cutting:
+            remaining_content.append(line)
+
+        if end_removal is None or end_removal in line:
+            cutting = False
+
+    bp_path = tmp_path / "bp.yaml"
+    bp_path.write_text("\n".join(remaining_content))
+
+    check(bp_path)
+
+    err_msg = f"{bp_path} should not pass validation"
+    assert "is valid" in capsys.readouterr().out, err_msg

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from cstar.cli.workplan.run import run
+
+
+def test_workplan_run_file_dne(
+    capsys: pytest.CaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """Verify that a path to a non-existent workplan fails to be started due
+    to validation.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Used to verify outputs from the CLI
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    wp_path = tmp_path / "workplan-dne.yml"
+
+    run(wp_path, "test-run-id")
+
+    assert "not found" in capsys.readouterr().out

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -28,12 +28,14 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fix failure to override output directories for orchestrated blueprints
-- Fix defect where steps defined before dependencies were not mapped correctly after time-splitting 
+- Fix defect where steps defined before dependencies were not mapped correctly after time-splitting
+- Fix unhandled exceptions in `cstar [blueprint|workplan] check` with invalid paths
 
 Improvements
 ~~~~~~~~~~~~
 
 - Improve error handling when `CachedRemoteRepositoryRetriever.refresh` fails
+- Validate inputs prior to execution with `cstar [blueprint|workplan] run`
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

Improve input validation in CLI when using:
- `cstar [blueprint|workplan] check`
- `cstar [blueprint|workplan] run`

## Bug Fixes

- Catch `FileNotFoundError` in `cstar.cli.blueprint.check`
- Catch `FileNotFoundError` in `cstar.cli.workplan.check`

## Improvements

- Perform input validation before executing workplan and blueprint in:
  - `cstar.cli.blueprint.run`
  - `cstar.cli.workplan.run`

## Review Checklist

- [X] Closes #CSD-575
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`