### PR TITLE
Refactor launcher instantiation

### DIFF
--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -29,7 +29,7 @@ from cstar.orchestration.transforms import (
     RomsMarblTimeSplitter,
     WorkplanTransformer,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS, ENV_CSTAR_ORCH_REQD_ENV
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS
 from cstar.system.manager import cstar_sysmgr
 
 log = get_logger(__name__)
@@ -50,12 +50,9 @@ class DagStatus:
 
 def get_launcher() -> "Launcher":
     """Get the appropriate launcher for the current environment."""
-    if cstar_sysmgr.scheduler:
-        return SlurmLauncher()
-    else:
-        os.environ[ENV_CSTAR_ORCH_REQD_ENV] = ""
-
-    return LocalLauncher()
+    launcher = SlurmLauncher() if cstar_sysmgr.scheduler else LocalLauncher()
+    launcher.check_preconditions()
+    return launcher
 
 
 def incremental_delays() -> t.Generator[float, None, None]:
@@ -162,7 +159,7 @@ async def reload_dag_status(path: Path, run_id: str) -> DagStatus:
     configure_environment(run_id=run_id)
 
     planner = Planner(workplan=wp)
-    launcher = SlurmLauncher()
+    launcher = get_launcher()
     orchestrator = Orchestrator(planner, launcher)
 
     return await attach_to_run(orchestrator)

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -80,6 +80,10 @@ class LocalHandle(ProcessHandle):
 class LocalLauncher(Launcher[LocalHandle]):
     """A launcher that executes steps in a local process."""
 
+    @classmethod
+    def check_preconditions(cls) -> None:
+        """Perform launcher-specific startup validation."""
+
     @staticmethod
     async def _submit(step: "LiveStep", dependencies: list[LocalHandle]) -> LocalHandle:
         """Submit a step to SLURM as a new batch allocation.

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -11,7 +11,6 @@ from cstar.base.env import (
     ENV_CSTAR_SLURM_POST_SUBMIT_DELAY,
     get_env_item,
 )
-from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import get_logger
 from cstar.base.utils import _run_cmd, slugify
 from cstar.execution.handler import ExecutionStatus
@@ -120,7 +119,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         for key, value in config.items():
             if not value:
                 msg = f"Missing required environment variable: {key}"
-                raise CstarExpectationFailed(msg)
+                raise ValueError(msg)
 
     @staticmethod
     def configured_queue() -> str:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -11,6 +11,7 @@ from cstar.base.env import (
     ENV_CSTAR_SLURM_POST_SUBMIT_DELAY,
     get_env_item,
 )
+from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import get_logger
 from cstar.base.utils import _run_cmd, slugify
 from cstar.execution.handler import ExecutionStatus
@@ -103,6 +104,23 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         get_env_item(ENV_CSTAR_SLURM_POST_SUBMIT_DELAY).value
     )
     """Delay after a submission to ensure status for a SLURM job can be queried."""
+
+    @classmethod
+    def check_preconditions(cls) -> None:
+        """Perform launcher-specific startup validation.
+
+        Raises
+        ------
+        CstarExpectationFailed
+            If an environment variable required by the launcher cannot be found.
+        """
+        keys = [ENV_CSTAR_SLURM_ACCOUNT, ENV_CSTAR_SLURM_QUEUE]
+        config = {key: get_env_item(key).value for key in keys}
+
+        for key, value in config.items():
+            if not value:
+                msg = f"Missing required environment variable: {key}"
+                raise CstarExpectationFailed(msg)
 
     @staticmethod
     def configured_queue() -> str:

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from cstar.base.env import (
     ENV_CSTAR_DATA_HOME,
     ENV_CSTAR_RUNID,
-    get_env_item,
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
@@ -23,7 +22,6 @@ from cstar.orchestration.serialization import (
     intenum_representer,
     register_representer,
 )
-from cstar.orchestration.utils import ENV_CSTAR_ORCH_REQD_ENV
 
 nx = lazy_import("networkx")
 
@@ -486,6 +484,11 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
     """Contract required to implement a task launcher."""
 
     @classmethod
+    def check_preconditions(cls) -> None:
+        """Perform launcher-specific startup validation."""
+        ...
+
+    @classmethod
     async def launch(
         cls,
         step: LiveStep,
@@ -813,9 +816,7 @@ def check_environment() -> None:
     ValueError
         If required environment variables are missing or empty.
     """
-    required_config = get_env_item(ENV_CSTAR_ORCH_REQD_ENV).value
     required_vars: set[str] = {ENV_CSTAR_RUNID}
-    required_vars.update({x.strip() for x in required_config.split(",") if x})
 
     for key in required_vars:
         if not os.getenv(key, ""):

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -68,16 +68,6 @@ ENV_CSTAR_SLURM_QUEUE: t.Annotated[
 ] = "CSTAR_SLURM_QUEUE"
 """Environment variable containing the SLURM priority (queue) used by the SLURM scheduler."""
 
-ENV_CSTAR_ORCH_REQD_ENV: t.Annotated[
-    t.Literal["CSTAR_ORCH_REQD_ENV"],
-    EnvVar(
-        "A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?).",
-        _GROUP_ORCH,
-        "CSTAR_SLURM_ACCOUNT,CSTAR_SLURM_QUEUE",
-    ),
-] = "CSTAR_ORCH_REQD_ENV"
-"""A comma-delimited list of required env configuration values. TEMPORARY (move to CStarEnvironment / per-platform settings?)."""
-
 
 def get_run_id() -> str:
     """Retrieve the current run-id.

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -12,7 +12,7 @@ This is a bug-fix release focused on stabilizing the orchestration of blueprints
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- N/A
+- Deprecated/removed `CSTAR_ORCH_REQD_ENV` environment variable
 
 New features
 ~~~~~~~~~~~~
@@ -27,12 +27,12 @@ Security Fixes
 Bug Fixes
 ~~~~~~~~~
 
-- N/A
+- Fix bug in `reload_dag_status` where the correct launcher may not be loaded
 
 Improvements
 ~~~~~~~~~~~~
 
-- N/A
+- Decouple launcher-specific precondition checks from the `dag_runner`
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
This pull request modifies the way required environment variables are verified before using a launcher. Prior to this PR, the orchestrator was forced to clear a default value from the `CSTAR_ORCH_REQD_ENV` environment variable when not using the `SlurmLauncher`

This change extracts the per-launcher precondition checks from orchestration and allows each launcher to execute their own unique checks. It now avoids coupling the dag runner to the SLURM requirements.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Deprecated/removed `CSTAR_ORCH_REQD_ENV` environment variable

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug in `reload_dag_status` where the correct launcher may not be loaded

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Decouple launcher-specific precondition checks from the `dag_runner`

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [X] New functionality has documentation
