### PR TITLE
Serialization tweaks

### DIFF
--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -211,7 +211,7 @@ def serialize(
         mode = _mode_detect(path)
 
     handlers = {
-        PersistenceMode.json: lambda model: model.model_dump_json(),
+        PersistenceMode.json: lambda model: model.model_dump_json(by_alias=True),
         PersistenceMode.yaml: model_to_yaml,
     }
 

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -111,9 +111,6 @@ def model_to_yaml(model: BaseModel) -> str:
     return yaml.dump(dumped, sort_keys=False)
 
 
-_DT = t.TypeVar("_DT", models.RomsMarblBlueprint, models.Workplan)
-
-
 def _mode_detect(path: Path) -> PersistenceMode:
     """Use the file extension to select the persistence mode.
 
@@ -133,9 +130,9 @@ def _mode_detect(path: Path) -> PersistenceMode:
 
 def deserialize(
     path: Path | str,
-    klass: type[_DT],
+    klass: type[_T],
     mode: PersistenceMode = PersistenceMode.auto,
-) -> _DT:
+) -> _T:
     """Deserialize a blueprint into a Simulation instance.
 
     Parameters

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -57,6 +57,34 @@ def _read_yaml(path: Path, klass: type[_T]) -> _T:
         return klass.model_validate(model_dict)
 
 
+def path_representer(
+    dumper: yaml.Dumper,
+    data: PosixPath,
+) -> yaml.ScalarNode:
+    """Create a representer for converting PosixPath values to a serialized string."""
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
+
+
+def strenum_representer(
+    dumper: yaml.Dumper,
+    data: enum.StrEnum,
+) -> yaml.ScalarNode:
+    """Create a representer for converting StrEnum values to a serialized string."""
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
+
+
+_RT = t.TypeVar("_RT", enum.IntEnum, enum.StrEnum, PosixPath)
+
+
+def register_representer(
+    model_type: type[_RT],
+    conversion_fn: t.Callable[[yaml.Dumper, _RT], yaml.ScalarNode],
+) -> None:
+    """Register a yaml representer for the serialization of a specific entity type."""
+    dumper = yaml.Dumper
+    dumper.add_representer(model_type, conversion_fn)
+
+
 def model_to_yaml(model: BaseModel) -> str:
     """Serialize a model to yaml.
 
@@ -72,37 +100,13 @@ def model_to_yaml(model: BaseModel) -> str:
     """
     dumped = model.model_dump(exclude_defaults=True, by_alias=True)
 
-    def path_representer(
-        dumper: yaml.Dumper,
-        data: PosixPath,
-    ) -> yaml.ScalarNode:
-        return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
-
-    def application_representer(
-        dumper: yaml.Dumper,
-        data: models.Application,
-    ) -> yaml.ScalarNode:
-        return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
-
-    def blueprintstate_representer(
-        dumper: yaml.Dumper,
-        data: models.BlueprintState,
-    ) -> yaml.ScalarNode:
-        return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
-
-    def workplanstate_representer(
-        dumper: yaml.Dumper,
-        data: models.WorkplanState,
-    ) -> yaml.ScalarNode:
-        return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
-
     dumper = yaml.Dumper
     dumper.ignore_aliases = lambda *_args: True  # type: ignore[method-assign]
 
-    dumper.add_representer(PosixPath, path_representer)
-    dumper.add_representer(models.WorkplanState, workplanstate_representer)
-    dumper.add_representer(models.Application, application_representer)
-    dumper.add_representer(models.BlueprintState, blueprintstate_representer)
+    register_representer(PosixPath, path_representer)
+    register_representer(models.WorkplanState, strenum_representer)
+    register_representer(models.Application, strenum_representer)
+    register_representer(models.BlueprintState, strenum_representer)
 
     return yaml.dump(dumped, sort_keys=False)
 

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -3,13 +3,31 @@ import uuid
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from cstar.orchestration.models import Application, Workplan
-from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
 
 
-def test_workplan_no_data(
+def test_serialization_json_aliased_fields(tmp_path: Path) -> None:
+    """Verify that an aliased field is serialized and deserialized."""
+    exp_value = "foo"
+
+    class FakeModel(BaseModel):
+        value: str = Field(alias="the_value")
+
+    model = FakeModel(the_value=exp_value)
+    assert model.value == exp_value
+
+    serialize_to = tmp_path / "fake.json"
+
+    serialize(serialize_to, model, mode=PersistenceMode.auto)
+    reloaded = deserialize(serialize_to, FakeModel)
+
+    assert reloaded.value == model.value
+
+
+def test_serialization_workplan_no_data(
     tmp_path: Path,
 ) -> None:
     """Verify that an empty workplan yaml file fails to deserialize."""
@@ -35,7 +53,7 @@ def test_workplan_no_data(
         ),
     ],
 )
-def test_workplan_required_fields(
+def test_serialization_workplan_required_fields(
     tmp_path: Path,
     fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
     attr_to_exclude: str,
@@ -70,7 +88,7 @@ def test_workplan_required_fields(
         "runtime_vars",
     ],
 )
-def test_workplan_optional_fields(
+def test_serialization_workplan_optional_fields(
     tmp_path: Path,
     fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
     attr_to_empty: str,
@@ -97,7 +115,7 @@ def test_workplan_optional_fields(
     assert workplan.name == data["name"]
 
 
-def test_workplan_happy_path(
+def test_serialization_workplan_happy_path(
     tmp_path: Path,
     fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
@@ -126,7 +144,7 @@ def test_workplan_happy_path(
     assert workplan.steps[0].compute_overrides["num_nodes"] == 4
 
 
-def test_workplan_compute_env(
+def test_serialization_workplan_compute_env(
     tmp_path: Path,
     fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
@@ -162,7 +180,7 @@ def test_workplan_compute_env(
     assert compute_env[cpus_var] == cpus_val
 
 
-def test_workplan_runtime_vars(
+def test_serialization_workplan_runtime_vars(
     tmp_path: Path,
     fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -32,6 +32,7 @@ Bug Fixes
 - Fix unhandled exceptions in `cstar [blueprint|workplan] check` with invalid paths
 - Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run`
 - Fix case-sensitivity bug when configuring split frequency via `CSTAR_ORCH_TRX_FREQ` env variable
+- Fix a `JSON` serialization bug with pydantic models using field aliases  
 
 Improvements
 ~~~~~~~~~~~~
@@ -39,6 +40,7 @@ Improvements
 - Improve error handling when `CachedRemoteRepositoryRetriever.refresh` fails
 - Validate inputs prior to execution with `cstar [blueprint|workplan] run`
 - Improve module load times
+- Extract nested/duplicate `YAML` representer functions for re-use
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This PR contains some minor fixes for the orchestration serialization module.

## Bug Fixes

- Fix a `JSON` serialization bug with pydantic models using field aliases  

## Improvements

- Extract nested/duplicate `YAML` representer functions for re-use

## Miscellaneous

- Remove unnecessary `TypeVar`
- Fix inconsistent test naming convention

## Review Checklist

- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`