### PR TITLE
Remove dupe/hardcoded job config defaults

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -26,7 +26,6 @@ DATE_FORMAT: Final[str] = "%Y-%m-%d %H:%M:%S"
 WORKER_LOG_FILE_TPL: Final[str] = "cstar-worker.{0}.log"
 JOBFILE_DATE_FORMAT: Final[str] = "%Y%m%d_%H%M%S"
 LOGS_DIRECTORY: Final[str] = "logs"
-DEFAULT_SLURM_MAX_WALLTIME: Final[str] = "48:00:00"
 
 
 def _generate_job_name() -> str:
@@ -68,14 +67,14 @@ class BlueprintRequest:
 class JobConfig:
     """Configuration required to submit HPC jobs."""
 
-    account_id: str = "m4746"
+    account_id: str
     """HPC account used for billing."""
-    walltime: str = "01:00:00"
+    walltime: str
     """Maximum walltime allowed for job."""
+    priority: str
+    """Job priority."""
     job_name: str = _generate_job_name()
     """User-friendly job name."""
-    priority: str = "regular"
-    """Job priority."""
 
 
 class SimulationRunner(Service):
@@ -411,9 +410,9 @@ def get_job_config() -> JobConfig:
     -------
     JobConfig
     """
-    account_id = os.getenv(ENV_CSTAR_SLURM_ACCOUNT, "")
-    walltime = os.getenv(ENV_CSTAR_SLURM_MAX_WALLTIME, DEFAULT_SLURM_MAX_WALLTIME)
-    priority = os.environ.get(ENV_CSTAR_SLURM_QUEUE, "")
+    account_id: str = get_env_item(ENV_CSTAR_SLURM_ACCOUNT).value
+    walltime: str = get_env_item(ENV_CSTAR_SLURM_MAX_WALLTIME).value
+    priority: str = get_env_item(ENV_CSTAR_SLURM_QUEUE).value
 
     return JobConfig(account_id, walltime, priority)
 

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -19,11 +19,17 @@ from cstar.entrypoint.worker.worker import (
     SimulationStages,
     configure_environment,
     create_parser,
+    get_job_config,
     get_request,
     get_service_config,
     main,
 )
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
+from cstar.orchestration.utils import (
+    ENV_CSTAR_SLURM_ACCOUNT,
+    ENV_CSTAR_SLURM_MAX_WALLTIME,
+    ENV_CSTAR_SLURM_QUEUE,
+)
 from cstar.simulation import Simulation
 
 DEFAULT_LOOP_DELAY = 5
@@ -59,9 +65,26 @@ def valid_args_short() -> dict[str, str]:
 
 
 @pytest.fixture
+def fake_job_config() -> Generator[JobConfig, None, None]:
+    """Return a `JobConfig` instance configured with mocked
+    values for account, priority, and walltime.
+    """
+    with mock.patch.dict(
+        os.environ,
+        {
+            ENV_CSTAR_SLURM_ACCOUNT: "mock-account",
+            ENV_CSTAR_SLURM_MAX_WALLTIME: "01:00:00",
+            ENV_CSTAR_SLURM_QUEUE: "debug",
+        },
+    ):
+        yield get_job_config()
+
+
+@pytest.fixture
 def sim_runner(
     blueprint_path: Path,
     patch_romssimulation_init_sourcedata,
+    fake_job_config: JobConfig,
 ) -> SimulationRunner:
     """Fixture to create a SimulationRunner instance.
 
@@ -83,10 +106,9 @@ def sim_runner(
         health_check_log_threshold=10,
         name="test_simulation_runner",
     )
-    job_config = JobConfig()
 
     with patch_romssimulation_init_sourcedata(from_worker=True):
-        runner = SimulationRunner(request, service_config, job_config)
+        runner = SimulationRunner(request, service_config, fake_job_config)
 
     output_path = runner._simulation.fs_manager.output_dir
 
@@ -304,6 +326,7 @@ def test_configure_environment_prebuilt() -> None:
 def test_start_runner(
     blueprint_path: Path,
     patch_romssimulation_init_sourcedata,
+    fake_job_config: JobConfig,
 ) -> None:
     """Test creating a SimulationRunner and starting it.
 
@@ -324,10 +347,9 @@ def test_start_runner(
         loop_delay=0,
         health_check_log_threshold=10,
     )
-    job_config = JobConfig()
 
     with patch_romssimulation_init_sourcedata(from_worker=True):
-        runner = SimulationRunner(request, service_config, job_config)
+        runner = SimulationRunner(request, service_config, fake_job_config)
 
     assert runner._blueprint_uri == request.blueprint_uri
 


### PR DESCRIPTION
# Summary

This change removes hardcoded job configuration defaults from the `JobConfig` class and re-uses the default configured on the appropriate environment variable instead.

## Improvements

- Remove default values provided in `JobConfig` class

## Review Checklist

- [x] Subtask of #CSD-496
- [x] Tests passing
- [x] Full type hint coverage
- [x] Changes are documented in `docs/releases.rst`