### PR TITLE
Improve help text for CLI subcommands and parameters

### DIFF
--- a/cstar/cli/blueprint/__init__.py
+++ b/cstar/cli/blueprint/__init__.py
@@ -3,7 +3,10 @@ import typer
 from cstar.cli.blueprint.check import app as app_check
 from cstar.cli.blueprint.run import app as app_run
 
-app = typer.Typer()
+app = typer.Typer(
+    name="blueprint",
+    help="Perform the validation and execution of blueprints.",
+)
 
 app.add_typer(app_run)
 app.add_typer(app_check)

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -8,7 +8,10 @@ from cstar.orchestration.serialization import validate_serialized_entity
 app = typer.Typer()
 
 
-@app.command()
+@app.command(
+    name="check",
+    help="Perform content validation on a user-supplied blueprint.",
+)
 def check(
     path: t.Annotated[str, typer.Argument(help="Path to a blueprint file.")],
 ) -> None:

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -17,7 +17,7 @@ from cstar.orchestration.serialization import validate_serialized_entity
 app = typer.Typer()
 
 
-@app.command()
+@app.command(name="run", help="Execute a blueprint in a local worker service.")
 def run(
     path: t.Annotated[
         str,

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -7,13 +7,10 @@ from cstar.cli.version import common_callback
 from cstar.cli.workplan import app as app_workplan
 
 
-def main() -> None:
-    """Main entrypoint for the complete C-Star CLI."""
-    app = typer.Typer(
-        callback=common_callback,
-        help="The C-Star CLI (installed as 'cstar') enables command-line management and execution of C-Star workplans and blueprints.",
-    )
-
+def attach_subcommands(app: typer.Typer) -> None:
+    """Attach subcommands dynamically to the main typer app and configure
+    the command callback to enable shared options.
+    """
     subcommands: list[tuple[typer.Typer, str]] = [
         (app_blueprint, "blueprint"),
         (app_env, "env"),
@@ -29,9 +26,22 @@ def main() -> None:
                     name=command_name,
                     callback=common_callback,
                 )
-        app()
+        # app()
     except Exception as ex:
         print(f"An error occurred while handling request: {ex}")
+
+
+app = typer.Typer(
+    callback=common_callback,
+    help="The C-Star CLI (installed as 'cstar') enables command-line management and execution of C-Star workplans and blueprints.",
+)
+attach_subcommands(app)
+
+
+def main() -> None:
+    """Main entrypoint for the complete C-Star CLI."""
+    global app
+    app()
 
 
 if __name__ == "__main__":

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -9,7 +9,10 @@ from cstar.cli.workplan import app as app_workplan
 
 def main() -> None:
     """Main entrypoint for the complete C-Star CLI."""
-    app = typer.Typer(callback=common_callback)
+    app = typer.Typer(
+        callback=common_callback,
+        help="The C-Star CLI (installed as 'cstar') enables command-line management and execution of C-Star workplans and blueprints.",
+    )
 
     subcommands: list[tuple[typer.Typer, str]] = [
         (app_blueprint, "blueprint"),

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -26,7 +26,6 @@ def attach_subcommands(app: typer.Typer) -> None:
                     name=command_name,
                     callback=common_callback,
                 )
-        # app()
     except Exception as ex:
         print(f"An error occurred while handling request: {ex}")
 

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -33,7 +33,7 @@ def attach_subcommands(app: typer.Typer) -> None:
 
 app = typer.Typer(
     callback=common_callback,
-    help="The C-Star CLI (installed as 'cstar') enables command-line management and execution of C-Star workplans and blueprints.",
+    help="The C-Star CLI (installed as `cstar`) enables command-line management and execution of C-Star workplans and blueprints.",
 )
 attach_subcommands(app)
 

--- a/cstar/cli/environment/__init__.py
+++ b/cstar/cli/environment/__init__.py
@@ -3,7 +3,10 @@ import typer
 from cstar.base.feature import is_feature_enabled
 from cstar.cli.environment.show import app as app_show
 
-app = typer.Typer()
+app = typer.Typer(
+    name="env",
+    help="Manage the environment variables consumed by C-Star.",
+)
 
 if is_feature_enabled("CSTAR_FF_CLI_ENV_SHOW"):
     app.add_typer(app_show)

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -88,10 +88,27 @@ class DisplayFormat(StrEnum):
     """Display a series of export statements."""
 
 
+ALL_GROUPS = t.Literal["all", "flags", "file", "orch", "sim", "dev"]
+
+
 @app.command(name="show", help="Display the active environment configuration.")
 def show(
-    group: str = "all",
-    display: DisplayFormat = DisplayFormat.INTERACTIVE,
+    group: t.Annotated[
+        ALL_GROUPS,
+        typer.Option(
+            "-g",
+            "--group",
+            help="Specify a group key to retrieve a subset of available configuration.",
+        ),
+    ] = "all",
+    display: t.Annotated[
+        DisplayFormat,
+        typer.Option(
+            "-d",
+            "--display",
+            help="Specify the desired format for displaying the configuration.",
+        ),
+    ] = DisplayFormat.INTERACTIVE,
 ) -> None:
     """Display the active environment configuration."""
     all_items = discover_env_vars([base_utils, env, orch_utils, feature])

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -88,7 +88,7 @@ class DisplayFormat(StrEnum):
     """Display a series of export statements."""
 
 
-@app.command()
+@app.command(name="show", help="Display the active environment configuration.")
 def show(
     group: str = "all",
     display: DisplayFormat = DisplayFormat.INTERACTIVE,

--- a/cstar/cli/template/__init__.py
+++ b/cstar/cli/template/__init__.py
@@ -3,7 +3,10 @@ import typer
 from cstar.base.feature import is_feature_enabled
 from cstar.cli.template.create import app as app_create
 
-app = typer.Typer()
+app = typer.Typer(
+    name="template",
+    help="Generate templates as a starting point for your blueprints and workplans.",
+)
 
 if is_feature_enabled("CLI_TEMPLATE_CREATE"):
     app.add_typer(app_create)

--- a/cstar/cli/template/create.py
+++ b/cstar/cli/template/create.py
@@ -152,7 +152,7 @@ def generate_template(path: Path | None, template_type: TemplateType) -> str:
 app = Typer()
 
 
-@app.command()
+@app.command(name="create", help="Generate a template document as a starting point.")
 def create(
     path: t.Annotated[
         Path,

--- a/cstar/cli/version.py
+++ b/cstar/cli/version.py
@@ -6,9 +6,11 @@ import cstar
 
 app = typer.Typer()
 
+HELP_SHORT = "Print the current version of the C-Star package and exit."
+
 
 def version_callback(value: bool) -> None:
-    """Print the version of C-Star and exit."""
+    """Print the current version of the C-Star package and exit."""
     if value:
         typer.echo(cstar.__version__)
         raise typer.Exit()
@@ -23,7 +25,7 @@ def common_callback(
             "-v",
             is_eager=True,
             callback=version_callback,
-            help="Show the version of C-Star and exit.",
+            help=HELP_SHORT,
         ),
     ] = False,
 ) -> None:

--- a/cstar/cli/workplan/__init__.py
+++ b/cstar/cli/workplan/__init__.py
@@ -14,7 +14,10 @@ from cstar.cli.workplan.plan import app as app_plan
 from cstar.cli.workplan.run import app as app_run
 from cstar.cli.workplan.status import app as app_status
 
-app = typer.Typer()
+app = typer.Typer(
+    name="workplan",
+    help="Perform validation and execution of workplans.",
+)
 
 app.add_typer(app_check)
 

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -8,7 +8,10 @@ from cstar.orchestration.serialization import validate_serialized_entity
 app = typer.Typer()
 
 
-@app.command()
+@app.command(
+    name="check",
+    help="Perform content validation on the workplan supplied by the user.",
+)
 def check(
     path: t.Annotated[str, typer.Argument(help="Path to the workplan")],
 ) -> None:

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -10,7 +10,7 @@ app = typer.Typer()
 
 @app.command(
     name="check",
-    help="Perform content validation on the workplan supplied by the user.",
+    help="Perform content validation on a user-supplied workplan.",
 )
 def check(
     path: t.Annotated[str, typer.Argument(help="Path to the workplan")],

--- a/cstar/cli/workplan/compose.py
+++ b/cstar/cli/workplan/compose.py
@@ -100,10 +100,12 @@ def compose(
         WorkplanTemplate | None,
         typer.Option(help="Specify the workplan template to populate."),
     ] = None,
-    run_plan: t.Annotated[
-        str,
-        typer.Option(help="Specify `1` to execute the workplan"),
-    ] = "0",
+    execute: t.Annotated[
+        bool,
+        typer.Option(
+            help="Set this flag to automatically execute the generated workplan."
+        ),
+    ] = False,
 ) -> Path:
     """Execute a workplan composed of user-supplied blueprints.
 
@@ -135,7 +137,7 @@ def compose(
     if wp_path is None or not wp_path.exists():
         raise ValueError("Workplan path is malformed.")
 
-    if run_plan == "1":
+    if execute:
         _run(wp_path, output_path, run_id)
 
     return wp_path

--- a/cstar/cli/workplan/compose.py
+++ b/cstar/cli/workplan/compose.py
@@ -17,6 +17,13 @@ BP_DEFAULT: t.Final[str] = (
 )
 BP_OUTDIR_DEFAULT: t.Final[str] = "output_dir: ."
 
+HELP_SHORT = "Execute a workplan composed of user-supplied blueprints."
+HELP_LONG = f"""\
+{HELP_SHORT}
+
+Specify a previously used `run_id` to re-start a prior run.
+"""
+
 
 class WorkplanTemplate(StrEnum):
     FANOUT = auto()
@@ -71,7 +78,7 @@ def _run(wp_path: Path, output_path: Path, run_id: str) -> None:
         )
 
 
-@app.command()
+@app.command(name="compose", help=HELP_LONG, short_help=HELP_SHORT)
 def compose(
     workplan: t.Annotated[
         str | None, typer.Argument(help="Path to a workplan file.")
@@ -98,9 +105,9 @@ def compose(
         typer.Option(help="Specify `1` to execute the workplan"),
     ] = "0",
 ) -> Path:
-    """Execute a workplan composed with a user-supplied blueprint.
+    """Execute a workplan composed of user-supplied blueprints.
 
-    Specify a previously used run_id option to re-start a prior run.
+    Specify a previously used `run_id` option to re-start a prior run.
 
     Returns
     -------

--- a/cstar/cli/workplan/generate.py
+++ b/cstar/cli/workplan/generate.py
@@ -83,7 +83,10 @@ def _populate_workplan(search_dir: Path, blueprints: list["BPResult"]) -> Workpl
     )
 
 
-@app.command()
+@app.command(
+    name="generate",
+    help="Interactively generate a new workplan using pre-existing blueprints.",
+)
 def generate(
     search_directory: t.Annotated[
         str,

--- a/cstar/cli/workplan/plan.py
+++ b/cstar/cli/workplan/plan.py
@@ -214,7 +214,10 @@ async def render(
     return write_to
 
 
-@app.command()
+@app.command(
+    name="plan",
+    help="Review the execution plan generated for a workplan.",
+)
 def plan(
     path: t.Annotated[
         Path,

--- a/cstar/cli/workplan/plan.py
+++ b/cstar/cli/workplan/plan.py
@@ -225,12 +225,18 @@ def plan(
     ],
     output_dir: t.Annotated[
         Path,
-        typer.Argument(help="Path to a directory where the plan will be stored."),
+        typer.Option(
+            "-d",
+            "--out-dir",
+            default_factory=lambda: Path.cwd(),
+            help="Path to a directory where the plan will be stored (defaults to current working directory)",
+        ),
     ],
     transform: t.Annotated[
         bool,
         typer.Option(
-            help="Apply runtime transformations to the workplan before rendering."
+            "--transform",
+            help="Apply runtime transformations to the workplan before rendering.",
         ),
     ] = False,
 ) -> None:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -211,7 +211,7 @@ def run(
             "-v",
             help=(
                 "Specify 0-to-many replacements as key-value pairs in "
-                "the form `<key>=<value>`."
+                "the form `key=value`."
             ),
             callback=preprocess_vars,
         ),
@@ -223,7 +223,7 @@ def run(
             "-f",
             help=(
                 "Specify the path to a file containing one replacements per line "
-                "as key-value pairs in the form `<key>=<value>`."
+                "as key-value pairs in the form `key=value`."
             ),
             callback=preprocess_varfile,
             exists=True,

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -20,6 +20,13 @@ from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 app = typer.Typer()
 log = get_logger(__name__)
 
+HELP_SHORT = "Execute a workplan."
+HELP_LONG = f"""\
+{HELP_SHORT}
+
+Specify a previously used `run_id` to re-start a prior run.
+"""
+
 
 def preprocess_vars(
     ctx: typer.Context,
@@ -186,7 +193,7 @@ def handle_run_reloading(run_id: str) -> str:
     return wp_run.trx_workplan_path.as_posix()
 
 
-@app.command()
+@app.command(name="run", help=HELP_LONG, short_help=HELP_SHORT)
 def run(
     ctx: typer.Context,
     run_id: t.Annotated[

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -14,7 +14,7 @@ app = typer.Typer()
 console = Console()
 
 
-@app.command()
+@app.command(name="status", help="Retrieve the current status of a workplan.")
 def status(
     run_id: t.Annotated[
         str,

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -61,7 +61,7 @@ async def test_compose_host_creation(
             output_dir.as_posix(),
             run_id=run_id,
             template=WorkplanTemplate[workplan_name.upper()],
-            run_plan="0",
+            execute=False,
         )
 
     wp = deserialize(generated_wp_path, Workplan)
@@ -86,10 +86,10 @@ async def test_compose_host_creation(
     assert expected_host_wp.exists()
 
 
-@pytest.mark.parametrize("do_run", ["0", "1"])
+@pytest.mark.parametrize("do_run", [False, True])
 @pytest.mark.asyncio
 async def test_compose_host_run_parameter(
-    do_run: str,
+    do_run: bool,
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
@@ -134,10 +134,10 @@ async def test_compose_host_run_parameter(
             output_dir.as_posix(),
             run_id=run_id,
             template=WorkplanTemplate[workplan_name.upper()],
-            run_plan=do_run,
+            execute=do_run,
         )
 
-    if do_run == "1":
+    if do_run:
         mock_run.assert_called()
     else:
         mock_run.assert_not_called()


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change improves the help text for the `cstar` CLI. 
- add short help text where useful
- declare help text on `typer.Option|Argument` to avoid leaking full docstrings
- declare boolean flags by name to avoid creating `--no-xxx` off flags
- add subcommand-level help text 

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Improve help text for CLI subcommands and parameters

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
