### PR TITLE
pin versions of example files

### DIFF
--- a/docs/tutorials/wales_toy_blueprint.yaml
+++ b/docs/tutorials/wales_toy_blueprint.yaml
@@ -17,7 +17,7 @@ code:
 
   run_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
-    branch: main
+    branch: 9c92011c10400b3f39f59247c41de7d67e3c220c
     filter:
       files:
         - roms.in
@@ -27,7 +27,7 @@ code:
       directory: wales-toy-domain/roms_runtime_code
   compile_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
-    branch: main
+    branch: 9c92011c10400b3f39f59247c41de7d67e3c220c
     filter:
       directory: wales-toy-domain/roms_compile_time_code
       files:

--- a/docs/tutorials/wio_toy_blueprint.yaml
+++ b/docs/tutorials/wio_toy_blueprint.yaml
@@ -15,7 +15,7 @@ code:
 
   run_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
-    branch: main
+    branch: 9c92011c10400b3f39f59247c41de7d67e3c220c
     filter:
       directory: wio-toy-domain/runtime_code
       files:
@@ -25,7 +25,7 @@ code:
         - marbl_diagnostic_output_list
   compile_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
-    branch: main
+    branch: 9c92011c10400b3f39f59247c41de7d67e3c220c
     filter:
       directory: wio-toy-domain/compile_time_code
       files:


### PR DESCRIPTION
# Summary
I update the example file repo to _not_ have a Makefile and to include a CDR file. This immediately broke the tutorial examples (which I serendipitously was using to test something else, so I noticed). Those blueprints now pin the commit of the test data repo and can be updated more intentionally when desired.


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Pin version of tutorial data repo

