### PR TITLE
CSD-713: Fix nested call to asyncio.run

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -169,7 +169,7 @@ class SlurmBatch:
     steps: t.Iterable[SlurmStep]
     """The collection of steps running in a batch."""
 
-    _job: SlurmStep
+    _job: SlurmStep | None = None
     """The parent step for the batch."""
 
     def __init__(self, steps: t.Iterable[SlurmStep]) -> None:
@@ -184,6 +184,9 @@ class SlurmBatch:
         if len(job_ids) > 1:
             raise ValueError("Attempted to create batch from multiple batches")
 
+        self._job = None
+        self.steps = []
+
         if all_steps := list(steps):
             try:
                 # a queued job will not have any steps, default to using first result
@@ -193,14 +196,23 @@ class SlurmBatch:
                 pass  # if batch status is retrieved too quickly, steps may be empty
 
     @property
-    def job(self) -> SlurmStep:
-        """Return the parent step for the batch.
+    def status(self) -> ExecutionStatus:
+        """Return the status of the parent job."""
+        if self._job is not None:
+            return self._job.status
+        return ExecutionStatus.UNSUBMITTED
+
+    @property
+    def job_id(self) -> str | None:
+        """Return the ID of the parent job.
 
         Returns
         -------
-        SlurmStep
+        str
         """
-        return self._job
+        if self._job is None:
+            return None
+        return self._job.job_id
 
     @classmethod
     def from_multi_query(cls, steps: t.Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
@@ -901,7 +913,7 @@ class SlurmJob(SchedulerJob):
             If the command to retrieve the job status fails or returns an unexpected result.
         """
         if batch := self.get_batch():
-            return batch.job.status
+            return batch.status
 
         return ExecutionStatus.UNSUBMITTED
 
@@ -911,7 +923,7 @@ class SlurmJob(SchedulerJob):
 
         # avoid refreshing status if the job is done
         if self._batch is None or not ExecutionStatus.is_terminal(
-            self._batch.job.status,
+            self._batch.status,
         ):
             self._batch = get_slurm_batch_sync(self.id)
         return self._batch

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -247,7 +247,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             The current status of the step.
         """
         batch = await get_slurm_batch(job_id)
-        return batch.job.status
+        return batch.status
 
     @staticmethod
     async def _locate_priors() -> t.Mapping[str, SlurmHandle]:
@@ -301,7 +301,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 successes = {
                     k
                     for k, v in batch_map.items()
-                    if v.job.status == ExecutionStatus.COMPLETED
+                    if v.status == ExecutionStatus.COMPLETED
                 }
                 if dependencies and successes:
                     # only keep dependencies that are not old/re-usable

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
+from cstar.execution.handler import ExecutionStatus
 from cstar.execution.scheduler_job import (
     PBSJob,
     SchedulerJob,
@@ -810,7 +811,7 @@ async def test_get_slurm_batch(job_id: int | str) -> None:
     job_ids = {x.job_id for x in result}
     assert len(job_ids) == exp_num_jobs
 
-    assert result.job.job_id == str(job_id)
+    assert result.job_id == str(job_id)
 
 
 @pytest.mark.asyncio
@@ -883,4 +884,23 @@ def test_get_slurm_batch_sync(job_id: str | int) -> None:
     job_ids = {x.job_id for x in result}
     assert len(job_ids) == exp_num_jobs
 
-    assert result.job.job_id == str(job_id)
+    assert result.job_id == str(job_id)
+
+
+def test_get_slurm_batch_sync_no_steps() -> None:
+    """Verify retrieving a batch does not blow up if no steps are located.
+
+    This is possible when the query occurs too quickly after a job is submitted.
+    """
+    sacct_output = ""
+    job_id = 15514059
+
+    with patch("cstar.execution.scheduler_job._run_cmd", return_value=sacct_output):
+        result = get_slurm_batch_sync(job_id)
+
+    # confirm that job_id and steps are accessible (but empty/null)
+    assert result.job_id is None
+    assert not result.steps
+
+    # confirm that status is reported as unsubmitted
+    assert result.status == ExecutionStatus.UNSUBMITTED

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -37,6 +37,7 @@ Bug Fixes
 - Fix bug causing intermittent `FileNotFound` errors
 - Fix workplan template with inconsistent blueprint path
 - Fix bug causing failures when invoking blueprints via `cstar blueprint run`
+- Fix uninitialized attributes error in `SlurmBatch`
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change fixes a flaw that results in uninitialized attributes when a query to `SLURM` occurs immediately after submission. The code was optimistic in assuming results would be present and did not handle "no result" correctly.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix uninitialized attributes error in `SlurmBatch`

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-713
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
