### PR TITLE
Default prefect analytics to disabled

### DIFF
--- a/cstar/__init__.py
+++ b/cstar/__init__.py
@@ -10,6 +10,10 @@ from importlib.metadata import version as _version
 # see https://github.com/numba/numba/issues/5275
 os.environ["KMP_WARNINGS"] = "off"
 
+# Disable prefect analytics, see: https://docs.prefect.io/v3/concepts/telemetry
+os.environ["PREFECT_SERVER_ANALYTICS_ENABLED"] = "false"
+os.environ["DO_NOT_TRACK"] = "1"
+
 
 try:
     __version__ = _version("cstar-ocean")

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -43,12 +43,10 @@ Improvements
 - Use computed attributes in place of duplicating keys found in `DagStatus.details`
 - Re-use `configure_environment` where applicable
 
-
-
 Miscellaneous
 ~~~~~~~~~~~~~
 
-- N/A
+- Default to having prefect analytics collection disabled
 
 ---
 


### PR DESCRIPTION
# Summary

This change is a down-and-dirty way to automatically disable prefect analytics. The environment is updated early in the module load order to ensure prefect doesn't fire up and emit the warning before `os.environ` can be updated.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->

- Default to having prefect analytics collection disabled

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-591
- [ ] Tests added
- [X] Tests passing
- [ ] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
