### PR TITLE
bump typer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "python-dotenv",
     "PyYAML==6.0.2",
     "roms_tools[dask]>=3.4.0,<4",
-    "typer>=0.17.5",
+    "typer>=0.24.1",
 ]
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 


### PR DESCRIPTION
# Summary
The version of typer I had installed (0.17.something) was causing an error with the some of the new preprocess hooks. I think they fixed the bug in 0.19.something, but I went ahead and bumped our req to the latest.

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Bump typer version to avoid list-default bug