### PR TITLE
Fix nested asyncio.run call

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -232,7 +232,7 @@ class SlurmBatch:
         yield from self.steps
 
 
-async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
+def get_slurm_steps_sync(job_id: str | int) -> tuple[SlurmStep, ...]:
     """Retrieve job metadata from SLURM.
 
     Parameters
@@ -248,11 +248,25 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
     format_string = SacctFieldMeta.as_format_string()
     sacct_cmd = f"sacct -j {job_id} --format={format_string} --noheader"
     msg_err = f"Failed to retrieve job status using {sacct_cmd}."
-    stdout = await asyncio.to_thread(
-        _run_cmd, sacct_cmd, msg_err=msg_err, raise_on_error=True
-    )
+    stdout = _run_cmd(sacct_cmd, msg_err=msg_err, raise_on_error=True)
 
     return SlurmStep.many_from_sacct(stdout)
+
+
+async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
+    """Retrieve job metadata from SLURM.
+
+    Parameters
+    ----------
+    job_id: str
+        The job_id to check
+
+    Returns
+    -------
+    tuple[SlurmStep, ...]
+        All step metadata retrieved for the job_id
+    """
+    return await asyncio.to_thread(get_slurm_steps_sync, job_id)
 
 
 async def get_slurm_batch(job_id: str | int) -> SlurmBatch:
@@ -267,6 +281,21 @@ async def get_slurm_batch(job_id: str | int) -> SlurmBatch:
     SlurmBatch
     """
     steps = await get_slurm_steps(job_id)
+    return SlurmBatch(steps)
+
+
+def get_slurm_batch_sync(job_id: str | int) -> SlurmBatch:
+    """Retrieve batch job metadata from SLURM.
+
+    Parameters
+    ----------
+    job_id : str
+
+    Returns
+    -------
+    SlurmBatch
+    """
+    steps = get_slurm_steps_sync(job_id)
     return SlurmBatch(steps)
 
 
@@ -882,9 +911,9 @@ class SlurmJob(SchedulerJob):
 
         # avoid refreshing status if the job is done
         if self._batch is None or not ExecutionStatus.is_terminal(
-            self._batch.job.status
+            self._batch.job.status,
         ):
-            self._batch = asyncio.run(get_slurm_batch(self.id))
+            self._batch = get_slurm_batch_sync(self.id)
         return self._batch
 
     @property

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -237,7 +237,7 @@ def get_slurm_steps_sync(job_id: str | int) -> tuple[SlurmStep, ...]:
 
     Parameters
     ----------
-    job_id: str
+    job_id: str | int
         The job_id to check
 
     Returns
@@ -258,7 +258,7 @@ async def get_slurm_steps(job_id: str | int) -> tuple[SlurmStep, ...]:
 
     Parameters
     ----------
-    job_id: str
+    job_id: str | int
         The job_id to check
 
     Returns
@@ -274,7 +274,7 @@ async def get_slurm_batch(job_id: str | int) -> SlurmBatch:
 
     Parameters
     ----------
-    job_id : str
+    job_id : str | int
 
     Returns
     -------
@@ -289,7 +289,7 @@ def get_slurm_batch_sync(job_id: str | int) -> SlurmBatch:
 
     Parameters
     ----------
-    job_id : str
+    job_id : str | int
 
     Returns
     -------

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -10,6 +10,7 @@ from cstar.execution.scheduler_job import (
     SlurmJob,
     create_scheduler_job,
     get_slurm_batch,
+    get_slurm_batch_sync,
     get_slurm_batches,
     get_slurm_steps,
 )
@@ -843,3 +844,43 @@ async def test_get_slurm_batches() -> None:
     batch = result[job_id]
     # confirm the "job record" is not in the steps
     assert len(list(batch.steps)) == 3
+
+
+@pytest.mark.parametrize(
+    "job_id",
+    [
+        15514059,
+        "15514059",
+    ],
+)
+def test_get_slurm_batch_sync(job_id: str) -> None:
+    """Verify multiple steps are parsed correctly from sacct std output with
+    both a string and integer job-id when using the synchronous batch API
+
+    Parameters
+    ----------
+    job_id : str
+        Parameterized job ID to verify correct handling of [int|str] Union type
+    """
+    sacct_output = textwrap.dedent(
+        """\
+        15514059         FAILED 2026-03-05T14:43:39 2026-03-05T14:44:05 2026-03-05T14:44:07 001_1-wee+
+        15514059.ba+     FAILED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:07      batch
+        15514059.ex+  COMPLETED 2026-03-05T14:44:05 2026-03-05T14:44:05 2026-03-05T14:44:08     extern
+        """
+    )
+
+    exp_num_steps = 2
+    exp_num_jobs = 1
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        result = get_slurm_batch_sync(job_id)
+
+    step_ids = {x.step_id for x in result}
+    assert len(step_ids) == exp_num_steps
+
+    # confirm each step correctly parses it's job ID from the step ID
+    job_ids = {x.job_id for x in result}
+    assert len(job_ids) == exp_num_jobs
+
+    assert result.job.job_id == str(job_id)

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -853,13 +853,13 @@ async def test_get_slurm_batches() -> None:
         "15514059",
     ],
 )
-def test_get_slurm_batch_sync(job_id: str) -> None:
+def test_get_slurm_batch_sync(job_id: str | int) -> None:
     """Verify multiple steps are parsed correctly from sacct std output with
     both a string and integer job-id when using the synchronous batch API
 
     Parameters
     ----------
-    job_id : str
+    job_id : str | int
         Parameterized job ID to verify correct handling of [int|str] Union type
     """
     sacct_output = textwrap.dedent(

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -35,7 +35,8 @@ Bug Fixes
 - Fix mutable default attribute value in `WorkplanRun`
 - Remove repeated check identifying remote workplan URI
 - Fix bug causing intermittent `FileNotFound` errors
-- Fix workplan template with inconsistent blueprint path 
+- Fix workplan template with inconsistent blueprint path
+- Fix bug causing failures when invoking blueprints via `cstar blueprint run`
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change adds some synchronous methods to the batch retrieval API to avoid a nested call to `asyncio.run`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug causing failures when invoking blueprints via `cstar blueprint run`

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-702
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
