### PR TITLE
avoid mutable defaults

### DIFF
--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -431,7 +431,7 @@ class OverrideTransform(Transform):
 
     _system_overrides: dict[str, t.Any] = {}
 
-    def __init__(self, sys_overrides: dict[str, t.Any] = {}) -> None:
+    def __init__(self, sys_overrides: dict[str, t.Any] = None) -> None:  # type: ignore[assignment]
         """Initialize the instance.
 
         Parameters
@@ -440,10 +440,12 @@ class OverrideTransform(Transform):
             System-level blueprint overrides that will be applied after
             the user-supplied values.
         """
-        self._system_overrides = sys_overrides
+        self._system_overrides = sys_overrides or {}
 
     def apply(
-        self, bp: RomsMarblBlueprint, overrides: dict[str, t.Any] = {}
+        self,
+        bp: RomsMarblBlueprint,
+        overrides: dict[str, t.Any] = None,  # type: ignore[assignment]
     ) -> RomsMarblBlueprint:
         """Apply all overrides from a blueprint.
 
@@ -462,6 +464,7 @@ class OverrideTransform(Transform):
         RomsMarblBlueprint
             The blueprint with all overrides applied.
         """
+        overrides = overrides or {}
         overrides = overrides.copy()
 
         model = bp.model_dump(exclude_defaults=True, exclude_unset=True)


### PR DESCRIPTION
# Summary
My IDE highlighted these while I was looking at other stuff. They weren't the cause of the problem I was looking at, but I figure we should fix it anyway. Though... mypy/ruff insist that you should add `| None` in these cases and I really disagree. None is not an ok value to pass and is immediately overridden. Not sure if there's a better way to handle this other than the `ignore`?

