### PR TITLE
Fix broken feature flag discovery

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 GROUP_FF: t.Final[str] = "Feature Flags"
 """Group name for feature flag environment variables in documentation."""
 GROUP_FS: t.Final[str] = "File System Configuration"
@@ -108,7 +107,7 @@ def get_env_item(var_name: str, prefix: str = "ENV_") -> EnvItem:
             if not metadata:
                 return EnvItem(
                     description="unknown",
-                    group=_GROUP_UNK,
+                    group=GROUP_UNK,
                     default="unknown",
                     name=var_name,
                 )
@@ -152,7 +151,7 @@ ENV_CSTAR_LOG_LEVEL: t.Annotated[
     t.Literal["CSTAR_LOG_LEVEL"],
     EnvVar(
         "Specify the logging level for terminal messages. Options: DEBUG, INFO, WARNING, ERROR, CRITICAL.",
-        _GROUP_SIM,
+        GROUP_SIM,
         default="INFO",
     ),
 ] = "CSTAR_LOG_LEVEL"
@@ -163,7 +162,7 @@ ENV_CSTAR_CLOBBER_WORKING_DIR: t.Annotated[
     t.Literal["CSTAR_CLOBBER_WORKING_DIR"],
     EnvVar(
         "Set to `1` to automatically clear the working directory specified in a blueprint before launching a SLURM job. Use at your own risk.",
-        _GROUP_SIM,
+        GROUP_SIM,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_CLOBBER_WORKING_DIR"
@@ -173,7 +172,7 @@ ENV_CSTAR_FRESH_CODEBASES: t.Annotated[
     t.Literal["CSTAR_FRESH_CODEBASES"],
     EnvVar(
         "Set to `1` to automatically clear codebase directories and create fresh clones during each run. Otherwise, use code found in locations specified in `ROMS_ROOT` and `ROMS_MARBL`.",
-        _GROUP_SIM,
+        GROUP_SIM,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FRESH_CODEBASES"
@@ -183,7 +182,7 @@ ENV_CSTAR_IN_ACTIVE_ALLOCATION: t.Annotated[
     t.Literal["CSTAR_IN_ACTIVE_ALLOCATION"],
     EnvVar(
         "Override behavior for launching new jobs via SLURM or simply executing via mpirun. Only set this to 0 if you need to launch new jobs from within an existing allocation.",
-        _GROUP_SIM,
+        GROUP_SIM,
         default="",
     ),
 ] = "CSTAR_IN_ACTIVE_ALLOCATION"
@@ -193,7 +192,7 @@ ENV_CSTAR_NPROCS_POST: t.Annotated[
     t.Literal["CSTAR_NPROCS_POST"],
     EnvVar(
         "Specify the number of processes to be used for post-processing simulation output files. Dynamic default ``os.cpu_count() // 3``",
-        _GROUP_SIM,
+        GROUP_SIM,
         default_factory=lambda _: nprocs_factory(),  # type: ignore[reportOptionalOperand]
     ),
 ] = "CSTAR_NPROCS_POST"
@@ -203,7 +202,7 @@ ENV_CSTAR_SCRATCH_DIRS: t.Annotated[
     t.Literal["CSTAR_SCRATCH_DIRS"],
     EnvVar(
         "A comma-separated list of environment variable names used to identify scratch paths on HPC systems, in search order.",
-        _GROUP_FS,
+        GROUP_FS,
         "SCRATCH,SCRATCH_DIR,LOCAL_SCRATCH",
     ),
 ] = "CSTAR_SCRATCH_DIRS"
@@ -213,7 +212,7 @@ ENV_CSTAR_CACHE_HOME: t.Annotated[
     t.Literal["CSTAR_CACHE_HOME"],
     EnvVar(
         "Environment variable used to override the home directory for C-Star file cache.",
-        _GROUP_FS,
+        GROUP_FS,
         "~/.cache",
         indirect_var="XDG_CACHE_HOME",
         default_factory=indirect_default_factory,
@@ -225,7 +224,7 @@ ENV_CSTAR_CONFIG_HOME: t.Annotated[
     t.Literal["CSTAR_CONFIG_HOME"],
     EnvVar(
         "Environment variable used to override the home directory for C-Star config storage.",
-        _GROUP_FS,
+        GROUP_FS,
         "~/.config",
         default_factory=indirect_default_factory,
         indirect_var="XDG_CONFIG_HOME",
@@ -237,7 +236,7 @@ ENV_CSTAR_DATA_HOME: t.Annotated[
     t.Literal["CSTAR_DATA_HOME"],
     EnvVar(
         "Environment variable used to override the home directory for C-Star dataset storage.",
-        _GROUP_FS,
+        GROUP_FS,
         "~/.local/share",
         indirect_var="XDG_DATA_HOME",
         default_factory=lambda x: hpc_data_directory() or indirect_default_factory(x),
@@ -249,7 +248,7 @@ ENV_CSTAR_STATE_HOME: t.Annotated[
     t.Literal["CSTAR_STATE_HOME"],
     EnvVar(
         "Environment variable used to override the home directory for C-Star state storage.",
-        _GROUP_FS,
+        GROUP_FS,
         "~/.local/state",
         indirect_var="XDG_STATE_HOME",
         default_factory=indirect_default_factory,
@@ -261,7 +260,7 @@ ENV_CSTAR_RUNID: t.Annotated[
     t.Literal["CSTAR_RUNID"],
     EnvVar(
         description="Unique run identifier used by the orchestrator.",
-        group=_GROUP_SIM,
+        group=GROUP_SIM,
         default_factory=lambda _: generate_run_id(),
     ),
 ] = "CSTAR_RUNID"
@@ -271,7 +270,7 @@ ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
     t.Literal["CSTAR_SLURM_POST_SUBMIT_DELAY"],
     EnvVar(
         "Delay (in seconds) after a submission to ensure status for a SLURM job can be queried.",
-        _GROUP_SIM,
+        GROUP_SIM,
         default="1.0",
     ),
 ] = "CSTAR_SLURM_POST_SUBMIT_DELAY"
@@ -298,7 +297,7 @@ def discover_env_vars(
                     items.append(
                         EnvItem(
                             description="unknown",
-                            group=_GROUP_UNK,
+                            group=GROUP_UNK,
                             default="unknown",
                             name=name,
                         ),

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -289,17 +289,17 @@ def discover_env_vars(
         for name, hint in hints.items():
             if name.startswith(prefix):
                 metadata = getattr(hint, "__metadata__", None)
-                name = name.replace(prefix, "")
+                value = getattr(module, name)
                 if metadata and isinstance(metadata[0], EnvVar):
                     meta = metadata[0]
-                    items.append(EnvItem.from_env_var(meta, name))
+                    items.append(EnvItem.from_env_var(meta, value))
                 elif not metadata:
                     items.append(
                         EnvItem(
                             description="unknown",
                             group=GROUP_UNK,
                             default="unknown",
-                            name=name,
+                            name=value,
                         ),
                     )
 

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -7,6 +7,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
+GROUP_FF: t.Final[str] = "Feature Flags"
+"""Group name for feature flag environment variables in documentation."""
+GROUP_FS: t.Final[str] = "File System Configuration"
+"""Group name for file system related environment variables in documentation."""
+GROUP_SIM: t.Final[str] = "Simulation Configuration"
+"""Group name for simulation-specific environment variables in documentation."""
+GROUP_UNK: t.Final[str] = "Uncategorized Configuration"
+"""Group name for uncategorized environment variables in documentation."""
+
+
+FLAG_ON: t.Final[str] = "1"
+"""Value indicating a toggle is enabled."""
+
+FLAG_OFF: t.Final[str] = "0"
+"""Value indicating a toggle is disabled."""
+
+
 @dataclass(slots=True)
 class EnvVar:
     """Annotation for specifying metadata about an environment variable."""
@@ -65,17 +82,6 @@ def indirect_default_factory(env_var: EnvVar) -> str:
     """
     var_name = env_var.indirect_var
     return os.environ.get(var_name, "")
-
-
-_GROUP_FS: t.Final[str] = "File System Configuration"
-_GROUP_SIM: t.Final[str] = "Simulation Configuration"
-_GROUP_UNK: t.Final[str] = "Uncategorized Configuration"
-
-FLAG_ON: t.Final[str] = "1"
-"""Value indicating a feature flag is enabled."""
-
-FLAG_OFF: t.Final[str] = "0"
-"""Value indicating a feature flag is disabled."""
 
 
 def get_env_item(var_name: str, prefix: str = "ENV_") -> EnvItem:

--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -1,19 +1,16 @@
 import os
 import typing as t
 
-from cstar.base.env import FLAG_OFF, FLAG_ON, EnvVar
+from cstar.base.env import FLAG_OFF, FLAG_ON, GROUP_FF, EnvVar
 
 FF_PREFIX: t.Literal["CSTAR_FF_"] = "CSTAR_FF_"
 """Conventional prefix of environment variables for feature flags."""
-
-_GROUP_FF: t.Final[str] = "Feature Flags"
-"""Group name for feature flag environment variables in documentation."""
 
 ENV_FF_DEVELOPER_MODE: t.Annotated[
     t.Literal["CSTAR_FF_DEVELOPER_MODE"],
     EnvVar(
         "Enable developer mode to enable all feature flags (not recommended).",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_DEVELOPER_MODE"
@@ -23,7 +20,7 @@ ENV_FF_CLI_ENV_SHOW: t.Annotated[
     t.Literal["CSTAR_FF_CLI_ENV_SHOW"],
     EnvVar(
         "Enable CLI for displaying environment configuration.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_ENV_SHOW"
@@ -33,7 +30,7 @@ ENV_FF_CLI_TEMPLATE_CREATE: t.Annotated[
     t.Literal["CSTAR_FF_CLI_TEMPLATE_CREATE"],
     EnvVar(
         "Enable CLI for creating blueprints and workplans from standard templates.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_TEMPLATE_CREATE"
@@ -43,7 +40,7 @@ ENV_FF_CLI_WORKPLAN_COMPOSE: t.Annotated[
     t.Literal["CSTAR_FF_CLI_WORKPLAN_COMPOSE"],
     EnvVar(
         "Enable CLI for composing a workplan from pre-existing blueprints.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_WORKPLAN_COMPOSE"
@@ -53,7 +50,7 @@ ENV_FF_CLI_WORKPLAN_GEN: t.Annotated[
     t.Literal["CSTAR_FF_CLI_WORKPLAN_GEN"],
     EnvVar(
         "Enable CLI for generating a workplan from a directory of blueprints.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_WORKPLAN_GEN"
@@ -63,7 +60,7 @@ ENV_FF_CLI_WORKPLAN_PLAN: t.Annotated[
     t.Literal["CSTAR_FF_CLI_WORKPLAN_PLAN"],
     EnvVar(
         "Enable CLI for generating the execution plan of a workplan.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_WORKPLAN_PLAN"
@@ -73,7 +70,7 @@ ENV_FF_CLI_WORKPLAN_STATUS: t.Annotated[
     t.Literal["CSTAR_FF_CLI_WORKPLAN_STATUS"],
     EnvVar(
         "Enable CLI for retrieving status about a workplan run.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_CLI_WORKPLAN_STATUS"
@@ -83,7 +80,7 @@ ENV_FF_ORCH_TRX_TIMESPLIT: t.Annotated[
     t.Literal["CSTAR_FF_ORCH_TRX_TIMESPLIT"],
     EnvVar(
         "Enable automatic time-splitting of simulations.",
-        _GROUP_FF,
+        GROUP_FF,
         default=FLAG_OFF,
     ),
 ] = "CSTAR_FF_ORCH_TRX_TIMESPLIT"

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -20,6 +20,8 @@ app = typer.Typer()
 H_CONFIG_ALL: t.Final[str] = "C-Star Environment Configuration"
 """Main header displayed before all configuration sections."""
 
+NOT_SET: t.Literal["<not-set>"] = "<not-set>"
+
 
 def _interactive(all_config: dict[str, list["EnvItem"]]) -> None:
     """Format configuration for an interactive user."""
@@ -38,8 +40,11 @@ def _interactive(all_config: dict[str, list["EnvItem"]]) -> None:
             def_in, def_out = "[blue]", "[/blue]"
             desc_in, desc_out = "[yellow italic]", "[/yellow italic]"
 
-            kvp_detail = f"{item.name}: {val_in}{item.value or '<not-set>'}{val_out}"
-            default_detail = f"(default: {def_in}{item.default or '<none>'}{def_out})"
+            kvp_value = item.value or NOT_SET
+            def_value = item.default or NOT_SET
+
+            kvp_detail = f"{item.name}: {val_in}{kvp_value}{val_out}"
+            default_detail = f"(default: {def_in}{def_value}{def_out})"
             desc_detail = f"{desc_in}{item.description}{desc_out}"
             details = f"{default_detail}, {desc_detail}"
             print(f"- {kvp_detail} {details}")
@@ -56,7 +61,7 @@ def _export(all_config: dict[str, list["EnvItem"]]) -> None:
         print(f"{header_sep}\n# {group_name}\n{header_sep}\n")
 
         for item in sorted(items, key=lambda x: x.name):
-            default_detail = f"(default: {item.default or '<none>'})"
+            default_detail = f"(default: {item.default or NOT_SET})"
             wrapped_header = textwrap.fill(
                 item.description, width=68, initial_indent="# ", subsequent_indent="# "
             )

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -112,4 +112,4 @@ def show(
 
 
 if __name__ == "__main__":
-    typer.run(app)
+    typer.run(show)

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -51,6 +51,7 @@ Improvements
 - Replace use of incorrect `mp.Queue` where `queue.Queue` is appropriate
 - Replace blocking `time.sleep` usage in health check thread
 - Removed slow status retrieval loop for previously submitted jobs
+- Ensure env var display consistency in `cstar env show` output
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -12,7 +12,7 @@ This is a bug-fix release focused on stabilizing the orchestration of blueprints
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- N/A
+- Rename env var group name constants to omit leading underscore
 
 New features
 ~~~~~~~~~~~~
@@ -38,6 +38,8 @@ Bug Fixes
 - Fix incorrect working directories resulting from `LiveStep.from_step` when a parent is specified
 - Fix failure to terminate health check thread
 - Fix issue when parsing SLURM status of the form `CANCELLED by <username>`
+- Fix incorrect env var discovery if `env_` appears repeatedly in variable name
+- Fix unhandled exception caused by attempting to execute `typer` app
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary

A flaw in the env var discovery method can be illustrated by reviewing the output from `cstar env show`:

```
Feature Flags
- FF_CLI_SHOW: 0 (default: 0), Enable CLI for displaying environment configuration.
- FF_CLI_TEMPLATE_CREATE: 0 (default: 0), Enable CLI for creating blueprints and workplans from standard templates.
- FF_CLI_WORKPLAN_COMPOSE: 0 (default: 0), Enable CLI for composing a workplan from pre-existing blueprints.
- FF_CLI_WORKPLAN_GEN: 0 (default: 0), Enable CLI for generating a workplan from a directory of blueprints.
```

This output is both _confusing_ and _wrong_:

1. Feature flag names are incomplete (`CSTAR_` prefix is not displayed) and inconsistent with all other keys
2. The feature flag `CSTAR_FF_CLI_ENV_SHOW` is incorrectly output as `FF_CLI_SHOW`

This pull request fixes two defects causing the confusing and incorrect output from `def discover_env_vars`.

## Breaking Changes

- Rename env var group name constants to omit leading underscore

## Bug Fixes

- Fix incorrect env var discovery if `env_` appears repeatedly in variable name
- Fix unhandled exception caused by attempting to execute `typer` app

## Improvements

- Ensure env var display consistency in `cstar env show` output


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-642
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
