### PR TITLE
Orchestrator re-entrance bug fixes

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -261,6 +261,16 @@ ENV_CSTAR_RUNID: t.Annotated[
 ] = "CSTAR_RUNID"
 """Environment variable containing a unique run identifier used by the orchestrator."""
 
+ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
+    t.Literal["CSTAR_SLURM_POST_SUBMIT_DELAY"],
+    EnvVar(
+        "Delay (in seconds) after a submission to ensure status for a SLURM job can be queried.",
+        _GROUP_SIM,
+        default="1.0",
+    ),
+] = "CSTAR_SLURM_POST_SUBMIT_DELAY"
+"""Delay (in seconds) after a submission to ensure status for a SLURM job can be queried."""
+
 
 def discover_env_vars(
     modules: list[types.ModuleType],

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 import typer
 
+from cstar.base.log import get_logger
 from cstar.cli.workplan.check import check
 from cstar.execution.file_system import local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
 
 app = typer.Typer()
+log = get_logger(__name__)
 
 
 @app.command()
@@ -37,9 +39,9 @@ def run(
     try:
         with local_copy(path) as wp_path:
             asyncio.run(build_and_run_dag(wp_path, run_id, output_path))
-        print("Workplan run has completed.")
-    except Exception as ex:
-        print(f"Workplan run has completed unsuccessfully: {ex!r}")
+        log.info(f"Workplan run `{run_id}` has completed")
+    except Exception:
+        log.exception(f"Workplan run `{run_id}` has completed unsuccessfully")
 
 
 if __name__ == "__main__":

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -242,6 +242,23 @@ class JobFileSystemManager(LoggingMixin):
                 shutil.rmtree(directory)
             directory.mkdir(parents=True)
 
+    def clear_prior(self) -> None:
+        """Ensure the job's working directories are empty."""
+        if not self.root.exists():
+            return
+
+        msg = f"Emptying working directories of outputs for previous run of `{self.root.name}`"
+        self.log.debug(msg)
+
+        for directory in [
+            self.input_dir,
+            self.logs_dir,
+            self.output_dir,
+        ]:
+            if directory.exists():
+                shutil.rmtree(directory)
+            directory.mkdir(parents=True)
+
     def get_subtask_manager(self, task_name: str) -> t.Self:
         """Create a JobFileSystemManager instance with a root directory
         configured for a subtask.

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -16,6 +16,7 @@ from cstar.base.env import (
     ENV_CSTAR_CACHE_HOME,
     ENV_CSTAR_CONFIG_HOME,
     ENV_CSTAR_DATA_HOME,
+    ENV_CSTAR_RUNID,
     ENV_CSTAR_STATE_HOME,
     get_env_item,
 )
@@ -358,6 +359,36 @@ class RomsFileSystemManager(JobFileSystemManager):
         ]:
             if directory.exists():
                 shutil.rmtree(directory)
+
+
+class StateDirectoryManager:
+    """Manage the system file system."""
+
+    _RUN_STATE_NAME: t.Final[str] = "run_state"
+    """The name of the directory where run-state files are written."""
+
+    @staticmethod
+    def root() -> Path:
+        """The root directory containing all job outputs.
+
+        Returns
+        -------
+        Path
+        """
+        root = DirectoryManager.state_home()
+        run_id = get_env_item(ENV_CSTAR_RUNID).value
+        return root / run_id
+
+    @staticmethod
+    def run_state() -> Path:
+        """The directory for run-state files.
+
+        The result is a _run-specific_ directory that varies
+        based on the current value of environment variables.
+        """
+        root = DirectoryManager.state_home()
+        run_id = get_env_item(ENV_CSTAR_RUNID).value
+        return root / StateDirectoryManager._RUN_STATE_NAME / run_id
 
 
 def is_remote_resource(uri: str) -> bool:

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -368,27 +368,24 @@ class StateDirectoryManager:
     """The name of the directory where run-state files are written."""
 
     @staticmethod
-    def root() -> Path:
+    def root_dir() -> Path:
         """The root directory containing all job outputs.
 
         Returns
         -------
         Path
         """
-        root = DirectoryManager.state_home()
         run_id = get_env_item(ENV_CSTAR_RUNID).value
-        return root / run_id
+        return DirectoryManager.state_home() / run_id
 
     @staticmethod
-    def run_state() -> Path:
+    def run_state_dir() -> Path:
         """The directory for run-state files.
 
         The result is a _run-specific_ directory that varies
         based on the current value of environment variables.
         """
-        root = DirectoryManager.state_home()
-        run_id = get_env_item(ENV_CSTAR_RUNID).value
-        return root / StateDirectoryManager._RUN_STATE_NAME / run_id
+        return StateDirectoryManager.root_dir() / StateDirectoryManager._RUN_STATE_NAME
 
 
 def is_remote_resource(uri: str) -> bool:

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -72,7 +72,7 @@ class SlurmStep(BaseModel):
     _state: t.Annotated[str, PrivateAttr("Unsubmitted")]
     """The short-form state of the job."""
 
-    TS_UNKNOWN: t.Final[str] = "Unknown"
+    TS_UNKNOWN: t.ClassVar[t.Literal["Unknown"]] = "Unknown"
     """The value returned by SLURM when a timestamp is not yet set."""
 
     @property

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -55,8 +55,8 @@ class SlurmStep:
     job_name: str
     """The unique name of the step."""
 
-    FIELDS: tuple[str, ...] = ("JobID", "State", "Submit", "Start", "End", "JobName")
-    FIELD_WIDTH: tuple[str, ...] = ("%15", "%20", "%20", "%20", "%20", "%100")
+    FIELDS: tuple[str, ...] = ("JobID", "Submit", "Start", "End", "JobName", "State")
+    FIELD_WIDTH: tuple[int, ...] = (10, 20, 20, 20, 100, 9)
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
@@ -212,7 +212,7 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
         All step metadata retrieved for the job_id
     """
     fields = [
-        f"{field}{spacing}"
+        f"{field}%{spacing}"
         for field, spacing in zip(SlurmStep.FIELDS, SlurmStep.FIELD_WIDTH)
     ]
     sacct_cmd = f"sacct -j {job_id} --format={','.join(fields)} --noheader"

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -56,7 +56,7 @@ class SlurmStep:
     """The unique name of the step."""
 
     FIELDS: tuple[str, ...] = ("JobID", "Submit", "Start", "End", "JobName", "State")
-    FIELD_WIDTH: tuple[int, ...] = (10, 20, 20, 20, 100, 9)
+    FIELD_WIDTH: tuple[int, ...] = (10, 20, 20, 20, 100, 30)
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
@@ -66,15 +66,9 @@ class SlurmStep:
         -------
         SlurmStep
         """
-        data = [item.strip() for item in sacct_stdout.split()]
-        ncols, nexpected = len(data), len(SlurmStep.FIELDS)
-        if ncols != nexpected:
-            msg = f"sacct output has {ncols} but {nexpected} were expected."
-            raise RuntimeError(msg)
-
-        job_id, submit_ts, start_ts, end_ts, job_name, raw_state = [
-            x.strip() for x in sacct_stdout.split()
-        ]
+        num_fields = len(SlurmStep.FIELDS)
+        data = [item.strip() for item in sacct_stdout.split(maxsplit=num_fields - 1)]
+        job_id, submit_ts, start_ts, end_ts, job_name, raw_state = data
 
         UNKNOWN: t.Final[str] = "Unknown"
         if start_ts == UNKNOWN:
@@ -87,7 +81,7 @@ class SlurmStep:
         #  YYYY-MM-DDTHH:MM:SS
         return SlurmStep(
             step_id=job_id,
-            raw_state=raw_state,
+            raw_state=raw_state.split(" ", maxsplit=1)[0],
             submit_ts=submit_ts,
             start_ts=start_ts if submit_ts else None,
             end_ts=end_ts if end_ts else None,

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -189,7 +189,7 @@ class SlurmBatch:
                 self._job = next((t for t in all_steps if t.is_job), all_steps[0])
                 self.steps = list(t for t in all_steps if not t.is_job) or all_steps
             except (StopIteration, IndexError):
-                ...  # if batch status is retrieved too quickly, steps may be empty
+                pass  # if batch status is retrieved too quickly, steps may be empty
 
     @property
     def job(self) -> SlurmStep:

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -1,4 +1,5 @@
 import asyncio
+import enum
 import json
 import os
 import re
@@ -11,7 +12,6 @@ from math import ceil
 from pathlib import Path
 
 from pydantic import BaseModel, Field, PrivateAttr
-from pydantic.fields import FieldInfo
 
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
@@ -40,58 +40,36 @@ sacct_status_map = defaultdict(
 """Map sacct states to ExecutionStatus enum."""
 
 
-def get_metadata(klass: type[t.Any]) -> dict[str, str]:  # noqa: ANN401
-    """Get all typing.Annotated metadata from an object."""
-    return t.get_type_hints(klass, include_extras=True)
+class SacctFieldMeta(enum.Enum):
+    STEP_ID = ("JobID", 20)
+    JOB_NAME = ("JobName", 100)
+    SUBMIT_TS = ("Submit", 20)
+    START_TS = ("Start", 20)
+    END_TS = ("End", 20)
+    RAW_STATE = ("State", 30)
 
-
-def get_metadata_string(klass: type[t.Any], key: str) -> t.Mapping[str, str]:  # noqa: ANN401
-    """Get all typing.Annotated metadata from an object."""
-    hints = get_metadata(klass)
-    field_hints: dict[str, str] = {}
-
-    for attr_name, attr_hints in hints.items():
-        annotations = t.get_args(attr_hints)
-        if target_annotation := next(
-            (x for x in annotations if isinstance(x, str) and ":" in x and key in x), ""
-        ):
-            field_hints[attr_name] = target_annotation.split(":")[1]
-
-    return field_hints
-
-
-def get_metadata_field(klass: type[t.Any], key: str) -> t.Mapping[str, str]:  # noqa: ANN401
-    """Get all typing.Annotated metadata from an object."""
-    hints = get_metadata(klass)
-    field_hints: dict[str, str] = {}
-
-    for attr_name, attr_hints in hints.items():
-        annotations = t.get_args(attr_hints)
-        if field_info := next(
-            (x for x in annotations if isinstance(x, FieldInfo)), None
-        ):
-            field_hints[attr_name] = getattr(field_info, key) or ""
-
-    return field_hints
+    @staticmethod
+    def as_format_string() -> str:
+        return ",".join(f"{x.value[0]}%{x.value[1]}" for x in SacctFieldMeta)
 
 
 class SlurmStep(BaseModel):
     """Metadata for a SLURM job submission."""
 
-    step_id: t.Annotated[str, "w:20", Field(alias="JobID")]
+    step_id: t.Annotated[str, Field(alias="JobID")]
     """The SLURM job-id."""
-    job_name: t.Annotated[str, "w:100", Field(alias="JobName")]
+    job_name: t.Annotated[str, Field(alias="JobName")]
     """The unique name of the step."""
-    submit_ts: t.Annotated[str, "w:20", Field(alias="Submit")]
+    submit_ts: t.Annotated[str, Field(alias="Submit")]
     """The timestamp for the time of submission."""
-    start_ts: t.Annotated[str | None, "w:20", Field(alias="Start")]
+    start_ts: t.Annotated[str | None, Field(alias="Start")]
     """The timestamp for the time the job started."""
-    end_ts: t.Annotated[str | None, "w:20", Field(alias="End")]
+    end_ts: t.Annotated[str | None, Field(alias="End")]
     """The timestamp for the time the job ended."""
-    raw_state: t.Annotated[str, "w:30", Field(alias="State")]
+    raw_state: t.Annotated[str, Field(alias="State")]
     """The status of the job."""
 
-    _status: ExecutionStatus = PrivateAttr("Unsubmitted")
+    _state: t.Annotated[str, PrivateAttr("Unsubmitted")]
     """The short-form state of the job."""
 
     TS_UNKNOWN: t.Final[str] = "Unknown"
@@ -109,22 +87,9 @@ class SlurmStep(BaseModel):
         -------
         str
         """
-        if self._status == "Unsubmitted":
-            self._status = self.raw_state.split(" ", maxsplit=1)[0]
-        return self._status
-
-    @classmethod
-    def format_string(cls) -> str:
-        """Return a format string for `sacct`.
-
-        Returns
-        -------
-        str
-        """
-        format_map = get_metadata_string(SlurmStep, "w")
-        alias_map = get_metadata_field(SlurmStep, "alias")
-        aliased_format = {alias_map[k]: v for k, v in format_map.items()}
-        return ",".join(f"{field}%{width}" for field, width in aliased_format.items())
+        if self._state == "Unsubmitted":
+            self._state = self.raw_state.split(" ", maxsplit=1)[0]
+        return self._state
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
@@ -136,9 +101,9 @@ class SlurmStep(BaseModel):
         """
         num_fields = len(SlurmStep.model_fields)
 
-        alias_map = get_metadata_field(SlurmStep, "alias")
+        alias_map = [v.alias or k for k, v in SlurmStep.model_fields.items()]
         data = [item.strip() for item in sacct_stdout.split(maxsplit=num_fields - 1)]
-        data_map = dict(zip(alias_map.values(), data))
+        data_map: dict[str, str | None] = dict(zip(alias_map, data))
 
         if data_map["Start"] == cls.TS_UNKNOWN:
             data_map["Start"] = None
@@ -150,17 +115,6 @@ class SlurmStep(BaseModel):
         #  YYYY-MM-DDTHH:MM:SS
 
         return SlurmStep(**data_map, by_alias=True)
-
-        # return SlurmStep(
-        #     step_id=data_map[SacctFields.JOB_ID],
-        #     raw_state=data_map[SacctFields.STATE].split(" ", maxsplit=1)[0],
-        #     submit_ts=data_map[SacctFields.SUBMIT],
-        #     start_ts=data_map[SacctFields.START]
-        #     if data_map[SacctFields.START]
-        #     else None,
-        #     end_ts=data_map[SacctFields.END] if data_map[SacctFields.END] else None,
-        #     job_name=data_map[SacctFields.JOB_NAME],
-        # )
 
     @property
     def is_job(self) -> bool:
@@ -290,7 +244,7 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
     tuple[SlurmStep, ...]
         All step metadata retrieved for the job_id
     """
-    format_string = SlurmStep.format_string()
+    format_string = SacctFieldMeta.as_format_string()
     sacct_cmd = f"sacct -j {job_id} --format={format_string} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
     stdout = await asyncio.to_thread(

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -6,10 +6,12 @@ import typing as t
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import ceil
 from pathlib import Path
+
+from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.fields import FieldInfo
 
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
@@ -38,25 +40,91 @@ sacct_status_map = defaultdict(
 """Map sacct states to ExecutionStatus enum."""
 
 
-@dataclass
-class SlurmStep:
+def get_metadata(klass: type[t.Any]) -> dict[str, str]:  # noqa: ANN401
+    """Get all typing.Annotated metadata from an object."""
+    return t.get_type_hints(klass, include_extras=True)
+
+
+def get_metadata_string(klass: type[t.Any], key: str) -> t.Mapping[str, str]:  # noqa: ANN401
+    """Get all typing.Annotated metadata from an object."""
+    hints = get_metadata(klass)
+    field_hints: dict[str, str] = {}
+
+    for attr_name, attr_hints in hints.items():
+        annotations = t.get_args(attr_hints)
+        if target_annotation := next(
+            (x for x in annotations if isinstance(x, str) and ":" in x and key in x), ""
+        ):
+            field_hints[attr_name] = target_annotation.split(":")[1]
+
+    return field_hints
+
+
+def get_metadata_field(klass: type[t.Any], key: str) -> t.Mapping[str, str]:  # noqa: ANN401
+    """Get all typing.Annotated metadata from an object."""
+    hints = get_metadata(klass)
+    field_hints: dict[str, str] = {}
+
+    for attr_name, attr_hints in hints.items():
+        annotations = t.get_args(attr_hints)
+        if field_info := next(
+            (x for x in annotations if isinstance(x, FieldInfo)), None
+        ):
+            field_hints[attr_name] = getattr(field_info, key) or ""
+
+    return field_hints
+
+
+class SlurmStep(BaseModel):
     """Metadata for a SLURM job submission."""
 
-    step_id: str
+    step_id: t.Annotated[str, "w:20", Field(alias="JobID")]
     """The SLURM job-id."""
-    raw_state: str
-    """The status of the job."""
-    submit_ts: str
-    """The timestamp for the time of submission."""
-    start_ts: str | None
-    """The timestamp for the time the job started."""
-    end_ts: str | None
-    """The timestamp for the time the job ended."""
-    job_name: str
+    job_name: t.Annotated[str, "w:100", Field(alias="JobName")]
     """The unique name of the step."""
+    submit_ts: t.Annotated[str, "w:20", Field(alias="Submit")]
+    """The timestamp for the time of submission."""
+    start_ts: t.Annotated[str | None, "w:20", Field(alias="Start")]
+    """The timestamp for the time the job started."""
+    end_ts: t.Annotated[str | None, "w:20", Field(alias="End")]
+    """The timestamp for the time the job ended."""
+    raw_state: t.Annotated[str, "w:30", Field(alias="State")]
+    """The status of the job."""
 
-    FIELDS: tuple[str, ...] = ("JobID", "Submit", "Start", "End", "JobName", "State")
-    FIELD_WIDTH: tuple[int, ...] = (10, 20, 20, 20, 100, 30)
+    _status: ExecutionStatus = PrivateAttr("Unsubmitted")
+    """The short-form state of the job."""
+
+    TS_UNKNOWN: t.Final[str] = "Unknown"
+    """The value returned by SLURM when a timestamp is not yet set."""
+
+    @property
+    def state(self) -> str:
+        """Return the short-form SLURM state of the step.
+
+        This is the status as reported by SLURM, such as `PENDING` or `RUNNING`.
+
+        See `raw_state` for full status string (e.g. CANCELLED by Username).
+
+        Returns
+        -------
+        str
+        """
+        if self._status == "Unsubmitted":
+            self._status = self.raw_state.split(" ", maxsplit=1)[0]
+        return self._status
+
+    @classmethod
+    def format_string(cls) -> str:
+        """Return a format string for `sacct`.
+
+        Returns
+        -------
+        str
+        """
+        format_map = get_metadata_string(SlurmStep, "w")
+        alias_map = get_metadata_field(SlurmStep, "alias")
+        aliased_format = {alias_map[k]: v for k, v in format_map.items()}
+        return ",".join(f"{field}%{width}" for field, width in aliased_format.items())
 
     @classmethod
     def from_sacct(cls, sacct_stdout: str) -> "SlurmStep":
@@ -66,27 +134,33 @@ class SlurmStep:
         -------
         SlurmStep
         """
-        num_fields = len(SlurmStep.FIELDS)
-        data = [item.strip() for item in sacct_stdout.split(maxsplit=num_fields - 1)]
-        job_id, submit_ts, start_ts, end_ts, job_name, raw_state = data
+        num_fields = len(SlurmStep.model_fields)
 
-        UNKNOWN: t.Final[str] = "Unknown"
-        if start_ts == UNKNOWN:
-            start_ts = ""
-        if end_ts == UNKNOWN:
-            end_ts = ""
+        alias_map = get_metadata_field(SlurmStep, "alias")
+        data = [item.strip() for item in sacct_stdout.split(maxsplit=num_fields - 1)]
+        data_map = dict(zip(alias_map.values(), data))
+
+        if data_map["Start"] == cls.TS_UNKNOWN:
+            data_map["Start"] = None
+        if data_map["End"] == cls.TS_UNKNOWN:
+            data_map["End"] = None
 
         # TODO: parse the time strings from the format:
         #  2026-03-02T20:36:32
         #  YYYY-MM-DDTHH:MM:SS
-        return SlurmStep(
-            step_id=job_id,
-            raw_state=raw_state.split(" ", maxsplit=1)[0],
-            submit_ts=submit_ts,
-            start_ts=start_ts if submit_ts else None,
-            end_ts=end_ts if end_ts else None,
-            job_name=job_name,
-        )
+
+        return SlurmStep(**data_map, by_alias=True)
+
+        # return SlurmStep(
+        #     step_id=data_map[SacctFields.JOB_ID],
+        #     raw_state=data_map[SacctFields.STATE].split(" ", maxsplit=1)[0],
+        #     submit_ts=data_map[SacctFields.SUBMIT],
+        #     start_ts=data_map[SacctFields.START]
+        #     if data_map[SacctFields.START]
+        #     else None,
+        #     end_ts=data_map[SacctFields.END] if data_map[SacctFields.END] else None,
+        #     job_name=data_map[SacctFields.JOB_NAME],
+        # )
 
     @property
     def is_job(self) -> bool:
@@ -216,11 +290,8 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
     tuple[SlurmStep, ...]
         All step metadata retrieved for the job_id
     """
-    fields = [
-        f"{field}%{spacing}"
-        for field, spacing in zip(SlurmStep.FIELDS, SlurmStep.FIELD_WIDTH)
-    ]
-    sacct_cmd = f"sacct -j {job_id} --format={','.join(fields)} --noheader"
+    format_string = SlurmStep.format_string()
+    sacct_cmd = f"sacct -j {job_id} --format={format_string} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
     stdout = await asyncio.to_thread(
         _run_cmd, sacct_cmd, msg_err=msg_err, raise_on_error=True

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -72,7 +72,7 @@ class SlurmStep:
             msg = f"sacct output has {ncols} but {nexpected} were expected."
             raise RuntimeError(msg)
 
-        job_id, raw_state, submit_ts, start_ts, end_ts, job_name = [
+        job_id, submit_ts, start_ts, end_ts, job_name, raw_state = [
             x.strip() for x in sacct_stdout.split()
         ]
 

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -76,6 +76,12 @@ class SlurmStep:
             x.strip() for x in sacct_stdout.split()
         ]
 
+        UNKNOWN: t.Final[str] = "Unknown"
+        if start_ts == UNKNOWN:
+            start_ts = ""
+        if end_ts == UNKNOWN:
+            end_ts = ""
+
         # TODO: parse the time strings from the format:
         #  2026-03-02T20:36:32
         #  YYYY-MM-DDTHH:MM:SS

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -155,8 +155,13 @@ class SlurmBatch:
         if len(job_ids) > 1:
             raise ValueError("Attempted to create batch from multiple batches")
 
-        self._job = next(t for t in steps if t.is_job)
-        self.steps = list(t for t in steps if not t.is_job)
+        if all_steps := list(steps):
+            try:
+                # a queued job will not have any steps, default to using first result
+                self._job = next((t for t in all_steps if t.is_job), all_steps[0])
+                self.steps = list(t for t in all_steps if not t.is_job) or all_steps
+            except (StopIteration, IndexError):
+                ...  # if batch status is retrieved too quickly, steps may be empty
 
     @property
     def job(self) -> SlurmStep:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -10,12 +10,11 @@ from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 if t.TYPE_CHECKING:
-    from cstar.orchestration.models import Step
-    from cstar.orchestration.orchestration import Launcher
+    from cstar.orchestration.orchestration import Launcher, LiveStep
 
 log = get_logger(__name__)
 
-StepToCommandConversionFn: t.TypeAlias = "t.Callable[[Step], str]"
+StepToCommandConversionFn: t.TypeAlias = "t.Callable[[LiveStep], str]"
 """Convert a `Step` into a command to be executed.
 
 Parameters
@@ -30,7 +29,7 @@ str
 """
 
 
-def convert_roms_step_to_command(step: "Step") -> str:
+def convert_roms_step_to_command(step: "LiveStep") -> str:
     """Convert a `Step` into a command to be executed.
 
     This function converts ROMS/ROMS-MARBL applications into a command triggering
@@ -38,7 +37,7 @@ def convert_roms_step_to_command(step: "Step") -> str:
 
     Parameters
     ----------
-    step : Step
+    step : LiveStep
         The step to be converted.
 
     Returns
@@ -50,7 +49,7 @@ def convert_roms_step_to_command(step: "Step") -> str:
     return f"{sys.executable} -m {worker_module}  -b {step.blueprint_path}"
 
 
-def convert_step_to_placeholder(step: "Step") -> str:
+def convert_step_to_placeholder(step: "LiveStep") -> str:
     """Convert a `Step` into a command to be executed.
 
     This function converts applications into mocks by starting a process that
@@ -58,7 +57,7 @@ def convert_step_to_placeholder(step: "Step") -> str:
 
     Parameters
     ----------
-    step : Step
+    step : LiveStep
         The step to be converted.
 
     Returns

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -65,13 +65,22 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     str
         The complete CLI command.
     """
+    if not step.fsm.work_dir.exists():
+        step.fsm.work_dir.mkdir(parents=True)
+
     sleep_time = random.randint(1, 10)
-    return textwrap.dedent(f"""\
+    script = textwrap.dedent(f"""\
         # this is a mock application script that produces verifiable output
         echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";
         sleep {sleep_time};
         echo "{step.name} completed at $(date "+%Y-%m-%d %H:%M:%S")";
         """)
+
+    # write it to a script asset
+    script_path = step.fsm.work_dir / "script.sh"
+    script_path.write_text(script)
+
+    return f"sh {script_path}"
 
 
 launcher_aware_app_to_cmd_map: dict[

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from itertools import cycle
 from pathlib import Path
 
+from prefect import flow
+
 from cstar.base.log import get_logger
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
@@ -194,7 +196,7 @@ async def prepare_workplan(
     return wp, persist_as
 
 
-# @flow(log_prints=True)
+@flow(log_prints=True)
 async def build_and_run_dag(
     wp_path: Path, run_id: str = "", output_dir: Path | None = None
 ) -> Path:

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -192,11 +192,11 @@ class LocalLauncher(Launcher[LocalHandle]):
             msg = f"Dependency of step {step.name} failed. Unable to continue."
             raise CstarExpectationFailed(msg)
 
-        # live_step = LiveStep.from_step(step)
-        handle = await LocalLauncher._submit(step, dependencies)
+        live_step = LiveStep.from_step(step)
+        handle = await LocalLauncher._submit(live_step, dependencies)
         return Task(
             status=Status.Submitted,
-            step=step,
+            step=live_step,
             handle=handle,
         )
 

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -6,6 +6,7 @@ from subprocess import run as sprun
 
 from psutil import NoSuchProcess
 from psutil import Process as PsProcess
+from pydantic import PrivateAttr
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.utils import slugify
@@ -26,38 +27,17 @@ def run_as_process(step: "Step", cmd: list[str]) -> dict[str, int]:
 class LocalHandle(ProcessHandle):
     """Handle enabling reference to a task running in local processes."""
 
-    process: MpProcess
-    """The process handle (used only for simulating local processes)."""
-    start_at: float
+    start_at: datetime.datetime | float
     """The process creation time as a posix timestamp (in seconds)."""
 
-    def __init__(
-        self,
-        step: "Step",
-        process: MpProcess,
-        pid: int,
-        start_at: datetime.datetime | float,
-    ) -> None:
-        """Initialize the local handle.
+    _process: MpProcess = PrivateAttr()
+    """The process handle (used only for simulating local processes)."""
 
-        Parameters
-        ----------
-        step : Step
-            The step used to create the task.
-        pid : int
-            The process ID.
-        start_at : datetime
-            The process start time.
-        """
-        super().__init__(pid=str(pid))
-
-        self.step = step
-        self.process = process
-        self.start_at = (
-            start_at.timestamp()
-            if isinstance(start_at, datetime.datetime)
-            else start_at
-        )
+    @property
+    def start_ts(self) -> float:
+        if isinstance(self.start_at, datetime.datetime):
+            self.start_at = self.start_at.timestamp()
+        return self.start_at
 
     @property
     def elapsed(self) -> float:
@@ -68,7 +48,15 @@ class LocalHandle(ProcessHandle):
         float
         """
         now = datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
-        return now - self.start_at
+        return now - self.start_ts
+
+    @property
+    def process(self) -> MpProcess:
+        return self._process
+
+    @process.setter
+    def process(self, value: MpProcess) -> None:
+        self._process = value
 
 
 class LocalLauncher(Launcher[LocalHandle]):

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -12,11 +12,16 @@ from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.utils import slugify
 from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application
-from cstar.orchestration.orchestration import Launcher, ProcessHandle, Status, Task
+from cstar.orchestration.orchestration import (
+    Launcher,
+    LiveStep,
+    ProcessHandle,
+    Status,
+    Task,
+)
 
 if t.TYPE_CHECKING:
     from cstar.orchestration.models import Step
-    from cstar.orchestration.orchestration import LiveStep
 
 
 def run_as_process(step: "Step", cmd: list[str]) -> dict[str, int]:
@@ -63,12 +68,12 @@ class LocalLauncher(Launcher[LocalHandle]):
     """A launcher that executes steps in a local process."""
 
     @staticmethod
-    async def _submit(step: "Step", dependencies: list[LocalHandle]) -> LocalHandle:
+    async def _submit(step: "LiveStep", dependencies: list[LocalHandle]) -> LocalHandle:
         """Submit a step to SLURM as a new batch allocation.
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step to execute in a local process.
         dependencies : list[LocalHandle]
             The list of tasks that must complete prior to execution of the submitted Step.
@@ -119,12 +124,12 @@ class LocalLauncher(Launcher[LocalHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(step: "Step", handle: LocalHandle) -> str:
+    async def _status(step: "LiveStep", handle: LocalHandle) -> str:
         """Retrieve the status of a step running in local process.
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step triggering the job.
         handle : LocalHandle
             A handle object for a process-based task.
@@ -154,7 +159,7 @@ class LocalLauncher(Launcher[LocalHandle]):
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step to run in a local process.
         dependencies : list[LocalHandle]
             The list of tasks that must complete prior to execution of the submitted Step.
@@ -191,13 +196,13 @@ class LocalLauncher(Launcher[LocalHandle]):
 
     @classmethod
     async def query_status(
-        cls, step: "Step", item: Task[LocalHandle] | LocalHandle
+        cls, step: "LiveStep", item: Task[LocalHandle] | LocalHandle
     ) -> Status:
         """Retrieve the status of an item.
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step that will be queried for.
         item : Task[LocalHandle] | LocalHandle
             An item with a handle to be used to execute a status query.

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -128,7 +128,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(step: "LiveStep", handle: LocalHandle) -> str:
+    async def _status(handle: LocalHandle) -> str:
         """Retrieve the status of a step running in local process.
 
         Parameters
@@ -145,7 +145,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         """
         # await LocalLauncher._update_processes()
         rc = handle.process.exitcode
-        step_name = step.name if step else handle.pid
+        step_name = handle.name
 
         if rc is None:
             status = "RUNNING"
@@ -174,7 +174,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         Task[LocalHandle]
             A Task containing information about the newly submitted job.
         """
-        tasks = [asyncio.Task(cls.query_status(step, h)) for h in dependencies]
+        tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
         statuses = await asyncio.gather(*tasks)
         active_found = any(map(Status.is_running, statuses))
         failure_found = any(map(Status.is_failure, statuses))
@@ -183,7 +183,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         while active_found and not failure_found:
             await asyncio.sleep(1)
 
-            tasks = [asyncio.Task(cls.query_status(step, h)) for h in dependencies]
+            tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
             statuses = await asyncio.gather(*tasks)
             active_found = any(map(Status.is_running, statuses))
             failure_found = any(map(Status.is_failure, statuses))
@@ -201,15 +201,11 @@ class LocalLauncher(Launcher[LocalHandle]):
         )
 
     @classmethod
-    async def query_status(
-        cls, step: "LiveStep", item: Task[LocalHandle] | LocalHandle
-    ) -> Status:
+    async def query_status(cls, item: Task[LocalHandle] | LocalHandle) -> Status:
         """Retrieve the status of an item.
 
         Parameters
         ----------
-        step : LiveStep
-            The step that will be queried for.
         item : Task[LocalHandle] | LocalHandle
             An item with a handle to be used to execute a status query.
 
@@ -219,7 +215,7 @@ class LocalLauncher(Launcher[LocalHandle]):
             The current status of the item.
         """
         handle = item.handle if isinstance(item, Task) else item
-        raw_status = await LocalLauncher._status(step, handle)
+        raw_status = await LocalLauncher._status(handle)
         if raw_status in ["PENDING", "RUNNING", "ENDING"]:
             return Status.Running
         if raw_status in ["COMPLETED", "FAILED"]:

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -90,6 +90,9 @@ class LocalLauncher(Launcher[LocalHandle]):
         cmd = step_converter(step)
 
         try:
+            if not step.fsm.root.exists():
+                step.fsm.prepare()
+
             mp_process = MpProcess(
                 target=run_as_process,
                 name=slugify(step.name),
@@ -111,12 +114,13 @@ class LocalLauncher(Launcher[LocalHandle]):
                 except NoSuchProcess:
                     print(f"Unable to retrieve exact start time for pid: {pid}")
 
-                return LocalHandle(
-                    step,
-                    mp_process,
-                    pid,
-                    create_time,
+                handle = LocalHandle(
+                    pid=str(pid),
+                    start_at=create_time,
                 )
+                handle.process = mp_process
+                return handle
+
         finally:
             ...
 
@@ -170,7 +174,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         Task[LocalHandle]
             A Task containing information about the newly submitted job.
         """
-        tasks = [asyncio.Task(cls.query_status(h.step, h)) for h in dependencies]
+        tasks = [asyncio.Task(cls.query_status(step, h)) for h in dependencies]
         statuses = await asyncio.gather(*tasks)
         active_found = any(map(Status.is_running, statuses))
         failure_found = any(map(Status.is_failure, statuses))
@@ -179,7 +183,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         while active_found and not failure_found:
             await asyncio.sleep(1)
 
-            tasks = [asyncio.Task(cls.query_status(h.step, h)) for h in dependencies]
+            tasks = [asyncio.Task(cls.query_status(step, h)) for h in dependencies]
             statuses = await asyncio.gather(*tasks)
             active_found = any(map(Status.is_running, statuses))
             failure_found = any(map(Status.is_failure, statuses))
@@ -188,6 +192,7 @@ class LocalLauncher(Launcher[LocalHandle]):
             msg = f"Dependency of step {step.name} failed. Unable to continue."
             raise CstarExpectationFailed(msg)
 
+        # live_step = LiveStep.from_step(step)
         handle = await LocalLauncher._submit(step, dependencies)
         return Task(
             status=Status.Submitted,

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -93,9 +93,10 @@ class LocalLauncher(Launcher[LocalHandle]):
             if not step.fsm.root.exists():
                 step.fsm.prepare()
 
+            process_name = slugify(step.name)
             mp_process = MpProcess(
                 target=run_as_process,
-                name=slugify(step.name),
+                name=process_name,
                 args=(step, cmd.split()),
                 daemon=True,
             )
@@ -116,6 +117,7 @@ class LocalLauncher(Launcher[LocalHandle]):
 
                 handle = LocalHandle(
                     pid=str(pid),
+                    name=process_name,
                     start_at=create_time,
                 )
                 handle.process = mp_process

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -141,15 +141,16 @@ class LocalLauncher(Launcher[LocalHandle]):
         """
         # await LocalLauncher._update_processes()
         rc = handle.process.exitcode
+        step_name = step.name if step else handle.pid
 
         if rc is None:
             status = "RUNNING"
         elif rc == 0:
             status = "COMPLETED"
-            print(f"Return code for pid `{handle.pid}` is `{rc}` for `{step.name}`")
+            print(f"Return code for pid `{handle.pid}` is `{rc}` for `{step_name}`")
         else:
             status = "FAILED"
-            print(f"Failure code for pid `{handle.pid}` is `{rc}` for `{step.name}`")
+            print(f"Failure code for pid `{handle.pid}` is `{rc}` for `{step_name}`")
 
         return status
 

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -9,7 +9,7 @@ from psutil import Process as PsProcess
 from pydantic import PrivateAttr
 
 from cstar.base.exceptions import CstarExpectationFailed
-from cstar.base.utils import slugify
+from cstar.base.log import get_logger
 from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application
 from cstar.orchestration.orchestration import (
@@ -22,6 +22,9 @@ from cstar.orchestration.orchestration import (
 
 if t.TYPE_CHECKING:
     from cstar.orchestration.models import Step
+
+
+log = get_logger(__name__)
 
 
 def run_as_process(step: "Step", cmd: list[str]) -> dict[str, int]:
@@ -93,10 +96,9 @@ class LocalLauncher(Launcher[LocalHandle]):
             if not step.fsm.root.exists():
                 step.fsm.prepare()
 
-            process_name = slugify(step.name)
             mp_process = MpProcess(
                 target=run_as_process,
-                name=process_name,
+                name=step.safe_name,
                 args=(step, cmd.split()),
                 daemon=True,
             )
@@ -117,7 +119,7 @@ class LocalLauncher(Launcher[LocalHandle]):
 
                 handle = LocalHandle(
                     pid=str(pid),
-                    name=process_name,
+                    name=step.safe_name,
                     start_at=create_time,
                 )
                 handle.process = mp_process
@@ -135,8 +137,6 @@ class LocalLauncher(Launcher[LocalHandle]):
 
         Parameters
         ----------
-        step : LiveStep
-            The step triggering the job.
         handle : LocalHandle
             A handle object for a process-based task.
 
@@ -151,10 +151,10 @@ class LocalLauncher(Launcher[LocalHandle]):
             status = "RUNNING"
         elif rc == 0:
             status = "COMPLETED"
-            print(f"Return code for pid `{handle.pid}` is `{rc}` for `{handle.name}`")
+            log.debug(f"Return code for handle `{handle}` is `{rc}`.")
         else:
             status = "FAILED"
-            print(f"Failure code for pid `{handle.pid}` is `{rc}` for `{handle.name}`")
+            log.warning(f"Failure code for handle `{handle}` is `{rc}`.")
 
         return status
 
@@ -216,16 +216,18 @@ class LocalLauncher(Launcher[LocalHandle]):
         """
         handle = item.handle if isinstance(item, Task) else item
         raw_status = await LocalLauncher._status(handle)
-        if raw_status in ["PENDING", "RUNNING", "ENDING"]:
-            return Status.Running
-        if raw_status in ["COMPLETED", "FAILED"]:
-            return Status.Done
-        if raw_status == "CANCELLED":
-            return Status.Cancelled
-        if raw_status == "FAILED":
-            return Status.Failed
 
-        return Status.Unsubmitted
+        match raw_status:
+            case "PENDING" | "RUNNING" | "ENDING":
+                return Status.Running
+            case "COMPLETED" | "FAILED":
+                return Status.Done
+            case "CANCELLED":
+                return Status.Cancelled
+            case "FAILED":
+                return Status.Failed
+            case _:
+                return Status.Unsubmitted
 
     @classmethod
     async def cancel(cls, item: Task[LocalHandle]) -> Task[LocalHandle]:

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -145,18 +145,16 @@ class LocalLauncher(Launcher[LocalHandle]):
         str
             The current status of the step.
         """
-        # await LocalLauncher._update_processes()
         rc = handle.process.exitcode
-        step_name = handle.name
 
         if rc is None:
             status = "RUNNING"
         elif rc == 0:
             status = "COMPLETED"
-            print(f"Return code for pid `{handle.pid}` is `{rc}` for `{step_name}`")
+            print(f"Return code for pid `{handle.pid}` is `{rc}` for `{handle.name}`")
         else:
             status = "FAILED"
-            print(f"Failure code for pid `{handle.pid}` is `{rc}` for `{step_name}`")
+            print(f"Failure code for pid `{handle.pid}` is `{rc}` for `{handle.name}`")
 
         return status
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -93,7 +93,7 @@ class SlurmHandle(ProcessHandle):
 class SlurmLauncher(Launcher[SlurmHandle]):
     """A launcher that executes steps in a SLURM-enabled cluster."""
 
-    POST_SUBMIT_DELAY: t.Final[float] = 0.25
+    POST_SUBMIT_DELAY: t.Final[float] = 1.0
     """Delay after a submission to ensure status for a SLURM job can be queried."""
 
     @staticmethod

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -6,7 +6,11 @@ from prefect import State, task
 from prefect import Task as PrefectTask
 from prefect.client.schemas import TaskRun
 
-from cstar.base.env import ENV_CSTAR_RUNID, get_env_item
+from cstar.base.env import (
+    ENV_CSTAR_RUNID,
+    ENV_CSTAR_SLURM_POST_SUBMIT_DELAY,
+    get_env_item,
+)
 from cstar.base.log import get_logger
 from cstar.base.utils import _run_cmd, slugify
 from cstar.execution.handler import ExecutionStatus
@@ -110,7 +114,9 @@ class SlurmHandle(ProcessHandle):
 class SlurmLauncher(Launcher[SlurmHandle]):
     """A launcher that executes steps in a SLURM-enabled cluster."""
 
-    POST_SUBMIT_DELAY: t.Final[float] = 1.0
+    POST_SUBMIT_DELAY: t.Final[float] = float(
+        get_env_item(ENV_CSTAR_SLURM_POST_SUBMIT_DELAY).value
+    )
     """Delay after a submission to ensure status for a SLURM job can be queried."""
 
     @staticmethod

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -267,7 +267,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         Task[SlurmHandle]
             A Task containing information about the newly submitted job.
         """
-        # item is persisted to a name that is shared by all instances
         prior_handle = await get_sentinel(step.sentinel_path, SlurmHandle)
         submit_fn = SlurmLauncher._submit
         current_status = Status.Unsubmitted
@@ -306,8 +305,20 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             status=current_status,
         )
 
-    @classmethod
-    def _map_status(cls, status: ExecutionStatus) -> Status:
+    @staticmethod
+    def _map_status(status: ExecutionStatus) -> Status:
+        """Map SLURM execution status to CSTAR status.
+
+        Parameters
+        ----------
+        status : ExecutionStatus
+            The raw SLURM status.
+
+        Returns
+        -------
+        Status
+            The C-Star status.
+        """
         match status:
             case (
                 ExecutionStatus.PENDING

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -223,7 +223,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         batch = await get_slurm_batch(job_id)
         status = batch.job.status
 
-        log.debug(f"Status of job `{job_id}` is `{status}`")
         return status
 
     @staticmethod

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -171,7 +171,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(step: "LiveStep", handle: SlurmHandle) -> ExecutionStatus:
+    async def _status(pid: str) -> ExecutionStatus:
         """Retrieve the status of a step running in SLURM.
 
         Parameters
@@ -186,10 +186,10 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         ExecutionStatus
             The current status of the step.
         """
-        batch = await get_slurm_batch(handle.pid)
+        batch = await get_slurm_batch(pid)
         status = batch.job.status
 
-        msg = f"Status of job {handle.pid} is {status} for step {step.name}"
+        msg = f"Status of job `{pid}` is {status}"
         log.debug(msg)
 
         return status
@@ -223,30 +223,45 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         # TODO: consider loading persisted values all at once during startup instead
         if prior:  #  and prior.task.status != Status.Done:
             # always retrieve real-deal in case persisting status updates failed.
-            last_status = await SlurmLauncher.query_status(step, prior.handle)
+            last_status = await SlurmLauncher.query_status(prior.handle)
             if Status.is_failure(last_status):
                 # if the task terminated in a failure code, we'll re-run it.
                 # - we don't re-run successful tasks
                 persist_as.unlink()
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
+
         handle = await submit_fn(step, dependencies)
 
-        task: Task[SlurmHandle] = Task(
+        return Task(
             step=step,
             handle=handle,
             status=Status.Submitted,
         )
-        if not task.persist():
-            # todo: if i raise, it's not really necessary to raise.... ignore?
-            msg = f"Failure when persisting step: {step.safe_name}"
-            print(msg)
 
-        return task
+    @classmethod
+    def _map_status(cls, status: ExecutionStatus) -> Status:
+        match status:
+            case (
+                ExecutionStatus.PENDING
+                | ExecutionStatus.RUNNING
+                | ExecutionStatus.ENDING
+                | ExecutionStatus.HELD
+            ):
+                return Status.Running
+            case ExecutionStatus.COMPLETED:
+                return Status.Done
+            case ExecutionStatus.CANCELLED:
+                return Status.Cancelled
+            case ExecutionStatus.FAILED:
+                return Status.Failed
+
+        return Status.Unsubmitted
 
     @classmethod
     async def query_status(
-        cls, step: "LiveStep", item: Task[SlurmHandle] | SlurmHandle
+        cls,
+        item: Task[SlurmHandle] | SlurmHandle,
     ) -> Status:
         """Retrieve the status of an item.
 
@@ -263,26 +278,12 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The current status of the item.
         """
         handle = item.handle if isinstance(item, Task) else item
-        exec_status = await SlurmLauncher._status(step, handle)
+        exec_status = await SlurmLauncher._status(handle.pid)
 
         msg = f"SLURM job `{handle.pid}` status is `{exec_status}`"
         log.debug(msg)
 
-        if exec_status in [
-            ExecutionStatus.PENDING,
-            ExecutionStatus.RUNNING,
-            ExecutionStatus.ENDING,
-            ExecutionStatus.HELD,
-        ]:
-            return Status.Running
-        if exec_status == ExecutionStatus.COMPLETED:
-            return Status.Done
-        if exec_status == ExecutionStatus.CANCELLED:
-            return Status.Cancelled
-        if exec_status == ExecutionStatus.FAILED:
-            return Status.Failed
-
-        return Status.Unsubmitted
+        return SlurmLauncher._map_status(exec_status)
 
     @classmethod
     async def cancel(cls, item: Task[SlurmHandle]) -> Task[SlurmHandle]:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -207,27 +207,23 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(pid: str) -> ExecutionStatus:
+    async def _status(job_id: str) -> ExecutionStatus:
         """Retrieve the status of a step running in SLURM.
 
         Parameters
         ----------
-        step : LiveStep
-            The step triggering the job.
-        handle : SlurmHandle
-            A handle object for a SLURM-based task.
+        job_id : str
+            The slurm job ID to retrieve status for.
 
         Returns
         -------
         ExecutionStatus
             The current status of the step.
         """
-        batch = await get_slurm_batch(pid)
+        batch = await get_slurm_batch(job_id)
         status = batch.job.status
 
-        msg = f"Status of job `{pid}` is {status}"
-        log.debug(msg)
-
+        log.debug(f"Status of job `{job_id}` is `{status}`")
         return status
 
     @staticmethod
@@ -345,8 +341,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         Parameters
         ----------
-        step : LiveStep
-            The step that will be queried for.
         item : Task[SlurmHandle] | SlurmHandle
             An item with a handle to be used to execute a status query.
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import typing as t
 
@@ -62,6 +63,9 @@ class SlurmHandle(ProcessHandle):
 
 class SlurmLauncher(Launcher[SlurmHandle]):
     """A launcher that executes steps in a SLURM-enabled cluster."""
+
+    POST_SUBMIT_DELAY: t.Final[float] = 0.25
+    """Delay after a submission to ensure status for a SLURM job can be queried."""
 
     @staticmethod
     def configured_queue() -> str:
@@ -162,6 +166,8 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         if job.id:
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
+            # add a small delay so batch can be queried
+            await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
             return SlurmHandle(pid=str(job.id), name=job_name)
 
         msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -48,6 +48,9 @@ async def on_submit_complete(
     successfully.
     """
     if state.is_completed():
+        # add a small delay so batch can be queried
+        await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
+
         params = prefect.runtime.task_run.get_parameters()
         step = t.cast("LiveStep", params.get("step"))
 
@@ -197,8 +200,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         if job.id:
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
-            # add a small delay so batch can be queried
-            await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
             return SlurmHandle(pid=str(job.id), name=job_name)
 
         msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -214,12 +214,35 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         Task[SlurmHandle]
             A Task containing information about the newly submitted job.
         """
-        handle = await SlurmLauncher._submit(step, dependencies)
-        return Task(
-            status=Status.Submitted,
+        # item is persisted to a name that is shared by all instances
+        persist_as = Task.persist_step_as(step)
+        prior = Task.load_persisted(persist_as)
+        handle: ProcessHandle | None = None
+        submit_fn = SlurmLauncher._submit
+
+        # TODO: consider loading persisted values all at once during startup instead
+        if prior:  #  and prior.task.status != Status.Done:
+            # always retrieve real-deal in case persisting status updates failed.
+            last_status = await SlurmLauncher.query_status(step, prior.handle)
+            if Status.is_failure(last_status):
+                # if the task terminated in a failure code, we'll re-run it.
+                # - we don't re-run successful tasks
+                persist_as.unlink()
+                submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
+
+        handle = await submit_fn(step, dependencies)
+
+        task: Task[SlurmHandle] = Task(
             step=step,
             handle=handle,
+            status=Status.Submitted,
         )
+        if not task.persist():
+            # todo: if i raise, it's not really necessary to raise.... ignore?
+            msg = f"Failure when persisting step: {step.safe_name}"
+            print(msg)
+
+        return task
 
     @classmethod
     async def query_status(

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -222,9 +222,8 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             # always retrieve real-deal in case persisting status updates failed.
             last_status = await SlurmLauncher.query_status(prior.handle)
             if Status.is_failure(last_status):
-                # if the task terminated in a failure code, we'll re-run it.
-                # - we don't re-run successful tasks
-                persist_as.unlink()
+                # force cache refresh for any tasks that didn't succeed
+                step.fsm.clear_prior()
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -60,21 +60,8 @@ def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:
 class SlurmHandle(ProcessHandle):
     """Handle enabling reference to a task running in SLURM."""
 
-    job_name: str | None
+    job_name: str = ""
     """The user-friendly, task-based job name."""
-
-    def __init__(self, job_id: str, job_name: str | None = None) -> None:
-        """Initialize the SLURM handle.
-
-        Parameters
-        ----------
-        job_id : str
-            The SLURM_JOB_ID identifying a job.
-        job_name : str or None
-            The job name assigned to the job.
-        """
-        super().__init__(pid=job_id)
-        self.job_name = job_name
 
 
 class SlurmLauncher(Launcher[SlurmHandle]):
@@ -179,7 +166,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         if job.id:
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
-            return SlurmHandle(job_id=str(job.id), job_name=job_name)
+            return SlurmHandle(pid=str(job.id), job_name=job_name)
 
         msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"
         raise RuntimeError(msg)

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,8 +1,12 @@
 import asyncio
 import os
 import typing as t
+from pathlib import Path
 
-from prefect import task
+import prefect.runtime
+from prefect import State, task
+from prefect import Task as PrefectTask
+from prefect.client.schemas import TaskRun
 
 from cstar.base.env import ENV_CSTAR_RUNID, get_env_item
 from cstar.base.log import get_logger
@@ -11,6 +15,7 @@ from cstar.execution.handler import ExecutionStatus
 from cstar.execution.scheduler_job import (
     create_scheduler_job,
     get_slurm_batch,
+    get_slurm_batches,
 )
 from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application, RomsMarblBlueprint
@@ -19,6 +24,9 @@ from cstar.orchestration.orchestration import (
     ProcessHandle,
     Status,
     Task,
+    get_sentinel,
+    list_sentinels,
+    put_sentinel,
 )
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
@@ -33,6 +41,27 @@ if t.TYPE_CHECKING:
     from cstar.orchestration.orchestration import LiveStep
 
 log = get_logger(__name__)
+
+
+async def on_submit_complete(
+    task: PrefectTask, task_run: TaskRun, state: State, **kwargs: str
+) -> None:
+    """Perform actions required when a job submission completes
+    successfully.
+    """
+    if state.is_completed():
+        params = prefect.runtime.task_run.get_parameters()
+        step = t.cast("LiveStep", params.get("step"))
+
+        try:
+            result = await state.aresult()
+            handle = t.cast("SlurmHandle", result)
+            await put_sentinel(handle, step.sentinel_path)
+        except Exception:
+            log.exception("An error occurred during the post-submit hook")
+
+    if state.name == "Cached":
+        log.debug(f"Re-using result from cached SLURM job: {handle.pid}")
 
 
 def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:
@@ -106,7 +135,11 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         """
         return get_env_item(ENV_CSTAR_SLURM_ACCOUNT).value
 
-    @task(persist_result=True, cache_key_fn=cache_key_func)
+    @task(
+        persist_result=True,
+        cache_key_fn=cache_key_func,
+        on_completion=[on_submit_complete],
+    )
     @staticmethod
     async def _submit(step: "LiveStep", dependencies: list[SlurmHandle]) -> SlurmHandle:
         """Submit a step to SLURM as a new batch allocation.
@@ -197,6 +230,23 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         return status
 
+    @staticmethod
+    async def _locate_priors(task_path: Path) -> t.Mapping[str, SlurmHandle]:
+        """Retrieve all task sentinels discovered in the output path.
+
+        Parameters
+        ----------
+        task_path : Path
+            The path to any asset in the output directory for the run.
+
+        Returns
+        -------
+        Mapping[str, Task[SlurmHandle]]
+            Mapping of all previously run PIDs to their sentinel content.
+        """
+        sentinels = await list_sentinels(task_path, SlurmHandle)
+        return {h.pid: h for h in sentinels}
+
     @classmethod
     async def launch(
         cls,
@@ -218,21 +268,33 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             A Task containing information about the newly submitted job.
         """
         # item is persisted to a name that is shared by all instances
-        persist_as = Task.persist_step_as(step)
-        prior = Task.load_persisted(persist_as)
-        handle: ProcessHandle | None = None
+        prior_handle = await get_sentinel(step.sentinel_path, SlurmHandle)
         submit_fn = SlurmLauncher._submit
         current_status = Status.Unsubmitted
 
-        # TODO: consider loading persisted values all at once during startup instead
-        if prior:  #  and prior.task.status != Status.Done:
-            # always retrieve real-deal in case persisting status updates failed.
-            last_status = await SlurmLauncher.query_status(prior.handle)
+        if prior_handle:
+            # use persisted task as sentinel only; query SLURM for up-to-date status
+            last_status = await SlurmLauncher.query_status(prior_handle)
+
             if Status.is_failure(last_status):
                 # force cache refresh for any tasks that didn't succeed
                 step.fsm.clear_prior()
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
+                # SLURM cannot use dependencies on previously completed jobs
+                pid_to_task = await cls._locate_priors(step.fsm.root)
+                batch_map = await get_slurm_batches(pid_to_task.keys())
+                successes = {
+                    k
+                    for k, v in batch_map.items()
+                    if v.job.status == ExecutionStatus.COMPLETED
+                }
+                if dependencies and successes:
+                    # only keep dependencies that are not old/re-usable
+                    active = set(x.pid for x in dependencies).difference(successes)
+                    dependencies = list(filter(lambda x: x.pid in active, dependencies))
+            else:
+                current_status = last_status
 
         handle = await submit_fn(step, dependencies)
         if current_status == Status.Unsubmitted:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,16 +1,14 @@
 import asyncio
 import os
 import typing as t
-from pathlib import Path
 
-import prefect.runtime
 from prefect import State, task
 from prefect import Task as PrefectTask
 from prefect.client.schemas import TaskRun
 
 from cstar.base.env import ENV_CSTAR_RUNID, get_env_item
 from cstar.base.log import get_logger
-from cstar.base.utils import _run_cmd
+from cstar.base.utils import _run_cmd, slugify
 from cstar.execution.handler import ExecutionStatus
 from cstar.execution.scheduler_job import (
     create_scheduler_job,
@@ -26,7 +24,11 @@ from cstar.orchestration.orchestration import (
     Task,
 )
 from cstar.orchestration.serialization import deserialize
-from cstar.orchestration.state import get_sentinel, list_sentinels, put_sentinel
+from cstar.orchestration.state import (
+    get_sentinel,
+    list_sentinels,
+    put_sentinel,
+)
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -51,13 +53,16 @@ async def on_submit_complete(
         # add a small delay so batch can be queried
         await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
 
-        params = prefect.runtime.task_run.get_parameters()
-        step = t.cast("LiveStep", params.get("step"))
-
         try:
             result = await state.aresult()
             handle = t.cast("SlurmHandle", result)
-            await put_sentinel(handle, step.sentinel_path)
+
+            prev_status = handle.status
+            if handle.status == Status.Unsubmitted:
+                handle.status = await SlurmLauncher.query_status(handle)
+
+            if handle.status != prev_status:
+                await put_sentinel(handle)
         except Exception:
             log.exception("An error occurred during the post-submit hook")
 
@@ -89,6 +94,16 @@ def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:
 
 class SlurmHandle(ProcessHandle):
     """Handle enabling reference to a task running in SLURM."""
+
+    status: Status = Status.Unsubmitted
+
+    @property
+    def safe_name(self) -> str:
+        """Return the path-safe name for the handle.
+
+        Implements the `StateProxy` protocol.
+        """
+        return slugify(self.name)
 
 
 class SlurmLauncher(Launcher[SlurmHandle]):
@@ -225,20 +240,16 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         return status
 
     @staticmethod
-    async def _locate_priors(task_path: Path) -> t.Mapping[str, SlurmHandle]:
+    async def _locate_priors() -> t.Mapping[str, SlurmHandle]:
         """Retrieve all task sentinels discovered in the output path.
 
-        Parameters
-        ----------
-        task_path : Path
-            The path to any asset in the output directory for the run.
 
         Returns
         -------
         Mapping[str, Task[SlurmHandle]]
             Mapping of all previously run PIDs to their sentinel content.
         """
-        sentinels = await list_sentinels(task_path, SlurmHandle)
+        sentinels = await list_sentinels(SlurmHandle)
         return {h.pid: h for h in sentinels}
 
     @classmethod
@@ -275,7 +286,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
                 # SLURM cannot use dependencies on previously completed jobs
-                pid_to_task = await cls._locate_priors(step.fsm.root)
+                pid_to_task = await cls._locate_priors()
                 batch_map = await get_slurm_batches(pid_to_task.keys())
                 successes = {
                     k
@@ -292,6 +303,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         handle = await submit_fn(step, dependencies)
         if current_status == Status.Unsubmitted:
             current_status = await SlurmLauncher.query_status(handle)
+            handle.status = current_status
 
         return Task(
             step=step,

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -29,7 +29,6 @@ from cstar.orchestration.utils import (
 if t.TYPE_CHECKING:
     from prefect.context import TaskRunContext
 
-    from cstar.orchestration.models import Step
     from cstar.orchestration.orchestration import LiveStep
 
 log = get_logger(__name__)
@@ -172,12 +171,12 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(step: "Step", handle: SlurmHandle) -> ExecutionStatus:
+    async def _status(step: "LiveStep", handle: SlurmHandle) -> ExecutionStatus:
         """Retrieve the status of a step running in SLURM.
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step triggering the job.
         handle : SlurmHandle
             A handle object for a SLURM-based task.
@@ -224,13 +223,13 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
     @classmethod
     async def query_status(
-        cls, step: "Step", item: Task[SlurmHandle] | SlurmHandle
+        cls, step: "LiveStep", item: Task[SlurmHandle] | SlurmHandle
     ) -> Status:
         """Retrieve the status of an item.
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step that will be queried for.
         item : Task[SlurmHandle] | SlurmHandle
             An item with a handle to be used to execute a status query.

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -28,6 +28,7 @@ from cstar.orchestration.state import (
     get_sentinel,
     list_sentinels,
     put_sentinel,
+    sentinel_path,
 )
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
@@ -272,7 +273,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         Task[SlurmHandle]
             A Task containing information about the newly submitted job.
         """
-        prior_handle = await get_sentinel(step.sentinel_path, SlurmHandle)
+        prior_handle = await get_sentinel(sentinel_path(step), SlurmHandle)
         submit_fn = SlurmLauncher._submit
         current_status = Status.Unsubmitted
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -222,6 +222,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         prior = Task.load_persisted(persist_as)
         handle: ProcessHandle | None = None
         submit_fn = SlurmLauncher._submit
+        current_status = Status.Unsubmitted
 
         # TODO: consider loading persisted values all at once during startup instead
         if prior:  #  and prior.task.status != Status.Done:
@@ -234,11 +235,13 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
 
         handle = await submit_fn(step, dependencies)
+        if current_status == Status.Unsubmitted:
+            current_status = await SlurmLauncher.query_status(handle)
 
         return Task(
             step=step,
             handle=handle,
-            status=Status.Submitted,
+            status=current_status,
         )
 
     @classmethod

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -59,9 +59,6 @@ def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:
 class SlurmHandle(ProcessHandle):
     """Handle enabling reference to a task running in SLURM."""
 
-    job_name: str = ""
-    """The user-friendly, task-based job name."""
-
 
 class SlurmLauncher(Launcher[SlurmHandle]):
     """A launcher that executes steps in a SLURM-enabled cluster."""
@@ -165,7 +162,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
 
         if job.id:
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
-            return SlurmHandle(pid=str(job.id), job_name=job_name)
+            return SlurmHandle(pid=str(job.id), name=job_name)
 
         msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"
         raise RuntimeError(msg)

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -24,11 +24,9 @@ from cstar.orchestration.orchestration import (
     ProcessHandle,
     Status,
     Task,
-    get_sentinel,
-    list_sentinels,
-    put_sentinel,
 )
 from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.state import get_sentinel, list_sentinels, put_sentinel
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -352,7 +352,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         handle = item.handle if isinstance(item, Task) else item
         exec_status = await SlurmLauncher._status(handle.pid)
 
-        msg = f"SLURM job `{handle.pid}` status is `{exec_status}`"
+        msg = f"SLURM job `{handle}` status is `{exec_status}`"
         log.debug(msg)
 
         return SlurmLauncher._map_status(exec_status)

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -23,6 +23,7 @@ from pydantic import (
 from pytimeparse import parse
 
 from cstar.base.utils import slugify
+from cstar.orchestration.serialization import register_representer, strenum_representer
 
 if t.TYPE_CHECKING:
     from pydantic import ValidationInfo
@@ -601,3 +602,8 @@ class Workplan(BaseModel):
     def _model_validator(self) -> "Workplan":
         """Validate attribute relationships."""
         return self
+
+
+register_representer(WorkplanState, strenum_representer)
+register_representer(Application, strenum_representer)
+register_representer(BlueprintState, strenum_representer)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -125,8 +125,11 @@ class LiveStep(Step):
     """A Step enriched with runtime metadata."""
 
     parent: t.Self | None = None
+    """The step for which this step is a sub-task."""
     work_dir: Path | None = None
+    """The root directory where this step can write outputs."""
     _fsm: JobFileSystemManager | None = None
+    """Manages the structure of outputs from the step."""
 
     @property
     def get_working_dir(self) -> Path:
@@ -145,6 +148,12 @@ class LiveStep(Step):
 
     @property
     def fsm(self) -> JobFileSystemManager:
+        """Retrieve a file system manager rooted on the step working directory.
+
+        Returns
+        -------
+        JobFileSystemManager
+        """
         if self._fsm is None:
             self._fsm = JobFileSystemManager(self.get_working_dir)
         return self._fsm
@@ -156,6 +165,17 @@ class LiveStep(Step):
         parent: "LiveStep | Step | None" = None,
         update: t.Mapping[str, t.Any] | None = None,
     ) -> "LiveStep":
+        """Convert a step from orchestration planning into a LiveStep.
+
+        Parameters
+        ----------
+        step : Step
+            The step to convert
+        parent : LiveStep | Step | None (default: None)
+            The parent of the converted step
+        update : Mapping[str, t.Any]
+            A mapping of updates to apply to the step
+        """
         step_attrs = step.model_dump(by_alias=True)
 
         if update:

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -15,6 +15,11 @@ from cstar.execution.file_system import (
     JobFileSystemManager,
 )
 from cstar.orchestration.models import Step, Workplan
+from cstar.orchestration.serialization import (
+    PersistenceMode,
+    deserialize,
+    serialize,
+)
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
 
 nx = lazy_import("networkx")
@@ -170,26 +175,32 @@ class Task(BaseModel, t.Generic[_THandle]):
     status: Status = Status.Unsubmitted
     """Current task status."""
 
-    # def __init__(
-    #     self,
-    #     step: LiveStep,
-    #     handle: _THandle,
-    #     status: Status = Status.Unsubmitted,
-    # ) -> None:
-    #     """Initialize the Task record.
+    @classmethod
+    def persist_step_as(
+        cls,
+        step: LiveStep,
+        *,
+        mode: PersistenceMode = PersistenceMode.yaml,
+    ) -> Path:
+        extension = "yml" if mode == PersistenceMode.yaml else "json"
+        return step.fsm.tasks_dir / f"{step.safe_name}.{extension}"
 
-    #     Parameters
-    #     ----------
-    #     step : Step
-    #         The workplan `Step` that triggered the task to run
-    #     handle : _THandle
-    #         A handle that used to identify the running task.
-    #     status : Status
-    #         The current status of the task
-    #     """
-    #     self.status = status
-    #     self.step = step
-    #     self.handle = handle
+    def persist_as(
+        self,
+        *,
+        mode: PersistenceMode = PersistenceMode.yaml,
+    ) -> Path:
+        return Task.persist_step_as(self.step, mode=mode)
+
+    def persist(self, *, mode: PersistenceMode = PersistenceMode.yaml) -> bool:
+        return serialize(Task.persist_step_as(self.step, mode=mode), self) > 0
+
+    @classmethod
+    def load_persisted(cls, path: Path) -> "Task | None":
+        if not path.exists():
+            return None
+
+        return deserialize(path, Task)
 
 
 class Planner(LoggingMixin):
@@ -730,3 +741,6 @@ def configure_environment(
 
     if run_id:
         os.environ[ENV_CSTAR_RUNID] = slugify(run_id)
+
+
+# register_representer(Status, intenum_representer)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -54,6 +54,71 @@ class ProcessHandle(BaseModel):
     """The name of the process."""
 
 
+_THandle = t.TypeVar("_THandle", bound=ProcessHandle)
+
+
+async def put_sentinel(handle: _THandle, persist_to: Path) -> bool:
+    """Store a sentinel file on disk.
+
+    The sentinel indicates that a step has been previously executed.
+    """
+    if persist_to.exists():
+        persist_to.unlink()
+
+    num_bytes = await asyncio.to_thread(
+        serialize, persist_to, handle, mode=PersistenceMode.auto
+    )
+    return num_bytes > 0
+
+
+async def get_sentinel(
+    persist_to: Path,
+    klass: type[_THandle],
+    *,
+    mode: PersistenceMode = PersistenceMode.auto,
+) -> _THandle | None:
+    """Read a sentinel file from disk.
+
+    Parameters
+    ----------
+    persist_to : Path
+        Path to a sentinel file
+
+    Returns
+    -------
+    ProcessHandle | None
+        Returns the handle loaded from disk if the file exists,
+        otherwise `None`
+    """
+    if persist_to.exists():
+        return await asyncio.to_thread(deserialize, persist_to, klass, mode=mode)
+    return None
+
+
+async def list_sentinels(persist_to: Path, klass: type[_THandle]) -> list[_THandle]:
+    """Find all sentinel files located in the specified run directory.
+
+    Parameters
+    ----------
+    persist_to : Path
+        The path to any asset in the output directory for the run.
+    klass : type[_THandle]
+        The type of handles to deserialize
+
+    Returns
+    -------
+    list[_THandle]
+        All previously persisted sentinels
+    """
+    run_id = get_env_item(ENV_CSTAR_RUNID).value
+    run_directory = Path(str(persist_to).split(run_id)[0]) / run_id
+    fsm = JobFileSystemManager(run_directory)
+
+    coros = [get_sentinel(p, klass) for p in fsm.work_dir.rglob("*.sentinel.*")]
+    results = await asyncio.gather(*coros)
+    return [x for x in results if x]
+
+
 class Status(IntEnum):
     """The state of a running task."""
 
@@ -118,9 +183,6 @@ class Status(IntEnum):
         return status in {Status.Submitted, Status.Running, Status.Ending}
 
 
-_THandle = t.TypeVar("_THandle", bound=ProcessHandle)
-
-
 class LiveStep(Step):
     """A Step enriched with runtime metadata."""
 
@@ -130,6 +192,8 @@ class LiveStep(Step):
     """The root directory where this step can write outputs."""
     _fsm: JobFileSystemManager | None = None
     """Manages the structure of outputs from the step."""
+    _put_mode: PersistenceMode = PersistenceMode.yaml
+    """The serialization mode for sentinel values written to disk."""
 
     @property
     def get_working_dir(self) -> Path:
@@ -187,6 +251,24 @@ class LiveStep(Step):
 
         return LiveStep(**step_attrs)
 
+    @property
+    def sentinel_path(
+        self,
+    ) -> Path:
+        """Return the path to a file on disk where a sentinel value for this
+        step should reside.
+
+        Returns
+        -------
+        Path
+        """
+        extension = "yml" if self._put_mode == PersistenceMode.yaml else "json"
+        run_id = get_env_item(ENV_CSTAR_RUNID).value
+        run_root = Path(self.fsm.root.as_posix().split(run_id)[0]) / run_id
+        root_fsm = JobFileSystemManager(run_root)
+
+        return root_fsm.work_dir / f"{self.safe_name}.sentinel.{extension}"
+
 
 class Task(BaseModel, t.Generic[_THandle]):
     """A task represents a live-execution of a step."""
@@ -199,33 +281,6 @@ class Task(BaseModel, t.Generic[_THandle]):
 
     status: Status = Status.Unsubmitted
     """Current task status."""
-
-    @classmethod
-    def persist_step_as(
-        cls,
-        step: LiveStep,
-        *,
-        mode: PersistenceMode = PersistenceMode.yaml,
-    ) -> Path:
-        extension = "yml" if mode == PersistenceMode.yaml else "json"
-        return step.fsm.tasks_dir / f"{step.safe_name}.{extension}"
-
-    def persist_as(
-        self,
-        *,
-        mode: PersistenceMode = PersistenceMode.yaml,
-    ) -> Path:
-        return Task.persist_step_as(self.step, mode=mode)
-
-    def persist(self, *, mode: PersistenceMode = PersistenceMode.yaml) -> bool:
-        return serialize(Task.persist_step_as(self.step, mode=mode), self) > 0
-
-    @classmethod
-    def load_persisted(cls, path: Path) -> "Task | None":
-        if not path.exists():
-            return None
-
-        return deserialize(path, Task)
 
 
 class Planner(LoggingMixin):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -262,7 +262,7 @@ class LiveStep(Step):
         -------
         Path
         """
-        extension = "yaml" if self._put_mode == PersistenceMode.yaml else "json"
+        extension = self._put_mode.value
         run_id = get_env_item(ENV_CSTAR_RUNID).value
         run_root = Path(self.fsm.root.as_posix().split(run_id)[0]) / run_id
         root_fsm = JobFileSystemManager(run_root)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -17,15 +17,12 @@ from cstar.base.utils import lazy_import, slugify
 from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
-    StateDirectoryManager,
 )
 from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.serialization import (
-    PersistenceMode,
     intenum_representer,
     register_representer,
 )
-from cstar.orchestration.state import EXT_SENTINEL
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
 
 nx = lazy_import("networkx")
@@ -134,8 +131,6 @@ class LiveStep(Step):
     """The root directory where this step can write outputs."""
     _fsm: JobFileSystemManager | None = None
     """Manages the structure of outputs from the step."""
-    _put_mode: PersistenceMode = PersistenceMode.yaml
-    """The serialization mode for sentinel values written to disk."""
 
     @property
     def get_working_dir(self) -> Path:
@@ -192,20 +187,6 @@ class LiveStep(Step):
             step_attrs["parent"] = LiveStep.from_step(parent).model_dump(by_alias=True)
 
         return LiveStep(**step_attrs)
-
-    @property
-    def sentinel_path(
-        self,
-    ) -> Path:
-        """Return the path to a file on disk where a sentinel value for this
-        step should reside.
-
-        Returns
-        -------
-        Path
-        """
-        run_state = StateDirectoryManager.run_state()
-        return run_state / f"{self.safe_name}.{EXT_SENTINEL}"
 
 
 class Task(BaseModel, t.Generic[_THandle]):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -409,7 +409,7 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
 
         Parameters
         ----------
-        step : Step
+        step : LiveStep
             The step to launch
 
         Returns

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -4,6 +4,8 @@ import typing as t
 from enum import IntEnum, StrEnum, auto
 from pathlib import Path
 
+from pydantic import BaseModel
+
 from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID, get_env_item
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
@@ -35,21 +37,11 @@ class RunMode(StrEnum):
     """Block until tasks are scheduled."""
 
 
-class ProcessHandle:
+class ProcessHandle(BaseModel):
     """Contract used to identify processes created by any launcher."""
 
     pid: str
     """The process identifier."""
-
-    def __init__(self, pid: str) -> None:
-        """Initialize the handle.
-
-        Parameters
-        ----------
-        pid : str
-            A unique ID identifying a running process.
-        """
-        self.pid = pid
 
 
 class Status(IntEnum):
@@ -166,11 +158,8 @@ class LiveStep(Step):
         return LiveStep(**step_attrs)
 
 
-class Task(t.Generic[_THandle]):
+class Task(BaseModel, t.Generic[_THandle]):
     """A task represents a live-execution of a step."""
-
-    status: Status
-    """Current task status."""
 
     step: LiveStep
     """The step containing task configuration."""
@@ -178,26 +167,29 @@ class Task(t.Generic[_THandle]):
     handle: _THandle
     """The unique process identifier for the task."""
 
-    def __init__(
-        self,
-        step: LiveStep,
-        handle: _THandle,
-        status: Status = Status.Unsubmitted,
-    ) -> None:
-        """Initialize the Task record.
+    status: Status = Status.Unsubmitted
+    """Current task status."""
 
-        Parameters
-        ----------
-        step : Step
-            The workplan `Step` that triggered the task to run
-        handle : _THandle
-            A handle that used to identify the running task.
-        status : Status
-            The current status of the task
-        """
-        self.status = status
-        self.step = step
-        self.handle = handle
+    # def __init__(
+    #     self,
+    #     step: LiveStep,
+    #     handle: _THandle,
+    #     status: Status = Status.Unsubmitted,
+    # ) -> None:
+    #     """Initialize the Task record.
+
+    #     Parameters
+    #     ----------
+    #     step : Step
+    #         The workplan `Step` that triggered the task to run
+    #     handle : _THandle
+    #         A handle that used to identify the running task.
+    #     status : Status
+    #         The current status of the task
+    #     """
+    #     self.status = status
+    #     self.step = step
+    #     self.handle = handle
 
 
 class Planner(LoggingMixin):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -18,6 +18,8 @@ from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.serialization import (
     PersistenceMode,
     deserialize,
+    intenum_representer,
+    register_representer,
     serialize,
 )
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
@@ -743,4 +745,4 @@ def configure_environment(
         os.environ[ENV_CSTAR_RUNID] = slugify(run_id)
 
 
-# register_representer(Status, intenum_representer)
+register_representer(Status, intenum_representer)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -262,7 +262,7 @@ class LiveStep(Step):
         -------
         Path
         """
-        extension = "yml" if self._put_mode == PersistenceMode.yaml else "json"
+        extension = "yaml" if self._put_mode == PersistenceMode.yaml else "json"
         run_id = get_env_item(ENV_CSTAR_RUNID).value
         run_root = Path(self.fsm.root.as_posix().split(run_id)[0]) / run_id
         root_fsm = JobFileSystemManager(run_root)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -6,22 +6,26 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID, get_env_item
+from cstar.base.env import (
+    ENV_CSTAR_DATA_HOME,
+    ENV_CSTAR_RUNID,
+    get_env_item,
+)
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import lazy_import, slugify
 from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
+    StateDirectoryManager,
 )
 from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.serialization import (
     PersistenceMode,
-    deserialize,
     intenum_representer,
     register_representer,
-    serialize,
 )
+from cstar.orchestration.state import EXT_SENTINEL
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
 
 nx = lazy_import("networkx")
@@ -55,68 +59,6 @@ class ProcessHandle(BaseModel):
 
 
 _THandle = t.TypeVar("_THandle", bound=ProcessHandle)
-
-
-async def put_sentinel(handle: _THandle, persist_to: Path) -> bool:
-    """Store a sentinel file on disk.
-
-    The sentinel indicates that a step has been previously executed.
-    """
-    if persist_to.exists():
-        persist_to.unlink()
-
-    num_bytes = await asyncio.to_thread(
-        serialize, persist_to, handle, mode=PersistenceMode.auto
-    )
-    return num_bytes > 0
-
-
-async def get_sentinel(
-    persist_to: Path,
-    klass: type[_THandle],
-    *,
-    mode: PersistenceMode = PersistenceMode.auto,
-) -> _THandle | None:
-    """Read a sentinel file from disk.
-
-    Parameters
-    ----------
-    persist_to : Path
-        Path to a sentinel file
-
-    Returns
-    -------
-    ProcessHandle | None
-        Returns the handle loaded from disk if the file exists,
-        otherwise `None`
-    """
-    if persist_to.exists():
-        return await asyncio.to_thread(deserialize, persist_to, klass, mode=mode)
-    return None
-
-
-async def list_sentinels(persist_to: Path, klass: type[_THandle]) -> list[_THandle]:
-    """Find all sentinel files located in the specified run directory.
-
-    Parameters
-    ----------
-    persist_to : Path
-        The path to any asset in the output directory for the run.
-    klass : type[_THandle]
-        The type of handles to deserialize
-
-    Returns
-    -------
-    list[_THandle]
-        All previously persisted sentinels
-    """
-    run_id = get_env_item(ENV_CSTAR_RUNID).value
-    run_directory = Path(str(persist_to).split(run_id)[0]) / run_id
-    fsm = JobFileSystemManager(run_directory)
-
-    coros = [get_sentinel(p, klass) for p in fsm.work_dir.rglob("*.sentinel.*")]
-    results = await asyncio.gather(*coros)
-    return [x for x in results if x]
 
 
 class Status(IntEnum):
@@ -262,12 +204,8 @@ class LiveStep(Step):
         -------
         Path
         """
-        extension = self._put_mode.value
-        run_id = get_env_item(ENV_CSTAR_RUNID).value
-        run_root = Path(self.fsm.root.as_posix().split(run_id)[0]) / run_id
-        root_fsm = JobFileSystemManager(run_root)
-
-        return root_fsm.work_dir / f"{self.safe_name}.sentinel.{extension}"
+        run_state = StateDirectoryManager.run_state()
+        return run_state / f"{self.safe_name}.{EXT_SENTINEL}"
 
 
 class Task(BaseModel, t.Generic[_THandle]):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -511,7 +511,7 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
 
         Parameters
         ----------
-        item : Task[_THandle] or ProcessHandle
+        item : Task[_THandle] or _THandle
             A task or process handle to query for status updates.
 
         Returns
@@ -527,8 +527,8 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
 
         Parameters
         ----------
-        item : Task[_THandle] or ProcessHandle
-            A task or process handle to cancel.
+        item : Task[_THandle]
+            A task to cancel.
 
         Returns
         -------

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -427,7 +427,6 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
     @classmethod
     async def query_status(
         cls,
-        step: LiveStep,
         item: Task[_THandle] | _THandle,
     ) -> Status:
         """Retrieve the current status for a running task.
@@ -603,7 +602,7 @@ class Orchestrator(LoggingMixin):
             return None
 
         if task := self.planner.retrieve(node, KEY_TASK):
-            status = await self.launcher.query_status(task.step, task)
+            status = await self.launcher.query_status(task.handle)
             task.status = status
         else:
             task = await self.launcher.launch(step, dependencies)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -50,6 +50,9 @@ class ProcessHandle(BaseModel):
     pid: str
     """The process identifier."""
 
+    name: str
+    """The name of the process."""
+
 
 class Status(IntEnum):
     """The state of a running task."""

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -25,7 +25,7 @@ class SerializableModel(t.Protocol):
     with metacalases in a protocol.
     """
 
-    def model_dump_json(self) -> str:
+    def model_dump_json(self, *args: t.Any, **kwargs: t.Any) -> str:
         """Return a JSON string representation of the object."""
         ...
 
@@ -34,12 +34,12 @@ class SerializableModel(t.Protocol):
         ...
 
     @classmethod
-    def model_validate_json(cls, json_data: str) -> t.Any:
+    def model_validate_json(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Return a dictionary representation of the object."""
         ...
 
     @classmethod
-    def model_validate(cls, model_dict: dict[str, t.Any]) -> t.Any:
+    def model_validate(cls, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Return a dictionary representation of the object."""
         ...
 

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -73,6 +73,14 @@ def strenum_representer(
     return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
 
 
+def intenum_representer(
+    dumper: yaml.Dumper,
+    data: enum.IntEnum,
+) -> yaml.ScalarNode:
+    """Create a representer for converting IntEnum values to a serialized string."""
+    return dumper.represent_scalar("tag:yaml.org,2002:int", str(data.value))
+
+
 _RT = t.TypeVar("_RT", enum.IntEnum, enum.StrEnum, PosixPath)
 
 

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -3,7 +3,6 @@ import typing as t
 from pathlib import Path, PosixPath
 
 import yaml
-from pydantic import BaseModel
 from yaml import safe_load
 
 from cstar.base.log import get_logger
@@ -19,7 +18,33 @@ class PersistenceMode(enum.StrEnum):
     auto = enum.auto()
 
 
-_T = t.TypeVar("_T", bound=BaseModel)
+class SerializableModel(t.Protocol):
+    """Protocol defining API required to serialize and deserialize objects.
+
+    This is a stand-in for pydantic's BaseModel, as it can cause issues
+    with metacalases in a protocol.
+    """
+
+    def model_dump_json(self) -> str:
+        """Return a JSON string representation of the object."""
+        ...
+
+    def model_dump(self, *args: t.Any, **kwargs: t.Any) -> dict[str, t.Any]:
+        """Return a dictionary representation of the object."""
+        ...
+
+    @classmethod
+    def model_validate_json(cls, json_data: str) -> t.Any:
+        """Return a dictionary representation of the object."""
+        ...
+
+    @classmethod
+    def model_validate(cls, model_dict: dict[str, t.Any]) -> t.Any:
+        """Return a dictionary representation of the object."""
+        ...
+
+
+_T = t.TypeVar("_T", bound=SerializableModel)
 
 
 def _read_json(path: Path, klass: type[_T]) -> _T:
@@ -95,12 +120,12 @@ def register_representer(
     dumper.add_representer(model_type, conversion_fn)
 
 
-def model_to_yaml(model: BaseModel) -> str:
+def model_to_yaml(model: _T) -> str:
     """Serialize a model to yaml.
 
     Parameters
     ----------
-    model : BaseModel
+    model : _T
         The model to be serialized.
 
     Returns
@@ -192,7 +217,7 @@ def deserialize(
 
 def serialize(
     path: Path,
-    model: BaseModel,
+    model: _T,
     mode: PersistenceMode = PersistenceMode.yaml,
 ) -> int:
     """Serialize a model into a file.
@@ -201,7 +226,7 @@ def serialize(
     ----------
     path : Path
         The location to store the serialized model in
-    model : BaseModel
+    model : _T
         The model to serialize
     mode : PersistenceMode
         Specify the type of document to produce (yaml or json)

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -6,6 +6,10 @@ import yaml
 from pydantic import BaseModel
 from yaml import safe_load
 
+from cstar.base.log import get_logger
+
+log = get_logger(__name__)
+
 
 class PersistenceMode(enum.StrEnum):
     """Supported serialization engines."""
@@ -209,7 +213,7 @@ def serialize(
     """
     if path.exists():
         msg = f"Overwriting existing file at `{path}`"
-        print(msg)
+        log.debug(msg)
 
     if mode == PersistenceMode.auto:
         mode = _mode_detect(path)

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -6,8 +6,6 @@ import yaml
 from pydantic import BaseModel
 from yaml import safe_load
 
-from cstar.orchestration import models
-
 
 class PersistenceMode(enum.StrEnum):
     """Supported serialization engines."""
@@ -112,9 +110,6 @@ def model_to_yaml(model: BaseModel) -> str:
     dumper.ignore_aliases = lambda *_args: True  # type: ignore[method-assign]
 
     register_representer(PosixPath, path_representer)
-    register_representer(models.WorkplanState, strenum_representer)
-    register_representer(models.Application, strenum_representer)
-    register_representer(models.BlueprintState, strenum_representer)
 
     return yaml.dump(dumped, sort_keys=False)
 

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -1,0 +1,76 @@
+import asyncio
+import typing as t
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from cstar.execution.file_system import StateDirectoryManager
+from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+
+EXT_SENTINEL: t.Final[str] = "sentinel"
+"""File exension used for persisting sentinels."""
+
+_TStateProxy = t.TypeVar("_TStateProxy", bound=BaseModel)
+
+
+async def put_sentinel(handle: _TStateProxy, persist_to: Path) -> bool:
+    """Store a sentinel file on disk.
+
+    The sentinel indicates that a step has been previously executed.
+    """
+    if persist_to.exists():
+        persist_to.unlink()
+
+    num_bytes = await asyncio.to_thread(
+        serialize, persist_to, handle, mode=PersistenceMode.auto
+    )
+    return num_bytes > 0
+
+
+async def get_sentinel(
+    persist_to: Path,
+    klass: type[_TStateProxy],
+    *,
+    mode: PersistenceMode = PersistenceMode.auto,
+) -> _TStateProxy | None:
+    """Read a sentinel file from disk.
+
+    Parameters
+    ----------
+    persist_to : Path
+        Path to a sentinel file
+
+    Returns
+    -------
+    _TStateProxy | None
+        Returns the handle loaded from disk if the file exists,
+        otherwise `None`
+    """
+    if persist_to.exists():
+        return await asyncio.to_thread(deserialize, persist_to, klass, mode=mode)
+    return None
+
+
+async def list_sentinels(
+    persist_to: Path, klass: type[_TStateProxy]
+) -> list[_TStateProxy]:
+    """Find all sentinel files located in the specified run directory.
+
+    Parameters
+    ----------
+    persist_to : Path
+        The path to any asset in the output directory for the run.
+    klass : type[_THandle]
+        The type of handles to deserialize
+
+    Returns
+    -------
+    list[_THandle]
+        All previously persisted sentinels
+    """
+    state_dir = StateDirectoryManager.run_state()
+    filter = f"*.{EXT_SENTINEL}"
+
+    coros = [get_sentinel(p, klass) for p in state_dir.rglob(filter)]
+    results = await asyncio.gather(*coros)
+    return [x for x in results if x]

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -22,6 +22,7 @@ class StateProxy(SerializableModel, t.Protocol):
     @property
     def safe_name(self) -> str:
         """Return a path-safe name for a state proxy object"""
+        ...
 
 
 _TStateProxy = t.TypeVar("_TStateProxy", bound=StateProxy)
@@ -31,7 +32,7 @@ the `StateProxy` protocol.
 
 
 def sentinel_path(
-    proxy: _TStateProxy, mode: PersistenceMode = PersistenceMode.yaml
+    proxy: StateProxy, mode: PersistenceMode = PersistenceMode.yaml
 ) -> Path:
     """Get the path to a sentinel file for a given handle.
 
@@ -54,7 +55,7 @@ def sentinel_path(
 
 
 async def put_sentinel(
-    proxy: _TStateProxy,
+    proxy: StateProxy,
     *,
     mode: PersistenceMode = PersistenceMode.yaml,
 ) -> bool:

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -2,28 +2,84 @@ import asyncio
 import typing as t
 from pathlib import Path
 
-from pydantic import BaseModel
-
 from cstar.execution.file_system import StateDirectoryManager
-from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+from cstar.orchestration.serialization import (
+    PersistenceMode,
+    SerializableModel,
+    deserialize,
+    serialize,
+)
 
 EXT_SENTINEL: t.Final[str] = "sentinel"
 """File exension used for persisting sentinels."""
 
-_TStateProxy = t.TypeVar("_TStateProxy", bound=BaseModel)
+
+class StateProxy(SerializableModel, t.Protocol):
+    """Protocol defining API required to serialize and deserialize objects
+    as a "sentinel" file.
+    """
+
+    @property
+    def safe_name(self) -> str:
+        """Return a path-safe name for a state proxy object"""
 
 
-async def put_sentinel(handle: _TStateProxy, persist_to: Path) -> bool:
+_TStateProxy = t.TypeVar("_TStateProxy", bound=StateProxy)
+"""Type variable bounding `StateProxy` to any `SerializableModel` implementing
+the `StateProxy` protocol.
+"""
+
+
+def sentinel_path(
+    proxy: _TStateProxy, mode: PersistenceMode = PersistenceMode.yaml
+) -> Path:
+    """Get the path to a sentinel file for a given handle.
+
+    Parameters
+    ----------
+    proxy : _TStateProxy
+        The handle to serialize
+    mode : PersistenceMode
+        The persistence mode to use when serializing
+
+    Returns
+    -------
+    Path
+        The path to the sentinel file
+    """
+    return (
+        StateDirectoryManager.run_state()
+        / f"{proxy.safe_name}.{EXT_SENTINEL}.{mode.value}"
+    )
+
+
+async def put_sentinel(
+    proxy: _TStateProxy,
+    *,
+    mode: PersistenceMode = PersistenceMode.yaml,
+) -> bool:
     """Store a sentinel file on disk.
 
     The sentinel indicates that a step has been previously executed.
+
+    Parameters
+    ----------
+    proxy : _TStateProxy
+        The handle to serialize
+    mode : PersistenceMode
+        The persistence mode to use when serializing
+
+    Returns
+    -------
+    bool
+        Whether the sentinel was successfully stored
     """
+    persist_to = sentinel_path(proxy, mode)
+
     if persist_to.exists():
         persist_to.unlink()
 
-    num_bytes = await asyncio.to_thread(
-        serialize, persist_to, handle, mode=PersistenceMode.auto
-    )
+    num_bytes = await asyncio.to_thread(serialize, persist_to, proxy, mode=mode)
     return num_bytes > 0
 
 
@@ -31,7 +87,7 @@ async def get_sentinel(
     persist_to: Path,
     klass: type[_TStateProxy],
     *,
-    mode: PersistenceMode = PersistenceMode.auto,
+    mode: PersistenceMode = PersistenceMode.yaml,
 ) -> _TStateProxy | None:
     """Read a sentinel file from disk.
 
@@ -39,6 +95,10 @@ async def get_sentinel(
     ----------
     persist_to : Path
         Path to a sentinel file
+    klass : type[_TStateProxy]
+        The type of handles to deserialize
+    mode : PersistenceMode
+        The persistence mode to use when deserializing
 
     Returns
     -------
@@ -52,25 +112,27 @@ async def get_sentinel(
 
 
 async def list_sentinels(
-    persist_to: Path, klass: type[_TStateProxy]
+    klass: type[_TStateProxy],
+    *,
+    mode: PersistenceMode = PersistenceMode.yaml,
 ) -> list[_TStateProxy]:
     """Find all sentinel files located in the specified run directory.
 
     Parameters
     ----------
-    persist_to : Path
-        The path to any asset in the output directory for the run.
-    klass : type[_THandle]
+    klass : type[_TStateProxy]
         The type of handles to deserialize
+    mode : PersistenceMode
+        The persistence mode to use when deserializing
 
     Returns
     -------
-    list[_THandle]
+    list[_TStateProxy]
         All previously persisted sentinels
     """
     state_dir = StateDirectoryManager.run_state()
-    filter = f"*.{EXT_SENTINEL}"
+    filter = f"*.{EXT_SENTINEL}.{mode.value}"
 
-    coros = [get_sentinel(p, klass) for p in state_dir.rglob(filter)]
+    coros = [get_sentinel(p, klass, mode=mode) for p in state_dir.rglob(filter)]
     results = await asyncio.gather(*coros)
     return [x for x in results if x]

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -48,7 +48,7 @@ def sentinel_path(
         The path to the sentinel file
     """
     return (
-        StateDirectoryManager.run_state()
+        StateDirectoryManager.run_state_dir()
         / f"{proxy.safe_name}.{EXT_SENTINEL}.{mode.value}"
     )
 
@@ -130,7 +130,7 @@ async def list_sentinels(
     list[_TStateProxy]
         All previously persisted sentinels
     """
-    state_dir = StateDirectoryManager.run_state()
+    state_dir = StateDirectoryManager.run_state_dir()
     filter = f"*.{EXT_SENTINEL}.{mode.value}"
 
     coros = [get_sentinel(p, klass, mode=mode) for p in state_dir.rglob(filter)]

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -463,35 +463,35 @@ class TestSlurmJob:
             (None, "", 0, ExecutionStatus.UNSUBMITTED, False),  # Unsubmitted job
             (
                 12345,
-                "15514059 PENDING 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                "15514059 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+ PENDING\n",
                 0,
                 ExecutionStatus.PENDING,
                 False,
             ),  # Pending job
             (
                 12345,
-                "15514059 RUNNING 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                "15514059 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+ RUNNING\n",
                 0,
                 ExecutionStatus.RUNNING,
                 False,
             ),  # Running job
             (
                 12345,
-                "15514059 COMPLETED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                "15514059 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+ COMPLETED\n",
                 0,
                 ExecutionStatus.COMPLETED,
                 False,
             ),  # Completed job
             (
                 12345,
-                "15514059 CANCELLED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                "15514059 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+ CANCELLED\n",
                 0,
                 ExecutionStatus.CANCELLED,
                 False,
             ),  # Cancelled job
             (
                 12345,
-                "15514059 FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+\n",
+                "15514059 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+ FAILED\n",
                 0,
                 ExecutionStatus.FAILED,
                 False,

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -12,7 +12,7 @@ from cstar.orchestration.converter.converter import (
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import Application, Step
-from cstar.orchestration.orchestration import Launcher
+from cstar.orchestration.orchestration import Launcher, LiveStep
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 
@@ -49,10 +49,11 @@ def test_converter_defaults(
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
-    step = Step(
+    step = LiveStep(
         name="test step",
         application=target_application.value,
         blueprint=bp_path,
+        work_dir=tmp_path / "unit-test-work-dir",
     )
 
     mapped_fn = get_command_mapping(target_application, launcher_type)
@@ -89,10 +90,11 @@ def test_converter_registration(
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
-    step = Step(
+    step = LiveStep(
         name="test step",
         application=target_application.value,
         blueprint=bp_path,
+        work_dir=tmp_path / "unit-test-work-dir",
     )
 
     # ensure registration doesn't persist after test completes.

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -262,5 +262,3 @@ def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
     assert dtask.status == task.status
     assert dtask.step.name == task.step.name
     assert dtask.handle.pid == task.handle.pid
-
-    # assert False

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -7,8 +7,8 @@ from pydantic import BaseModel, Field, ValidationError
 
 from cstar.orchestration.launch.slurm import SlurmHandle
 from cstar.orchestration.models import Application, Workplan
-from cstar.orchestration.orchestration import LiveStep, Status
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+from cstar.orchestration.state import sentinel_path
 
 
 def test_serialization_json_aliased_fields(tmp_path: Path) -> None:
@@ -222,19 +222,9 @@ def test_serialization_workplan_runtime_vars(
 def test_serialization_handle(tmp_path: Path, mode: PersistenceMode) -> None:
     """Verify that a task can be properly serialized to disk and reloaded."""
     pid, job_name = "test-pid", "abc123"
-    name, app, path, _ = (
-        "test-step",
-        Application.ROMS_MARBL,
-        tmp_path / "blueprint.yaml",
-        Status.Done,
-    )
-
-    path.touch()
-
-    step = LiveStep(name=name, application=app, blueprint=path, depends_on=[])
     handle = SlurmHandle(pid=pid, name=job_name)
 
-    persist_as = step.sentinel_path
+    persist_as = sentinel_path(handle, mode)
 
     # confirm the parametrized serialization mode is supported
     nbytes = serialize(
@@ -244,7 +234,7 @@ def test_serialization_handle(tmp_path: Path, mode: PersistenceMode) -> None:
     )
     assert nbytes > 0
 
-    print(f"Task persisted to: {path}")
+    print(f"Task persisted to: {persist_as}")
     print(persist_as.read_text(encoding="utf-8"))
 
     # confirm the output from `serialize` is valid and can be deserialized

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from cstar.orchestration.launch.slurm import SlurmHandle
 from cstar.orchestration.models import Application, Workplan
-from cstar.orchestration.orchestration import LiveStep, Status, Task
+from cstar.orchestration.orchestration import LiveStep, Status
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
 
 
@@ -219,10 +219,10 @@ def test_serialization_workplan_runtime_vars(
         PersistenceMode.yaml,
     ],
 )
-def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
+def test_serialization_handle(tmp_path: Path, mode: PersistenceMode) -> None:
     """Verify that a task can be properly serialized to disk and reloaded."""
     pid, job_name = "test-pid", "abc123"
-    name, app, path, status = (
+    name, app, path, _ = (
         "test-step",
         Application.ROMS_MARBL,
         tmp_path / "blueprint.yaml",
@@ -233,18 +233,13 @@ def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
 
     step = LiveStep(name=name, application=app, blueprint=path, depends_on=[])
     handle = SlurmHandle(pid=pid, name=job_name)
-    task: Task[SlurmHandle] = Task(
-        step=step,
-        handle=handle,
-        status=status,
-    )
 
-    persist_as = task.persist_as()
+    persist_as = step.sentinel_path
 
     # confirm the parametrized serialization mode is supported
     nbytes = serialize(
         persist_as,
-        task,
+        handle,
         mode,
     )
     assert nbytes > 0
@@ -253,12 +248,11 @@ def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
     print(persist_as.read_text(encoding="utf-8"))
 
     # confirm the output from `serialize` is valid and can be deserialized
-    dtask: Task[SlurmHandle] = deserialize(
+    dhandle: SlurmHandle = deserialize(
         persist_as,
-        Task[SlurmHandle],
+        SlurmHandle,
         mode,
     )
 
-    assert dtask.status == task.status
-    assert dtask.step.name == task.step.name
-    assert dtask.handle.pid == task.handle.pid
+    assert dhandle.name == handle.name
+    assert dhandle.pid == handle.pid

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -232,7 +232,7 @@ def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
     path.touch()
 
     step = LiveStep(name=name, application=app, blueprint=path, depends_on=[])
-    handle = SlurmHandle(pid=pid, job_name=job_name)
+    handle = SlurmHandle(pid=pid, name=job_name)
     task: Task[SlurmHandle] = Task(
         step=step,
         handle=handle,

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -5,7 +5,9 @@ from pathlib import Path
 import pytest
 from pydantic import BaseModel, Field, ValidationError
 
+from cstar.orchestration.launch.slurm import SlurmHandle
 from cstar.orchestration.models import Application, Workplan
+from cstar.orchestration.orchestration import LiveStep, Status, Task
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
 
 
@@ -208,3 +210,57 @@ def test_serialization_workplan_runtime_vars(
     expected = set(expected_vars)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        PersistenceMode.json,
+        PersistenceMode.yaml,
+    ],
+)
+def test_serialization_task(tmp_path: Path, mode: PersistenceMode) -> None:
+    """Verify that a task can be properly serialized to disk and reloaded."""
+    pid, job_name = "test-pid", "abc123"
+    name, app, path, status = (
+        "test-step",
+        Application.ROMS_MARBL,
+        tmp_path / "blueprint.yaml",
+        Status.Done,
+    )
+
+    path.touch()
+
+    step = LiveStep(name=name, application=app, blueprint=path, depends_on=[])
+    handle = SlurmHandle(pid=pid, job_name=job_name)
+    task: Task[SlurmHandle] = Task(
+        step=step,
+        handle=handle,
+        status=status,
+    )
+
+    persist_as = task.persist_as()
+
+    # confirm the parametrized serialization mode is supported
+    nbytes = serialize(
+        persist_as,
+        task,
+        mode,
+    )
+    assert nbytes > 0
+
+    print(f"Task persisted to: {path}")
+    print(persist_as.read_text(encoding="utf-8"))
+
+    # confirm the output from `serialize` is valid and can be deserialized
+    dtask: Task[SlurmHandle] = deserialize(
+        persist_as,
+        Task[SlurmHandle],
+        mode,
+    )
+
+    assert dtask.status == task.status
+    assert dtask.step.name == task.step.name
+    assert dtask.handle.pid == task.handle.pid
+
+    # assert False

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -18,6 +18,7 @@ New features
 ~~~~~~~~~~~~
 
 - Enable status retrieval for multiple SLURM jobs in a single `sacct` call
+- The orchestrator writes a sentinel file to disk to dynamically alter dependencies
 
 Security Fixes
 ~~~~~~~~~~~~~~
@@ -35,6 +36,7 @@ Bug Fixes
 - Fix a `JSON` serialization bug with pydantic models using field aliases
 - Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified
 - Fix failure to terminate health check thread
+- Fix issue when parsing SLURM status of the form `CANCELLED by <username>`
 
 Improvements
 ~~~~~~~~~~~~
@@ -44,7 +46,8 @@ Improvements
 - Improve module load times
 - Extract nested/duplicate `YAML` representer functions for re-use
 - Replace use of incorrect `mp.Queue` where `queue.Queue` is appropriate
-- Replace blocking `time.sleep` usage in health check thread 
+- Replace blocking `time.sleep` usage in health check thread
+- Removed slow status retrieval loop for previously submitted jobs
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

This pull request fixes re-entrance issues encountered when cancelling tasks, reattaching a local monitor, or restarting a run.

## New Features

- The orchestrator writes a sentinel file to disk to dynamically alter dependencies

## Improvements

- Removed slow status retrieval loop for previously submitted jobs

## Bug Fixes

- Fix issue when parsing SLURM status of the form `cancelled by Username`

# Review Checklist

- [X] Closes #CSD-496, #CSD-45
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation