### PR TITLE
Fix tests supplying invalid CLI arguments

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -482,11 +482,8 @@ def main() -> int:
     int
         The exit code of the worker script. Returns 0 on success, 1 on failure.
     """
-    try:
-        parser = create_parser()
-        args = parser.parse_args()
-    except SystemExit:
-        return 1
+    parser = create_parser()
+    args = parser.parse_args()
 
     job_cfg = get_job_config()
     service_cfg = get_service_config(args.log_level)

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import sys
 from datetime import datetime, timezone
-from typing import Final, override
+from typing import Final, Literal, override
 
 from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
 from cstar.base.exceptions import BlueprintError, CstarError
@@ -26,6 +26,15 @@ DATE_FORMAT: Final[str] = "%Y-%m-%d %H:%M:%S"
 WORKER_LOG_FILE_TPL: Final[str] = "cstar-worker.{0}.log"
 JOBFILE_DATE_FORMAT: Final[str] = "%Y%m%d_%H%M%S"
 LOGS_DIRECTORY: Final[str] = "logs"
+
+ARG_URI_LONG: Literal["--blueprint-uri"] = "--blueprint-uri"
+ARG_URI_SHORT: Literal["-b"] = "-b"
+
+ARG_LOGLEVEL_LONG: Literal["--log-level"] = "--log-level"
+ARG_LOGLEVEL_SHORT: Literal["-l"] = "-l"
+
+ARG_STAGE_LONG: Literal["--stage"] = "--stage"
+ARG_STAGE_SHORT: Literal["-g"] = "-g"
 
 
 def _generate_job_name() -> str:
@@ -316,15 +325,15 @@ def create_parser() -> argparse.ArgumentParser:
         exit_on_error=True,
     )
     parser.add_argument(
-        "-b",
-        "--blueprint-uri",
+        ARG_URI_SHORT,
+        ARG_URI_LONG,
         type=str,
         required=True,
         help="The URI of a blueprint.",
     )
     parser.add_argument(
-        "-l",
-        "--log-level",
+        ARG_LOGLEVEL_SHORT,
+        ARG_LOGLEVEL_LONG,
         default=get_env_item(ENV_CSTAR_LOG_LEVEL).value,
         type=str,
         required=False,
@@ -340,8 +349,8 @@ def create_parser() -> argparse.ArgumentParser:
         ],
     )
     parser.add_argument(
-        "-g",
-        "--stage",
+        ARG_STAGE_SHORT,
+        ARG_STAGE_LONG,
         choices=[x.value for x in SimulationStages],
         type=str,
         required=False,

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -6,6 +6,7 @@ import typing as t
 from collections import defaultdict
 
 from cstar.base.log import get_logger
+from cstar.entrypoint.worker.worker import ARG_URI_LONG
 from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
@@ -46,7 +47,7 @@ def convert_roms_step_to_command(step: "LiveStep") -> str:
         The complete CLI command.
     """
     worker_module = "cstar.entrypoint.worker.worker"
-    return f"{sys.executable} -m {worker_module}  -b {step.blueprint_path}"
+    return f"{sys.executable} -m {worker_module} {ARG_URI_LONG} {step.blueprint_path}"
 
 
 def convert_step_to_placeholder(step: "LiveStep") -> str:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -69,12 +69,14 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
         step.fsm.work_dir.mkdir(parents=True)
 
     sleep_time = random.random()
-    script = textwrap.dedent(f"""\
+    script = textwrap.dedent(
+        f"""\
         # this is a mock application script that produces verifiable output
         echo "{step.name} started at $(date "+%Y-%m-%d %H:%M:%S")";
         sleep {sleep_time};
         echo "{step.name} completed at $(date "+%Y-%m-%d %H:%M:%S")";
-        """)
+        """
+    )
 
     # write it to a script asset
     script_path = step.fsm.work_dir / "script.sh"

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -429,14 +429,14 @@ class RomsMarblTimeSplitter(Transform):
 class OverrideTransform(Transform):
     """Transform that overrides a step by returning a blueprint with all overridden attributes applied."""
 
-    _system_overrides: dict[str, t.Any] = {}
+    _system_overrides: dict[str, t.Any]
 
