### PR TITLE
Fix unexpected linter warnings for parameters with defaults

### DIFF
--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -25,9 +25,9 @@ class ServiceConfiguration(BaseModel):
     shutdown criteria are met. When `False`, the service completes a single
     pass through the service lifecycle and automatically exits.
     """
-    loop_delay: float = Field(0.0, ge=0.0)
+    loop_delay: float = Field(default=0.0, ge=0.0)
     """Duration (in seconds) of a delay between iterations of the main event loop."""
-    health_check_frequency: float | None = Field(None, ge=0.0)
+    health_check_frequency: float | None = Field(default=None, ge=0.0)
     """Time (in seconds) between calls to a health check handler.
 
     NOTE:
@@ -36,7 +36,7 @@ class ServiceConfiguration(BaseModel):
     """
     log_level: int = logging.INFO
     """The logging level used by the service."""
-    health_check_log_threshold: int = Field(10, ge=3)
+    health_check_log_threshold: int = Field(default=10, ge=3)
     """The number of health-checks that may be missed before logging."""
     name: str = "Service"
     """A user-friendly name for logging."""

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -45,6 +45,7 @@ Improvements
 - Re-use `configure_environment` where applicable
 - Refactor `cli.workplan.run` to make use of `typer` callbacks for input validation
 - Add `--dry-run` option to test workplan generation in `cstar workplan run`
+- Fix unexpected linting warnings about missing required parameters to `ServiceConfiguration`
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request fixes an annoying IDE/linter warning that occurs when using `ServiceConfiguration`. By adding the keyword `default`, the linter and IDE can correctly identify that the affected fields are optional.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->

- Fix unexpected linting warnings about missing required parameters to `ServiceConfiguration`

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
