### PR TITLE
Fix merge behavior on mismatched node types and list lengths

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -1,3 +1,4 @@
+import copy
 import datetime as dt
 import functools
 import hashlib
@@ -6,6 +7,7 @@ import re
 import subprocess
 import sys
 import typing as t
+from itertools import zip_longest
 from pathlib import Path
 from types import ModuleType
 
@@ -341,19 +343,29 @@ def deep_merge(d1: dict[str, t.Any], d2: dict[str, t.Any]) -> dict[str, t.Any]:
     dict[str, t.Any]
         The merged dictionaries.
     """
-    for k, v in d2.items():
-        if isinstance(v, dict):
-            d1[k] = deep_merge(d1.get(k, {}), v)
-        elif isinstance(v, list):
-            list_items = []
-            for i, item in enumerate(v):
-                if isinstance(item, dict):
-                    list_items.append(deep_merge(d1.get(k, {})[i], item))
+    for k, target in d2.items():
+        source = d1.get(k)
+
+        if isinstance(source, dict) and isinstance(target, dict):
+            d1[k] = deep_merge(source, target)
+        elif isinstance(target, dict):
+            d1[k] = {**target}
+        elif isinstance(source, list) and isinstance(target, list):
+            items = []
+            for x0, x1 in zip_longest(source, target, fillvalue=None):
+                if x0 is None:
+                    items.append(copy.deepcopy(x1))
+                elif x1 is None:
+                    items.append(copy.deepcopy(x0))
+                elif isinstance(x0, dict) and isinstance(x1, dict):
+                    items.append(deep_merge(x0, x1))
                 else:
-                    list_items.append(item)
-            d1[k] = list_items
+                    items.append(copy.deepcopy(x1))
+            d1[k] = items
+        elif isinstance(target, list):
+            d1[k] = copy.deepcopy(target)
         else:
-            d1[k] = v
+            d1[k] = target
     return d1
 
 

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -7,6 +7,7 @@ from cstar.base.utils import (
     _get_sha256_hash,
     _list_to_concise_str,
     _replace_text_in_file,
+    deep_merge,
 )
 
 
@@ -266,3 +267,101 @@ class TestDictToTree:
             "        └── leaf6\n"
         )
         assert result == expected_output
+
+
+@pytest.mark.parametrize(
+    ("original", "to_merge", "expected"),
+    [
+        pytest.param(
+            {},
+            {"a": 10},
+            {"a": 10},
+            id="no overlap, scalar",
+        ),
+        pytest.param(
+            {"a": 0},
+            {"a": 10},
+            {"a": 10},
+            id="overlap, scalar",
+        ),
+        pytest.param(
+            {"a": [1]},
+            {"a": [1, 2, 3]},
+            {"a": [1, 2, 3]},
+            id="overlap, scalar list to same",
+        ),
+        pytest.param(
+            {"a": 0},
+            {"a": [1, 2, 3]},
+            {"a": [1, 2, 3]},
+            id="overlap, scalar list over scalar",
+        ),
+        pytest.param(
+            {"a": 0, "b": {"x": 9}},
+            {"c": 4},
+            {"a": 0, "b": {"x": 9}, "c": 4},
+            id="value from update and source",
+        ),
+        pytest.param(
+            {"a": [9, 8, 7]},
+            {"a": [1, 2, 3]},
+            {"a": [1, 2, 3]},
+            id="list replacement",
+        ),
+        pytest.param(
+            {"a": 0},
+            {"b": {"c": 1}},
+            {"a": 0, "b": {"c": 1}},
+            id="copy dict from update",
+        ),
+        pytest.param(
+            {"a": {"d": 2}},
+            {"b": {"c": 1}},
+            {"a": {"d": 2}, "b": {"c": 1}},
+            id="copy dict from source and update",
+        ),
+        pytest.param(
+            {"a": {"b": 0}},
+            {"a": {"b": {"c": 1}}},
+            {"a": {"b": {"c": 1}}},
+            id="copy nested dict over scalar",
+        ),
+        pytest.param(
+            {"a": {"b": {"a": 0}}},
+            {"a": {"b": {"c": 1}}},
+            {"a": {"b": {"a": 0, "c": 1}}},
+            id="merge nested dict",
+        ),
+        pytest.param(
+            {"a": {"b": [9, 8, 7]}},
+            {"a": {"b": 1}},
+            {"a": {"b": 1}},
+            id="overwrite list with dict",
+        ),
+        pytest.param(
+            {"a": {"b": {"c": 9}}},
+            {"a": {"b": [1, 2, 3]}},
+            {"a": {"b": [1, 2, 3]}},
+            id="overwrite dict with list",
+        ),
+        pytest.param(
+            {"a": {"b": {"c": 9}}},
+            {"a": {"b": 1}},
+            {"a": {"b": 1}},
+            id="overwrite nested dict with scalar",
+        ),
+        pytest.param(
+            {"a": {"b": {"c": 1, "d": 2}}},
+            {"a": {"b": {"d": 3}}},
+            {"a": {"b": {"c": 1, "d": 3}}},
+            id="nested key interleave",
+        ),
+    ],
+)
+def test_deep_merge(
+    original: dict[str, str],
+    to_merge: dict[str, str],
+    expected: dict[str, str],
+) -> None:
+    actual = deep_merge(original, to_merge)
+    assert actual == expected

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -71,6 +71,7 @@ Bug Fixes
 - Bump typer version to avoid list-default bug (`#476 <https://github.com/CWorthy-ocean/C-Star/pull/476>`_)
 - Fix uninitialized attributes error in `SlurmBatch`
 - Mitigate a dependency issue with prefect and fakeredis (pin `fakeredis<2.35`)
+- Fix bug when merging dictionaries during application of blueprint overrides
 
 Improvements
 ~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a pair of bugs when performing a deep-merge on dictionaries:
- If the node type is mismatched (e.g. None and dict, scalar and dict)
- If merging lists of different lengths (e.g. [1], [1,2])

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug when merging dictionaries during application of blueprint overrides

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
