### PR TITLE
Add helpful error for misread HTML yamls

### DIFF
--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -5,6 +5,7 @@ from pathlib import Path, PosixPath
 
 import yaml
 from yaml import safe_load
+from yaml.scanner import ScannerError
 
 from cstar.base.log import get_logger
 from cstar.execution.file_system import local_copy
@@ -102,7 +103,14 @@ def _read_yaml(path: Path, klass: type[_T]) -> _T:
     _T
     """
     with path.open("r", encoding="utf-8") as fp:
-        model_dict = safe_load(fp)
+        try:
+            model_dict = safe_load(fp)
+        except ScannerError as e:
+            msg = (
+                f"Failed to load yaml from {path}. If are loading a remote YAML, your URL "
+                f"may point to a HTML page instead of the raw YAML content."
+            )
+            raise RuntimeError(msg) from e
         return klass.model_validate(model_dict)
 
 


### PR DESCRIPTION
# Summary
I was getting a really obtuse error when trying to run a remote blueprint from github. It ended up being because the content it was getting was HTML content, not raw YAML content. This seems like a potentially common problem, if you just copy a github link without going to the "raw" version. I added some additional error text, wrapping the original exception. We could do additional validation of the content or try to modify to the right link, but I'm not sure it's worth all that effort right this moment.


## Improvements
<!-- List any improvements made to existing code or processes  -->
- Improve error message when failing to load a remote YAML file.
