### PR TITLE
Enable multi-job status retrieval from SLURM

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -1,9 +1,12 @@
+import asyncio
 import json
 import os
 import re
 import typing as t
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import ceil
 from pathlib import Path
@@ -22,8 +25,158 @@ if t.TYPE_CHECKING:
     from cstar.system.scheduler import Queue, Scheduler
 
 
-def get_status_of_slurm_job(job_id: str) -> ExecutionStatus:
-    """Check the status of a Slurm job using sacct.
+sacct_status_map = defaultdict(
+    lambda: ExecutionStatus.UNKNOWN,
+    {
+        "PENDING": ExecutionStatus.PENDING,
+        "RUNNING": ExecutionStatus.RUNNING,
+        "COMPLETED": ExecutionStatus.COMPLETED,
+        "CANCELLED": ExecutionStatus.CANCELLED,
+        "FAILED": ExecutionStatus.FAILED,
+    },
+)
+"""Map sacct states to ExecutionStatus enum."""
+
+
+@dataclass
+class SlurmStep:
+    """Metadata for a SLURM job submission."""
+
+    step_id: str
+    """The SLURM job-id."""
+    raw_state: str
+    """The status of the job."""
+    submit_ts: str
+    """The timestamp for the time of submission."""
+    start_ts: str | None
+    """The timestamp for the time the job started."""
+    end_ts: str | None
+    """The timestamp for the time the job ended."""
+    job_name: str
+    """The unique name of the step."""
+
+    FIELDS: tuple[str, ...] = ("JobID", "State", "Submit", "Start", "End", "JobName")
+
+    @classmethod
+    def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
+        """Instntiate a SlurmStep by parsing attributes from a single line of sacct output.
+
+        Returns
+        -------
+        SlurmStep
+        """
+        data = [item.strip() for item in sacct_stdout.split()]
+        ncols, nexpected = len(data), len(SlurmStep.FIELDS)
+        if ncols != nexpected:
+            msg = f"sacct output has {ncols} but {nexpected} were expected."
+            raise RuntimeError(msg)
+
+        job_id, raw_state, submit_ts, start_ts, end_ts, job_name = [
+            x.strip() for x in sacct_stdout.split()
+        ]
+
+        # TODO: parse the time strings from the format:
+        #  2026-03-02T20:36:32
+        #  YYYY-MM-DDTHH:MM:SS
+        return SlurmStep(
+            step_id=job_id,
+            raw_state=raw_state,
+            submit_ts=submit_ts,
+            start_ts=start_ts if submit_ts else None,
+            end_ts=end_ts if end_ts else None,
+            job_name=job_name,
+        )
+
+    @property
+    def is_job(self) -> bool:
+        """Return `True` when this job is the parent job of a batch.
+
+        Returns
+        -------
+        bool
+        """
+        return self.job_id == self.step_id
+
+    @property
+    def status(self) -> ExecutionStatus:
+        """Return the current status of the step.
+
+        Returns
+        -------
+        ExecutionStatus
+        """
+        return sacct_status_map[self.raw_state]
+
+    @property
+    def job_id(self) -> str:
+        """The batch job ID the task was run under.
+
+        Returns
+        -------
+        str
+        """
+        if "." not in self.step_id:
+            return self.step_id
+
+        return self.step_id.split(".")[0]
+
+    @classmethod
+    def many_from_sacct(cls, sacct_stdout: str) -> "tuple[SlurmStep, ...]":
+        """Parse sacct output into a collection of details items.
+
+        Returns
+        -------
+        t.Iterable[SlurmJobDetail]
+        """
+        return tuple(
+            cls.from_sacct(line) for line in sacct_stdout.split("\n") if line.strip()
+        )
+
+
+class SlurmBatch:
+    """Metadata for all tasks in a SLURM job."""
+
+    steps: t.Iterable[SlurmStep]
+    """The collection of subtasks running under the job."""
+
+    _job: SlurmStep
+    """The primary job detail record."""
+
+    def __init__(self, steps: t.Iterable[SlurmStep]) -> None:
+        """Initialize the instance."""
+        job_ids = {x.job_id for x in steps}
+        if len(job_ids) > 1:
+            raise ValueError("Attempted to create batch from multiple batches")
+
+        self._job = next(t for t in steps if t.is_job)
+        self.steps = list(t for t in steps if not t.is_job)
+
+    @property
+    def job(self) -> SlurmStep:
+        """Return the primary task for the job.
+
+        Returns
+        -------
+        SlurmJobDetail
+        """
+        return self._job
+
+    @classmethod
+    def from_multi_query(cls, tasks: t.Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
+        """Create metadata for a multi-job query."""
+        multi_map: dict[str, list[SlurmStep]] = defaultdict(lambda: [])
+        for item in tasks:
+            multi_map[item.job_id].append(item)
+
+        return {k: SlurmBatch(multi_map[k]) for k in multi_map}
+
+    def __iter__(self) -> t.Iterator["SlurmStep"]:
+        """Iterate through the steps associated with the batch."""
+        yield from self.steps
+
+
+async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
+    """Retrieve job metadata from SLURM.
 
     Parameters
     ----------
