### PR TITLE
Revert min length requirement for datasets

### DIFF
--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -99,7 +99,7 @@ DataResource: t.TypeAlias = Resource | VersionedResource
 class Dataset(DocLocMixin):
     """A dataset contains a data block alongside documentation and locking fields."""
 
-    data: list[DataResource] = Field(min_length=1)
+    data: list[DataResource]
     """A list of one or more data resources."""
 
     def __len__(self) -> int:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

Reverts a change from #465 that adds a min-length check for Datasets. Forge currently relies on building empty datasets and appending to them over time, so this validation is incompatible with that pattern.
