### PR TITLE
Dynamically load roms_tools package

### DIFF
--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -4,13 +4,13 @@ import tempfile
 from abc import ABC
 from pathlib import Path
 
-import roms_tools
-
 from cstar.base.input_dataset import InputDataset
-from cstar.base.utils import _list_to_concise_str, coerce_datetime
+from cstar.base.utils import _list_to_concise_str, coerce_datetime, lazy_import
 from cstar.io.constants import FileEncoding
 from cstar.io.source_data import SourceData, SourceDataCollection
 from cstar.io.staged_data import StagedDataCollection
+
+roms_tools = lazy_import("roms_tools")
 
 
 class ROMSPartitioning:

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from unittest import mock
 
 import pytest
+import roms_tools  # noqa: F401, pre-load to avoid the lazy loader
 
 from cstar.io.source_data import SourceDataCollection
 from cstar.io.staged_data import StagedDataCollection


### PR DESCRIPTION
## Summary

This change adds a `lazy_import` function to `cstar.base.utils` that enables the import of slow-loading packages to be delayed until they are used. This drastically improves normal import times, and reduces the average execution time of CLI actions from ~11s to ~4s

## Changes

1. Add `lazy_import`
2. Update `cstar.roms.input_dataset.py` to lazy load `roms_tools`
3. Update tests using `input_dataset` module to pre-load `roms_tools` to make mocking work

## Improvements

- Reduce package import time by lazy loading expensive modules

## Review Checklist

- [X] Closes #CSD-579
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
