### PR TITLE
Fix pegging CPU with health check thread

### DIFF
--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -68,7 +68,14 @@ class Service(ABC, LoggingMixin):
 
     CMD_PREFIX: Literal["cmd"] = "cmd"
     CMD_QUIT: Literal["quit"] = "quit"
-    MIN_HCF: ClassVar[Final[float]] = 0.01
+    MIN_HCF: ClassVar[float] = 0.01
+
+    _config: Final[ServiceConfiguration]
+    """Runtime configuration of the `Service`"""
+    _hc_thread: Thread | None = None
+    """A thread for executing an unblocked healthcheck callback."""
+    _hc_queue: Queue | None = None
+    """A queue for sending shutdown messages to the healthcheck thread."""
 
     def __init__(
         self,
@@ -83,12 +90,6 @@ class Service(ABC, LoggingMixin):
         """
         self._config = config
         """Runtime configuration of the `Service`"""
-
-        self._hc_thread: Thread | None = None
-        """A thread for executing an unblocked healthcheck callback."""
-        self._hc_queue: Queue | None = None
-        """A queue for sending shutdown messages to the healthcheck thread."""
-
         self._register_signal_handlers()
 
     @property

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -7,7 +7,7 @@ from queue import Empty, Full, Queue
 from threading import Event, Thread
 from typing import TYPE_CHECKING, ClassVar, Final, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field
 
 from cstar.base.log import LoggingMixin
 
@@ -50,18 +50,6 @@ class ServiceConfiguration(BaseModel):
         bool
         """
         return self.health_check_frequency is not None
-
-    @computed_field  # type: ignore[misc]
-    @property
-    def max_health_check_latency(self) -> float:
-        """Get the max latency allowed before missed health checks should be logged.
-
-        When no healthcheck frequency is supplied, defaults to 1 second.
-        """
-        if not self.health_check_frequency:
-            return 1.0
-
-        return self.health_check_frequency * self.health_check_log_threshold
 
 
 class Service(ABC, LoggingMixin):

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -3,8 +3,7 @@ import logging
 import signal
 import time
 from abc import ABC, abstractmethod
-from multiprocessing import Queue
-from queue import Empty, Full
+from queue import Empty, Full, Queue
 from threading import Thread
 from typing import TYPE_CHECKING, ClassVar, Final, Literal
 

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -3,11 +3,10 @@ import logging
 import signal
 import time
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
 from multiprocessing import Queue
-from queue import Empty
+from queue import Empty, Full
 from threading import Thread
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Final, Literal
 
 from pydantic import BaseModel, Field, computed_field
 
@@ -43,6 +42,10 @@ class ServiceConfiguration(BaseModel):
     name: str = "Service"
     """A user-friendly name for logging."""
 
+    @property
+    def healthcheck_enabled(self) -> bool:
+        return self.health_check_frequency is not None
+
     @computed_field  # type: ignore[misc]
     @property
     def max_health_check_latency(self) -> float:
@@ -50,7 +53,7 @@ class ServiceConfiguration(BaseModel):
 
         When no healthcheck frequency is supplied, defaults to 1 second.
         """
-        if self.health_check_frequency is None or self.health_check_frequency == 0:
+        if not self.health_check_frequency:
             return 1.0
 
         return self.health_check_frequency * self.health_check_log_threshold
@@ -65,6 +68,7 @@ class Service(ABC, LoggingMixin):
 
     CMD_PREFIX: Literal["cmd"] = "cmd"
     CMD_QUIT: Literal["quit"] = "quit"
+    MIN_HCF: ClassVar[Final[float]] = 0.01
 
     def __init__(
         self,
@@ -204,56 +208,27 @@ class Service(ABC, LoggingMixin):
         """
         self.log.debug(f"Service delay for {self._service_type}")
 
-    def _create_hc_update(self, content: dict[str, str]) -> dict[str, str]:
-        """Create a health check update message.
-
-        Parameters
-        ----------
-        content: dict[str, str]
-            Key-value mapping of content to include in the health check update.
-
-        Returns
-        -------
-        dict[str, str]
-            The complete content of a health check update ready to be sent.
-        """
-        update_base = {"ts": datetime.now(tz=timezone.utc).isoformat()}
-        update_base.update(content)
-        return update_base
-
-    def _send_update_to_hc(self, content: dict[str, str]) -> None:
-        """Send an update to the health check thread.
-
-        Parameters
-        ----------
-        content: dict[str, str]
-            Key-value mapping of content to include in the health check update.
+    def _acknowledge_hc(self) -> None:
+        """Confirm any requests for an update from the health check queue.
 
         Returns
         -------
         None
         """
-        if self._hc_queue:
-            msg = self._create_hc_update(content)
-            self._hc_queue.put_nowait(msg)
-        else:
+        if not self._config.healthcheck_enabled:
+            return
+
+        if self._hc_queue is None:
             self.log.debug("No healthcheck queue available")
+            return
 
-    def _send_terminate_to_hc(self, reason: str) -> None:
-        """Send a termination message to the health check thread.
-
-        Parameters
-        ----------
-        reason: str
-            A string describing the reason for termination.
-
-        Returns
-        -------
-        None
-        """
-        self.log.debug("Terminating healthcheck")
-        self._send_update_to_hc({self.CMD_PREFIX: self.CMD_QUIT, "reason": reason})
-        self._send_update_to_hc({"cmd": "quit", "reason": reason})
+        # ACK any requests for HC updates
+        try:
+            if self._hc_queue.get_nowait():
+                self._on_health_check()
+        except Empty:
+            # nothing to ACK
+            ...
 
     def _healthcheck(
         self,
@@ -283,42 +258,43 @@ class Service(ABC, LoggingMixin):
             self.log.debug("Health check disabled.")
             return
 
+        def _get_remaining_wait(start_at: float) -> float:
+            """Determine the remaining time before the next health check message
+            is expected.
+            """
+            elapsed = time.time() - start_at
+            user_freq = config.health_check_frequency or 0
+            return user_freq - elapsed
+
         last_health_check = time.time()  # timestamp of last health check
+        num_missed = 0
         running = True
-        hc_elapsed = 0.0
 
         while running:
+            raw_remaining = _get_remaining_wait(last_health_check)
+            remaining = max(raw_remaining, Service.MIN_HCF)
+            time.sleep(remaining)
+
             try:
-                hc_elapsed = time.time() - last_health_check
-                hcf_remaining = config.health_check_frequency - hc_elapsed
-                remaining_wait = max(hcf_remaining, 0)
-
-                # report large gaps between updates.
-                if hc_elapsed > config.max_health_check_latency:
-                    self.log.warning(
-                        f"No health update in last {hc_elapsed:.2f} seconds."
-                    )
-
-                if msg := msg_queue.get_nowait():
-                    if hc_elapsed >= config.health_check_frequency:
-                        self._on_health_check()
-                        last_health_check = time.time()
-
-                    command = msg.get(self.CMD_PREFIX, None)
-                    if not command:
-                        self.log.info(
-                            f"Healthcheck thread received message: {msg}",
-                        )
-                    elif command == self.CMD_QUIT:
-                        running = False
-                else:
-                    time.sleep(remaining_wait)
-
-            except Empty:  # noqa: PERF203
-                ...  # ignore empty queue; just wait for shutdown msg
+                msg_queue.put(None, timeout=1.0)
+                self._on_health_check()
+            except Full:
+                # message was not acknowledged in expected timeframe
+                num_missed += 1
+                last_health_check = time.time()
             except Exception:  # noqa: BLE001
-                # queue was shutdown on other side. ignore and exit.
+                # queue was shutdown on other side, exit HC loop
                 running = False
+            else:
+                last_health_check = time.time()
+                num_missed = 0
+
+            # only report consecutive gaps.
+            if num_missed > config.health_check_log_threshold:
+                self.log.warning(
+                    f"No successful health checks in {num_missed} attempts."
+                )
+                num_missed = 0  # reset to avoid spamming log
 
     def _start_healthcheck(self) -> None:
         """Create a thread for health check updates.
@@ -326,10 +302,13 @@ class Service(ABC, LoggingMixin):
         The health check thread is not blocked by the main thread when service
         operations are blocking.
         """
-        if self._config.health_check_frequency is None:
+        if self.is_healthcheck_queue_ready:
+            # health check is already running
             return
 
-        if self._config.health_check_frequency >= 0:
+        freq = self._config.health_check_frequency
+
+        if freq is not None and freq >= 0:
             self.log.debug(
                 "Starting healthcheck thread w/frequency: %s.",
                 self._config.health_check_frequency,
@@ -344,6 +323,7 @@ class Service(ABC, LoggingMixin):
                 self._hc_thread = Thread(
                     target=self._healthcheck,
                     name=thread_name,
+                    daemon=True,
                     kwargs={
                         "config": self._config,
                         "msg_queue": self._hc_queue,
@@ -351,21 +331,15 @@ class Service(ABC, LoggingMixin):
                 )
                 self._hc_thread.start()
 
-    def _terminate_hc(self, reason: str) -> None:
+    def _terminate_hc(self) -> None:
         """Send a termination message to the healthcheck thread.
 
         After sending signal, waits for the thread to complete prior to returning.
-
-        Parameters
-        ----------
-        reason: str
-            A string describing the reason for termination.
 
         Returns
         -------
         None
         """
-        self._send_terminate_to_hc(reason=reason)
         if self._hc_thread and self._hc_thread.is_alive():
             self._hc_thread.join(timeout=1.0)
 
@@ -378,7 +352,7 @@ class Service(ABC, LoggingMixin):
         self.log.debug("Shutting down service.")
 
         try:
-            self._terminate_hc("Run complete")
+            self._terminate_hc()
             self._on_shutdown()
         except Exception:
             self.log.debug("Service shutdown may not have completed.")
@@ -403,6 +377,8 @@ class Service(ABC, LoggingMixin):
             exc = e
 
         while running:
+            self._acknowledge_hc()
+
             try:
                 await self._on_iteration()
                 self._on_iteration_complete()
@@ -435,8 +411,6 @@ class Service(ABC, LoggingMixin):
                         "Terminating service due to failure in _on_delay."
                     )
                     exc = e
-
-            self._send_update_to_hc({self.CMD_PREFIX: "heartbeat"})
 
         self._shutdown()
 

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -71,7 +71,6 @@ class Service(ABC, LoggingMixin):
     health checks, and for specifying shutdown criteria.
     """
 
-    CMD_KEY: Literal["cmd"] = "cmd"
     CMD_HEARTBEAT: Literal["heartbeat"] = "heartbeat"
     MIN_HCF: ClassVar[float] = 0.01
 

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -294,9 +294,8 @@ class Service(ABC, LoggingMixin):
 
             # only report consecutive gaps.
             if num_missed > config.health_check_log_threshold:
-                self.log.warning(
-                    f"No successful health checks in {num_missed} attempts."
-                )
+                msg = f"No successful health checks in {num_missed} attempts."
+                self.log.warning(msg)
                 num_missed = 0  # reset to avoid spamming log
 
     def _start_healthcheck(self) -> None:

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -4,7 +4,7 @@ import signal
 import time
 from abc import ABC, abstractmethod
 from queue import Empty, Full, Queue
-from threading import Thread
+from threading import Event, Thread
 from typing import TYPE_CHECKING, ClassVar, Final, Literal
 
 from pydantic import BaseModel, Field, computed_field
@@ -65,8 +65,8 @@ class Service(ABC, LoggingMixin):
     health checks, and for specifying shutdown criteria.
     """
 
-    CMD_PREFIX: Literal["cmd"] = "cmd"
-    CMD_QUIT: Literal["quit"] = "quit"
+    CMD_KEY: Literal["cmd"] = "cmd"
+    CMD_HEARTBEAT: Literal["heartbeat"] = "heartbeat"
     MIN_HCF: ClassVar[float] = 0.01
 
     _config: Final[ServiceConfiguration]
@@ -75,6 +75,8 @@ class Service(ABC, LoggingMixin):
     """A thread for executing an unblocked healthcheck callback."""
     _hc_queue: Queue | None = None
     """A queue for sending shutdown messages to the healthcheck thread."""
+    _hc_stop_event: Final[Event]
+    """An event triggering health-check thread termination."""
 
     def __init__(
         self,
@@ -88,7 +90,7 @@ class Service(ABC, LoggingMixin):
             Configuration to modify the behavior of the service.
         """
         self._config = config
-        """Runtime configuration of the `Service`"""
+        self._hc_stop_event = Event()
         self._register_signal_handlers()
 
     @property
@@ -208,7 +210,7 @@ class Service(ABC, LoggingMixin):
         """
         self.log.debug(f"Service delay for {self._service_type}")
 
-    def _acknowledge_hc(self) -> None:
+    def acknowledge_hc(self) -> None:
         """Confirm any requests for an update from the health check queue.
 
         Returns
@@ -222,10 +224,15 @@ class Service(ABC, LoggingMixin):
             self.log.debug("No healthcheck queue available")
             return
 
-        # ACK any requests for HC updates
         try:
-            if self._hc_queue.get_nowait():
-                self._on_health_check()
+            match self._hc_queue.get_nowait():
+                case Service.CMD_HEARTBEAT:
+                    # ACK any requests for HC updates
+                    self.log.debug("Health check succeeded")
+                    self._on_health_check()
+                case message:
+                    msg = f"Health check sent unknown message: {message}"
+                    self.log.debug(msg)
         except Empty:
             # nothing to ACK
             ...
@@ -271,25 +278,22 @@ class Service(ABC, LoggingMixin):
 
         last_health_check = time.time()  # timestamp of last health check
         num_missed = 0
-        running = True
 
-        while running:
-            raw_remaining = _get_remaining_wait(last_health_check)
-            remaining = max(raw_remaining, Service.MIN_HCF)
-            time.sleep(remaining)
+        while not self._hc_stop_event.is_set():
+            remaining = _get_remaining_wait(last_health_check)
+            if self._hc_stop_event.wait(timeout=remaining):
+                return
+
+            last_health_check = time.time()
 
             try:
-                msg_queue.put(None, timeout=1.0)
-                self._on_health_check()
+                msg_queue.put(self.CMD_HEARTBEAT, timeout=0.1)
             except Full:
                 # message was not acknowledged in expected timeframe
                 num_missed += 1
-                last_health_check = time.time()
             except Exception:  # noqa: BLE001
                 # queue was shutdown on other side, exit HC loop
-                running = False
-            else:
-                last_health_check = time.time()
+                self._hc_stop_event.set()
                 num_missed = 0
 
             # only report consecutive gaps.
@@ -342,8 +346,14 @@ class Service(ABC, LoggingMixin):
         -------
         None
         """
-        if self._hc_thread and self._hc_thread.is_alive():
-            self._hc_thread.join(timeout=1.0)
+        self._hc_stop_event.set()
+
+        if self._hc_thread is not None:
+            self._hc_thread.join(timeout=10)
+
+            if self._hc_thread.is_alive():
+                msg = "Health check thread did not terminate before timeout"
+                self.log.warning(msg)
 
     def _shutdown(self) -> None:
         """Perform a clean shutdown of the service.
@@ -379,9 +389,8 @@ class Service(ABC, LoggingMixin):
             exc = e
 
         while running:
-            self._acknowledge_hc()
-
             try:
+                self.acknowledge_hc()
                 await self._on_iteration()
                 self._on_iteration_complete()
             except Exception:

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -384,10 +384,9 @@ class Service(ABC, LoggingMixin):
             try:
                 await self._on_iteration()
                 self._on_iteration_complete()
-            except Exception as e:
+            except Exception:
                 running = False
                 self.log.exception("Terminating service due to failure in event loop.")
-                exc = e
                 continue
 
             # shutdown if not set to run as a service

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -264,7 +264,10 @@ class Service(ABC, LoggingMixin):
             """
             elapsed = time.time() - start_at
             user_freq = config.health_check_frequency or 0
-            return user_freq - elapsed
+            raw_remaining = user_freq - elapsed
+
+            # never allow exactly 0 wait (causing a busy-wait loop)
+            return max(raw_remaining, Service.MIN_HCF)
 
         last_health_check = time.time()  # timestamp of last health check
         num_missed = 0

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -43,6 +43,12 @@ class ServiceConfiguration(BaseModel):
 
     @property
     def healthcheck_enabled(self) -> bool:
+        """Return `True` when the health check frequency is non-null.
+
+        Returns
+        -------
+        bool
+        """
         return self.health_check_frequency is not None
 
     @computed_field  # type: ignore[misc]

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -258,7 +258,6 @@ class SimulationRunner(Service):
                     self.log.debug("Skipping simulation run")
             else:
                 await self._handler.updates(seconds=1.0)
-                self._send_update_to_hc({"status": str(self._handler.status)})
         except Exception:
             self.log.exception("An error occurred while running the simulation")
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -6,12 +6,19 @@ import time
 import types
 import typing as t
 from collections import defaultdict
+from math import ceil
+from threading import Thread
 from unittest import mock
 
 import pytest
 from pydantic import ValidationError
 
 from cstar.entrypoint.service import Service, ServiceConfiguration
+
+
+def _wait_for_thread_alive(thread: Thread) -> None:
+    while not thread.is_alive():
+        time.sleep(0.00001)
 
 
 class PrintingService(Service):
@@ -321,36 +328,35 @@ async def test_event_loop_hc_start(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [10, 30, 100])
-async def test_event_loop_hc_freq(loop_count: int) -> None:
+@pytest.mark.parametrize(
+    ("max_duration", "delay"),
+    [
+        (0.5, 0.1),
+        (0.5, 0.02),
+        (0.25, 0.05),
+    ],
+)
+async def test_event_loop_hc_freq(max_duration: float, delay: float) -> None:
     """Verify that the health check occurs at the correct frequency.
 
-    Confirm that using a frequency of 0 results in the health-check being executed in
-    lockstep with _on_iteration.
+    Confirm that using a frequency ~equal to the loop frequency results
+    in the health-check being executed in lockstep with _on_iteration.
     """
-    # Configure the health check to update every event loop iteration
+    expected_max_hc_calls = ceil(max_duration / delay)
+
+    # Configure the health check at the same rate as the HC
     with PrintingService(
-        max_iterations=loop_count, hc_freq=0.001, delay=0.001
+        max_duration=max_duration,
+        hc_freq=delay,
+        delay=delay,
     ) as service:
-        service._start_healthcheck()  # noqa: SLF001
-        # await asyncio.sleep(0.1)
-        if service._hc_thread is None:
-            assert False, "health check thread failed to start"
-
-        while not service._hc_thread.is_alive():
-            await asyncio.sleep(0.001)
-
-        # Confirm the HC thread and queue are created
-        assert service.is_healthcheck_running
-        assert service.is_healthcheck_queue_ready
-
         # Complete the service lifecycle
         await service.execute()
 
         # Collect any leftover call metrics from the HC thread.
         service.summarize(finalize=True)
 
-        assert service.n_on_health_check >= loop_count
+        assert service.n_on_health_check <= expected_max_hc_calls
 
 
 @pytest.mark.asyncio

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -7,18 +7,12 @@ import types
 import typing as t
 from collections import defaultdict
 from math import ceil
-from threading import Thread
 from unittest import mock
 
 import pytest
 from pydantic import ValidationError
 
 from cstar.entrypoint.service import Service, ServiceConfiguration
-
-
-def _wait_for_thread_alive(thread: Thread) -> None:
-    while not thread.is_alive():
-        time.sleep(0.00001)
 
 
 class PrintingService(Service):

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -251,7 +251,7 @@ async def test_config_check_hcfreq_out_of_range(value: float) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [1, 10, 100])
+@pytest.mark.parametrize("loop_count", [1, 10, 50])
 async def test_event_loop_shutdown(loop_count: int) -> None:
     """Verify that _on_iteration repeats until _can_shutdown returns True."""
     service = PrintingService(max_iterations=loop_count)
@@ -266,7 +266,7 @@ async def test_event_loop_shutdown(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [0, 10, 50, 100])
+@pytest.mark.parametrize("loop_count", [0, 10, 50])
 async def test_event_loop_task_service(loop_count: int) -> None:
     """Verify that  using as_service=False executes _on_iteration 1x."""
     with PrintingService(
@@ -290,7 +290,7 @@ async def test_event_loop_task_service(loop_count: int) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("loop_count", [10, 40, 100])
+@pytest.mark.parametrize("loop_count", [10, 30, 50])
 async def test_event_loop_hc_start(loop_count: int) -> None:
     """Verify aspects of the health-check startup.
 
@@ -357,8 +357,8 @@ async def test_event_loop_hc_freq(loop_count: int) -> None:
 @pytest.mark.parametrize(
     ("max_duration", "frequency"),
     [
-        (2.0, 0.5),
-        (3.0, 0.01),
+        (1.0, 0.1),
+        (0.5, 0.01),
     ],
 )
 async def test_event_hc_freq(max_duration: float, frequency: float) -> None:
@@ -392,8 +392,8 @@ async def test_event_hc_freq(max_duration: float, frequency: float) -> None:
 @pytest.mark.parametrize(
     ("loop_delay", "loop_count"),
     [
-        (0.05, 20),
-        (0.1, 10),
+        (0.05, 10),
+        (0.1, 5),
     ],
 )
 async def test_delay(loop_delay: float, loop_count: int) -> None:

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 import queue
 import time
 import types
+import typing as t
 from collections import defaultdict
 from unittest import mock
 
@@ -144,7 +145,7 @@ class PrintingService(Service):
 
         return self.metrics
 
-    def __enter__(self) -> "PrintingService":
+    def __enter__(self) -> t.Self:
         """Context manager entry point."""
         return self
 

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -328,9 +328,16 @@ async def test_event_loop_hc_freq(loop_count: int) -> None:
     lockstep with _on_iteration.
     """
     # Configure the health check to update every event loop iteration
-    with PrintingService(max_iterations=loop_count, hc_freq=0) as service:
+    with PrintingService(
+        max_iterations=loop_count, hc_freq=0.001, delay=0.001
+    ) as service:
         service._start_healthcheck()  # noqa: SLF001
-        await asyncio.sleep(0.1)
+        # await asyncio.sleep(0.1)
+        if service._hc_thread is None:
+            assert False, "health check thread failed to start"
+
+        while not service._hc_thread.is_alive():
+            await asyncio.sleep(0.001)
 
         # Confirm the HC thread and queue are created
         assert service.is_healthcheck_running
@@ -360,7 +367,10 @@ async def test_event_hc_freq(max_duration: float, frequency: float) -> None:
     """
     # Configure the test service to run for <max_duration> seconds.
     with PrintingService(
-        as_service=True, hc_freq=frequency, max_duration=max_duration
+        as_service=True,
+        hc_freq=frequency,
+        max_duration=max_duration,
+        delay=frequency,
     ) as service:
         # Complete the service lifecycle
         await service.execute()
@@ -371,74 +381,7 @@ async def test_event_hc_freq(max_duration: float, frequency: float) -> None:
         # Confirm the hc frequency doesn't exceed maximum count possible (if
         # each HC occurred at exactly the right timestep and takes 0 time).
         # Off by small amount is acceptable.
-        max_hc_calls = max_duration / frequency
-        lower_bound = (0.9 * max_hc_calls) // max_hc_calls
-
-        assert lower_bound <= service.n_on_health_check <= max_hc_calls
-
-
-@pytest.mark.asyncio
-async def test_event_hc_unknown_msg() -> None:
-    """Verify message handling behavior of the health check thread.
-
-    Confirms that the health check thread does not crash when it receives an unknown
-    message type.
-    """
-    # Configure the test service to run for 2 seconds.
-    with PrintingService(
-        as_service=True,
-        hc_freq=0.1,
-        max_duration=2,
-    ) as service:
-        # Complete the service lifecycle
-        service._start_healthcheck()  # noqa: SLF001
-        await asyncio.sleep(0.05)
-
-        # Send trash to the the HC thread
-        service._send_update_to_hc(  # noqa: SLF001
-            {"command": "unknown_command"},
-        )
-
-        # Confirm the hc thread is still alive and processing
-        # messages by sending more!
-        service._send_terminate_to_hc(  # noqa: SLF001
-            "testing the message is still processed."
-        )
-        # Give the HC thread time to process the message
-        await asyncio.sleep(0.05)
-
-        assert not service.is_healthcheck_running
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("max_duration", "frequency"),
-    [
-        (2.0, 0.5),
-        (3.0, 0.01),
-    ],
-)
-async def test_event_hc_term(max_duration: float, frequency: float) -> None:
-    """Verify that the health check thread terminates when asked to do so."""
-    # Configure the test service to run for <max-duration> seconds.
-    with PrintingService(
-        as_service=True, hc_freq=frequency, max_duration=max_duration
-    ) as service:
-        # Complete the service lifecycle
-        service._start_healthcheck()  # noqa: SLF001
-        await asyncio.sleep(0.1)
-        service._send_terminate_to_hc("test_event_hc_term")  # noqa: SLF001
-        await asyncio.sleep(0.1)
-
-        assert not service.is_healthcheck_running
-
-        # Collect any leftover call metrics from the HC thread.
-        service.summarize(finalize=True)
-
-        # Confirm the hc frequency doesn't exceed maximum count possible (if
-        # each HC occurred at exactly the right timestep and takes 0 time). Off
-        # by small amount is acceptable.
-        max_hc_calls = max_duration / frequency
+        max_hc_calls = 1 + (max_duration / frequency)
         lower_bound = (0.9 * max_hc_calls) // max_hc_calls
 
         assert lower_bound <= service.n_on_health_check <= max_hc_calls

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -286,7 +286,7 @@ def test_dep_keys(tmp_path: Path) -> None:
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
-    with pytest.raises(ValueError, match="unknown dep"):
+    with pytest.raises(ValueError, match=r".*Unknown dep.*"):
         _ = Workplan(
             name="Invalid Dependency Key Example",
             description="Workplan with a dependency that doesn't match a step",

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -286,7 +286,7 @@ def test_dep_keys(tmp_path: Path) -> None:
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
-    with pytest.raises(ValueError) as ex:
+    with pytest.raises(ValueError, match="unknown dep"):
         _ = Workplan(
             name="Invalid Dependency Key Example",
             description="Workplan with a dependency that doesn't match a step",
@@ -304,8 +304,6 @@ def test_dep_keys(tmp_path: Path) -> None:
                 ),
             ],
         )
-
-    assert "unknown dep" in str(ex).lower()
 
 
 def test_workplan_transformation(diamond_workplan: Workplan) -> None:

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -35,6 +35,7 @@ Bug Fixes
 - Fix a `JSON` serialization bug with pydantic models using field aliases
 - Fix incorrect initial-conditions file paths created in `RomsMarblTimeSplitter`
 - Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified
+- Fix failure to terminate health check thread
 
 Improvements
 ~~~~~~~~~~~~
@@ -43,6 +44,8 @@ Improvements
 - Validate inputs prior to execution with `cstar [blueprint|workplan] run`
 - Improve module load times
 - Extract nested/duplicate `YAML` representer functions for re-use
+- Replace use of incorrect `mp.Queue` where `queue.Queue` is appropriate
+- Replace blocking `time.sleep` usage in health check thread 
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

This pull request fixes numerous bugs in managing the health check thread used by the `Service` to confirm it is still executing.

## Bug Fixes

- Fix failure to terminate health check thread

## Improvements

- Replace use of incorrect `mp.Queue` where `queue.Queue` is appropriate
- Replace blocking `time.sleep` usage in health check thread 

## Review Checklist

- [X] Closes #CSD-468
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`