### PR TITLE
Enable Workplan run-tracking

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -15,12 +15,13 @@ GROUP_SIM: t.Final[str] = "Simulation Configuration"
 GROUP_UNK: t.Final[str] = "Uncategorized Configuration"
 """Group name for uncategorized environment variables in documentation."""
 
-
 FLAG_ON: t.Final[str] = "1"
 """Value indicating a toggle is enabled."""
-
 FLAG_OFF: t.Final[str] = "0"
 """Value indicating a toggle is disabled."""
+
+ENV_PREFIX: t.Final[str] = "CSTAR_"
+"""The common env var prefix that identifies a C-Star configuration setting."""
 
 
 @dataclass(slots=True)
@@ -69,6 +70,16 @@ class EnvItem(EnvVar):
             env_var.indirect_var,
             name,
         )
+
+
+def capture_environment() -> dict[str, str]:
+    """Capture the C-Star-owned environment variables at the current time.
+
+    Returns
+    -------
+    dict[str, str]
+    """
+    return {k: v for k, v in os.environ.items() if k.startswith(ENV_PREFIX)}
 
 
 def indirect_default_factory(env_var: EnvVar) -> str:

--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -397,3 +397,13 @@ def lazy_import(module_name: str) -> ModuleType:
     loader.exec_module(module)
 
     return module
+
+
+def utc_now() -> dt.datetime:
+    """Return the current datetime for the UTC timezone.
+
+    Returns
+    -------
+    datetime
+    """
+    return dt.datetime.now(tz=dt.timezone.utc)

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -2,9 +2,8 @@ import typing as t
 
 import typer
 
-from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import RomsMarblBlueprint
-from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.serialization import validate_serialized_entity
 
 app = typer.Typer()
 
@@ -12,7 +11,7 @@ app = typer.Typer()
 @app.command()
 def check(
     path: t.Annotated[str, typer.Argument(help="Path to a blueprint file.")],
-) -> bool:
+) -> None:
     """Perform content validation on a user-supplied blueprint.
 
     Returns
@@ -20,16 +19,9 @@ def check(
     bool
         `True` if valid
     """
-    bp: RomsMarblBlueprint | None = None
+    result = validate_serialized_entity(path, RomsMarblBlueprint)
+    if result.item is None:
+        print(result.error_msg)
+        return
 
-    try:
-        with local_copy(path) as bp_path:
-            bp = deserialize(bp_path, RomsMarblBlueprint)
-    except ValueError as ex:
-        print(f"The blueprint is invalid: {ex}")
-    except FileNotFoundError:
-        print(f"Blueprint not found at path: {path}")
-    else:
-        print("The blueprint is valid")
-
-    return bp is not None
+    print(f"The blueprint `{result.item.name}` is valid")

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -4,7 +4,6 @@ import typing as t
 import typer
 
 from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
-from cstar.cli.blueprint.check import check
 from cstar.entrypoint.worker.worker import (
     SimulationStages,
     execute_runner,
@@ -12,6 +11,8 @@ from cstar.entrypoint.worker.worker import (
     get_request,
     get_service_config,
 )
+from cstar.orchestration.models import RomsMarblBlueprint
+from cstar.orchestration.serialization import validate_serialized_entity
 
 app = typer.Typer()
 
@@ -31,7 +32,9 @@ def run(
     ] = None,
 ) -> None:
     """Execute a blueprint in a local worker service."""
-    if not check(path):
+    result = validate_serialized_entity(path, RomsMarblBlueprint)
+    if not result.is_valid:
+        print(result.error_msg)
         return
 
     print("Executing blueprint in a worker service")

--- a/cstar/cli/workplan/__init__.py
+++ b/cstar/cli/workplan/__init__.py
@@ -1,9 +1,16 @@
 import typer
 
-from cstar.base.feature import is_feature_enabled
+from cstar.base.feature import (
+    ENV_FF_CLI_WORKPLAN_COMPOSE,
+    ENV_FF_CLI_WORKPLAN_GEN,
+    ENV_FF_CLI_WORKPLAN_PLAN,
+    ENV_FF_CLI_WORKPLAN_STATUS,
+    is_feature_enabled,
+)
 from cstar.cli.workplan.check import app as app_check
 from cstar.cli.workplan.compose import app as app_compose
 from cstar.cli.workplan.generate import app as app_gen
+from cstar.cli.workplan.monitor import app as app_monitor
 from cstar.cli.workplan.plan import app as app_plan
 from cstar.cli.workplan.run import app as app_run
 from cstar.cli.workplan.status import app as app_status
@@ -12,16 +19,18 @@ app = typer.Typer()
 
 app.add_typer(app_check)
 
-if is_feature_enabled("CLI_WORKPLAN_GEN"):
+if is_feature_enabled(ENV_FF_CLI_WORKPLAN_GEN):
     app.add_typer(app_gen)
 
-if is_feature_enabled("CLI_WORKPLAN_PLAN"):
+if is_feature_enabled(ENV_FF_CLI_WORKPLAN_PLAN):
     app.add_typer(app_plan)
 
 app.add_typer(app_run)
 
-if is_feature_enabled("CLI_WORKPLAN_STATUS"):
+if is_feature_enabled(ENV_FF_CLI_WORKPLAN_STATUS):
     app.add_typer(app_status)
 
-if is_feature_enabled("CLI_WORKPLAN_COMPOSE"):
+if is_feature_enabled(ENV_FF_CLI_WORKPLAN_COMPOSE):
     app.add_typer(app_compose)
+
+app.add_typer(app_monitor)

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -2,9 +2,8 @@ import typing as t
 
 import typer
 
-from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import Workplan
-from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.serialization import validate_serialized_entity
 
 app = typer.Typer()
 
@@ -12,7 +11,7 @@ app = typer.Typer()
 @app.command()
 def check(
     path: t.Annotated[str, typer.Argument(help="Path to the workplan")],
-) -> bool:
+) -> None:
     """Perform content validation on the workplan supplied by the user.
 
     Returns
@@ -20,16 +19,9 @@ def check(
     bool
         `True` if valid
     """
-    wp: Workplan | None = None
+    result = validate_serialized_entity(path, Workplan)
+    if result.item is None:
+        print(result.error_msg)
+        return
 
-    try:
-        with local_copy(path) as wp_path:
-            wp = deserialize(wp_path, Workplan)
-    except ValueError as ex:
-        print(f"The workplan is invalid: {ex}")
-    except FileNotFoundError:
-        print(f"Workplan not found at path: {path}")
-    else:
-        print("The workplan is valid")
-
-    return wp is not None
+    print(f"The workplan `{result.item.name}` is valid")

--- a/cstar/cli/workplan/monitor.py
+++ b/cstar/cli/workplan/monitor.py
@@ -1,0 +1,55 @@
+import asyncio
+import os
+import typing as t
+
+import typer
+from rich.console import Console
+
+from cstar.base.log import get_logger
+from cstar.cli.workplan.shared import list_runs
+from cstar.cli.workplan.status import display_summary
+from cstar.orchestration.dag_runner import reload_dag_status
+from cstar.orchestration.tracking import TrackingRepository
+
+log = get_logger(__name__)
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def monitor(
+    run_id: t.Annotated[
+        str,
+        typer.Option(
+            help="The unique identifier of a specific workplan execution.",
+            autocompletion=list_runs,
+        ),
+    ] = "...",
+) -> None:
+    """Reattach to a running workplan without triggering any new tasks."""
+    repo = TrackingRepository()
+    workplan_run = asyncio.run(repo.get_workplan_run(run_id))
+
+    if workplan_run is None:
+        print("An unknown run-id was supplied.")
+        return
+
+    for k, v in workplan_run.environment.items():
+        os.environ[k] = v
+
+    path = workplan_run.trx_workplan_path
+    if not path.exists():
+        console.print(f"The workplan could not be found at `{path}`")
+        raise typer.Exit(code=1)
+
+    log.debug(f"Checking status on workplan in: {path}")
+
+    try:
+        status = asyncio.run(reload_dag_status(path, run_id))
+        display_summary(run_id, status.open_items, status.closed_items)
+    except FileNotFoundError:  # blueprint not found.
+        console.print_exception()
+
+
+if __name__ == "__main__":
+    typer.run(monitor)

