### PR TITLE
Fix recursive calls to determine if a path is local or remote

### DIFF
--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -7,7 +7,7 @@ import typer
 
 from cstar.base.log import get_logger
 from cstar.cli.workplan.shared import list_runs
-from cstar.execution.file_system import is_remote_resource, local_copy
+from cstar.execution.file_system import local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import validate_serialized_entity
@@ -43,11 +43,7 @@ def run(
         return
 
     if not run_id:
-        if is_remote_resource(path):
-            with local_copy(path) as local_path:
-                run_id = WorkplanRun.get_default_run_id(local_path)
-        else:
-            run_id = WorkplanRun.get_default_run_id(path)
+        run_id = WorkplanRun.get_default_run_id(path)
 
         log.debug(f"Using default run-id: {run_id}")
 

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -465,15 +465,12 @@ def local_copy(uri: str) -> t.Generator[Path, None, None]:
     Path
         A path to a local copy of the resource
     """
-    is_remote = is_remote_resource(uri)
-
-    with TemporaryDirectory() as tmp_dir:
-        bp_path = write_local_copy(uri, Path(tmp_dir)) if is_remote else Path(uri)
-        try:
+    if is_remote_resource(uri):
+        with TemporaryDirectory() as tmp_dir:
+            bp_path = write_local_copy(uri, Path(tmp_dir))
             yield bp_path
-        finally:
-            if is_remote and bp_path.exists():
-                bp_path.unlink()
+    else:
+        yield Path(uri)
 
 
 @asynccontextmanager

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -9,7 +9,6 @@ from cstar.base.log import LoggingMixin
 from cstar.base.utils import slugify, utc_now
 from cstar.execution.file_system import (
     StateDirectoryManager,
-    is_remote_resource,
     local_copy,
 )
 from cstar.orchestration.models import Workplan
@@ -38,24 +37,20 @@ class WorkplanRun(BaseModel):
     """The environment variables at the time of the run."""
 
     @staticmethod
-    def get_default_run_id(path: Path | str) -> str:
+    def get_default_run_id(uri: str) -> str:
         """Generate a run-id based on the name of a `Workplan`
 
         Parameters
         ----------
-        path : Path
-            The path to a persisted workplan.
+        uri : str
+            The local or remote path to a persisted workplan.
 
         Returns
         -------
         str
         """
-        path_string = str(path)
-        if is_remote_resource(path_string):
-            with local_copy(path_string) as local_path:
-                wp = deserialize(local_path, Workplan)
-        else:
-            wp = deserialize(Path(path), Workplan)
+        with local_copy(uri) as local_path:
+            wp = deserialize(local_path, Workplan)
 
         return slugify(wp.name)
 

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -181,7 +181,7 @@ async def test_default_run_id(
     # create a workplan so the default run-id can be determined by loading the workplan
     serialize(wp_path, single_step_workplan)
 
-    run_id = WorkplanRun.get_default_run_id(wp_path)
+    run_id = WorkplanRun.get_default_run_id(wp_path.as_posix())
 
     # verify it uses the supplied workplan
     assert run_id == slugify(single_step_workplan.name)

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -33,6 +33,8 @@ Bug Fixes
 - Fix bug in `reload_dag_status` where the correct launcher may not be loaded
 - Fix comparison-to-self bug for orchestrator `open_set` 
 - Fix mutable default attribute value in `WorkplanRun`
+- Remove repeated check identifying remote workplan URI
+- Fix bug causing intermittent `FileNotFound` errors
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
This change fixes an unnecessary, recursive check when performing a local copy of a remote workplan.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Remove repeated check identifying remote workplan URI
- Fix bug causing intermittent `FileNotFound` errors

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
