### PR TITLE
Don't ncjoin ext files

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1658,7 +1658,11 @@ class ROMSSimulation(Simulation):
 
         output_dir = self.fs_manager.output_dir
         files = list(output_dir.glob("*.??????????????.*.nc"))
-        unique_wildcards = {Path(fname.stem).stem + ".*.nc" for fname in files}
+        unique_wildcards = {
+            Path(fname.stem).stem + ".*.nc"
+            for fname in files
+            if "_ext." not in fname.name
+        }
         if not files:
             self.log.warning(f"No suitable output found in `{output_dir}`")
         else:

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1772,6 +1772,9 @@ class TestProcessingAndExecution:
         (output_dir / "ocean_his.20240101000000.002.nc").touch()
         (output_dir / "ocean_rst.20240101000000.001.nc").touch()
 
+        # Create fake partitioned ext files which shouldn't be joined
+        (output_dir / "ocean_ext.20240101000000.001.nc").touch()
+
         # Create fake output of join process to make sure it gets moved
         (output_dir / "ocean_his.20240101000000.nc").touch()
         (output_dir / "ocean_rst.20240101000000.nc").touch()
@@ -1802,11 +1805,16 @@ class TestProcessingAndExecution:
             shell=True,
         )
 
+        # check that ext files weren't joined
+        for call in mock_subprocess.call_args_list:
+            assert "ocean_ext" not in call.args[0]
+
         # Check that output file was moved
         new_out_dir = sim.fs_manager.joined_output_dir
         assert new_out_dir.exists()
         assert (new_out_dir / "ocean_his.20240101000000.nc").exists()
         assert (new_out_dir / "ocean_rst.20240101000000.nc").exists()
+        assert not (new_out_dir / "ocean_ext.20240101000000.nc").exists()
 
         mock_persist.assert_called_once()
 


### PR DESCRIPTION
# Summary
`ncjoin` crashes when trying to join outputs from `extract_data`. We should call the separate `extract_data_join` tool for those. There is existing work to address that use case, and it could potentially be folded into `post_run` in the same way as `ncjoin`, but for now, we just want to skip the ext files so the process doesn't crash.


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- post_run() no longer tries to join `_ext` files


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [x] Tests added
- [x] Tests passing

