### PR TITLE
Fix case-sensitivity bug when reading `CSTAR_ORCH_TRX_FREQ` env var

### DIFF
--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -324,7 +324,8 @@ class RomsMarblTimeSplitter(Transform):
 
     def __init__(self, frequency: str = SplitFrequency.Monthly.value) -> None:
         """Initialize the transform instance."""
-        self.frequency = os.getenv(ENV_CSTAR_ORCH_TRX_FREQ, frequency)
+        freq_config = os.getenv(ENV_CSTAR_ORCH_TRX_FREQ, frequency)
+        self.frequency = freq_config.lower()
 
     def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
         """Split a step into multiple sub-steps.

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -30,7 +30,8 @@ Bug Fixes
 - Fix failure to override output directories for orchestrated blueprints
 - Fix defect where steps defined before dependencies were not mapped correctly after time-splitting
 - Fix unhandled exceptions in `cstar [blueprint|workplan] check` with invalid paths
-- Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run` 
+- Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run`
+- Fix case-sensitivity bug when configuring split frequency via `CSTAR_ORCH_TRX_FREQ` env variable
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
This PR fixes a case-sensitivity bug when consuming the user-specified env var `CSTAR_ORCH_TRX_FREQ`. When a value in the env var is not all-lowercase, conversion to the `StrEnum` fails.

# Bug Fixes

- Fix case-sensitivity bug when configuring split frequency via `CSTAR_ORCH_TRX_FREQ` env variable


# Review Checklist

- [X] Tests passing
- [X] Changes are documented in `docs/releases.rst`