@@ -32,27 +185,37 @@ def get_status_of_slurm_job(job_id: str) -> ExecutionStatus:
 
     Returns
     -------
-    status: ExecutionStatus
-        The status of the job
+    list[SlurmJobDetail]
     """
-    sacct_cmd = f"sacct -j {job_id} --format=State%20 --noheader"
+    sacct_cmd = f"sacct -j {job_id} --format={','.join(SlurmStep.FIELDS)} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
-    stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
+    stdout = await asyncio.to_thread(
+        _run_cmd, sacct_cmd, msg_err=msg_err, raise_on_error=True
+    )
 
-    # Map sacct states to ExecutionStatus enum
-    sacct_status_map = {
-        "PENDING": ExecutionStatus.PENDING,
-        "RUNNING": ExecutionStatus.RUNNING,
-        "COMPLETED": ExecutionStatus.COMPLETED,
-        "CANCELLED": ExecutionStatus.CANCELLED,
-        "FAILED": ExecutionStatus.FAILED,
-    }
-    for state, status in sacct_status_map.items():
-        if state in stdout:
-            return status
+    return SlurmStep.many_from_sacct(stdout)
 
-    # Fallback if no known state is found
-    return ExecutionStatus.UNKNOWN
+
+async def get_slurm_batch(job_id: str | int) -> SlurmBatch:
+    """Retrieve the primary job metadata from SLURM.
+
+    Parameters
+    ----------
+    job_id : str
+    """
+    tasks = await get_slurm_steps(job_id)
+    return SlurmBatch(tasks)
+
+
+async def get_slurm_batches(
+    job_ids: t.Iterable[str | int],
+) -> t.Mapping[str, SlurmBatch]:
+    batch_ids = {str(x).split(".")[0] for x in job_ids}
+    jobid_query = ",".join(batch_ids)
+
+    # gross to send `jobid_query` as job_id, but making another method is... grosser?
+    all_tasks = await get_slurm_steps(jobid_query)
+    return SlurmBatch.from_multi_query(all_tasks)
 
 
 def create_scheduler_job(
@@ -608,6 +771,8 @@ class SlurmJob(SchedulerJob):
         Cancel the job using the SLURM `scancel` command.
     """
 
+    _batch: SlurmBatch | None = None
+
     @property
     def status(self) -> ExecutionStatus:
         """Retrieve the current status of the job from the SLURM scheduler.
@@ -631,9 +796,21 @@ class SlurmJob(SchedulerJob):
         RuntimeError
             If the command to retrieve the job status fails or returns an unexpected result.
         """
+        if batch := self.get_batch():
+            return batch.job.status
+
+        return ExecutionStatus.UNSUBMITTED
+
+    def get_batch(self) -> SlurmBatch | None:
         if self.id is None:
-            return ExecutionStatus.UNSUBMITTED
-        return get_status_of_slurm_job(str(self.id))
+            return None
+
+        # avoid refreshing status if the job is done
+        if self._batch is None or not ExecutionStatus.is_terminal(
+            self._batch.job.status
+        ):
+            self._batch = asyncio.run(get_slurm_batch(self.id))
+        return self._batch
 
     @property
     def script(self) -> str:

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -109,7 +109,7 @@ class SlurmStep:
 
     @property
     def job_id(self) -> str:
-        """The batch job ID the task was run under.
+        """The batch job ID the step was run under.
 
         Returns
         -------
@@ -134,16 +134,22 @@ class SlurmStep:
 
 
 class SlurmBatch:
