### PR TITLE
Perform lazy loading of networkx package

### DIFF
--- a/cstar/cli/workplan/plan.py
+++ b/cstar/cli/workplan/plan.py
@@ -3,10 +3,9 @@ import typing as t
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-import networkx as nx
 import typer
 
-from cstar.base.utils import slugify
+from cstar.base.utils import lazy_import, slugify
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import Planner
 from cstar.orchestration.serialization import deserialize
@@ -14,6 +13,8 @@ from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
     WorkplanTransformer,
 )
+
+nx = lazy_import("networkx")
 
 app = typer.Typer()
 


### PR DESCRIPTION
## Summary

This change makes use of `lazy_import` function to delay the import of `networkx` until it is used. This greatly improves normal import times, and reduces the average execution time of CLI actions from ~4s to ~3s

## Changes

1. Update `Planner` to use a lazy-loaded `networkx`
3. Update `plan` CLI action to use a lazy-loaded `networkx`

## Improvements

- Reduce package import time by lazy loading expensive modules

## Review Checklist

- [X] Closes #CSD-582
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