-    def __init__(self, sys_overrides: dict[str, t.Any] = None) -> None:  # type: ignore[assignment]
+    def __init__(self, sys_overrides: dict[str, t.Any] | None = None) -> None:
         """Initialize the instance.
 
         Parameters
         ----------
-        sys_overrides : dict[str, t.Any]
+        sys_overrides : dict[str, t.Any] | None
             System-level blueprint overrides that will be applied after
             the user-supplied values.
         """
@@ -445,7 +445,7 @@ class OverrideTransform(Transform):
     def apply(
         self,
         bp: RomsMarblBlueprint,
-        overrides: dict[str, t.Any] = None,  # type: ignore[assignment]
+        overrides: dict[str, t.Any] | None = None,
     ) -> RomsMarblBlueprint:
         """Apply all overrides from a blueprint.
 
@@ -456,7 +456,7 @@ class OverrideTransform(Transform):
         ----------
         bp : RomsMarblBlueprint
             The blueprint to apply overrides to
-        overrides : dict[str, t.Any]
+        overrides : dict[str, t.Any] | None
             A dictionary containing overrides for attributes of a blueprint.
 
         Returns
@@ -514,8 +514,11 @@ class OverrideTransform(Transform):
 
     @staticmethod
     def suffix() -> str:
-        """Return the standard prefix to be used when persisting
-        a resource modified by this transform.
+        """Return a suffix used when persisting a resource modified by this transform.
+
+        Returns
+        -------
+        str
         """
         return "ovrd"
 

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -19,6 +19,7 @@ from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.gitutils import git_location_to_raw
 from cstar.base.input_dataset import InputDataset
 from cstar.base.log import get_logger
+from cstar.base.utils import additional_files_dir
 from cstar.io.constants import SourceClassification
 from cstar.io.retriever import Retriever
 from cstar.io.source_data import SourceData, SourceDataCollection, _SourceInspector
@@ -1807,3 +1808,49 @@ def prefect_server_url(prefect_server: str) -> Generator[str, None, None]:
     """Configure the Prefect API URL for the duration of the tests."""
     os.environ["PREFECT_API_URL"] = prefect_server
     yield prefect_server