-    """Metadata for all tasks in a SLURM job."""
+    """Metadata for all steps in a SLURM batch."""
 
     steps: t.Iterable[SlurmStep]
-    """The collection of subtasks running under the job."""
+    """The collection of steps running in a batch."""
 
     _job: SlurmStep
-    """The primary job detail record."""
+    """The parent step for the batch."""
 
     def __init__(self, steps: t.Iterable[SlurmStep]) -> None:
-        """Initialize the instance."""
+        """Initialize the instance.
+
+        Parameters
+        ----------
+        steps: t.Iterable[SlurmStep]
+            The steps belonging to the batch.
+        """
         job_ids = {x.job_id for x in steps}
         if len(job_ids) > 1:
             raise ValueError("Attempted to create batch from multiple batches")
@@ -153,25 +159,41 @@ class SlurmBatch:
 
     @property
     def job(self) -> SlurmStep:
-        """Return the primary task for the job.
+        """Return the parent step for the batch.
 
         Returns
         -------
-        SlurmJobDetail
+        SlurmStep
         """
         return self._job
 
     @classmethod
-    def from_multi_query(cls, tasks: t.Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
-        """Create metadata for a multi-job query."""
+    def from_multi_query(cls, steps: t.Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
+        """Create a mapping of job-id to Batch for all discovered job-ids
+        resulting from a multi-job query.
+
+        Parameters
+        ----------
+        steps: t.Iterable[SlurmStep]
+            The steps belonging to 1-to-many batches.
+
+        Returns
+        -------
+        dict[str, SlurmBatch]
+        """
         multi_map: dict[str, list[SlurmStep]] = defaultdict(lambda: [])
-        for item in tasks:
+        for item in steps:
             multi_map[item.job_id].append(item)
 
         return {k: SlurmBatch(multi_map[k]) for k in multi_map}
 
     def __iter__(self) -> t.Iterator["SlurmStep"]:
-        """Iterate through the steps associated with the batch."""
+        """Iterate through the steps associated with the batch.
+
+        Returns
+        -------
+        t.Iterator[SlurmStep]
+        """
         yield from self.steps
 
 
@@ -185,7 +207,8 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
 
     Returns
     -------
-    list[SlurmJobDetail]
+    tuple[SlurmJobDetail, ...]
+        All step metadata retrieved for the job_id
     """
     sacct_cmd = f"sacct -j {job_id} --format={','.join(SlurmStep.FIELDS)} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
@@ -197,25 +220,41 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
 
 
 async def get_slurm_batch(job_id: str | int) -> SlurmBatch:
-    """Retrieve the primary job metadata from SLURM.
+    """Retrieve batch job metadata from SLURM.
 
     Parameters
     ----------
     job_id : str
+
+    Returns
+    -------
+    SlurmBatch
     """
-    tasks = await get_slurm_steps(job_id)
-    return SlurmBatch(tasks)
+    steps = await get_slurm_steps(job_id)
+    return SlurmBatch(steps)
 
 
 async def get_slurm_batches(
     job_ids: t.Iterable[str | int],
 ) -> t.Mapping[str, SlurmBatch]:
+    """Query SLURM for job status.
+
+    Parameters
+    ----------
+    job_ids: t.Iterable[str | int]
+        A collection containing batch job ID's
+
+    Returns
+    -------
+    Mapping[str, SlurmBatch]:
+        A mapping of job-id to SlurmBatch for the supplied job ID's
+    """
     batch_ids = {str(x).split(".")[0] for x in job_ids}
     jobid_query = ",".join(batch_ids)
 
     # gross to send `jobid_query` as job_id, but making another method is... grosser?
-    all_tasks = await get_slurm_steps(jobid_query)
-    return SlurmBatch.from_multi_query(all_tasks)
+    all_steps = await get_slurm_steps(jobid_query)
+    return SlurmBatch.from_multi_query(all_steps)
 
 
 def create_scheduler_job(

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -59,7 +59,7 @@ class SlurmStep:
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
-        """Instntiate a SlurmStep by parsing attributes from a single line of sacct output.
+        """Instantiate a `SlurmStep` by parsing attributes from a single line of sacct output.
 
         Returns
         -------

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -56,6 +56,7 @@ class SlurmStep:
     """The unique name of the step."""
 
     FIELDS: tuple[str, ...] = ("JobID", "State", "Submit", "Start", "End", "JobName")
+    FIELD_WIDTH: tuple[str, ...] = ("%15", "%20", "%20", "%20", "%20", "%100")
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
@@ -207,10 +208,14 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
 
     Returns
     -------
-    tuple[SlurmJobDetail, ...]
+    tuple[SlurmStep, ...]
         All step metadata retrieved for the job_id
     """
