### PR TITLE
Fix incorrect reset-file paths generated by time splitter

### DIFF
--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -160,6 +160,7 @@ class LiveStep(Step):
             step_attrs.update(update)
 
         if parent:
+            step_attrs.pop("work_dir", None)
             step_attrs["parent"] = LiveStep.from_step(parent).model_dump(by_alias=True)
 
         return LiveStep(**step_attrs)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -16,6 +16,7 @@ from cstar.base.utils import (
     deep_merge,
     slugify,
 )
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import (
     Application,
     RomsMarblBlueprint,
@@ -412,8 +413,8 @@ class RomsMarblTimeSplitter(Transform):
             # - reset file names are formatted as: <stem>_rst.YYYYMMDDHHMMSS.{partition}.nc
             reset_file_name = f"{output_root_name}_rst.{compact_ed}.000.nc"
 
-            step_output_dir = child_fs.output_dir
-            restart_file_path = step_output_dir / reset_file_name
+            roms_fsm = RomsFileSystemManager(child_step.fsm.root)
+            restart_file_path = roms_fsm.joined_output_dir / reset_file_name
 
             # use output dir of the last step as the input for the next step
             last_restart_file = restart_file_path

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -6,8 +6,9 @@ from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_RUNID
+from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
 from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import Application, Step, Workplan
 from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.transforms import (
@@ -116,14 +117,20 @@ def test_sleep_transform_registry(application: str) -> None:
     assert not transform
 
 
-def test_splitter(single_step_workplan: Workplan) -> None:
+def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
     """Verify the splitter returns the expected steps for a given time range."""
     transform = RomsMarblTimeSplitter()
 
-    step = LiveStep.from_step(single_step_workplan.steps[0])
+    original_step = LiveStep.from_step(single_step_workplan.steps[0])
 
-    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: "12345"}, clear=True):
-        transformed_steps = list(transform(step))
+    # mock data home to ensure test works on HPC if scratch directories are identified
+    data_home = tmp_path / "data"
+    with mock.patch.dict(
+        os.environ,
+        {ENV_CSTAR_RUNID: "12345", ENV_CSTAR_DATA_HOME: data_home.as_posix()},
+        clear=True,
+    ):
+        transformed_steps = list(transform(original_step))
 
     # one step transforms into 12 monthly steps
     assert len(transformed_steps) == 12
@@ -159,7 +166,10 @@ def test_splitter(single_step_workplan: Workplan) -> None:
             # verify the initial conditions reference the prior step's time slice
             compact_sd = ed.strftime("%Y%m%d%H%M%S")
 
-            expected = f"output/{DEFAULT_OUTPUT_ROOT_NAME}_rst.{compact_sd}.000.nc"
+            # verify the joined reset files are used
+            join_dir = RomsFileSystemManager(step.fsm.root).joined_output_dir
+            expected = f"{join_dir}/{DEFAULT_OUTPUT_ROOT_NAME}_rst.{compact_sd}.000.nc"
+
             assert expected in str(ic_loc_successor)
 
         # verify successor starts right where current step ends

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -32,7 +32,9 @@ Bug Fixes
 - Fix unhandled exceptions in `cstar [blueprint|workplan] check` with invalid paths
 - Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run`
 - Fix case-sensitivity bug when configuring split frequency via `CSTAR_ORCH_TRX_FREQ` env variable
-- Fix a `JSON` serialization bug with pydantic models using field aliases  
+- Fix a `JSON` serialization bug with pydantic models using field aliases
+- Fix incorrect initial-conditions file paths created in `RomsMarblTimeSplitter`
+- Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
Fix a defect identified by @smaticka where the reset file paths were calculated incorrectly.

## Bug Fixes

- Fix incorrect initial-conditions file paths created in `RomsMarblTimeSplitter`
- Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified

## Review Checklist

- [X] Closes #CSD-595
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases/v0.4.0.rst`