### PR TITLE
Reduce unit test duration and fix dependency conflict

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         shell: micromamba-shell {0}        
         run: |
            python -V
-           prefect server start --port 4200
+           prefect server start --port 4200 --no-ui
            export PREFECT_API_URL=http://127.0.0.1:4200/api
            coverage run --rcfile=coverage.toml -m pytest -s --verbose cstar/tests/unit_tests/*
            

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         shell: micromamba-shell {0}        
         run: |
            python -V
-           prefect server start --port 4200 --no-ui
+           prefect server start --port 4200 --no-ui --analytics-off
            export PREFECT_API_URL=http://127.0.0.1:4200/api
            coverage run --rcfile=coverage.toml -m pytest -s --verbose cstar/tests/unit_tests/*
            

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         shell: micromamba-shell {0}        
         run: |
            python -V
-           prefect server start --port 4200 --no-ui --analytics-off
+           prefect server start --port 4200 --no-ui --analytics-off --background
            export PREFECT_API_URL=http://127.0.0.1:4200/api
            coverage run --rcfile=coverage.toml -m pytest -s --verbose cstar/tests/unit_tests/*
            

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install C-Star
         shell: micromamba-shell {0}
         run: |
-           python - V
+           python -V
            python -m pip install -e ".[dev]" --force-reinstall
 
       - name: Running Tests

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,6 +44,8 @@ jobs:
         shell: micromamba-shell {0}        
         run: |
            python -V
+           prefect server start --port 4200
+           export PREFECT_API_URL=http://127.0.0.1:4200/api
            coverage run --rcfile=coverage.toml -m pytest -s --verbose cstar/tests/unit_tests/*
            
       - name: Get coverage report

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -214,14 +214,14 @@ class Service(ABC, LoggingMixin):
             return
 
         if self._hc_queue is None:
-            self.log.debug("No healthcheck queue available")
+            self.log.trace("No healthcheck queue available")
             return
 
         try:
             match self._hc_queue.get_nowait():
                 case Service.CMD_HEARTBEAT:
                     # ACK any requests for HC updates
-                    self.log.debug("Health check succeeded")
+                    self.log.trace("Health check succeeded")
                     self._on_health_check()
                 case message:
                     msg = f"Health check sent unknown message: {message}"
@@ -354,7 +354,7 @@ class Service(ABC, LoggingMixin):
         This method is called when the service is ready to shut down, either the service
         has completed its work, or it has received a term signal.
         """
-        self.log.debug("Shutting down service.")
+        self.log.info("Shutting down service.")
 
         try:
             self._terminate_hc()
@@ -399,7 +399,7 @@ class Service(ABC, LoggingMixin):
 
             # shutdown if service reports completion
             if self.can_shutdown:
-                self.log.info("Service is ready for shutdown.")
+                self.log.trace("Service is ready for shutdown.")
                 running = False
                 continue
 

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -68,7 +68,7 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     if not step.fsm.work_dir.exists():
         step.fsm.work_dir.mkdir(parents=True)
 
-    sleep_time = random.randint(1, 3)
+    sleep_time = random.random()
     script = textwrap.dedent(f"""\
         # this is a mock application script that produces verifiable output
         echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,9 +1,11 @@
 import functools
 import logging
+import os
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
 from pathlib import Path
+from subprocess import Popen
 from typing import Any
 from unittest import mock
 
@@ -1767,3 +1769,41 @@ def mock_placeholder_delay() -> Generator[None, None, None]:
         return_value=0.01,
     ):
         yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_server() -> Generator[str, None, None]:
+    """Starts a Prefect server and stops it when the tests are done."""
+    if "PREFECT_API_URL" in os.environ:
+        # use a running local prefect server if one exists
+        yield os.environ["PREFECT_API_URL"]
+        return
+
+    prefect_port = "12345"
+    api_url = f"http://127.0.0.1:{prefect_port}/api"
+
+    try:
+        process = Popen(
+            [
+                "prefect",
+                "server",
+                "start",
+                "--port",
+                prefect_port,
+            ],
+            text=True,
+            encoding="utf-8",
+        )
+        yield api_url
+    except Exception as ex:
+        print(f"Failed to start Prefect server: {ex}")
+    finally:
+        if process and process.returncode is None:
+            process.terminate()
+
+
+@pytest.fixture
+def prefect_server_url(prefect_server: str) -> Generator[str, None, None]:
+    """Configure the Prefect API URL for the duration of the tests."""
+    os.environ["PREFECT_API_URL"] = prefect_server
+    yield prefect_server

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1802,7 +1802,7 @@ def prefect_server() -> Generator[str, None, None]:
             process.terminate()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def prefect_server_url(prefect_server: str) -> Generator[str, None, None]:
     """Configure the Prefect API URL for the duration of the tests."""
     os.environ["PREFECT_API_URL"] = prefect_server

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1757,3 +1757,13 @@ def patch_romssimulation_init_sourcedata(
             yield
 
     return _context
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_placeholder_delay() -> Generator[None, None, None]:
+    """Ensure delay for simulating processes during unit tests is tiny."""
+    with mock.patch(
+        "cstar.orchestration.converter.converter.random.random",
+        return_value=0.01,
+    ):
+        yield

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -56,12 +56,12 @@ class PrintingService(Service):
 
     def _on_start(self) -> None:
         super()._on_start()
-        self.log.debug("Running PrintingService._on_start")
+        self.log.trace("Running PrintingService._on_start")
         self.start_time = time.time()
 
     def _on_delay(self) -> None:
         super()._on_delay()
-        self.log.debug("Running PrintingService._on_delay")
+        self.log.trace("Running PrintingService._on_delay")
         self.test_queue.put_nowait("_on_delay")
 
     @property
@@ -71,13 +71,13 @@ class PrintingService(Service):
 
     async def _on_iteration(self) -> None:
         await super()._on_iteration()
-        self.log.debug("Running PrintingService._on_iteration")
+        self.log.trace("Running PrintingService._on_iteration")
         self.test_queue.put_nowait("_on_iteration")
         self.summarize()  # update each loop; don't let queues grow too large
 
     def _on_iteration_complete(self) -> None:
         super()._on_iteration_complete()
-        self.log.debug("Running PrintingService._on_iteration_complete")
+        self.log.trace("Running PrintingService._on_iteration_complete")
         self.test_queue.put_nowait("_on_iteration_complete")
         self.summarize()
 
@@ -88,7 +88,7 @@ class PrintingService(Service):
 
     def _on_health_check(self) -> None:
         super()._on_health_check()
-        self.log.debug("Running PrintingService._on_health_check")
+        self.log.trace("Running PrintingService._on_health_check")
         self.test_queue.put_nowait("_on_health_check")
 
     @property
@@ -98,7 +98,7 @@ class PrintingService(Service):
 
     def _can_shutdown(self) -> bool:
         super()._can_shutdown()  # type: ignore[safe-super]
-        self.log.debug("Running PrintingService._can_shutdown")
+        self.log.trace("Running PrintingService._can_shutdown")
         self.test_queue.put_nowait("_can_shutdown")
 
         if self._do_shutdown:
@@ -115,7 +115,7 @@ class PrintingService(Service):
 
     def _on_shutdown(self) -> None:
         super()._on_shutdown()
-        self.log.debug("Running PrintingService._on_shutdown")
+        self.log.trace("Running PrintingService._on_shutdown")
         self.test_queue.put_nowait("_on_shutdown")
         self.summarize()
 

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -157,6 +157,7 @@ async def test_build_and_run_dag_env(
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
+    prefect_server_url: str,
 ) -> None:
     """Verify that the DAG runner fails when required environment variables are not passed.
 

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -99,6 +99,7 @@ def test_workplan_run_variable_unknown(
     bp_templates_dir: Path,
     wp_templates_dir: Path,
     default_blueprint_path: str,
+    prefect_server_url: str,
 ) -> None:
     """Verify that attempting to run a workplan with runtime variables that are
     not declared by the workplan results in a failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,14 @@ dynamic = ["version"]
 dependencies = [
     "networkx>=3.6.1",
     "prefect>=3.6.1",
+    "fakeredis<2.35",
     "pydantic>=2.12",
     "python-dateutil>=2.8.2",
     "pytimeparse>=1.1.8",
     "python-dotenv",
     "PyYAML==6.0.2",
     "roms_tools[dask]>=3.4.0,<4",
-    "typer>=0.24.1",
+    "typer<=0.25",
 ]
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change mitigates some slowdowns in the unit tests by:
- reducing repetitive logging
- re-using a local prefect server (if possible)
- re-using a prefect server throughout the session
- removing unnecessary delays for _simulated processes_

It also fixes a defect caused by the latest version of `fakeredis`, which is installed for `prefect`. Version `2.35.0` causes prefect to break, so it is temporarily pinned to `<2.35`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce unit test duration
- Mitigate a dependency issue with prefect and fakeredis (pin `fakeredis<2.35`)

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-777
- [ ] Tests added
- [X] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
