### PR TITLE
Use lazy import with matplotlib

### DIFF
--- a/cstar/cli/workplan/plan.py
+++ b/cstar/cli/workplan/plan.py
@@ -2,7 +2,6 @@ import asyncio
 import typing as t
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import typer
 
 from cstar.base.utils import lazy_import, slugify
@@ -15,6 +14,7 @@ from cstar.orchestration.transforms import (
 )
 
 nx = lazy_import("networkx")
+plt = lazy_import("matplotlib.pyplot")
 
 app = typer.Typer()
 


### PR DESCRIPTION
## Summary

This change makes use of `lazy_import` function to delay the import of `matplotlib` until it is used. This greatly improves normal import times, and reduces the average execution time of CLI actions from ~3s to ~2s

## Changes

1. Update `plan` CLI action to use a lazy-loaded `matplotlib`

## Improvements

- Reduce package import time by lazy loading expensive modules

## Review Checklist

- [X] Closes #CSD-581
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
