### PR TITLE
Add ability to join .ext files during post_run

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -20,11 +20,13 @@ from cstar.base.env import (
     ENV_CSTAR_STATE_HOME,
     get_env_item,
 )
-from cstar.base.log import LoggingMixin
+from cstar.base.log import LoggingMixin, get_logger
 from cstar.base.utils import slugify
 
 if t.TYPE_CHECKING:
     from cstar.base.env import EnvItem
+
+log = get_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -497,3 +499,24 @@ async def local_copy_async(uri: str) -> t.AsyncGenerator[Path, None]:
     finally:
         exc_type, exc_val, exc_tb = sys.exc_info()
         await asyncio.to_thread(sync_local_copy.__exit__, exc_type, exc_val, exc_tb)
+
+
+def remove_files(file_dir: Path, wildcard_pattern: str) -> bool:
+    """Removes files in the input dir matching the wildcard pattern.
+
+    Parameters
+    ----------
+    file_dir: directory in which to search for and remove matching files
+    wildcard_pattern: the glob pattern to match files against
+
+    Returns
+    -------
+    True if any files were removed, False otherwise
+    """
+    log.debug(f"Removing files matching wildcard pattern {wildcard_pattern}...")
+    removed = False
+    for p in file_dir.glob(wildcard_pattern):
+        p.unlink()
+        removed = True
+
+    return removed

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -25,7 +25,7 @@ from cstar.base.utils import (
     _run_cmd,
     slugify,
 )
-from cstar.execution.file_system import RomsFileSystemManager
+from cstar.execution.file_system import RomsFileSystemManager, remove_files
 from cstar.execution.handler import ExecutionStatus
 from cstar.execution.local_process import LocalProcess
 from cstar.execution.scheduler_job import create_scheduler_job
@@ -72,30 +72,11 @@ if TYPE_CHECKING:
     from cstar.execution.handler import ExecutionHandler
 
 
-def _remove_wildcard_pattern(
-    input_dir: Path, wildcard_pattern: str, logger: logging.Logger
-) -> None:
-    """Removes files in the input dir matching the wildcard pattern.
-
-    Parameters
-    ----------
-    input_dir: directory in which to search for and remove matching files
-    wildcard_pattern: the glob pattern to match files against
-    logger: logger object to post log messages to
-
-    Returns
-    -------
-    None
-    """
-    logger.debug(f"Removing files matching wildcard pattern {wildcard_pattern}...")
-    for p in input_dir.glob(wildcard_pattern):
-        p.unlink()
-
-
 def _ncjoin_wildcard(
     wildcard_pattern: str, input_dir: Path, output_dir: Path, logger: logging.Logger
 ) -> None:
-    """Spatially join netcdfs matching the wildcard pattern using ncjoin, and move the joined output to output_dir.
+    """Spatially join netcdfs matching the wildcard pattern using ncjoin, move the joined output to output_dir, and
+    remove the unjoined outputs (except for rst files, which would need to be repartitioned later).
 
     Parameters
     ----------