-    sacct_cmd = f"sacct -j {job_id} --format={','.join(SlurmStep.FIELDS)} --noheader"
+    fields = [
+        f"{field}{spacing}"
+        for field, spacing in zip(SlurmStep.FIELDS, SlurmStep.FIELD_WIDTH)
+    ]
+    sacct_cmd = f"sacct -j {job_id} --format={','.join(fields)} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
     stdout = await asyncio.to_thread(
         _run_cmd, sacct_cmd, msg_err=msg_err, raise_on_error=True

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -9,7 +9,7 @@ from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionStatus
 from cstar.execution.scheduler_job import (
     create_scheduler_job,
-    get_status_of_slurm_job,
+    get_slurm_batch,
 )
 from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application, RomsMarblBlueprint
@@ -200,7 +200,8 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         ExecutionStatus
             The current status of the step.
         """
-        status = get_status_of_slurm_job(handle.pid)
+        batch = await get_slurm_batch(handle.pid)
+        status = batch.job.status
 
         msg = f"Status of job {handle.pid} is {status} for step {step.name}"
         log.debug(msg)

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -8,6 +9,9 @@ from cstar.execution.scheduler_job import (
     SchedulerJob,
     SlurmJob,
     create_scheduler_job,
+    get_slurm_batch,
+    get_slurm_batches,
+    get_slurm_steps,
 )
 from cstar.system.scheduler import (
     PBSQueue,
@@ -693,3 +697,149 @@ class TestCreateSchedulerJob:
                 account_key="test_account",
                 walltime="01:00:00",
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("job_id"), ["15527988", 15527988])
+async def test_get_slurm_steps_job_id_type(job_id: int | str) -> None:
+    """Verify both integer and string job ID values are accepted."""
+    job_id = "15527988"
+    slurm_output = textwrap.dedent(
+        """15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+"""
+    )
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=slurm_output):
+        results = await get_slurm_steps(job_id)
+
+    assert results
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sacct_output", "exp_num_steps"),
+    [
+        (
+            "15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+",
+            1,
+        ),
+        (
+            "15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+\n",
+            1,
+        ),
+        (
+            """\
+            15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+
+            15527988.ba+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09      batch
+            15527988.ex+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09     extern
+            15527988.0    COMPLETED 2026-03-06T15:04:48 2026-03-06T15:04:48 2026-03-06T15:05:09       roms
+            """,
+            4,
+        ),
+    ],
+)
+async def test_get_slurm_steps_single_job_id(
+    sacct_output: str, exp_num_steps: int
+) -> None:
+    """Verify steps for single job are parsed correctly from sacct std output."""
+    job_id = "15527988"
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        results = await get_slurm_steps(job_id)
+
+    step_ids = {x.step_id for x in results}
+    assert len(step_ids) == exp_num_steps
+
+
+@pytest.mark.asyncio
+async def test_get_slurm_steps_multi_job_id() -> None:
+    """Verify multiple jobs are parsed correctly from sacct std output"""
+    job_id = "1552798,15527988"
+    sacct_output = textwrap.dedent("""\
+        15514059         FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+
+        15514059.ba+     FAILED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:07      batch
+        15514059.ex+  COMPLETED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:08     extern
+        15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+
+        15527988.ba+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09      batch
+        15527988.ex+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09     extern
+        15527988.0    COMPLETED 2026-03-06T15:04:48 2026-03-06T15:04:48 2026-03-06T15:05:09       roms
+        """)
+
+    exp_num_steps = 7
+    exp_num_jobs = 2
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        results = await get_slurm_steps(job_id)
+
+    step_ids = {x.step_id for x in results}
+    assert len(step_ids) == exp_num_steps
+
+    # confirm each step correctly parses it's job ID from the step ID
+    job_ids = {x.job_id for x in results}
+    assert len(job_ids) == exp_num_jobs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "job_id",
+    [
+        15514059,
+        "15514059",
+    ],
+)
+async def test_get_slurm_batch(job_id: int | str) -> None:
+    """Verify multiple steps are parsed correctly from sacct std output with
+    both a string and integer job-id.
+    """
+    sacct_output = textwrap.dedent("""\
+        15514059         FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+
+        15514059.ba+     FAILED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:07      batch
+        15514059.ex+  COMPLETED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:08     extern
+        """)
+
+    exp_num_steps = 2
+    exp_num_jobs = 1
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        result = await get_slurm_batch(job_id)
+
+    step_ids = {x.step_id for x in result}
+    assert len(step_ids) == exp_num_steps
+
+    # confirm each step correctly parses it's job ID from the step ID
+    job_ids = {x.job_id for x in result}
+    assert len(job_ids) == exp_num_jobs
+
+    assert result.job.job_id == str(job_id)
+
+
+@pytest.mark.asyncio
+async def test_get_slurm_batches() -> None:
+    """Verify multiple steps are parsed correctly from sacct std output with
+    both a string and integer job-id.
+    """
+    job_id_1, job_id_2 = 15514059, 15527988
+    sacct_output = textwrap.dedent("""\
+        15514059         FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+
+        15514059.ba+     FAILED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:07      batch
+        15514059.ex+  COMPLETED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:08     extern
+        15527988      COMPLETED 2026-03-06T15:03:24 2026-03-06T15:04:46 2026-03-06T15:05:09 cstar_wor+
+        15527988.ba+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09      batch
+        15527988.ex+  COMPLETED 2026-03-06T15:04:46 2026-03-06T15:04:46 2026-03-06T15:05:09     extern
+        15527988.0    COMPLETED 2026-03-06T15:04:48 2026-03-06T15:04:48 2026-03-06T15:05:09       roms
+        """)
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        result = await get_slurm_batches((job_id_1, job_id_2))
+
+    assert str(job_id_1) in result
+    assert str(job_id_2) in result
+
+    job_id = str(job_id_1)
+    batch = result[job_id]
+    # confirm the "job record" is not in the steps
+    assert len(list(batch.steps)) == 2
+
+    job_id = str(job_id_2)
+    batch = result[job_id]
+    # confirm the "job record" is not in the steps
+    assert len(list(batch.steps)) == 3

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -461,23 +461,41 @@ class TestSlurmJob:
         "job_id, sacct_output, return_code, expected_status, should_raise",
         [
             (None, "", 0, ExecutionStatus.UNSUBMITTED, False),  # Unsubmitted job
-            (12345, "PENDING\n", 0, ExecutionStatus.PENDING, False),  # Pending job
-            (12345, "RUNNING\n", 0, ExecutionStatus.RUNNING, False),  # Running job
             (
                 12345,
-                "COMPLETED\n",
+                "15514059 PENDING 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                0,
+                ExecutionStatus.PENDING,
+                False,
+            ),  # Pending job
+            (
+                12345,
+                "15514059 RUNNING 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                0,
+                ExecutionStatus.RUNNING,
+                False,
+            ),  # Running job
+            (
+                12345,
+                "15514059 COMPLETED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
                 0,
                 ExecutionStatus.COMPLETED,
                 False,
             ),  # Completed job
             (
                 12345,
-                "CANCELLED\n",
+                "15514059 CANCELLED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
                 0,
                 ExecutionStatus.CANCELLED,
                 False,
             ),  # Cancelled job
-            (12345, "FAILED\n", 0, ExecutionStatus.FAILED, False),  # Failed job
+            (
+                12345,
+                "15514059 FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                0,
+                ExecutionStatus.FAILED,
+                False,
+            ),  # Failed job
             (12345, "", 1, None, True),  # sacct command failure
         ],
     )

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -17,7 +17,7 @@ Breaking Changes
 New features
 ~~~~~~~~~~~~
 
-- N/A
+- Enable status retrieval for multiple SLURM jobs in a single `sacct` call
 
 Security Fixes
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

This PR enhances the SLURM status retrieval code to:

1. retrieve details for multiple jobs in a single `sacct` call
2. retrieve additional details about a job (e.g. start/end time, job name, etc.)
3. avoid status retrieval when job is terminal

## New Features

1. Enable status retrieval for multiple SLURM jobs in a single `sacct` call

## Review Checklist

- [X] Closes #CSD-620
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`