### PR TITLE
Revert use of joined outputs during time-splitting/restarts

### DIFF
--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -16,7 +16,6 @@ from cstar.base.utils import (
     deep_merge,
     slugify,
 )
-from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import (
     Application,
     RomsMarblBlueprint,
@@ -413,8 +412,8 @@ class RomsMarblTimeSplitter(Transform):
             # - reset file names are formatted as: <stem>_rst.YYYYMMDDHHMMSS.{partition}.nc
             reset_file_name = f"{output_root_name}_rst.{compact_ed}.000.nc"
 
-            roms_fsm = RomsFileSystemManager(child_step.fsm.root)
-            restart_file_path = roms_fsm.joined_output_dir / reset_file_name
+            step_output_dir = child_fs.output_dir
+            restart_file_path = step_output_dir / reset_file_name
 
             # use output dir of the last step as the input for the next step
             last_restart_file = restart_file_path

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -166,8 +166,8 @@ def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
             compact_sd = ed.strftime("%Y%m%d%H%M%S")
 
             # verify the joined reset files are used
-            join_dir = step.fsm.output_dir
-            expected = f"{join_dir}/{DEFAULT_OUTPUT_ROOT_NAME}_rst.{compact_sd}.000.nc"
+            out_dir = step.fsm.output_dir
+            expected = f"{out_dir}/{DEFAULT_OUTPUT_ROOT_NAME}_rst.{compact_sd}.000.nc"
 
             assert expected in str(ic_loc_successor)
 

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -8,7 +8,6 @@ import pytest
 
 from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
 from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME
-from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import Application, Step, Workplan
 from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.transforms import (
@@ -167,7 +166,7 @@ def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
             compact_sd = ed.strftime("%Y%m%d%H%M%S")
 
             # verify the joined reset files are used
-            join_dir = RomsFileSystemManager(step.fsm.root).joined_output_dir
+            join_dir = step.fsm.output_dir
             expected = f"{join_dir}/{DEFAULT_OUTPUT_ROOT_NAME}_rst.{compact_sd}.000.nc"
 
             assert expected in str(ic_loc_successor)

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -33,7 +33,6 @@ Bug Fixes
 - Fix posix-path conversion bug when passing blueprint URLs to `cstar blueprint run`
 - Fix case-sensitivity bug when configuring split frequency via `CSTAR_ORCH_TRX_FREQ` env variable
 - Fix a `JSON` serialization bug with pydantic models using field aliases
-- Fix incorrect initial-conditions file paths created in `RomsMarblTimeSplitter`
 - Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified
 
 Improvements


### PR DESCRIPTION
# Summary

This PR reverts the change to make use of joined reset files by the `RomsMarblTimeSplitter`

## Bug Fixes

- Use `step.fsm.output_dir` as the source of reset files instead of `step.fsm.joined_output_dir`

## Review Checklist

- [X] Closes #CSD-595
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