--- a/cstar/cli/workplan/monitor.py
+++ b/cstar/cli/workplan/monitor.py
@@ -46,7 +46,7 @@ def monitor(
 
     try:
         status = asyncio.run(reload_dag_status(path, run_id))
-        display_summary(run_id, status.open_items, status.closed_items)
+        display_summary(run_id, status)
     except FileNotFoundError:  # blueprint not found.
         console.print_exception()
 

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -47,17 +47,22 @@ def run(
                 run_id = WorkplanRun.get_default_run_id(local_path)
         else:
             run_id = WorkplanRun.get_default_run_id(path)
-    elif not path:
+
+        log.debug(f"Using default run-id: {run_id}")
+
+    if not path:
         repo = TrackingRepository()
-        workplan_run = asyncio.run(repo.get_workplan_run(run_id))
-        if workplan_run is None:
+        wp_run: WorkplanRun | None = asyncio.run(repo.get_workplan_run(run_id))
+        if wp_run is None:
             log.error(f"No runs with the id `{run_id}` could be found.")
             return
 
-        for k, v in workplan_run.environment.items():
+        # ensure the environment matches the prior run
+        for k, v in wp_run.environment.items():
             os.environ[k] = v
 
-        path = str(workplan_run.workplan_path)
+        path = str(wp_run.workplan_path)
+        log.debug(f"Starting run-id `{run_id}` with workplan at `{path}`")
 
     if not check(path):
         return

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -45,7 +45,7 @@ def run(
         else:
             run_id = WorkplanRun.get_default_run_id(path)
     elif not path:
-        workplan_run = repo.get_workplan_run(run_id)
+        workplan_run = asyncio.run(repo.get_workplan_run(run_id))
         if workplan_run is None:
             log.error(f"No runs with the id `{run_id}` could be found.")
             return

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import typer
 
 from cstar.base.log import get_logger
-from cstar.cli.workplan.check import check
 from cstar.cli.workplan.shared import list_runs
 from cstar.execution.file_system import is_remote_resource, local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.serialization import validate_serialized_entity
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 
 app = typer.Typer()
@@ -64,7 +65,9 @@ def run(
         path = str(wp_run.workplan_path)
         log.debug(f"Starting run-id `{run_id}` with workplan at `{path}`")
 
-    if not check(path):
+    validation_result = validate_serialized_entity(path, Workplan)
+    if not validation_result.is_valid:
+        print(validation_result.error_msg)
         return
 
     output_path = Path(output_dir) if output_dir else None

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -41,7 +41,6 @@ def run(
         log.error("A run-id or workplan path is required.")
         return
 
-    repo = TrackingRepository()
     if not run_id:
         if is_remote_resource(path):
             with local_copy(path) as local_path:
@@ -49,6 +48,7 @@ def run(
         else:
             run_id = WorkplanRun.get_default_run_id(path)
     elif not path:
+        repo = TrackingRepository()
         workplan_run = asyncio.run(repo.get_workplan_run(run_id))
         if workplan_run is None:
             log.error(f"No runs with the id `{run_id}` could be found.")

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import typing as t
 from pathlib import Path
 
@@ -6,8 +7,9 @@ import typer
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.check import check
-from cstar.execution.file_system import local_copy
+from cstar.execution.file_system import is_remote_resource, local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 
 app = typer.Typer()
 log = get_logger(__name__)
@@ -15,11 +17,11 @@ log = get_logger(__name__)
 
 @app.command()
 def run(
-    path: t.Annotated[str, typer.Argument(help="Path to a workplan file.")],
     run_id: t.Annotated[
         str,
         typer.Option(help="The unique identifier for an execution of the workplan."),
     ],
+    path: t.Annotated[str, typer.Argument(help="Path to a workplan file.")] = "",
     output_dir: t.Annotated[
         str,
         typer.Option(
@@ -31,6 +33,28 @@ def run(
 
     Specify a previously used run_id option to re-start a prior run.
     """
+    if not run_id and not path:
+        log.error("A run-id or workplan path is required.")
+        return
+
+    repo = TrackingRepository()
+    if not run_id:
+        if is_remote_resource(path):
+            with local_copy(path) as local_path:
+                run_id = WorkplanRun.get_default_run_id(local_path)
+        else:
+            run_id = WorkplanRun.get_default_run_id(path)
+    elif not path:
+        workplan_run = repo.get_workplan_run(run_id)
+        if workplan_run is None:
+            log.error(f"No runs with the id `{run_id}` could be found.")
+            return
+
+        for k, v in workplan_run.environment.items():
+            os.environ[k] = v
+
+        path = str(workplan_run.workplan_path)
+
     if not check(path):
         return
 

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -7,6 +7,7 @@ import typer
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.check import check
+from cstar.cli.workplan.shared import list_runs
 from cstar.execution.file_system import is_remote_resource, local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
@@ -19,7 +20,10 @@ log = get_logger(__name__)
 def run(
     run_id: t.Annotated[
         str,
-        typer.Option(help="The unique identifier for an execution of the workplan."),
+        typer.Option(
+            help="The unique identifier for an execution of the workplan.",
+            autocompletion=list_runs,
+        ),
     ],
     path: t.Annotated[str, typer.Argument(help="Path to a workplan file.")] = "",
     output_dir: t.Annotated[

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -4,9 +4,11 @@ import typing as t
 from rich.console import Console
 from rich.table import Column, Table
 
+from cstar.base.log import get_logger
 from cstar.orchestration.tracking import TrackingRepository
 
 console = Console()
+log = get_logger(__name__)
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -1,10 +1,11 @@
 import asyncio
-import typing as t
 
 from rich.console import Console
 from rich.table import Column, Table
 
 from cstar.base.log import get_logger
+from cstar.orchestration.dag_runner import DagStatus
+from cstar.orchestration.orchestration import Status
 from cstar.orchestration.tracking import TrackingRepository
 
 console = Console()
@@ -34,10 +35,13 @@ def list_runs(incomplete: str) -> list[tuple[str, str]]:
     return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
 
 
+def checkmark(color: str) -> str:
+    return f"[{color}]:heavy_check_mark:"
+
+
 def display_summary(
     run_id: str,
-    open_set: t.Iterable[str] | None,
-    closed_set: t.Iterable[str] | None,
+    dag_status: DagStatus,
 ) -> None:
     """Display a summary describing the current state of
     a DAG executed by the orchestrator.
@@ -49,32 +53,30 @@ def display_summary(
     open_set : Iterable[str] | None
         The names of jobs that have completed.
     """
-    lookup = {k: 1 for k in closed_set or []}
-    lookup.update({k: 0 for k in open_set or []})
+    # don't pad the top and bottom but give some horizontal space
+    padding = (0, 1)
 
     table = Table(
         Column(header="Step", justify="right"),
-        Column(header="Incomplete", justify="center"),
-        Column(header="Complete", justify="center"),
+        Column(header="Ready", justify="center"),
+        Column(header="Running", justify="center"),
+        Column(header="Done", justify="center"),
+        Column(header="Failed", justify="center"),
+        Column(header="Cancelled", justify="center"),
         title=f"Run [yellow]{run_id}[/yellow] Results",
         show_lines=True,
-        padding=(0, 1),  # 0 pad T/B, 1 pad L/R
+        padding=padding,
         pad_edge=False,
     )
 
-    for task_name, is_complete in sorted(lookup.items()):
-        RED_CHECK = "[red]:heavy_check_mark:"
-        GREEN_CHECK = "[green]:heavy_check_mark:"
-
+    for task_name, status in sorted(dag_status.details.items()):
         table.add_row(
             task_name,
-            RED_CHECK if not is_complete else "",
-            GREEN_CHECK if is_complete else "",
+            checkmark("green") if Status.is_ready(status) else "",
+            checkmark("cyan") if Status.is_running(status) else "",
+            checkmark("green") if status == Status.Done else "",
+            checkmark("red") if status == Status.Failed else "",
+            checkmark("yellow") if status == Status.Cancelled else "",
         )
-
-    num_closed = sum(lookup.values())
-    num_open = len(lookup) - num_closed
-
-    table.add_row("[magenta]Total", f"[red]{num_open}", f"[green]{num_closed}")
 
     console.print(table)

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -1,6 +1,12 @@
 import asyncio
+import typing as t
+
+from rich.console import Console
+from rich.table import Column, Table
 
 from cstar.orchestration.tracking import TrackingRepository
+
+console = Console()
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:
@@ -24,3 +30,49 @@ def list_runs(incomplete: str) -> list[tuple[str, str]]:
         return [("run-id", "no results found")]
 
     return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
+
+
+def display_summary(
+    run_id: str,
+    open_set: t.Iterable[str] | None,
+    closed_set: t.Iterable[str] | None,
+) -> None:
+    """Display a summary describing the current state of
+    a DAG executed by the orchestrator.
+
+    Parameters
+    ----------
+    open_set : Iterable[str] | None
+        The names of jobs that are unstarted or incomplete.
+    open_set : Iterable[str] | None
+        The names of jobs that have completed.
+    """
+    lookup = {k: 1 for k in closed_set or []}
+    lookup.update({k: 0 for k in open_set or []})
+
+    table = Table(
+        Column(header="Step", justify="right"),
+        Column(header="Incomplete", justify="center"),
+        Column(header="Complete", justify="center"),
+        title=f"Run [yellow]{run_id}[/yellow] Results",
+        show_lines=True,
+        padding=(0, 1),  # 0 pad T/B, 1 pad L/R
+        pad_edge=False,
+    )
+
+    for task_name, is_complete in sorted(lookup.items()):
+        RED_CHECK = "[red]:heavy_check_mark:"
+        GREEN_CHECK = "[green]:heavy_check_mark:"
+
+        table.add_row(
+            task_name,
+            RED_CHECK if not is_complete else "",
+            GREEN_CHECK if is_complete else "",
+        )
+
+    num_closed = sum(lookup.values())
+    num_open = len(lookup) - num_closed
+
+    table.add_row("[magenta]Total", f"[red]{num_open}", f"[green]{num_closed}")
+
+    console.print(table)

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -1,14 +1,6 @@
 import asyncio
 
-import typer
-from rich.console import Console
-
-from cstar.base.log import get_logger
 from cstar.orchestration.tracking import TrackingRepository
-
-log = get_logger(__name__)
-app = typer.Typer()
-console = Console()
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import typer
+from rich.console import Console
+
+from cstar.base.log import get_logger
+from cstar.orchestration.tracking import TrackingRepository
+
+log = get_logger(__name__)
+app = typer.Typer()
+console = Console()
+
+
+def list_runs(incomplete: str) -> list[tuple[str, str]]:
+    """Retrieve a list of all recorded run-ids.
+
+    Parameters
+    ----------
+    incomplete : str
+        Any value from the user is provided to autocompletion.
+
+    Returns
+    -------
+    t.Iterable[str]
+    """
+    repo = TrackingRepository()
+    run_list = asyncio.run(repo.list_latest_runs(incomplete))
+
+    if not run_list and incomplete:
+        return [(incomplete, "no results found")]
+    elif not run_list:
+        return [("run-id", "no results found")]
+
+    return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -6,7 +6,7 @@ from rich.console import Console
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.shared import display_summary, list_runs
-from cstar.orchestration.dag_runner import load_run_state
+from cstar.orchestration.dag_runner import get_launcher, load_run_state
 from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
@@ -32,9 +32,11 @@ def status(
         print("An unknown run-id was supplied.")
         return
 
+    launcher = get_launcher()
+
     try:
-        status = asyncio.run(load_run_state(run_id))
-        display_summary(run_id, status.open_items, status.closed_items)
+        status = asyncio.run(load_run_state(run_id, launcher))
+        display_summary(run_id, status)
     except FileNotFoundError:  # blueprint not found.
         console.print_exception()
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -1,12 +1,14 @@
 import asyncio
+import os
 import typing as t
 from itertools import zip_longest
-from pathlib import Path
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+
+from cstar.orchestration.tracking import TrackingRepository
 
 app = typer.Typer()
 console = Console()
@@ -40,16 +42,29 @@ def display_summary(
 
 @app.command()
 def status(
-    path: t.Annotated[Path, typer.Argument(help="Path to a workplan file.")],
+    # path: t.Annotated[Path, typer.Argument(help="Path to a workplan file.")],
     run_id: t.Annotated[
         str,
         typer.Option(help="The unique identifier of a specific workplan execution."),
     ] = "...",
 ) -> None:
     """Retrieve the current status of a workplan."""
+    repo = TrackingRepository()
+    workplan_run = repo.get_workplan_run(run_id)
+
+    if workplan_run is None:
+        print("An unknown run-id was supplied.")
+        return
+
+    for k, v in workplan_run.environment.items():
+        os.environ[k] = v
+
+    path = workplan_run.trx_workplan_path
     if not path.exists():
         console.print(f"The workplan could not be found at `{path}`")
         raise typer.Exit(code=1)
+
+    print(f"Checking status on workplan in: {path}")
 
     from cstar.orchestration.dag_runner import load_dag_status
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -1,12 +1,10 @@
 import asyncio
 import os
 import typing as t
-from itertools import zip_longest
 
 import typer
 from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
+from rich.table import Column, Table
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.shared import list_runs
@@ -32,13 +30,33 @@ def display_summary(
     open_set : Iterable[str] | None
         The names of jobs that have completed.
     """
-    open_closed = zip_longest(open_set or ["N/A"], closed_set or ["N/A"])
-    table = Table("Incomplete", "Complete")
+    lookup = {k: 1 for k in closed_set or []}
+    lookup.update({k: 0 for k in open_set or []})
 
-    console.print(Panel.fit(f"Run `{run_id}` Current Status"))
+    table = Table(
+        Column(header="Step", justify="right"),
+        Column(header="Incomplete", justify="center"),
+        Column(header="Complete", justify="center"),
+        title=f"Run [yellow]{run_id}[/yellow] Results",
+        show_lines=True,
+        padding=(0, 1),  # 0 pad T/B, 1 pad L/R
+        pad_edge=False,
+    )
 
-    for open_item, closed_item in open_closed:
-        table.add_row(open_item, closed_item)
+    for task_name, is_complete in sorted(lookup.items()):
+        RED_CHECK = "[red]:heavy_check_mark:"
+        GREEN_CHECK = "[green]:heavy_check_mark:"
+
+        table.add_row(
+            task_name,
+            RED_CHECK if not is_complete else "",
+            GREEN_CHECK if is_complete else "",
+        )
+
+    num_closed = sum(lookup.values())
+    num_open = len(lookup) - num_closed
+
+    table.add_row("[magenta]Total", f"[red]{num_open}", f"[green]{num_closed}")
 
     console.print(table)
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from cstar.base.log import get_logger
+from cstar.cli.workplan.shared import list_runs
 from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
@@ -40,29 +41,6 @@ def display_summary(
         table.add_row(open_item, closed_item)
 
     console.print(table)
-
-
-def list_runs(incomplete: str) -> list[tuple[str, str]]:
-    """Retrieve a list of all recorded run-ids.
-
-    Parameters
-    ----------
-    incomplete : str
-        Any value from the user is provided to autocompletion.
-
-    Returns
-    -------
-    t.Iterable[str]
-    """
-    repo = TrackingRepository()
-    run_list = asyncio.run(repo.list_latest_runs(incomplete))
-
-    if not run_list and incomplete:
-        return [(incomplete, "no results found")]
-    elif not run_list:
-        return [("run-id", "no results found")]
-
-    return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
 
 
 @app.command()

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -42,7 +42,7 @@ def display_summary(
     console.print(table)
 
 
-def list_runs(incomplete: str) -> list[str]:
+def list_runs(incomplete: str) -> list[tuple[str, str]]:
     """Retrieve a list of all recorded run-ids.
 
     Parameters
@@ -55,12 +55,14 @@ def list_runs(incomplete: str) -> list[str]:
     t.Iterable[str]
     """
     repo = TrackingRepository()
-    run_list = asyncio.run(repo.list_latest_runs())
-    if not run_list:
-        return ["run-id"]
+    run_list = asyncio.run(repo.list_latest_runs(incomplete))
 
-    run_ids = [r.run_id for r in run_list if r]
-    return run_ids
+    if not run_list and incomplete:
+        return [(incomplete, "no results found")]
+    elif not run_list:
+        return [("run-id", "no results found")]
+
+    return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
 
 
 @app.command()

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import typing as t
 
 import typer
@@ -7,6 +6,7 @@ from rich.console import Console
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.shared import display_summary, list_runs
+from cstar.orchestration.dag_runner import load_run_state
 from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
@@ -32,20 +32,8 @@ def status(
         print("An unknown run-id was supplied.")
         return
 
-    for k, v in workplan_run.environment.items():
-        os.environ[k] = v
-
-    path = workplan_run.trx_workplan_path
-    if not path.exists():
-        console.print(f"The workplan could not be found at `{path}`")
-        raise typer.Exit(code=1)
-
-    log.debug(f"Checking status on workplan in: {path}")
-
-    from cstar.orchestration.dag_runner import load_dag_status
-
     try:
-        status = asyncio.run(load_dag_status(path, run_id))
+        status = asyncio.run(load_run_state(run_id))
         display_summary(run_id, status.open_items, status.closed_items)
     except FileNotFoundError:  # blueprint not found.
         console.print_exception()

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -4,61 +4,14 @@ import typing as t
 
 import typer
 from rich.console import Console
-from rich.table import Column, Table
 
 from cstar.base.log import get_logger
-from cstar.cli.workplan.shared import list_runs
+from cstar.cli.workplan.shared import display_summary, list_runs
 from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
 app = typer.Typer()
 console = Console()
-
-
-def display_summary(
-    run_id: str,
-    open_set: t.Iterable[str] | None,
-    closed_set: t.Iterable[str] | None,
-) -> None:
-    """Display a summary describing the current state of
-    a DAG executed by the orchestrator.
-
-    Parameters
-    ----------
-    open_set : Iterable[str] | None
-        The names of jobs that are unstarted or incomplete.
-    open_set : Iterable[str] | None
-        The names of jobs that have completed.
-    """
-    lookup = {k: 1 for k in closed_set or []}
-    lookup.update({k: 0 for k in open_set or []})
-
-    table = Table(
-        Column(header="Step", justify="right"),
-        Column(header="Incomplete", justify="center"),
-        Column(header="Complete", justify="center"),
-        title=f"Run [yellow]{run_id}[/yellow] Results",
-        show_lines=True,
-        padding=(0, 1),  # 0 pad T/B, 1 pad L/R
-        pad_edge=False,
-    )
-
-    for task_name, is_complete in sorted(lookup.items()):
-        RED_CHECK = "[red]:heavy_check_mark:"
-        GREEN_CHECK = "[green]:heavy_check_mark:"
-
-        table.add_row(
-            task_name,
-            RED_CHECK if not is_complete else "",
-            GREEN_CHECK if is_complete else "",
-        )
-
-    num_closed = sum(lookup.values())
-    num_open = len(lookup) - num_closed
-
-    table.add_row("[magenta]Total", f"[red]{num_open}", f"[green]{num_closed}")
-
-    console.print(table)
 
 
 @app.command()

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -8,8 +8,10 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from cstar.base.log import get_logger
 from cstar.orchestration.tracking import TrackingRepository
 
+log = get_logger(__name__)
 app = typer.Typer()
 console = Console()
 
@@ -40,17 +42,40 @@ def display_summary(
     console.print(table)
 
 
+def list_runs(incomplete: str) -> list[str]:
+    """Retrieve a list of all recorded run-ids.
+
+    Parameters
+    ----------
+    incomplete : str
+        Any value from the user is provided to autocompletion.
+
+    Returns
+    -------
+    t.Iterable[str]
+    """
+    repo = TrackingRepository()
+    run_list = asyncio.run(repo.list_latest_runs())
+    if not run_list:
+        return ["run-id"]
+
+    run_ids = [r.run_id for r in run_list if r]
+    return run_ids
+
+
 @app.command()
 def status(
-    # path: t.Annotated[Path, typer.Argument(help="Path to a workplan file.")],
     run_id: t.Annotated[
         str,
-        typer.Option(help="The unique identifier of a specific workplan execution."),
+        typer.Option(
+            help="The unique identifier of a specific workplan execution.",
+            autocompletion=list_runs,
+        ),
     ] = "...",
 ) -> None:
     """Retrieve the current status of a workplan."""
     repo = TrackingRepository()
-    workplan_run = repo.get_workplan_run(run_id)
+    workplan_run = asyncio.run(repo.get_workplan_run(run_id))
 
     if workplan_run is None:
         print("An unknown run-id was supplied.")
@@ -64,7 +89,7 @@ def status(
         console.print(f"The workplan could not be found at `{path}`")
         raise typer.Exit(code=1)
 
-    print(f"Checking status on workplan in: {path}")
+    log.debug(f"Checking status on workplan in: {path}")
 
     from cstar.orchestration.dag_runner import load_dag_status
 

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -364,10 +364,10 @@ class RomsFileSystemManager(JobFileSystemManager):
 class StateDirectoryManager:
     """Manage the system file system."""
 
-    _RUN_STATE_NAME: t.Final[str] = "run_state"
+    _RUN_STATE_NAME: t.ClassVar[t.Literal["run_state"]] = "run_state"
     """The name of the directory where run-state files are written."""
 
-    _RUN_TRACKING_NAME: t.Final[str] = "run_tracking"
+    _RUN_TRACKING_NAME: t.ClassVar[t.Literal["run_tracking"]] = "run_tracking"
     """The name of the directory where run-tracking files are written."""
 
     @classmethod

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -367,25 +367,45 @@ class StateDirectoryManager:
     _RUN_STATE_NAME: t.Final[str] = "run_state"
     """The name of the directory where run-state files are written."""
 
-    @staticmethod
-    def root_dir() -> Path:
+    _RUN_TRACKING_NAME: t.Final[str] = "run_tracking"
+    """The name of the directory where run-tracking files are written."""
+
+    @classmethod
+    def root_dir(cls) -> Path:
         """The root directory containing all job outputs.
 
         Returns
         -------
         Path
         """
-        run_id = get_env_item(ENV_CSTAR_RUNID).value
-        return DirectoryManager.state_home() / run_id
+        return DirectoryManager.state_home()
 
-    @staticmethod
-    def run_state_dir() -> Path:
+    @classmethod
+    def run_state_dir(cls) -> Path:
         """The directory for run-state files.
 
         The result is a _run-specific_ directory that varies
         based on the current value of environment variables.
+
+        Returns
+        -------
+        Path
         """
-        return StateDirectoryManager.root_dir() / StateDirectoryManager._RUN_STATE_NAME
+        run_id = get_env_item(ENV_CSTAR_RUNID).value
+        return cls.root_dir() / cls._RUN_STATE_NAME / run_id
+
+    @classmethod
+    def tracking_dir(cls) -> Path:
+        """The directory for run-tracking files.
+
+        The result is a _non-run-specific_ directory.
+
+        Returns
+        -------
+        Path
+        """
+        root = cls.root_dir()
+        return root / cls._RUN_TRACKING_NAME
 
 
 def is_remote_resource(uri: str) -> bool:

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -134,7 +134,8 @@ class SlurmStep(BaseModel):
         -------
         ExecutionStatus
         """
-        return sacct_status_map[self.raw_state]
+        state_base = self.raw_state.split(" ", maxsplit=1)[0]
+        return sacct_status_map[state_base]
 
     @property
     def job_id(self) -> str:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -68,7 +68,7 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     if not step.fsm.work_dir.exists():
         step.fsm.work_dir.mkdir(parents=True)
 
-    sleep_time = random.randint(1, 10)
+    sleep_time = random.randint(1, 3)
     script = textwrap.dedent(f"""\
         # this is a mock application script that produces verifiable output
         echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from prefect import flow
 
+from cstar.base.env import capture_environment
 from cstar.base.log import get_logger
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
@@ -20,6 +21,7 @@ from cstar.orchestration.orchestration import (
     configure_environment,
 )
 from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
     WorkplanTransformer,
@@ -31,6 +33,7 @@ if t.TYPE_CHECKING:
     from cstar.orchestration.orchestration import Launcher
 
 log = get_logger(__name__)
+repo = TrackingRepository()
 
 
 @dataclass
@@ -228,11 +231,21 @@ async def build_and_run_dag(
         os.environ[ENV_CSTAR_ORCH_REQD_ENV] = ""
 
     check_environment()
-    wp, wp_path = await prepare_workplan(wp_path, output_dir, run_id)
+    wp, prepared_wp_path = await prepare_workplan(wp_path, output_dir, run_id)
 
     planner = Planner(workplan=wp)
 
     orchestrator = Orchestrator(planner, launcher)
+
+    repo.put_workplan_run(
+        WorkplanRun(
+            workplan_path=wp_path,
+            trx_workplan_path=prepared_wp_path,
+            output_path=output_dir,
+            run_id=run_id,
+            environment=capture_environment(),
+        ),
+    )
 
     # schedule the tasks without waiting for completion
     await process_plan(orchestrator, RunMode.Schedule)
@@ -240,4 +253,4 @@ async def build_and_run_dag(
     # monitor the scheduled tasks until they complete
     await process_plan(orchestrator, RunMode.Monitor)
 
-    return wp_path
+    return prepared_wp_path

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -63,8 +63,8 @@ def incremental_delays() -> t.Generator[float, None, None]:
     yield from delay_cycle
 
 
-async def retrieve_run_progress(orchestrator: Orchestrator) -> DagStatus:
-    """Load the run state.
+async def attach_to_run(orchestrator: Orchestrator) -> DagStatus:
+    """Load the run state and monitor until it completes.
 
     Parameters
     ----------
@@ -117,7 +117,7 @@ async def load_dag_status(path: Path, run_id: str) -> DagStatus:
     launcher = SlurmLauncher()
     orchestrator = Orchestrator(planner, launcher)
 
-    return await retrieve_run_progress(orchestrator)
+    return await attach_to_run(orchestrator)
 
 
 async def process_plan(orchestrator: Orchestrator, mode: RunMode) -> None:

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -94,7 +94,7 @@ async def attach_to_run(orchestrator: Orchestrator) -> DagStatus:
     return DagStatus(open_set or [], closed_set)
 
 
-async def load_dag_status(path: Path, run_id: str) -> DagStatus:
+async def reload_dag_status(path: Path, run_id: str) -> DagStatus:
     """Determine the current status of a workplan run.
 
     Parameters

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import typing as t
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import cycle
 from pathlib import Path
 
@@ -14,6 +14,7 @@ from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmHandle, SlurmLauncher
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import (
+    Launcher,
     Orchestrator,
     Planner,
     RunMode,
@@ -31,9 +32,6 @@ from cstar.orchestration.transforms import (
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS, ENV_CSTAR_ORCH_REQD_ENV
 from cstar.system.manager import cstar_sysmgr
 
-if t.TYPE_CHECKING:
-    from cstar.orchestration.orchestration import Launcher
-
 log = get_logger(__name__)
 repo = TrackingRepository()
 
@@ -44,6 +42,20 @@ class DagStatus:
 
     open_items: t.Iterable[str]
     closed_items: t.Iterable[str]
+    details: t.Annotated[
+        dict[str, Status],
+        field(default_factory=dict, init=True, repr=True),
+    ]
+
+
+def get_launcher() -> "Launcher":
+    """Get the appropriate launcher for the current environment."""
+    if cstar_sysmgr.scheduler:
+        return SlurmLauncher()
+    else:
+        os.environ[ENV_CSTAR_ORCH_REQD_ENV] = ""
+
+    return LocalLauncher()
 
 
 def incremental_delays() -> t.Generator[float, None, None]:
@@ -93,10 +105,13 @@ async def attach_to_run(orchestrator: Orchestrator) -> DagStatus:
         closed_set = orchestrator.get_closed_nodes(mode=mode)
         open_set = orchestrator.get_open_nodes(mode=mode)
 
-    return DagStatus(open_set or [], closed_set)
+    if open_set is None:
+        open_set = {}
+
+    return DagStatus(open_set.keys(), closed_set.keys(), {**open_set, **closed_set})
 
 
-async def load_run_state(run_id: str) -> DagStatus:
+async def load_run_state(run_id: str, launcher: Launcher) -> DagStatus:
     """Load the run state.
 
     Parameters
@@ -111,16 +126,20 @@ async def load_run_state(run_id: str) -> DagStatus:
     os.environ[ENV_CSTAR_RUNID] = run_id
     sentinels = await load_sentinels(SlurmHandle)
 
-    open_set: list[str] = []
-    closed_set: list[str] = []
+    open_set: dict[str, Status] = {}
+    closed_set: dict[str, Status] = {}
+
+    # ensure most recent status is retrieved in case of crash or system failure
+    updates = [launcher.update_status(sentinel) for sentinel in sentinels]
+    await asyncio.gather(*updates)
 
     for sentinel in sentinels:
         if Status.is_terminal(sentinel.status):
-            closed_set.append(sentinel.name)
+            closed_set[sentinel.name] = sentinel.status
         else:
-            open_set.append(sentinel.name)
+            open_set[sentinel.name] = sentinel.status
 
-    return DagStatus(open_set or [], closed_set)
+    return DagStatus(open_set.keys(), closed_set.keys(), {**open_set, **closed_set})
 
 
 async def reload_dag_status(path: Path, run_id: str) -> DagStatus:
@@ -252,12 +271,7 @@ async def build_and_run_dag(
     configure_environment(output_dir, run_id)
     output_dir = DirectoryManager.data_home()
 
-    launcher: Launcher | None = None
-    if cstar_sysmgr.scheduler:
-        launcher = SlurmLauncher()
-    else:
-        launcher = LocalLauncher()
-        os.environ[ENV_CSTAR_ORCH_REQD_ENV] = ""
+    launcher = get_launcher()
 
     check_environment()
     wp, prepared_wp_path = await prepare_workplan(wp_path, output_dir, run_id)

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -237,7 +237,7 @@ async def build_and_run_dag(
 
     orchestrator = Orchestrator(planner, launcher)
 
-    repo.put_workplan_run(
+    await repo.put_workplan_run(
         WorkplanRun(
             workplan_path=wp_path,
             trx_workplan_path=prepared_wp_path,

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -7,20 +7,22 @@ from pathlib import Path
 
 from prefect import flow
 
-from cstar.base.env import capture_environment
+from cstar.base.env import ENV_CSTAR_RUNID, capture_environment
 from cstar.base.log import get_logger
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
-from cstar.orchestration.launch.slurm import SlurmLauncher
+from cstar.orchestration.launch.slurm import SlurmHandle, SlurmLauncher
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import (
     Orchestrator,
     Planner,
     RunMode,
+    Status,
     check_environment,
     configure_environment,
 )
 from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.state import load_sentinels
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
@@ -90,6 +92,33 @@ async def attach_to_run(orchestrator: Orchestrator) -> DagStatus:
 
         closed_set = orchestrator.get_closed_nodes(mode=mode)
         open_set = orchestrator.get_open_nodes(mode=mode)
+
+    return DagStatus(open_set or [], closed_set)
+
+
+async def load_run_state(run_id: str) -> DagStatus:
+    """Load the run state.
+
+    Parameters
+    ----------
+    run_id : str
+        The run-id to load status for
+
+    Returns
+    -------
+    DagStatus
+    """
+    os.environ[ENV_CSTAR_RUNID] = run_id
+    sentinels = await load_sentinels(SlurmHandle)
+
+    open_set: list[str] = []
+    closed_set: list[str] = []
+
+    for sentinel in sentinels:
+        if Status.is_terminal(sentinel.status):
+            closed_set.append(sentinel.name)
+        else:
+            open_set.append(sentinel.name)
 
     return DagStatus(open_set or [], closed_set)
 

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -176,7 +176,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         """
         tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
         statuses = await asyncio.gather(*tasks)
-        active_found = any(map(Status.is_running, statuses))
+        active_found = any(map(Status.is_in_progress, statuses))
         failure_found = any(map(Status.is_failure, statuses))
 
         # wait for the dependencies to complete before launching
@@ -185,7 +185,7 @@ class LocalLauncher(Launcher[LocalHandle]):
 
             tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
             statuses = await asyncio.gather(*tasks)
-            active_found = any(map(Status.is_running, statuses))
+            active_found = any(map(Status.is_in_progress, statuses))
             failure_found = any(map(Status.is_failure, statuses))
 
         if failure_found:

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -230,6 +230,34 @@ class LocalLauncher(Launcher[LocalHandle]):
                 return Status.Unsubmitted
 
     @classmethod
+    async def update_status(
+        cls,
+        item: Task[LocalHandle] | LocalHandle,
+    ) -> Task[LocalHandle] | LocalHandle:
+        """Query and update the status for a running task.
+
+        Parameters
+        ----------
+        item : Task[LocalHandle] | LocalHandle
+            An item with a handle to be used to execute a status query.
+
+        Returns
+        -------
+        Task[LocalHandle] | LocalHandle
+        """
+        # handle = item.handle if isinstance(item, Task) else item
+        # prior = handle.status
+        # current = await LocalLauncher.query_status(item)
+
+        # if prior != current:
+        #     handle.status = current
+        #     await put_sentinel(handle)
+
+        # TODO: implement LocalLauncher.update_status
+
+        return item
+
+    @classmethod
     async def cancel(cls, item: Task[LocalHandle]) -> Task[LocalHandle]:
         """Cancel a task, if possible.
 

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -10,6 +10,7 @@ from pydantic import PrivateAttr
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import get_logger
+from cstar.base.utils import slugify
 from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Application
 from cstar.orchestration.orchestration import (
@@ -19,6 +20,7 @@ from cstar.orchestration.orchestration import (
     Status,
     Task,
 )
+from cstar.orchestration.state import put_sentinel
 
 if t.TYPE_CHECKING:
     from cstar.orchestration.models import Step
@@ -40,6 +42,9 @@ class LocalHandle(ProcessHandle):
 
     _process: MpProcess = PrivateAttr()
     """The process handle (used only for simulating local processes)."""
+
+    status: Status = Status.Unsubmitted
+    """The current status of the task."""
 
     @property
     def start_ts(self) -> float:
@@ -64,7 +69,12 @@ class LocalHandle(ProcessHandle):
 
     @process.setter
     def process(self, value: MpProcess) -> None:
+        self.status = Status.Submitted
         self._process = value
+
+    @property
+    def safe_name(self) -> str:
+        return slugify(self.name)
 
 
 class LocalLauncher(Launcher[LocalHandle]):
@@ -121,6 +131,7 @@ class LocalLauncher(Launcher[LocalHandle]):
                     pid=str(pid),
                     name=step.safe_name,
                     start_at=create_time,
+                    status=Status.Submitted,
                 )
                 handle.process = mp_process
                 return handle
@@ -218,7 +229,9 @@ class LocalLauncher(Launcher[LocalHandle]):
         raw_status = await LocalLauncher._status(handle)
 
         match raw_status:
-            case "PENDING" | "RUNNING" | "ENDING":
+            case "PENDING":
+                return Status.Submitted
+            case "RUNNING" | "ENDING":
                 return Status.Running
             case "COMPLETED" | "FAILED":
                 return Status.Done
@@ -245,15 +258,13 @@ class LocalLauncher(Launcher[LocalHandle]):
         -------
         Task[LocalHandle] | LocalHandle
         """
-        # handle = item.handle if isinstance(item, Task) else item
-        # prior = handle.status
-        # current = await LocalLauncher.query_status(item)
+        handle = item.handle if isinstance(item, Task) else item
+        prior = handle.status
+        current = await LocalLauncher.query_status(item)
 
-        # if prior != current:
-        #     handle.status = current
-        #     await put_sentinel(handle)
-
-        # TODO: implement LocalLauncher.update_status
+        if prior != current:
+            handle.status = current
+            await put_sentinel(handle)
 
         return item
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -317,11 +317,10 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The C-Star status.
         """
         match status:
+            case ExecutionStatus.PENDING:
+                return Status.Submitted
             case (
-                ExecutionStatus.PENDING
-                | ExecutionStatus.RUNNING
-                | ExecutionStatus.ENDING
-                | ExecutionStatus.HELD
+                ExecutionStatus.RUNNING | ExecutionStatus.ENDING | ExecutionStatus.HELD
             ):
                 return Status.Running
             case ExecutionStatus.COMPLETED:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -54,24 +54,10 @@ async def on_submit_complete(
     """Perform actions required when a job submission completes
     successfully.
     """
-    if state.is_completed():
-        # add a small delay so batch can be queried
+    if state.is_completed() and state.name == "Cached":
         result = await state.aresult()
         handle = t.cast("SlurmHandle", result)
-
-        try:
-            prev_status = handle.status
-            if handle.status == Status.Unsubmitted:
-                await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
-                handle.status = await SlurmLauncher.query_status(handle)
-
-            if handle.status != prev_status:
-                await put_sentinel(handle)
-        except Exception:
-            log.exception("An error occurred during the post-submit hook")
-
-        if state.name == "Cached":
-            log.debug(f"Re-using result from cached SLURM job: {handle.pid}")
+        log.debug(f"Re-using result from cached SLURM job: {handle}")
 
 
 def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -30,7 +30,7 @@ from cstar.orchestration.orchestration import (
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.state import (
     get_sentinel,
-    list_sentinels,
+    load_sentinels,
     put_sentinel,
     sentinel_path,
 )
@@ -56,14 +56,13 @@ async def on_submit_complete(
     """
     if state.is_completed():
         # add a small delay so batch can be queried
-        await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
+        result = await state.aresult()
+        handle = t.cast("SlurmHandle", result)
 
         try:
-            result = await state.aresult()
-            handle = t.cast("SlurmHandle", result)
-
             prev_status = handle.status
             if handle.status == Status.Unsubmitted:
+                await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
                 handle.status = await SlurmLauncher.query_status(handle)
 
             if handle.status != prev_status:
@@ -71,8 +70,8 @@ async def on_submit_complete(
         except Exception:
             log.exception("An error occurred during the post-submit hook")
 
-    if state.name == "Cached":
-        log.debug(f"Re-using result from cached SLURM job: {handle.pid}")
+        if state.name == "Cached":
+            log.debug(f"Re-using result from cached SLURM job: {handle.pid}")
 
 
 def cache_key_func(context: "TaskRunContext", params: dict[str, t.Any]) -> str:
@@ -256,7 +255,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         Mapping[str, Task[SlurmHandle]]
             Mapping of all previously run PIDs to their sentinel content.
         """
-        sentinels = await list_sentinels(SlurmHandle)
+        sentinels = await load_sentinels(SlurmHandle)
         return {h.pid: h for h in sentinels}
 
     @classmethod

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -307,10 +307,8 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             else:
                 current_status = last_status
 
-        handle = await submit_fn(step, dependencies)
-        if current_status == Status.Unsubmitted:
-            current_status = await SlurmLauncher.query_status(handle)
-            handle.status = current_status
+        submitted = await submit_fn(step, dependencies)
+        handle = t.cast("SlurmHandle", await SlurmLauncher.update_status(submitted))
 
         return Task(
             step=step,
@@ -373,6 +371,32 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         log.trace(msg)
 
         return SlurmLauncher._map_status(exec_status)
+
+    @classmethod
+    async def update_status(
+        cls,
+        item: Task[SlurmHandle] | SlurmHandle,
+    ) -> Task[SlurmHandle] | SlurmHandle:
+        """Retrieve the status of an item and return the item with the updated state.
+
+        Parameters
+        ----------
+        item : Task[SlurmHandle] | SlurmHandle
+            An item with a handle to be used to execute a status query.
+
+        Returns
+        -------
+        Task[SlurmHandle] | SlurmHandle
+        """
+        handle = item.handle if isinstance(item, Task) else item
+        prior = handle.status
+        current = await SlurmLauncher.query_status(item)
+
+        if prior != current:
+            handle.status = current
+            await put_sentinel(handle)
+
+        return item
 
     @classmethod
     async def cancel(cls, item: Task[SlurmHandle]) -> Task[SlurmHandle]:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -220,6 +220,9 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         job.submit()
 
         if job.id:
+            # introduce slight delay so `sacct` queries can locate this job
+            await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
+
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
             return SlurmHandle(pid=str(job.id), name=job_name)
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -227,7 +227,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _status(job_id: str) -> ExecutionStatus:
+    async def _get_status(job_id: str) -> ExecutionStatus:
         """Retrieve the status of a step running in SLURM.
 
         Parameters
@@ -366,7 +366,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The current status of the item.
         """
         handle = item.handle if isinstance(item, Task) else item
-        exec_status = await SlurmLauncher._status(handle.pid)
+        exec_status = await SlurmLauncher._get_status(handle.pid)
 
         msg = f"Retrieved status `{exec_status}` for SLURM job `{handle.pid}`"
         log.trace(msg)

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -49,7 +49,7 @@ log = get_logger(__name__)
 
 
 async def on_submit_complete(
-    task: PrefectTask, task_run: TaskRun, state: State, **kwargs: str
+    task: PrefectTask, task_run: TaskRun, state: State
 ) -> None:
     """Perform actions required when a job submission completes
     successfully.

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -363,7 +363,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         cls,
         item: Task[SlurmHandle] | SlurmHandle,
     ) -> Task[SlurmHandle] | SlurmHandle:
-        """Retrieve the status of an item and return the item with the updated state.
+        """Query and update the status for a running task.
 
         Parameters
         ----------

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -241,9 +241,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The current status of the step.
         """
         batch = await get_slurm_batch(job_id)
-        status = batch.job.status
-
-        return status
+        return batch.job.status
 
     @staticmethod
     async def _locate_priors() -> t.Mapping[str, SlurmHandle]:

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -77,6 +77,16 @@ class Status(IntEnum):
     """A task that terminated due to some failure in the task."""
 
     @classmethod
+    def terminal_states(cls) -> set["Status"]:
+        """Return the set of terminal statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Done, Status.Cancelled, Status.Failed}
+
+    @classmethod
     def is_terminal(cls, status: "Status") -> bool:
         """Return `True` if a status is in the set of terminal statuses.
 
@@ -89,7 +99,17 @@ class Status(IntEnum):
         -------
         bool
         """
-        return status in {Status.Done, Status.Cancelled, Status.Failed}
+        return status in cls.terminal_states()
+
+    @classmethod
+    def failure_states(cls) -> set["Status"]:
+        """Return the set of failure statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Cancelled, Status.Failed}
 
     @classmethod
     def is_failure(cls, status: "Status") -> bool:
@@ -104,11 +124,21 @@ class Status(IntEnum):
         -------
         bool
         """
-        return status in {Status.Cancelled, Status.Failed}
+        return status in cls.failure_states()
 
     @classmethod
-    def is_running(cls, status: "Status") -> bool:
-        """Return `True` if a status is in the set of in-progress statuses.
+    def ready_states(cls) -> set["Status"]:
+        """Return the set of ready statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Unsubmitted, Status.Submitted}
+
+    @classmethod
+    def is_ready(cls, status: "Status") -> bool:
+        """Return `True` if a status is in the set of ready statuses.
 
         Paramters
         ---------
@@ -119,7 +149,57 @@ class Status(IntEnum):
         -------
         bool
         """
-        return status in {Status.Submitted, Status.Running, Status.Ending}
+        return status in cls.ready_states()
+
+    @classmethod
+    def in_progress_states(cls) -> set["Status"]:
+        """Return the set of in-progress statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Submitted, Status.Running, Status.Ending}
+
+    @classmethod
+    def is_in_progress(cls, status: "Status") -> bool:
+        """Return `True` if a status is in the set of in-progress statuses (any non-terminal status).
+
+        Paramters
+        ---------
+        status : "Status"
+            The status to evaluate.
+
+        Returns
+        -------
+        bool
+        """
+        return status in cls.in_progress_states()
+
+    @classmethod
+    def running_states(cls) -> set["Status"]:
+        """Return the set of running statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Running, Status.Ending}
+
+    @classmethod
+    def is_running(cls, status: "Status") -> bool:
+        """Return `True` if a status is in the set of running statuses.
+
+        Paramters
+        ---------
+        status : "Status"
+            The status to evaluate.
+
+        Returns
+        -------
+        bool
+        """
+        return status in cls.running_states()
 
 
 class LiveStep(Step):
@@ -538,7 +618,7 @@ class Orchestrator(LoggingMixin):
 
             satisfied = all(
                 (
-                    Status.is_running(g.nodes[u][KEY_STATUS])
+                    Status.is_in_progress(g.nodes[u][KEY_STATUS])
                     or Status.is_terminal(g.nodes[u][KEY_STATUS])
                     if mode == RunMode.Schedule
                     else Status.is_terminal(g.nodes[u][KEY_STATUS])
@@ -563,10 +643,11 @@ class Orchestrator(LoggingMixin):
         set of str
             A set of node IDs identifying nodes with a Done status.
         """
-        targets = {Status.Done, Status.Cancelled, Status.Failed}
+        targets = Status.terminal_states()
 
         if mode == RunMode.Schedule:
-            targets.update({Status.Submitted, Status.Running})
+            # any "in progress" status is "closed" for scheduling purposes
+            targets.update(Status.in_progress_states())
 
         return set(
             self.planner.retrieve_all(KEY_STATUS, filter_fn=lambda x: x in targets)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -701,7 +701,8 @@ class Orchestrator(LoggingMixin):
             return None
 
         if task := self.planner.retrieve(node, KEY_TASK):
-            task = await self.launcher.update_status(task.handle)
+            if updated := await self.launcher.update_status(task.handle):
+                task.status = updated.status
         else:
             task = await self.launcher.launch(step, dependencies)
             self.planner.store(node, KEY_TASK, task)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -246,7 +246,11 @@ class Planner(LoggingMixin):
 
         g = nx.DiGraph(data)
         defaults = {
-            n.name: {KEY_STATUS: Status.Unsubmitted, KEY_STEP: n, KEY_TASK: None}
+            n.name: {
+                KEY_STATUS: Status.Unsubmitted,
+                KEY_STEP: LiveStep.from_step(n),
+                KEY_TASK: None,
+            }
             for n in workplan.steps
         }
         nx.set_node_attributes(g, values=defaults)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -152,31 +152,6 @@ class Status(IntEnum):
         return status in cls.ready_states()
 
     @classmethod
-    def in_progress_states(cls) -> set["Status"]:
-        """Return the set of in-progress statuses.
-
-        Returns
-        -------
-        set["Status"]
-        """
-        return {Status.Submitted, Status.Running, Status.Ending}
-
-    @classmethod
-    def is_in_progress(cls, status: "Status") -> bool:
-        """Return `True` if a status is in the set of in-progress statuses (any non-terminal status).
-
-        Paramters
-        ---------
-        status : "Status"
-            The status to evaluate.
-
-        Returns
-        -------
-        bool
-        """
-        return status in cls.in_progress_states()
-
-    @classmethod
     def running_states(cls) -> set["Status"]:
         """Return the set of running statuses.
 
@@ -200,6 +175,31 @@ class Status(IntEnum):
         bool
         """
         return status in cls.running_states()
+
+    @classmethod
+    def in_progress_states(cls) -> set["Status"]:
+        """Return the set of in-progress statuses.
+
+        Returns
+        -------
+        set["Status"]
+        """
+        return {Status.Submitted, Status.Running, Status.Ending}
+
+    @classmethod
+    def is_in_progress(cls, status: "Status") -> bool:
+        """Return `True` if a status is in the set of in-progress statuses (any non-terminal status).
+
+        Paramters
+        ---------
+        status : "Status"
+            The status to evaluate.
+
+        Returns
+        -------
+        bool
+        """
+        return status in cls.in_progress_states()
 
 
 class LiveStep(Step):
@@ -582,7 +582,7 @@ class Orchestrator(LoggingMixin):
         self.planner = planner
         self.launcher = launcher
 
-    def get_open_nodes(self, *, mode: RunMode) -> set[str] | None:
+    def get_open_nodes(self, *, mode: RunMode) -> t.Mapping[str, Status] | None:
         """Retrieve the set of task nodes with a non-terminal state that are
         executing or ready to execute.
 
@@ -594,7 +594,7 @@ class Orchestrator(LoggingMixin):
             - Null indicates all nodes are closed (traversal is complete).
         """
         g = self.planner.graph
-        open_nodes: list[str] = []
+        open_nodes: dict[str, Status] = {}
         closed_set = self.get_closed_nodes(mode=mode)
 
         if self.planner.workplan:
@@ -602,13 +602,9 @@ class Orchestrator(LoggingMixin):
         else:
             nodes = {n for n in self.planner.graph}
 
-        working_list = set(nodes).difference(closed_set)
+        working_list = set(nodes).difference(closed_set.keys())
 
-        if failures := {
-            u: g.nodes[u][KEY_STATUS]
-            for u in closed_set
-            if Status.is_failure(g.nodes[u][KEY_STATUS])
-        }:
+        if failures := {u: s for u, s in closed_set.items() if Status.is_failure(s)}:
             self.log.error(f"Exiting due to task failures: {failures}")
             return None
 
@@ -626,16 +622,18 @@ class Orchestrator(LoggingMixin):
                 for (u, _) in in_edges
             )
 
-            if in_degree == 0 or satisfied:
-                open_nodes.append(n)
+            if in_degree == 0:
+                open_nodes[n] = Status.Unsubmitted
+            elif satisfied:
+                open_nodes[n] = g.nodes[n][KEY_STATUS]
 
         if working_list:
             # working list has options. if none are ready, return empty set.
-            return set(open_nodes)
+            return open_nodes
 
         return None
 
-    def get_closed_nodes(self, *, mode: RunMode) -> set[str]:
+    def get_closed_nodes(self, *, mode: RunMode) -> t.Mapping[str, Status]:
         """Retrieve the set of task nodes with a terminal state.
 
         Returns
@@ -646,12 +644,10 @@ class Orchestrator(LoggingMixin):
         targets = Status.terminal_states()
 
         if mode == RunMode.Schedule:
-            # any "in progress" status is "closed" for scheduling purposes
-            targets.update(Status.in_progress_states())
+            # anything previously scheduled is "closed" when scheduling
+            targets.update({Status.Submitted, Status.Running, Status.Ending})
 
-        return set(
-            self.planner.retrieve_all(KEY_STATUS, filter_fn=lambda x: x in targets)
-        )
+        return self.planner.retrieve_all(KEY_STATUS, filter_fn=lambda x: x in targets)
 
     def _locate_dependencies(self, step: LiveStep) -> list[ProcessHandle] | None:
         """Look for the dependencies of the step.
@@ -763,11 +759,10 @@ class Orchestrator(LoggingMixin):
             )
 
         # Ensure task/result pairing is consistent with a list
-        open_nodes = list(open_set)
-        exec_tasks = [asyncio.Task(self.process_node(n)) for n in open_nodes]
+        exec_tasks = [asyncio.Task(self.process_node(n)) for n in open_set.keys()]
         exec_results = await asyncio.gather(*exec_tasks)
 
-        kvp = dict(zip(open_nodes, exec_results))
+        kvp = dict(zip(open_set.keys(), exec_results))
         postproc_tasks = [
             asyncio.Task(self.update_planner_state(n, t)) for n, t in kvp.items()
         ]
@@ -777,7 +772,7 @@ class Orchestrator(LoggingMixin):
             await asyncio.gather(*postproc_tasks)
         except CstarExpectationFailed:
             cancellations = {
-                v for v in kvp.values() if v and Status.is_running(v.status)
+                v for v in kvp.values() if v and Status.is_in_progress(v.status)
             }
             self.log.exception("A task has failed unexpectedly")
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -445,6 +445,25 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
         ...
 
     @classmethod
+    async def update_status(
+        cls,
+        item: Task[_THandle] | _THandle,
+    ) -> Task[_THandle] | _THandle:
+        """Query and update the status for a running task.
+
+        Parameters
+        ----------
+        item : Task[_THandle] or _THandle
+            A task or process handle to query for status updates.
+
+        Returns
+        -------
+        Status
+            The current status of the item.
+        """
+        ...
+
+    @classmethod
     async def cancel(cls, item: Task[_THandle]) -> Task[_THandle]:
         """Cancel a task, if possible.
 
@@ -518,10 +537,12 @@ class Orchestrator(LoggingMixin):
             in_degree = g.in_degree(n)
 
             satisfied = all(
-                Status.is_running(g.nodes[u][KEY_STATUS])
-                or Status.is_terminal(g.nodes[u][KEY_STATUS])
-                if mode == RunMode.Schedule
-                else Status.is_terminal(g.nodes[u][KEY_STATUS])
+                (
+                    Status.is_running(g.nodes[u][KEY_STATUS])
+                    or Status.is_terminal(g.nodes[u][KEY_STATUS])
+                    if mode == RunMode.Schedule
+                    else Status.is_terminal(g.nodes[u][KEY_STATUS])
+                )
                 for (u, _) in in_edges
             )
 
@@ -603,8 +624,7 @@ class Orchestrator(LoggingMixin):
             return None
 
         if task := self.planner.retrieve(node, KEY_TASK):
-            status = await self.launcher.query_status(task.handle)
-            task.status = status
+            task = await self.launcher.update_status(task.handle)
         else:
             task = await self.launcher.launch(step, dependencies)
             self.planner.store(node, KEY_TASK, task)

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -1,11 +1,13 @@
 import enum
 import typing as t
+from dataclasses import dataclass
 from pathlib import Path, PosixPath
 
 import yaml
 from yaml import safe_load
 
 from cstar.base.log import get_logger
+from cstar.execution.file_system import local_copy
 
 log = get_logger(__name__)
 
@@ -45,6 +47,26 @@ class SerializableModel(t.Protocol):
 
 
 _T = t.TypeVar("_T", bound=SerializableModel)
+
+
+@dataclass
+class ValidationResult(t.Generic[_T]):
+    """Disposition and reason for a validation failure."""
+
+    error_msg: str | None = None
+    """An error message that is populated if validation fails."""
+    item: _T | None = None
+    """The deserialized workplan if validation succeeds."""
+
+    @property
+    def is_valid(self) -> bool:
+        """Return `True` if the workplan was successfully validated.
+
+        Returns
+        -------
+        bool
+        """
+        return self.item is not None
 
 
 def _read_json(path: Path, klass: type[_T]) -> _T:
@@ -255,3 +277,34 @@ def serialize(
         nbytes = fp.write(content)
 
     return nbytes
+
+
+def validate_serialized_entity(
+    path: str | Path,
+    item_type: type[_T],
+) -> ValidationResult[_T]:
+    """Perform content validation on a deserialized `Workplan`.
+
+    Parameters
+    ----------
+    path : str
+        A path-like string supplied by a user.
+    item_type : type[_TValidating]
+        The type to deserialize the file content to
+
+    Returns
+    -------
+    ValidationResult
+        Result with a populated `error_msg` if validation has failed.
+    """
+    item: _T | None = None
+
+    try:
+        with local_copy(str(path)) as wp_path:
+            item = deserialize(wp_path, item_type)
+    except ValueError as ex:
+        return ValidationResult(f"The {item_type.__name__} is invalid: {ex}")
+    except FileNotFoundError:
+        return ValidationResult(f"File not found at path: {path}")
+
+    return ValidationResult(item=item)

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -38,7 +38,7 @@ def sentinel_path(
 
     Parameters
     ----------
-    proxy : _TStateProxy
+    proxy : StateProxy
         The handle to serialize
     mode : PersistenceMode
         The persistence mode to use when serializing
@@ -65,7 +65,7 @@ async def put_sentinel(
 
     Parameters
     ----------
-    proxy : _TStateProxy
+    proxy : StateProxy
         The handle to serialize
     mode : PersistenceMode
         The persistence mode to use when serializing

--- a/cstar/orchestration/state.py
+++ b/cstar/orchestration/state.py
@@ -112,12 +112,33 @@ async def get_sentinel(
     return None
 
 
-async def list_sentinels(
+def find_sentinels(
+    *,
+    mode: PersistenceMode = PersistenceMode.yaml,
+) -> t.Iterable[Path]:
+    """Find all sentinel files located in the run directory.
+
+    Parameters
+    ----------
+    mode : PersistenceMode
+        The persistence mode to use when deserializing
+
+    Returns
+    -------
+    list[Path]
+    """
+    state_dir = StateDirectoryManager.run_state_dir()
+    filter = f"*.{EXT_SENTINEL}.{mode.value}"
+
+    yield from state_dir.rglob(filter)
+
+
+async def load_sentinels(
     klass: type[_TStateProxy],
     *,
     mode: PersistenceMode = PersistenceMode.yaml,
 ) -> list[_TStateProxy]:
-    """Find all sentinel files located in the specified run directory.
+    """Load all sentinel files located in the run directory.
 
     Parameters
     ----------
@@ -131,9 +152,8 @@ async def list_sentinels(
     list[_TStateProxy]
         All previously persisted sentinels
     """
-    state_dir = StateDirectoryManager.run_state_dir()
-    filter = f"*.{EXT_SENTINEL}.{mode.value}"
+    sentinel_paths = find_sentinels(mode=mode)
 
-    coros = [get_sentinel(p, klass, mode=mode) for p in state_dir.rglob(filter)]
+    coros = [get_sentinel(p, klass, mode=mode) for p in sentinel_paths]
     results = await asyncio.gather(*coros)
     return [x for x in results if x]

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -85,6 +85,12 @@ class TrackingRepository(LoggingMixin):
 
     @property
     def latest_dir(self) -> Path:
+        """Return the path to the directory containing latest-run records.
+
+        Returns
+        -------
+        Path
+        """
         target_path = self._root / self._LATEST_DIR
         if not target_path.exists():
             target_path.mkdir(parents=True)
@@ -92,30 +98,98 @@ class TrackingRepository(LoggingMixin):
 
     @property
     def history_dir(self) -> Path:
+        """Return the path to the directory containing history records for all runs.
+
+        Returns
+        -------
+        Path
+        """
         target_path = self._root / self._HISTORY_DIR
         if not target_path.exists():
             target_path.mkdir(parents=True)
         return target_path
 
-    def _format_run_date_as_path(self, run_date: datetime) -> str:
-        return run_date.strftime("%Y/%m/%d/%H/%M/%S")
+    @classmethod
+    def _format_run_date(cls, run_date: datetime) -> str:
+        """Format a run date as a unique name for writing the run record to disk.
 
-    def _format_run_date(self, run_date: datetime) -> str:
-        return run_date.strftime("%Y%m%d%H%M%S")
+        Parameters
+        ----------
+        run_date : datetime
+            The date to format
+
+        Returns
+        -------
+        str
+        """
+        return run_date.strftime("%Y%m%d%H%M%S.%f")
 
     def _runfile_name(self, run_id: str) -> str:
+        """Generate the file name for persisting a `WorkplanRun` to disk.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+
+        Returns
+        -------
+        str
+        """
         return f"{run_id}.{TrackingRepository._MODE.value}"
 
     def _latest_path(self, run_id: str) -> Path:
+        """Generate the full path for persisting a `WorkplanRun` to disk as
+        the "latest run" record.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+
+        Returns
+        -------
+        Path
+        """
         runfile_name = self._runfile_name(run_id)
         return self.latest_dir / runfile_name
 
     def _history_path(self, run_id: str, run_date: datetime) -> Path:
+        """Generate the full path for persisting a `WorkplanRun` to disk as
+        a history record.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+        run_date : datetime
+            The datetime the run was executed
+
+        Returns
+        -------
+        Path
+        """
         formatted_dt = self._format_run_date(run_date)
         runfile_name = self._runfile_name(formatted_dt)
         return self.history_dir / run_id / runfile_name
 
     def _find_run_path(self, run_id: str, run_date: datetime | None) -> Path:
+        """Identify a path where a `WorkplanRun` is persisted to disk.
+
+        Looks for an exact match in history if `run_date` is supplied and falls back
+        to latest run if it cannot be found.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+        run_date : datetime | None
+            The datetime the run was executed or `None`.
+
+        Returns
+        -------
+        Path
+        """
         if run_date:
             path = self._history_path(run_id, run_date)
             if path.exists():
@@ -126,6 +200,20 @@ class TrackingRepository(LoggingMixin):
     async def get_workplan_run(
         self, run_id: str, run_date: datetime | None = None
     ) -> WorkplanRun | None:
+        """Locate a WorkplanRun record.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+        run_date : datetime | None
+            The datetime the run was executed or `None`.
+
+        Returns
+        -------
+        WorkplanRun | None
+            The record when it can be located in history or latest runs, otherwise `None`.
+        """
         run_path = self._find_run_path(run_id, run_date)
 
         if not run_path.exists():
@@ -137,6 +225,20 @@ class TrackingRepository(LoggingMixin):
         return await asyncio.to_thread(deserialize, run_path, WorkplanRun)
 
     async def put_workplan_run(self, run: WorkplanRun) -> Path:
+        """Persist a run record to disk.
+
+        Inserts a new history record and updates the "latest" record for the run-id
+
+        Parameters
+        ----------
+        run : WorkplanRun
+            The run to persist
+
+        Returns
+        -------
+        Path
+            The path to the persisted history record
+        """
         run_path = self._history_path(run.run_id, run.start_at)
         latest_path = self._latest_path(run.run_id)
 
@@ -155,6 +257,9 @@ class TrackingRepository(LoggingMixin):
 
     async def list_latest_runs(self, run_id_filter: str) -> list[WorkplanRun]:
         """Retrieve a list of the latest WorkplanRun for all known run-id's.
+
+        run_id_filter : str
+            A run-id used to filter records. Matches will be included in results.
 
         Returns
         -------

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -1,12 +1,12 @@
 import asyncio
 import typing as t
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from pydantic import BaseModel, Field
 
 from cstar.base.log import LoggingMixin
-from cstar.base.utils import slugify
+from cstar.base.utils import slugify, utc_now
 from cstar.execution.file_system import (
     StateDirectoryManager,
     is_remote_resource,
@@ -14,10 +14,6 @@ from cstar.execution.file_system import (
 )
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
-
-
-def utc_now() -> datetime:
-    return datetime.now(tz=timezone.utc)
 
 
 class WorkplanRun(BaseModel):

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -153,14 +153,14 @@ class TrackingRepository(LoggingMixin):
         self.log.debug(msg)
         return run_path
 
-    async def list_latest_runs(self) -> list[WorkplanRun]:
+    async def list_latest_runs(self, run_id_filter: str) -> list[WorkplanRun]:
         """Retrieve a list of the latest WorkplanRun for all known run-id's.
 
         Returns
         -------
         list[WorkplanRun]
         """
-        run_paths = list(self.latest_dir.glob(f"*.{self._MODE}"))
+        run_paths = list(self.latest_dir.glob(f"{run_id_filter}*.{self._MODE}"))
         coros = [
             asyncio.to_thread(deserialize, run_path, WorkplanRun)
             for run_path in run_paths

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -1,3 +1,4 @@
+import asyncio
 import typing as t
 from datetime import datetime, timezone
 from pathlib import Path
@@ -84,11 +85,17 @@ class TrackingRepository(LoggingMixin):
 
     @property
     def latest_dir(self) -> Path:
-        return self._root / self._LATEST_DIR
+        target_path = self._root / self._LATEST_DIR
+        if not target_path.exists():
+            target_path.mkdir(parents=True)
+        return target_path
 
     @property
     def history_dir(self) -> Path:
-        return self._root / self._HISTORY_DIR
+        target_path = self._root / self._HISTORY_DIR
+        if not target_path.exists():
+            target_path.mkdir(parents=True)
+        return target_path
 
     def _format_run_date_as_path(self, run_date: datetime) -> str:
         return run_date.strftime("%Y/%m/%d/%H/%M/%S")
@@ -116,7 +123,7 @@ class TrackingRepository(LoggingMixin):
 
         return self._latest_path(run_id)
 
-    def get_workplan_run(
+    async def get_workplan_run(
         self, run_id: str, run_date: datetime | None = None
     ) -> WorkplanRun | None:
         run_path = self._find_run_path(run_id, run_date)
@@ -127,21 +134,35 @@ class TrackingRepository(LoggingMixin):
             self.log.warning(msg)
             return None
 
-        return deserialize(run_path, WorkplanRun)
+        return await asyncio.to_thread(deserialize, run_path, WorkplanRun)
 
-    def put_workplan_run(self, run: WorkplanRun) -> Path:
+    async def put_workplan_run(self, run: WorkplanRun) -> Path:
         run_path = self._history_path(run.run_id, run.start_at)
         latest_path = self._latest_path(run.run_id)
 
-        if not serialize(run_path, run):
+        if not await asyncio.to_thread(serialize, run_path, run):
             self.log.warning("Run could not be persisted")
 
         if not latest_path.parent.exists():
             latest_path.parent.mkdir(parents=True)
 
-        latest_path.unlink(missing_ok=True)
-        latest_path.symlink_to(run_path)
+        await asyncio.to_thread(latest_path.unlink, missing_ok=True)
+        await asyncio.to_thread(latest_path.symlink_to, run_path)
 
         msg = f"Run persisted to: {run_path}"
         self.log.debug(msg)
         return run_path
+
+    async def list_latest_runs(self) -> list[WorkplanRun]:
+        """Retrieve a list of the latest WorkplanRun for all known run-id's.
+
+        Returns
+        -------
+        list[WorkplanRun]
+        """
+        run_paths = list(self.latest_dir.glob(f"*.{self._MODE}"))
+        coros = [
+            asyncio.to_thread(deserialize, run_path, WorkplanRun)
+            for run_path in run_paths
+        ]
+        return await asyncio.gather(*coros)

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -1,0 +1,147 @@
+import typing as t
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from cstar.base.log import LoggingMixin
+from cstar.base.utils import slugify
+from cstar.execution.file_system import (
+    StateDirectoryManager,
+    is_remote_resource,
+    local_copy,
+)
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+
+
+def utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class WorkplanRun(BaseModel):
+    """A record containing metadata about an individual execution of a `Workplan`."""
+
+    workplan_path: Path
+    """The path to the original workplan."""
+
+    trx_workplan_path: Path
+    """The path to the transformed workplan."""
+
+    output_path: Path
+    """The path where workplan output is written."""
+
+    run_id: str
+    """The unique identifier used to reference the run."""
+
+    start_at: datetime = Field(default_factory=utc_now)
+    """The date and time when the workplan run was triggered."""
+
+    environment: dict[str, str] = {}
+    """The environment variables at the time of the run."""
+
+    @staticmethod
+    def get_default_run_id(path: Path | str) -> str:
+        """Generate a run-id based on the name of a `Workplan`
+
+        Parameters
+        ----------
+        path : Path
+            The path to a persisted workplan.
+
+        Returns
+        -------
+        str
+        """
+        path_string = str(path)
+        if is_remote_resource(path_string):
+            with local_copy(path_string) as local_path:
+                wp = deserialize(local_path, Workplan)
+        else:
+            wp = deserialize(Path(path), Workplan)
+
+        return slugify(wp.name)
+
+
+class TrackingRepository(LoggingMixin):
+    """The API for persisting tracking data."""
+
+    _root: t.Final[Path]
+    """The root directory where tracking files are stored."""
+
+    _LATEST_DIR: t.Final[str] = "latest"
+    """The directory containing a mapping to the last run using a given run-id."""
+
+    _HISTORY_DIR: t.Final[str] = "history"
+    """The directory containing all run history."""
+
+    _MODE: PersistenceMode = PersistenceMode.yaml
+    """The serialization mode to use."""
+
+    def __init__(self) -> None:
+        """Initialize the repository."""
+        self._root = StateDirectoryManager.tracking_dir()
+
+    @property
+    def latest_dir(self) -> Path:
+        return self._root / self._LATEST_DIR
+
+    @property
+    def history_dir(self) -> Path:
+        return self._root / self._HISTORY_DIR
+
+    def _format_run_date_as_path(self, run_date: datetime) -> str:
+        return run_date.strftime("%Y/%m/%d/%H/%M/%S")
+
+    def _format_run_date(self, run_date: datetime) -> str:
+        return run_date.strftime("%Y%m%d%H%M%S")
+
+    def _runfile_name(self, run_id: str) -> str:
+        return f"{run_id}.{TrackingRepository._MODE.value}"
+
+    def _latest_path(self, run_id: str) -> Path:
+        runfile_name = self._runfile_name(run_id)
+        return self.latest_dir / runfile_name
+
+    def _history_path(self, run_id: str, run_date: datetime) -> Path:
+        formatted_dt = self._format_run_date(run_date)
+        runfile_name = self._runfile_name(formatted_dt)
+        return self.history_dir / run_id / runfile_name
+
+    def _find_run_path(self, run_id: str, run_date: datetime | None) -> Path:
+        if run_date:
+            path = self._history_path(run_id, run_date)
+            if path.exists():
+                return path
+
+        return self._latest_path(run_id)
+
+    def get_workplan_run(
+        self, run_id: str, run_date: datetime | None = None
+    ) -> WorkplanRun | None:
+        run_path = self._find_run_path(run_id, run_date)
+
+        if not run_path.exists():
+            rd_out = run_date if run_date else "latest"
+            msg = f"No run file for `{run_id}` on `{rd_out}` found in {run_path}`"
+            self.log.warning(msg)
+            return None
+
+        return deserialize(run_path, WorkplanRun)
+
+    def put_workplan_run(self, run: WorkplanRun) -> Path:
+        run_path = self._history_path(run.run_id, run.start_at)
+        latest_path = self._latest_path(run.run_id)
+
+        if not serialize(run_path, run):
+            self.log.warning("Run could not be persisted")
+
+        if not latest_path.parent.exists():
+            latest_path.parent.mkdir(parents=True)
+
+        latest_path.unlink(missing_ok=True)
+        latest_path.symlink_to(run_path)
+
+        msg = f"Run persisted to: {run_path}"
+        self.log.debug(msg)
+        return run_path

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -166,3 +166,22 @@ class TrackingRepository(LoggingMixin):
             for run_path in run_paths
         ]
         return await asyncio.gather(*coros)
+
+    async def list_history_runs(self, run_id_filter: str) -> list[WorkplanRun]:
+        """Retrieve a list of the latest WorkplanRun for all known run-id's.
+
+        run_id_filter : str
+            A run-id used to filter records. Matches will be included in results.
+
+        Returns
+        -------
+        list[WorkplanRun]
+        """
+        # Filter run-id subfolder w/filename format YYYYMMDDHHMMSS.XXXXXX.yaml
+        filter = f"{run_id_filter}*/??????????????.??????.{self._MODE}"
+        run_paths = list(self.history_dir.rglob(filter))
+        coros = [
+            asyncio.to_thread(deserialize, run_path, WorkplanRun)
+            for run_path in run_paths
+        ]
+        return await asyncio.gather(*coros)

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -64,5 +64,4 @@ def test_blueprint_run_remote_blueprint(
     ) as mock_exec:
         run(bp_path)
 
-    assert "is valid" in capsys.readouterr().out
     mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -70,7 +70,10 @@ def test_workplan_run_remote_workplan(
         "cstar.cli.workplan.run.build_and_run_dag",
         return_value=0,
     ) as mock_exec:
-        run(wp_uri, "12345")
+        run(
+            "12345",
+            wp_uri,
+        )
 
     assert "is valid" in capsys.readouterr().out
     mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -22,7 +22,7 @@ def test_workplan_run_file_dne(
     """
     wp_path = tmp_path / "workplan-dne.yml"
 
-    run(wp_path.as_posix(), "test-run-id")
+    run("test-run-id", wp_path.as_posix())
 
     assert "not found" in capsys.readouterr().out
 
@@ -40,7 +40,7 @@ def test_workplan_run_remote_workplan_dne(
     """
     wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml_XXX"
 
-    run(wp_path, "my-run-id")
+    run("my-run-id", wp_path)
 
     assert "not found" in capsys.readouterr().out
 
@@ -52,10 +52,7 @@ def test_workplan_run_remote_workplan_dne(
         "HTTPS://raw.githubusercontent.com/cworthy-ocean/c-star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml",
     ],
 )
-def test_workplan_run_remote_workplan(
-    capsys: pytest.CaptureFixture,
-    wp_uri: str,
-) -> None:
+def test_workplan_run_remote_workplan(wp_uri: str) -> None:
     """Verify that a URL to a remote workplan is handled properly and the
     workplan is executed.
 
@@ -75,5 +72,4 @@ def test_workplan_run_remote_workplan(
             wp_uri,
         )
 
-    assert "is valid" in capsys.readouterr().out
     mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from cstar.base.utils import additional_files_dir
-from cstar.orchestration.models import RomsMarblBlueprint, Step, Workplan
+from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 
 
 @pytest.fixture
@@ -422,3 +422,45 @@ def default_blueprint_path() -> str:
     str
     """
     return "~/code/cstar/cstar/additional_files/templates/blueprint.yaml"
+
+
+@pytest.fixture
+def single_step_workplan(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> Workplan:
+    """Generate a workplan that contains a single step.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    bp_templates_dir : Path
+        Fixture returning the path to the directory containing blueprint template files
+
+    Returns
+    -------
+    Workplan
+    """
+    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
+    default_output_dir = "output_dir: ."
+
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_content = bp_tpl_path.read_text()
+    bp_content = bp_content.replace(
+        default_output_dir, f"output_dir: {tmp_path.as_posix()}"
+    )
+    bp_content.replace(Application.SLEEP.value, Application.ROMS_MARBL.value)
+    bp_path.write_text(bp_content)
+
+    return Workplan(
+        name="single-step-workplan",
+        description="A workplan with a single step.",
+        steps=[
+            Step(
+                name="s-00",
+                application=Application.SLEEP.value,
+                blueprint=bp_path.as_posix(),
+            ),
+        ],
+    )

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -17,48 +17,6 @@ from cstar.orchestration.transforms import (
 )
 
 
-@pytest.fixture
-def single_step_workplan(
-    tmp_path: Path,
-    bp_templates_dir: Path,
-) -> Workplan:
-    """Generate a workplan that contains a single step.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary directory for test outputs
-    bp_templates_dir : Path
-        Fixture returning the path to the directory containing blueprint template files
-
-    Returns
-    -------
-    Workplan
-    """
-    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
-    default_output_dir = "output_dir: ."
-
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_content = bp_tpl_path.read_text()
-    bp_content = bp_content.replace(
-        default_output_dir, f"output_dir: {tmp_path.as_posix()}"
-    )
-    bp_content.replace("sleep", Application.ROMS_MARBL.value)
-    bp_path.write_text(bp_content)
-
-    return Workplan(
-        name="single-step-workplan",
-        description="A workplan with a single step.",
-        steps=[
-            Step(
-                name="s-00",
-                application="sleep",
-                blueprint=bp_path.as_posix(),
-            ),
-        ],
-    )
-
-
 def test_time_splitting() -> None:
     """Verify that the time splitting function honors the start and end dates.
 

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -1,0 +1,319 @@
+import asyncio
+import os
+import unittest.mock as mock
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from cstar.base.env import ENV_CSTAR_STATE_HOME
+from cstar.base.utils import slugify
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.serialization import serialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
+
+
+@pytest.mark.asyncio
+async def test_tracking_create(tmp_path: Path) -> None:
+    """Verify that run-tracking writes to the expected location.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    run_id = "test-tracking-create-run-id"
+
+    repo = TrackingRepository()
+    wp_run = WorkplanRun(
+        workplan_path=wp_path,
+        trx_workplan_path=wp_trx_path,
+        output_path=output_path,
+        run_id=run_id,
+    )
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
+        latest_dir = repo.latest_dir
+        history_dir = repo.history_dir
+
+        persisted_to = await repo.put_workplan_run(wp_run)
+
+    # confirm the record is persisted
+    assert persisted_to.exists()
+
+    # confirm the history path is returned (not the path to the latest use of the run-id)
+    assert "latest" not in persisted_to.as_posix()
+
+    # confirm latest and history are not overlapping
+    assert latest_dir.as_posix() != history_dir.as_posix()
+
+    # confirm the `put` operation saves to both the latest and run-tracking history
+    found_files = list(latest_dir.rglob("*.yaml"))
+    assert found_files
+
+    found_files = list(history_dir.rglob("*.yaml"))
+    assert found_files
+
+
+@pytest.mark.asyncio
+async def test_tracking_retrieve(tmp_path: Path) -> None:
+    """Verify that run-tracking retrieves a persisted record and deserializes it
+    as expected.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    run_id = "test-tracking-retrieve-run-id"
+    start_at = datetime.now(tz=timezone.utc)
+    captured_env = {"foo": "foo-value"}
+
+    wp_run = WorkplanRun(
+        workplan_path=wp_path,
+        trx_workplan_path=wp_trx_path,
+        output_path=output_path,
+        run_id=run_id,
+        start_at=start_at,
+        environment=captured_env,
+    )
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
+        repo = TrackingRepository()
+        _ = await repo.put_workplan_run(wp_run)
+
+    # use public API to retrieve using "latest" record (by passing only run_id)
+    latest = await repo.get_workplan_run(run_id=run_id)
+    assert latest
+    assert latest.__dict__ == wp_run.__dict__  # confirm same stored values
+
+    # use public API to retrieve using "history" record (by passing run_id & run_date)
+    history = await repo.get_workplan_run(run_id=run_id, run_date=wp_run.start_at)
+    assert history
+    assert history.__dict__ == wp_run.__dict__  # confirm same stored values
+
+    assert history.output_path == output_path
+    assert history.workplan_path == wp_path
+    assert history.trx_workplan_path == wp_trx_path
+    assert history.run_id == run_id
+    assert history.start_at == start_at
+    assert history.environment == captured_env
+
+
+@pytest.mark.asyncio
+async def test_tracking_retrieve_variant(
+    tmp_path: Path,
+) -> None:
+    """Verify that run-tracking retrieves a persisted record from the `history`
+    if start date is supplied and from `latest` if start date is not supplied.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    # single_step_workplan: Workplan
+    #     Fixture returning a simple workplan
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    run_id = "test-tracking-retrieve-run-id"
+
+    repo = TrackingRepository()
+    wp_run = WorkplanRun(
+        workplan_path=wp_path,
+        trx_workplan_path=wp_trx_path,
+        output_path=output_path,
+        run_id=run_id,
+    )
+
+    # manually serialize so i have access to a known, working path for mocks
+    mock_doc_path = tmp_path / repo._runfile_name(run_id)
+    assert serialize(mock_doc_path, wp_run)
+
+    with (
+        mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}),
+        mock.patch.object(repo, "_history_path", return_value=mock_doc_path) as hp_fn,
+        mock.patch.object(repo, "_latest_path", return_value=mock_doc_path) as lp_fn,
+    ):
+        latest = await repo.get_workplan_run(wp_run.run_id, None)
+        assert latest
+
+        # confirm the latest search was used
+        lp_fn.assert_called_once()
+        hp_fn.assert_not_called()
+
+        history = await repo.get_workplan_run(wp_run.run_id, wp_run.start_at)
+        assert history
+
+        # confirm the history search was used
+        hp_fn.assert_called_once()
+        lp_fn.assert_called_once()  # no new call made
+
+
+@pytest.mark.asyncio
+async def test_default_run_id(
+    tmp_path: Path,
+    single_step_workplan: Workplan,
+) -> None:
+    """Verify the default run id matches the workplan safe name.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    single_step_workplan: Workplan
+        Fixture returning a simple workplan
+    """
+    wp_path = tmp_path / "workplan.yaml"
+    run_id = "test-tracking-retrieve-run-id"
+
+    # create a workplan so the default run-id can be determined by loading the workplan
+    serialize(wp_path, single_step_workplan)
+
+    run_id = WorkplanRun.get_default_run_id(wp_path)
+
+    # verify it uses the supplied workplan
+    assert run_id == slugify(single_step_workplan.name)
+
+
+@pytest.mark.parametrize("num_runs", [1, 2, 4, 8])
+@pytest.mark.asyncio
+async def test_tracking_list_latest_run_id(tmp_path: Path, num_runs: int) -> None:
+    """Verify that using the `list_latest_runs` filter finds the
+    expected set of persisted records.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    base_run_id = "test-tracking-list-latest-run-id"
+    captured_env = {"foo": "foo-value"}
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
+        repo = TrackingRepository()
+
+        # insert some runs to test filtering...
+        run_ids: list[str] = []
+
+        for i in range(num_runs):
+            current_run_id = f"{base_run_id}-{i}"
+            run_ids.append(current_run_id)
+
+            _ = await repo.put_workplan_run(
+                WorkplanRun(
+                    workplan_path=wp_path,
+                    trx_workplan_path=wp_trx_path,
+                    output_path=output_path,
+                    run_id=current_run_id,
+                    environment=captured_env,
+                )
+            )
+
+        # confirm per-run-id retrieval meets expectations
+        for run_id in set(run_ids):
+            wp_runs = await repo.list_latest_runs(run_id)
+
+            # confirm each unique run-id returns a list
+            assert wp_runs
+
+            # confirm only the desired, exact run is returned
+            assert len(wp_runs) == 1
+
+        # confirm that a non-exact search finds all the expected things
+        base_matches = await repo.list_latest_runs(base_run_id)
+
+        # more than one run should be found when using base-run-id as filter
+        assert len(base_matches) == num_runs
+
+
+@pytest.mark.parametrize(
+    ("num_runs", "num_unique"), [(2, 1), (2, 2), (2, 3), (3, 3), (4, 2)]
+)
+@pytest.mark.asyncio
+async def test_tracking_list_history_run_id(
+    tmp_path: Path, num_runs: int, num_unique: int
+) -> None:
+    """Verify that using the `list_history_runs` filter finds the
+    expected set of persisted records when a run-id is re-used.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    num_runs : int
+        The number of runs to insert for a given run id
+    num_unique : int
+        The number of unique run ids to generate
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    base_run_id = "test-tracking-list-history-run-id"
+    captured_env = {"foo": "foo-value"}
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
+        repo = TrackingRepository()
+        coros = []
+
+        # insert some run-ids that won't conform to the search and should be omitted
+        for _ in range(3):
+            coros.append(
+                repo.put_workplan_run(
+                    WorkplanRun(
+                        workplan_path=wp_path,
+                        trx_workplan_path=wp_trx_path,
+                        output_path=output_path,
+                        run_id=str(uuid4()),
+                        environment=captured_env,
+                    )
+                )
+            )
+
+        await asyncio.gather(*coros)
+        target_run_ids = [f"{base_run_id}-{i}" for i in range(num_unique)]
+
+        # NOTE: this is NOT thread-safe and assumes a single user env
+        for current_run_id in target_run_ids:
+            # insert some runs to test filtering...
+            for _ in range(num_runs):
+                await repo.put_workplan_run(
+                    WorkplanRun(
+                        workplan_path=wp_path,
+                        trx_workplan_path=wp_trx_path,
+                        output_path=output_path,
+                        run_id=current_run_id,
+                        environment=captured_env,
+                    )
+                )
+
+        # run a new loop to ensure multiple unique IDs have been inserted
+        # and a bug can present itself
+        for current_run_id in target_run_ids:
+            # confirm that re-using a run-id does not increase the number of "latest" runs
+            wp_runs = await repo.list_latest_runs(current_run_id)
+
+            # confirm that the run-id was re-used
+            assert len(wp_runs) == 1
+
+        # confirm that a search finds all the individual runs
+        base_matches = await repo.list_history_runs(base_run_id)
+
+        # confirm 2 separate run-ids had the same number of runs inserted.
+        assert len(base_matches) == num_unique * num_runs

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -13,6 +13,7 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 - Rename env var group name constants to omit leading underscore
+- Modified the interpretation of `Status.is_running` to exclude `Unsubmitted`
 
 New features
 ~~~~~~~~~~~~
@@ -20,6 +21,8 @@ New features
 - Enable status retrieval for multiple SLURM jobs in a single `sacct` call
 - The orchestrator writes a sentinel file to disk to dynamically alter dependencies
 - Add trace log level to reduce log frequency during `Workplan` execution
+- Persist `WorkplanRun` record for every invocation of the orchestrator for run history and lookup
+- Add `cstar workplan monitor --run-id <run-id>` for reattaching to a running `Workplan`
 
 Security Fixes
 ~~~~~~~~~~~~~~
@@ -40,6 +43,7 @@ Bug Fixes
 - Fix issue when parsing SLURM status of the form `CANCELLED by <username>`
 - Fix incorrect env var discovery if `env_` appears repeatedly in variable name
 - Fix unhandled exception caused by attempting to execute `typer` app
+- Fix `cstar workplan status ...` triggering a re-build of the entire workplan
 
 Improvements
 ~~~~~~~~~~~~
@@ -52,6 +56,8 @@ Improvements
 - Replace blocking `time.sleep` usage in health check thread
 - Removed slow status retrieval loop for previously submitted jobs
 - Ensure env var display consistency in `cstar env show` output
+- Enable "path-less" CLI commands, such as `cstar workplan status --run-id <id>`.
+- Display detailed status information for tasks in a `Workplan`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
+    "networkx>=3.6.1",
     "prefect>=3.6.1",
     "pydantic>=2.12",
     "python-dateutil>=2.8.2",


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request introduces state storage for a `Workplan`. It persists a new `WorkplanRun` model for each invocation of `cstar workplan run ...` and maintains a persisted `ProcessHandle` for simplifying status checks with `cstar workplan status ...`


## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Modified the interpretation of `Status.is_running` to exclude `Unsubmitted` 

## New Features
<!-- List any new capabilities added -->
- Persist `WorkplanRun` record for every invocation of the orchestrator for run history and lookup
- Add `cstar workplan monitor --run-id <run-id>` for reattaching to a running `Workplan`


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix `cstar workplan status ...` triggering a re-build of the entire workplan

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Enable "path-less" CLI commands, such as `cstar workplan status --run-id <id>`.
- Display detailed status information for tasks in a `Workplan`

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-631
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