+
+
+@pytest.fixture
+def templates_dir() -> Path:
+    """Return the path to the templates directory contained in the package
+    "additional files."
+
+    Returns
+    -------
+    Path
+    """
+    return additional_files_dir() / "templates"
+
+
+@pytest.fixture
+def wp_templates_dir(templates_dir: Path) -> Path:
+    """Return the path to the `Workplan` templates directory contained in the package
+    "additional files."
+
+    Parameters
+    ----------
+    templates_dir : Path
+        Fixture returning the path to the templates root directory.
+
+    Returns
+    -------
+    Path
+    """
+    return templates_dir / "wp"
+
+
+@pytest.fixture
+def bp_templates_dir(templates_dir: Path) -> Path:
+    """Return the path to the `Blueprint` templates directory contained in the package
+    "additional files."
+
+    Parameters
+    ----------
+    templates_dir : Path
+        Fixture returning the path to the templates root directory.
+
+    Returns
+    -------
+    Path
+    """
+    return templates_dir / "bp"

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -13,6 +13,10 @@ import pytest
 from cstar.base.exceptions import BlueprintError, CstarError
 from cstar.entrypoint.service import ServiceConfiguration
 from cstar.entrypoint.worker.worker import (
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
+    ARG_URI_LONG,
+    ARG_URI_SHORT,
     BlueprintRequest,
     JobConfig,
     SimulationRunner,
@@ -50,8 +54,8 @@ def clean_up_logs() -> Generator[None, None, None]:
 def valid_args() -> dict[str, str]:
     """Fixture to provide valid arguments for the SimulationRunner."""
     return {
-        "--blueprint-uri": "blueprint.yaml",
-        "--log-level": "INFO",
+        ARG_URI_LONG: "blueprint.yaml",
+        ARG_LOGLEVEL_LONG: "INFO",
     }
 
 
@@ -59,8 +63,8 @@ def valid_args() -> dict[str, str]:
 def valid_args_short() -> dict[str, str]:
     """Fixture to provide valid arguments for the SimulationRunner."""
     return {
-        "-b": "blueprint.yaml",
-        "-l": "INFO",
+        ARG_URI_SHORT: "blueprint.yaml",
+        ARG_LOGLEVEL_SHORT: "INFO",
     }
 
 
@@ -124,8 +128,8 @@ def test_create_parser_happy_path() -> None:
     parser = create_parser()
 
     # ruff: noqa: SLF001
-    assert "--blueprint-uri" in parser._option_string_actions
-    assert "--log-level" in parser._option_string_actions
+    assert ARG_URI_LONG in parser._option_string_actions
+    assert ARG_LOGLEVEL_LONG in parser._option_string_actions
 
 
 @pytest.mark.parametrize(
@@ -150,10 +154,10 @@ def test_parser_good_log_level(
     """Verify that a log level is parsed correctly."""
     valid_args: dict[str, str] = request.getfixturevalue(args_fixture_name)
     valid_args = valid_args.copy()
-    if "--log-level" in valid_args:
-        valid_args["--log-level"] = log_level
+    if ARG_LOGLEVEL_LONG in valid_args:
+        valid_args[ARG_LOGLEVEL_LONG] = log_level
     else:
-        valid_args["-l"] = log_level
+        valid_args[ARG_LOGLEVEL_SHORT] = log_level
 
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
@@ -182,7 +186,7 @@ def test_parser_lowercase_log_level(
 ) -> None:
     """Verify that lower-case log levels are parsed correctly."""
     valid_args = valid_args.copy()
-    valid_args["--log-level"] = log_level
+    valid_args[ARG_LOGLEVEL_LONG] = log_level
 
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
@@ -197,7 +201,7 @@ def test_parser_lowercase_log_level(
 def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     """Verify that a bad log level fails to parse."""
     valid_args = valid_args.copy()
-    valid_args["--log-level"] = "INVALID"
+    valid_args[ARG_LOGLEVEL_LONG] = "INVALID"
 
     valid_args_tuples = ((k, v) for k, v in valid_args.items())
     args = list(itertools.chain.from_iterable(valid_args_tuples))
@@ -212,20 +216,20 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     ("blueprint_uri", "log_level"),
     [
         (
-            "-b blueprint1.yaml",
-            "-l DEBUG",
+            f"{ARG_URI_SHORT} blueprint1.yaml",
+            f"{ARG_LOGLEVEL_SHORT} DEBUG",
         ),
         (
-            "--blueprint-uri blueprint2.yaml",
-            "--log-level INFO",
+            f"{ARG_URI_LONG} blueprint2.yaml",
+            f"{ARG_LOGLEVEL_LONG} INFO",
         ),
         (
-            "--blueprint-uri blueprint3.yaml",
-            "--log-level WARNING",
+            f"{ARG_URI_SHORT} blueprint3.yaml",
+            f"{ARG_LOGLEVEL_SHORT} WARNING",
         ),
         (
-            "-b blueprint1.yaml",
-            "-l ERROR",
+            f"{ARG_URI_LONG} blueprint1.yaml",
+            f"{ARG_LOGLEVEL_LONG} ERROR",
         ),
     ],
 )
@@ -273,9 +277,9 @@ def test_get_request(
     parser = create_parser()
     parsed_args = parser.parse_args(
         [
-            "--blueprint-uri",
+            ARG_URI_LONG,
             blueprint_uri,
-            "--log-level",
+            ARG_LOGLEVEL_LONG,
             "INFO",
         ]
     )
@@ -1075,8 +1079,9 @@ def test_worker_main(tmp_path: Path, sim_runner: SimulationRunner) -> None:
 
     args = [
         "cstar.entrypoint.worker.worker",
+        ARG_URI_LONG,
         str(bp_path),
-        "--log-level",
+        ARG_LOGLEVEL_LONG,
         "DEBUG",
     ]
 
@@ -1103,9 +1108,9 @@ def test_worker_main_exec(
 
     args = [
         "cstar.entrypoint.worker.worker",
-        "--blueprint-uri",
+        ARG_URI_LONG,
         str(blueprint_path),
-        "--log-level",
+        ARG_LOGLEVEL_LONG,
         "DEBUG",
     ]
 
@@ -1139,9 +1144,10 @@ def test_worker_main_cstar_error(
     gracefully.
     """
     args = [
-        "--blueprint-uri",
+        "cstar.entrypoint.worker.worker",
+        ARG_URI_LONG,
         str(blueprint_path),
-        "--log-level",
+        ARG_LOGLEVEL_LONG,
         "DEBUG",
     ]
 

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -1074,16 +1074,10 @@ def test_worker_main(tmp_path: Path, sim_runner: SimulationRunner) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     args = [
-        "--blueprint-uri",
+        "cstar.entrypoint.worker.worker",
         str(bp_path),
-        "--output-dir",
-        str(output_dir),
         "--log-level",
         "DEBUG",
-        "--start-date",
-        "2024-01-01 00:00:00",
-        "--end-date",
-        "2024-02-01 00:00:00",
     ]
 
     with mock.patch.dict(os.environ, {}), mock.patch.object(sys, "argv", args):

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -1,5 +1,3 @@
-# ruff: noqa: S101
-
 import json
 import textwrap
 import typing as t
@@ -7,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-from cstar.base.utils import additional_files_dir
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 
 
@@ -23,52 +20,6 @@ def fake_blueprint_path(tmp_path: Path) -> Path:
     path = tmp_path / "blueprint.yml"
     path.touch()
     return path
-
-
-@pytest.fixture
-def templates_dir() -> Path:
-    """Return the path to the templates directory contained in the package
-    "additional files."
-
-    Returns
-    -------
-    Path
-    """
-    return additional_files_dir() / "templates"
-
-
-@pytest.fixture
-def wp_templates_dir(templates_dir: Path) -> Path:
-    """Return the path to the `Workplan` templates directory contained in the package
-    "additional files."
-
-    Parameters
-    ----------
-    templates_dir : Path
-        Fixture returning the path to the templates root directory.
-
-    Returns
-    -------
-    Path
-    """
-    return templates_dir / "wp"
-
-
-@pytest.fixture
-def bp_templates_dir(templates_dir: Path) -> Path:
-    """Return the path to the `Blueprint` templates directory contained in the package
-    "additional files."
-
-    Parameters
-    ----------
-    templates_dir : Path
-        Fixture returning the path to the templates root directory.
-
-    Returns
-    -------
-    Path
-    """
-    return templates_dir / "bp"
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -174,8 +174,8 @@ def test_converter_override_capability(
         Temporary path fixture for writing per-test outputs
     target_application: Application
         The application type to locate a mapping for
-    target_application: Application
-        The application type to locate a mapping for
+    overridden_target: Application
+        The application type to use in place of the original target application
     launcher_type: type[Launcher]
         The type of launcher that will consume the command
     """

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -72,6 +72,7 @@ Bug Fixes
 - Fix uninitialized attributes error in `SlurmBatch`
 - Mitigate a dependency issue with prefect and fakeredis (pin `fakeredis<2.35`)
 - Fix bug when merging dictionaries during application of blueprint overrides
+- Fix bug where `SimulationRunner` fails to display errors when parsing bad CLI arguments
 
 Improvements
 ~~~~~~~~~~~~
@@ -111,6 +112,7 @@ Improvements
 - Improve naming of module containing shared CLI callbacks
 - Add callbacks for automatic export of pertinent environment variables from CLI parameters
 - Reduce unit test duration
+- Reduce usage of hardcoded strings in CLI and tests
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change includes:

1. A bug fix for deprecated CLI arguments to the `SimulationRunner` being hidden/swallowed. Tests supplying the old arguments were updated.

2. Quality of life improvements
   
  - relocate pytest fixtures for re-use across `orchestration` and `entrypoint` tests
  - adjust type hints where linter was explicitly ignoring issues
  - minor docstring corrections
  - replace hardcoded constants for CLI arguments with literals 

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug where `SimulationRunner` fails to display errors when parsing bad CLI arguments

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce usage of hardcoded strings in CLI and tests

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`