@@ -117,17 +98,17 @@ def _ncjoin_wildcard(
     out_file = input_dir / wildcard_pattern.replace("*.", "")
     out_file_name = out_file.name
     out_file.rename(output_dir / out_file_name)
-    logger.info(f"done spatially joining {out_file}")
+    logger.info(f"Done spatially joining {out_file}")
 
     if "rst" not in wildcard_pattern:
-        _remove_wildcard_pattern(input_dir, wildcard_pattern, logger)
+        remove_files(input_dir, wildcard_pattern)
 
 
 def _extract_data_join_wildcard(
     wildcard_pattern: str, input_dir: Path, output_dir: Path, logger: logging.Logger
 ) -> None:
     """Spatially join netcdfs matching the wildcard pattern using extract_data_join,
-    and move the joined output to output_dir.
+     move the joined output to output_dir, and remove the unjoined outputs.
 
     Parameters
     ----------
@@ -158,9 +139,9 @@ def _extract_data_join_wildcard(
     ocean_file = input_dir / ocean_file_name
     ocean_file.unlink(missing_ok=True)
 
-    _remove_wildcard_pattern(input_dir, wildcard_pattern, logger)
+    remove_files(input_dir, wildcard_pattern)
 
-    logger.info(f"done spatially joining {out_file}")
+    logger.info(f"Done spatially joining {out_file}")
 
 
 class ROMSSimulation(Simulation):
@@ -1790,11 +1771,14 @@ class ROMSSimulation(Simulation):
             )
 
         nprocs = int(get_env_item(ENV_CSTAR_NPROCS_POST).value)
-        unique_wildcards = {Path(fname.stem).stem + ".*.nc" for fname in files}
+        unique_wildcards = {
+            str(Path(fname.stem).with_suffix(".*.nc")) for fname in files
+        }
 
         with ThreadPoolExecutor(max_workers=nprocs) as executor:
-            results = executor.map(_spatial_join, unique_wildcards)
-            _ = [r for r in results]  # exhaust iterator
+            # list() exhausts the returned iterator, which is needed to surface any errors
+            # that were raised in the threaded join operations
+            list(executor.map(_spatial_join, unique_wildcards))
 
         self.persist()
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -91,7 +91,8 @@ def _ncjoin_wildcard(
     """
     logger.info(f"Joining netCDF files {wildcard_pattern}...")
 
-    command = "extract_data_join" if "ext" in wildcard_pattern else "ncjoin"
+    extract_data = "ext" in wildcard_pattern
+    command = "extract_data_join" if extract_data else "ncjoin"
 
     _run_cmd(
         f"{command} {wildcard_pattern}",
@@ -100,7 +101,20 @@ def _ncjoin_wildcard(
     )
 
     out_file = input_dir / wildcard_pattern.replace("*.", "")
-    out_file.rename(output_dir / out_file.name)
+    if extract_data:
+        out_file_name = out_file.name
+        out_file_timestamp_dot_nc = out_file_name.split(".")[1:]
+        out_file_name = ".".join(["child_bry", *out_file_timestamp_dot_nc])
+        out_file = input_dir / out_file_name
+        ocean_file_name = ".".join(["ocean", *out_file_timestamp_dot_nc])
+    else:
+        out_file_name = out_file.name
+
+    out_file.rename(output_dir / out_file_name)
+
+    if extract_data:
+        ocean_file = input_dir / ocean_file_name
+        ocean_file.unlink(missing_ok=True)
 
     logger.info(f"done spatially joining {out_file}")
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1710,11 +1710,7 @@ class ROMSSimulation(Simulation):
 
         output_dir = self.fs_manager.output_dir
         files = list(output_dir.glob("*.??????????????.*.nc"))
-        unique_wildcards = {
-            Path(fname.stem).stem + ".*.nc"
-            for fname in files
-            if "_ext." not in fname.name
-        }
+        unique_wildcards = {Path(fname.stem).stem + ".*.nc" for fname in files}
         if not files:
             self.log.warning(f"No suitable output found in `{output_dir}`")
         else:

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -91,8 +91,10 @@ def _ncjoin_wildcard(
     """
     logger.info(f"Joining netCDF files {wildcard_pattern}...")
 
+    command = "extract_data_join" if "ext" in wildcard_pattern else "ncjoin"
+
     _run_cmd(
-        f"ncjoin {wildcard_pattern}",
+        f"{command} {wildcard_pattern}",
         cwd=input_dir,
         raise_on_error=True,
     )

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1768,29 +1768,33 @@ class ROMSSimulation(Simulation):
 
         output_dir = self.fs_manager.output_dir
         files = list(output_dir.glob("*.??????????????.*.nc"))
-        unique_wildcards = {Path(fname.stem).stem + ".*.nc" for fname in files}
         if not files:
             self.log.warning(f"No suitable output found in `{output_dir}`")
-        else:
-            self.fs_manager.joined_output_dir.mkdir(exist_ok=True, parents=True)
+            self.persist()
+            return
 
-            def _spatial_join(wildcard_pattern: str) -> None:
-                fn = (
-                    _extract_data_join_wildcard
-                    if "ext" in wildcard_pattern
-                    else _ncjoin_wildcard
-                )
-                fn(
-                    wildcard_pattern,
-                    input_dir=self.fs_manager.output_dir,
-                    output_dir=self.fs_manager.joined_output_dir,
-                    logger=self.log,
-                )
+        self.fs_manager.joined_output_dir.mkdir(exist_ok=True, parents=True)
 
-            nprocs = int(get_env_item(ENV_CSTAR_NPROCS_POST).value)
-            with ThreadPoolExecutor(max_workers=nprocs) as executor:
-                results = executor.map(_spatial_join, unique_wildcards)
-                _ = [r for r in results]  # exhaust iterator
+        def _spatial_join(wildcard_pattern: str) -> None:
+            """Choose and execute correct joining function for the file type."""
+            joiner = (
+                _extract_data_join_wildcard
+                if "ext" in wildcard_pattern
+                else _ncjoin_wildcard
+            )
+            joiner(
+                wildcard_pattern,
+                input_dir=self.fs_manager.output_dir,
+                output_dir=self.fs_manager.joined_output_dir,
+                logger=self.log,
+            )
+
+        nprocs = int(get_env_item(ENV_CSTAR_NPROCS_POST).value)
+        unique_wildcards = {Path(fname.stem).stem + ".*.nc" for fname in files}
+
+        with ThreadPoolExecutor(max_workers=nprocs) as executor:
+            results = executor.map(_spatial_join, unique_wildcards)
+            _ = [r for r in results]  # exhaust iterator
 
         self.persist()
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -3,7 +3,6 @@ import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from functools import partial
 from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
@@ -73,6 +72,26 @@ if TYPE_CHECKING:
     from cstar.execution.handler import ExecutionHandler
 
 
+def _remove_wildcard_pattern(
+    input_dir: Path, wildcard_pattern: str, logger: logging.Logger
+) -> None:
+    """Removes files in the input dir matching the wildcard pattern.
+
+    Parameters
+    ----------
+    input_dir: directory in which to search for and remove matching files
+    wildcard_pattern: the glob pattern to match files against
+    logger: logger object to post log messages to
+
+    Returns
+    -------
+    None
+    """
+    logger.debug(f"Removing files matching wildcard pattern {wildcard_pattern}...")
+    for p in input_dir.glob(wildcard_pattern):
+        p.unlink()
+
+
 def _ncjoin_wildcard(
     wildcard_pattern: str, input_dir: Path, output_dir: Path, logger: logging.Logger
 ) -> None:
@@ -90,31 +109,56 @@ def _ncjoin_wildcard(
     None
     """
     logger.info(f"Joining netCDF files {wildcard_pattern}...")
-
-    extract_data = "ext" in wildcard_pattern
-    command = "extract_data_join" if extract_data else "ncjoin"
-
     _run_cmd(
-        f"{command} {wildcard_pattern}",
+        f"ncjoin {wildcard_pattern}",
+        cwd=input_dir,
+        raise_on_error=True,
+    )
+    out_file = input_dir / wildcard_pattern.replace("*.", "")
+    out_file_name = out_file.name
+    out_file.rename(output_dir / out_file_name)
+    logger.info(f"done spatially joining {out_file}")
+
+    if "rst" not in wildcard_pattern:
+        _remove_wildcard_pattern(input_dir, wildcard_pattern, logger)
+
+
+def _extract_data_join_wildcard(
+    wildcard_pattern: str, input_dir: Path, output_dir: Path, logger: logging.Logger
+) -> None:
+    """Spatially join netcdfs matching the wildcard pattern using extract_data_join,
+    and move the joined output to output_dir.
+
+    Parameters
+    ----------
+    wildcard_pattern: the wildcard pattern to match for files within input_dir
+    input_dir: location of the partitioned netcdfs to be joined
+    output_dir: location to move the joined output to
+    logger: logger object to post log messages to
+
+    Returns
+    -------
+    None
+    """
+    logger.info(f"Joining netCDF files {wildcard_pattern}...")
+    _run_cmd(
+        f"extract_data_join {wildcard_pattern}",
         cwd=input_dir,
         raise_on_error=True,
     )
 
-    out_file = input_dir / wildcard_pattern.replace("*.", "")
-    if extract_data:
-        out_file_name = out_file.name
-        out_file_timestamp_dot_nc = out_file_name.split(".")[1:]
-        out_file_name = ".".join(["child_bry", *out_file_timestamp_dot_nc])
-        out_file = input_dir / out_file_name
-        ocean_file_name = ".".join(["ocean", *out_file_timestamp_dot_nc])
-    else:
-        out_file_name = out_file.name
+    out_file_name = wildcard_pattern.replace("*.", "")
+    _, out_file_timestamp_dot_nc = out_file_name.split(".", maxsplit=1)
 
+    out_file_name = f"child_bry.{out_file_timestamp_dot_nc}"
+    out_file = input_dir / out_file_name
     out_file.rename(output_dir / out_file_name)
 
-    if extract_data:
-        ocean_file = input_dir / ocean_file_name
-        ocean_file.unlink(missing_ok=True)
+    ocean_file_name = f"ocean.{out_file_timestamp_dot_nc}"
+    ocean_file = input_dir / ocean_file_name
+    ocean_file.unlink(missing_ok=True)
+
+    _remove_wildcard_pattern(input_dir, wildcard_pattern, logger)
 
     logger.info(f"done spatially joining {out_file}")
 
@@ -1730,16 +1774,22 @@ class ROMSSimulation(Simulation):
         else:
             self.fs_manager.joined_output_dir.mkdir(exist_ok=True, parents=True)
 
-            spatial_joiner = partial(
-                _ncjoin_wildcard,
-                logger=self.log,
-                input_dir=self.fs_manager.output_dir,
-                output_dir=self.fs_manager.joined_output_dir,
-            )
+            def _spatial_join(wildcard_pattern: str) -> None:
+                fn = (
+                    _extract_data_join_wildcard
+                    if "ext" in wildcard_pattern
+                    else _ncjoin_wildcard
+                )
+                fn(
+                    wildcard_pattern,
+                    input_dir=self.fs_manager.output_dir,
+                    output_dir=self.fs_manager.joined_output_dir,
+                    logger=self.log,
+                )
 
             nprocs = int(get_env_item(ENV_CSTAR_NPROCS_POST).value)
             with ThreadPoolExecutor(max_workers=nprocs) as executor:
-                results = executor.map(spatial_joiner, unique_wildcards)
+                results = executor.map(_spatial_join, unique_wildcards)
                 _ = [r for r in results]  # exhaust iterator
 
         self.persist()

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1859,7 +1859,11 @@ class TestProcessingAndExecution:
         assert (new_out_dir / "ocean_rst.20240101000000.nc").exists()
         assert (new_out_dir / "child_bry.20240101000000.nc").exists()
 
-        mock_persist.assert_called_once()
+        # assert all non-rst partitioned files got cleaned up
+        assert not (output_dir / "ocean_his.20240101000000.001.nc").exists()
+        assert not (output_dir / "ocean_his.20240101000000.002.nc").exists()
+        assert not (output_dir / "ocean_ext.20240101000000.001.nc").exists()
+        assert (output_dir / "ocean_rst.20240101000000.001.nc").exists()
 
     @mock.patch("cstar.roms.ROMSSimulation.persist")
     @mock.patch.object(Path, "glob", return_value=[])  # Mock glob to return no files

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1816,6 +1816,7 @@ class TestProcessingAndExecution:
         # Create fake output of join process to make sure it gets moved
         (output_dir / "ocean_his.20240101000000.nc").touch()
         (output_dir / "ocean_rst.20240101000000.nc").touch()
+        (output_dir / "child_bry.20240101000000.nc").touch()
 
         # Mock execution handler
         sim._execution_handler = mock.MagicMock()
@@ -1843,16 +1844,20 @@ class TestProcessingAndExecution:
             shell=True,
         )
 
-        # check that ext files weren't joined
-        for call in mock_subprocess.call_args_list:
-            assert "ocean_ext" not in call.args[0]
+        mock_subprocess.assert_any_call(
+            "extract_data_join ocean_ext.20240101000000.*.nc",
+            cwd=output_dir,
+            capture_output=True,
+            text=True,
+            shell=True,
+        )
 
         # Check that output file was moved
         new_out_dir = sim.fs_manager.joined_output_dir
         assert new_out_dir.exists()
         assert (new_out_dir / "ocean_his.20240101000000.nc").exists()
         assert (new_out_dir / "ocean_rst.20240101000000.nc").exists()
-        assert not (new_out_dir / "ocean_ext.20240101000000.nc").exists()
+        assert (new_out_dir / "child_bry.20240101000000.nc").exists()
 
         mock_persist.assert_called_once()
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Adds ability to join .ext files using the correct tool, instead of skipping them. 

Note: these functions could be abstracted better, but this gets the job done for now, and these will all go away in a few months once the PIO project is completed and partitioning/joining is no longer needed.

## New Features
<!-- List any new capabilities added -->
- .ext files are now passed through extract_data_join at the same time as other files are passed through ncjoin


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
