### PR TITLE
loosen nested dict typealias

### DIFF
--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -43,12 +43,7 @@ KeyValueStore: t.TypeAlias = dict[
     | list[float]
     | dict[
         str,
-        str
-        | float
-        | datetime
-        | list[str]
-        | list[dict[str, str | float]]
-        | dict[str, str | float | list[str]],
+        t.Any,
     ],
 ]
 """A collection of user-defined key-value pairs."""


### PR DESCRIPTION
# Summary
This solves the warning spam that Sam was getting. I'm not 100% sure if we want to loosen this much, but I also don't want to try to guess every possible combination of nested override types for a wide expanse of possible blueprints in the future.

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Loosen Pydantic type validation for override dictionaries to mitigate pydantic warnings
