### PR TITLE
Add initial SimulationRunner preprocessing directive

### DIFF
--- a/cstar/base/utils.py
+++ b/cstar/base/utils.py
@@ -343,13 +343,15 @@ def deep_merge(d1: dict[str, t.Any], d2: dict[str, t.Any]) -> dict[str, t.Any]:
     dict[str, t.Any]
         The merged dictionaries.
     """
+    result: dict[str, t.Any] = copy.deepcopy(d1)
+
     for k, target in d2.items():
-        source = d1.get(k)
+        source = result.get(k)
 
         if isinstance(source, dict) and isinstance(target, dict):
-            d1[k] = deep_merge(source, target)
+            result[k] = deep_merge(source, target)
         elif isinstance(target, dict):
-            d1[k] = {**target}
+            result[k] = {**target}
         elif isinstance(source, list) and isinstance(target, list):
             items = []
             for x0, x1 in zip_longest(source, target, fillvalue=None):
@@ -361,12 +363,12 @@ def deep_merge(d1: dict[str, t.Any], d2: dict[str, t.Any]) -> dict[str, t.Any]:
                     items.append(deep_merge(x0, x1))
                 else:
                     items.append(copy.deepcopy(x1))
-            d1[k] = items
+            result[k] = items
         elif isinstance(target, list):
-            d1[k] = copy.deepcopy(target)
+            result[k] = copy.deepcopy(target)
         else:
-            d1[k] = target
-    return d1
+            result[k] = target
+    return result
 
 
 def additional_files_dir() -> Path:

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -12,21 +12,21 @@ from cstar.base.env import (
 from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import clobber_callback, log_level_callback
 from cstar.cli.workplan.shared import create_xrunner, get_registered_bp
+from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,
+    ARG_DIRECTIVES_URI_LONG,
+    ARG_DIRECTIVES_URI_SHORT,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
 )
 from cstar.entrypoint.worker.worker import execute_runner as exec_romsmarbl_runner
-from cstar.entrypoint.worker.worker import (
-    get_job_config,
-    get_request,
-    get_service_config,
-)
+from cstar.entrypoint.worker.worker import get_request
 from cstar.entrypoint.xrunner import XRunnerRequest
 from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import Application, Blueprint
 from cstar.orchestration.serialization import deserialize, validate_serialized_entity
+from cstar.orchestration.transforms import DirectiveConfig
 
 app = typer.Typer()
 log = get_logger(__name__)
@@ -74,6 +74,40 @@ def path_callback(
     return path
 
 
+def directives_callback(path: str | None) -> str | None:
+    """Validate the directive content after typer has parsed the path.
+
+    Parameters
+    ----------
+    path : str
+        The path to the directive file to validate.
+
+    Returns
+    -------
+    str.
+    """
+    if path is None:
+        return path
+
+    try:
+        with local_copy(path) as local_path:
+            if not local_path.exists():
+                msg = f"Directive file not found at path: {path}"
+                raise typer.BadParameter(msg)
+
+            # deserialize content to validate
+            _ = deserialize(path, DirectiveConfig)
+
+    except FileNotFoundError as ex:
+        msg = f"Directive file not found: {path}"
+        raise typer.BadParameter(msg) from ex
+    except ValidationError as ex:
+        msg = f"Directive file {path!r} is malformed: {ex}"
+        raise typer.BadParameter(msg) from ex
+
+    return path
+
+
 @app.command(name="run", help="Execute a blueprint in a local worker service.")
 def run(
     ctx: typer.Context,
@@ -103,6 +137,15 @@ def run(
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,
+    directive_uri: t.Annotated[
+        str | None,
+        typer.Option(
+            ARG_DIRECTIVES_URI_LONG,
+            ARG_DIRECTIVES_URI_SHORT,
+            help="The URI (or path) to a file containing directive configuration to be applied.",
+            callback=directives_callback,
+        ),
+    ] = None,
 ) -> None:
     """Execute a blueprint in a local worker service."""
     bp = t.cast("Blueprint", ctx.obj)
@@ -118,6 +161,9 @@ def run(
     if not result.is_valid:
         print(result.error_msg)
         return
+
+    if directive_uri:
+        uri = DirectiveConfig.apply_directives(directive_uri, uri)
 
     if bp.application == Application.ROMS_MARBL.value:
         # NOTE: temporary conditional to use old runner until it is converted to XRunner

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -7,3 +7,6 @@ ARG_LOGLEVEL_LONG: t.Literal["--log-level"] = "--log-level"
 ARG_LOGLEVEL_SHORT: t.Literal["-l"] = "-l"
 
 ARG_CLOBBER: t.Literal["--clobber"] = "--clobber"
+
+ARG_DIRECTIVES_URI_LONG: t.Literal["--directives"] = "--directives"
+ARG_DIRECTIVES_URI_SHORT: t.Literal["-d"] = "-d"

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -17,6 +17,7 @@ from cstar.entrypoint.service import Service
 from cstar.entrypoint.xrunner import XRunnerRequest, create_parser
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.orchestration.models import RomsMarblBlueprint
+from cstar.orchestration.transforms import DirectiveConfig
 from cstar.roms import ROMSSimulation
 
 if TYPE_CHECKING:
@@ -306,7 +307,12 @@ def main() -> int:
 
     job_cfg = get_job_config()
     service_cfg = get_service_config(args.log_level, name="SimulationRunner")
-    request = get_request(args.blueprint_uri)
+
+    blueprint_uri = args.blueprint_uri
+    if args.directives:
+        blueprint_uri = DirectiveConfig.apply_directives(args.directives, blueprint_uri)
+
+    request = get_request(blueprint_uri)
 
     return asyncio.run(execute_runner(job_cfg, service_cfg, request))
 

--- a/cstar/entrypoint/xrunner.py
+++ b/cstar/entrypoint/xrunner.py
@@ -12,6 +12,8 @@ from cstar.entrypoint.config import (
 )
 from cstar.entrypoint.service import Service
 from cstar.entrypoint.utils import (
+    ARG_DIRECTIVES_URI_LONG,
+    ARG_DIRECTIVES_URI_SHORT,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
     ARG_URI_LONG,
@@ -41,26 +43,37 @@ class XRunnerRequest(t.Generic[TBlueprint]):
     """User-friendly name for the process (or job) handling the request."""
     blueprint_uri: str
     """The URI of a blueprint to be used to parameterize the application."""
+    directive_uri: str
+    """The URI of a file containing directive configuration."""
     bp_type: type[TBlueprint]
     """The type of blueprint that the URI will be deserialized into."""
     _bp: TBlueprint | None = None
     """The deserialized blueprint."""
 
-    def __init__(self, uri: str, bp_type: type[TBlueprint], name: str = "") -> None:
+    def __init__(
+        self,
+        uri: str,
+        bp_type: type[TBlueprint],
+        name: str = "",
+        directive_uri: str = "",
+    ) -> None:
         """Initialize the request instance.
 
         Parameters
         ----------
         name : str
             User-friendly name for the process (or job) handling the request.
-        path : Path
+        uri : str
             The URI of a blueprint to be used to parameterize the application.
         bp_type : type[TBlueprint]
             The type of blueprint that the path will be deserialized into.
+        directive_uri : str
+            The URI of a file containing directive configuration for a runner.
         """
-        self.blueprint_uri = uri
+        self.blueprint_uri = uri.strip()
         self.bp_type = bp_type
         self.name = name.strip() or XRunnerRequest._generate_job_name()
+        self.directive_uri = directive_uri.strip()
 
     @property
     def application(self) -> str:
@@ -403,5 +416,12 @@ def create_parser() -> argparse.ArgumentParser:
         required=False,
         help="Logging level for the simulation.",
         choices=list(LogLevelChoices),
+    )
+    parser.add_argument(
+        ARG_DIRECTIVES_URI_LONG,
+        ARG_DIRECTIVES_URI_SHORT,
+        type=str,
+        required=False,
+        help="The URI of a file containing directive configuration.",
     )
     return parser

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -51,8 +51,10 @@ def prepare_directive_file(step: "LiveStep") -> Path:
         The path to the directive file.
     """
     directives_path = step.fsm.work_dir / "directives.yaml"
+    if not step.fsm.work_dir.exists():
+        step.fsm.work_dir.mkdir(parents=True)
     with directives_path.open("w") as fp:
-        model = step.model_dump_json(include={"directives"})
+        model = step.model_dump(include={"directives"})
         content = yaml.dump(model, sort_keys=False)
         fp.write(content)
     return directives_path

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -1,15 +1,17 @@
 import os
 import random
-import sys
 import textwrap
 import typing as t
 from collections import defaultdict
+from pathlib import Path
+
+import yaml
 
 from cstar.base.env import ENV_CSTAR_CLOBBER_WORKING_DIR
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
-from cstar.entrypoint.utils import ARG_CLOBBER, ARG_URI_LONG
+from cstar.entrypoint.utils import ARG_CLOBBER, ARG_DIRECTIVES_URI_LONG
 from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
@@ -35,24 +37,25 @@ str
 """
 
 
-def convert_roms_step_to_command(step: "LiveStep") -> str:
-    """Convert a `Step` into a command to be executed.
-
-    This function converts ROMS/ROMS-MARBL applications into a command triggering
-    a C-Star worker to run a simulation.
+def prepare_directive_file(step: "LiveStep") -> Path:
+    """Create a directives file in the step work directory.
 
     Parameters
     ----------
     step : LiveStep
-        The step to be converted.
+        The step to prepare a directive file for.
 
     Returns
     -------
     str
-        The complete CLI command.
+        The path to the directive file.
     """
-    worker_module = "cstar.entrypoint.worker.worker"
-    return f"{sys.executable} -m {worker_module}  {ARG_URI_LONG} {step.blueprint_path}"
+    directives_path = step.fsm.work_dir / "directives.yaml"
+    with directives_path.open("w") as fp:
+        model = step.model_dump_json(include={"directives"})
+        content = yaml.dump(model, sort_keys=False)
+        fp.write(content)
+    return directives_path
 
 
 def convert_step_to_blueprint_run_command(step: "LiveStep") -> str:
@@ -77,6 +80,10 @@ def convert_step_to_blueprint_run_command(step: "LiveStep") -> str:
 
     if is_flag_enabled(ENV_CSTAR_CLOBBER_WORKING_DIR):
         cmd_array.append(ARG_CLOBBER)
+
+    if step.directives:
+        directives_path = prepare_directive_file(step)
+        cmd_array.extend([ARG_DIRECTIVES_URI_LONG, str(directives_path)])
 
     return " ".join(cmd_array)
 
@@ -121,7 +128,7 @@ app_to_cmd_map: dict[str, StepToCommandConversionFn] = defaultdict(
     lambda: convert_step_to_blueprint_run_command,
     {
         Application.SLEEP.value: convert_step_to_placeholder,
-        Application.ROMS_MARBL.value: convert_roms_step_to_command,
+        Application.ROMS_MARBL.value: convert_step_to_blueprint_run_command,
     },
 )
 """Map application types to a function that converts a step to a CLI command."""

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import typing as t
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Awaitable, Generator, Iterable, Mapping
 from dataclasses import dataclass, field
 from itertools import cycle
 from pathlib import Path
@@ -215,7 +215,7 @@ async def prepare_workplan(
     run_root_dir = output_dir / run_id
 
     fill_transform: TemplateFillTransform | None = None
-    file_io_extras: list = []
+    file_io_extras: list[Awaitable[int]] = []
 
     if user_variables is not None:
         named_config = UserDefinedVariables(
@@ -244,7 +244,7 @@ async def prepare_workplan(
     )
     persist_as = WorkplanTransformer.derived_path(wp_path, run_root_dir, "_transformed")
 
-    file_io = [
+    file_io: list[Awaitable[int]] = [
         asyncio.to_thread(serialize, persist_orig, wp_orig),
         asyncio.to_thread(serialize, persist_as, wp),
         *file_io_extras,

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -490,6 +490,13 @@ class Step(BaseModel):
     )
     """A collection of key-value pairs specifying overrides for workflow attributes."""
 
+    directives: KeyValueStore = Field(
+        default_factory=dict,
+        validate_default=False,
+        frozen=True,
+    )
+    """A collection of key-value pairs specifying configuration for runtime directives."""
+
     @property
     def safe_name(self) -> str:
         """Return a URL-safe version of the step name.

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -208,9 +208,9 @@ class Status(IntEnum):
 class LiveStep(Step):
     """A Step enriched with runtime metadata."""
 
-    parent: t.Self | None = Field(None, exclude=True)
+    parent: t.Self | None = Field(default=None, exclude=True)
     """The step for which this step is a sub-task."""
-    work_dir: Path | None = Field(None, exclude=True)
+    work_dir: Path | None = Field(default=None, exclude=True)
     """The root directory where this step can write outputs."""
     _fsm: JobFileSystemManager | None = None
     """Manages the structure of outputs from the step."""

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -1027,24 +1027,27 @@ class DirectiveConfig(BaseModel):
         -------
         str
         """
-        with local_copy(directive_uri) as local_path:
+        with (
+            local_copy(directive_uri) as local_path,
+            local_copy(blueprint_uri) as local_bp,
+        ):
             model = deserialize(local_path, DirectiveConfig)
 
-        directives = model.directives
-        if not directives:
-            return blueprint_uri
+            directives = model.directives
+            if not directives:
+                return blueprint_uri
 
-        step = LiveStep(
-            name="directive-step",
-            application=Application.SLEEP,
-            blueprint=blueprint_uri,
-        )
-        directive_map = DirectiveConfig.directive_map
-        transforms = {
-            directive_map[key](config=t.cast("dict[str, dict[str, t.Any]]", config))
-            for key, config in directives.items()
-        }
-        for transform in transforms:
-            step = transform(step)[0]
+            step = LiveStep(
+                name="directive-step",
+                application=Application.ROMS_MARBL,
+                blueprint=local_bp,
+            )
+            directive_map = DirectiveConfig.directive_map
+            transforms = {
+                directive_map[key](config=t.cast("dict[str, dict[str, t.Any]]", config))
+                for key, config in directives.items()
+            }
+            for transform in transforms:
+                step = transform(step)[0]
 
         return str(step.blueprint_path)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -677,12 +677,7 @@ class OverrideTransform(Transform):
         blueprint: Blueprint = deserialize(bp_path, bp_type)
 
         updated_bp = self.apply(blueprint, step.blueprint_overrides)
-
         update: dict[str, t.Any] = {"blueprint_overrides": {}}
-        if bp_type == RomsMarblBlueprint:
-            update["work_dir"] = t.cast(
-                "RomsMarblBlueprint", updated_bp
-            ).runtime_params.output_dir
 
         live_step = LiveStep.from_step(step, update=update)
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -2,10 +2,12 @@ import os
 import re
 import typing as t
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
+
+from pydantic import BaseModel
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import (
@@ -18,10 +20,12 @@ from cstar.base.utils import (
     deep_merge,
     slugify,
 )
+from cstar.execution.file_system import local_copy
 from cstar.orchestration.application import APP_CAT_BLUEPRINTS
 from cstar.orchestration.models import (
     Application,
     Blueprint,
+    KeyValueStore,
     RomsMarblBlueprint,
     Workplan,
 )
@@ -120,8 +124,8 @@ class TemplateFillTransform:
 
     def __init__(
         self,
-        variable_resolver: t.Callable[[str], str] | None = None,
-        path_resolver: t.Callable[[str], Path] | None = None,
+        variable_resolver: Callable[[str], str] | None = None,
+        path_resolver: Callable[[str], Path] | None = None,
     ) -> None:
         """Initialize the transform.
 
@@ -137,7 +141,7 @@ class TemplateFillTransform:
         self._path_resolver = path_resolver
 
     def with_path_resolver(
-        self, path_resolver: t.Callable[[str], Path]
+        self, path_resolver: Callable[[str], Path]
     ) -> "TemplateFillTransform":
         """Return a new instance with the given path resolver bound.
 
@@ -207,7 +211,7 @@ class TemplateFillTransform:
 
         return step.model_validate_json(content)
 
-    def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
         """Apply template filling to a step's blueprint_overrides.
 
         Parameters
@@ -430,13 +434,14 @@ class WorkplanTransformer(LoggingMixin):
 
         # apply user blueprint_overrides and ensure consistent output targets;
         # must happen before time-splitting so the splitter reads correct blueprint values
-        steps = []
-        for step in live_steps:
+        steps: list[LiveStep] = []
+
+        for i in range(len(live_steps)):
+            step = live_steps[i]
+
             if step.application in apply_to:
-                new_step = override_output_directory(step)
-            else:
-                new_step = step
-            steps.append(new_step)
+                step = override_output_directory(step)
+            steps.append(step)
 
         if is_feature_enabled(ENV_FF_ORCH_TRX_TIMESPLIT):
             split_steps: list[LiveStep] = []
@@ -649,7 +654,7 @@ class OverrideTransform(Transform):
         bp_type = type(bp)
         return bp_type(**merged)
 
-    def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
         """Apply the transform to a step.
 
         Parameters
@@ -704,11 +709,121 @@ def override_output_directory(step: LiveStep) -> LiveStep:
 
     Returns
     -------
-    list[Step]
-        The transformed steps.
+    LiveStep
+        The updated step.
     """
     sys_overrides = {"runtime_params": {"output_dir": step.fsm.root}}
     override_transform = OverrideTransform(sys_overrides)
     overridden_step_result = iter(override_transform(step))
 
     return next(overridden_step_result)
+
+
+class Directive(Transform, t.Protocol):
+    _config: Mapping[str, t.Any]
+    """Contract of a transform that can be used as a directive."""
+
+    def __init__(self, config: dict[str, t.Any]) -> None:
+        """Initialize the instance.
+
+        Parameters
+        ----------
+        config : dict[str, t.Any] | None
+            A dictionary containing configuration for the directive.
+        """
+        if not config:
+            msg = "Configuration must be provided"
+            raise ValueError(msg)
+
+        self._config = config
+
+
+class ContinuanceTransform(Directive, OverrideTransform):
+    """A transform that locates a reset file with an unknown path at the
+    time the task was scheduled.
+    """
+
+    def __init__(self, config: dict[str, t.Any]) -> None:
+        """Initialize the instance.
+
+
+        Parameters
+        ----------
+        config : dict[str, t.Any] | None
+            A dictionary containing configuration for the directive.
+        """
+        Directive.__init__(self, config)
+        OverrideTransform.__init__(self, self._create_reset_override())
+
+    def _create_reset_override(
+        self,
+    ) -> dict[str, t.Any]:
+        source = Path(self._config["path"])
+        matches = sorted(source.rglob("*_rst*.nc"), reverse=True)
+
+        if not matches:
+            msg = f"No reset files located. Unable to continue from {source!r}"
+            raise CstarExpectationFailed(msg)
+
+        match = matches.pop(0).as_posix()
+        return {"initial_conditions": {"data": [{"location": match}]}}
+
+    @t.override
+    @staticmethod
+    def suffix() -> str:
+        """Return a suffix used when persisting a resource modified by this transform.
+
+        Returns
+        -------
+        str
+        """
+        return "cfrom"
+
+
+class DirectiveConfig(BaseModel):
+    directive_map: t.ClassVar[Mapping[str, type[Directive]]] = {
+        "continue-from": ContinuanceTransform,
+    }
+    directives: KeyValueStore
+
+    @classmethod
+    def apply_directives(
+        cls,
+        directive_uri: str,
+        blueprint_uri: str,
+    ) -> str:
+        """Apply the specified directives to the blueprint and
+        return the path to the final, transformed blueprint.
+
+        Parameters
+        ----------
+        directive_uri : str
+            The URI to configuration for directives the runner must execute.
+        blueprint_uri : str
+            The user-supplied blueprint URI specifying the blueprint to preprocess.
+
+        Returns
+        -------
+        str
+        """
+        with local_copy(directive_uri) as local_path:
+            model = deserialize(local_path, DirectiveConfig)
+
+        directives = model.directives
+        if not directives:
+            return blueprint_uri
+
+        step = LiveStep(
+            name="directive-step",
+            application="directive",
+            blueprint=blueprint_uri,
+        )
+        directive_map = DirectiveConfig.directive_map
+        transforms = {
+            directive_map[key](config=t.cast("dict[str, dict[str, t.Any]]", config))
+            for key, config in directives.items()
+        }
+        for transform in transforms:
+            step = next(iter(transform(step)))
+
+        return str(step.blueprint_path)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -708,7 +708,7 @@ def override_output_directory(step: LiveStep) -> LiveStep:
     Returns
     -------
     LiveStep
-        The updated step.
+        The transformed step.
     """
     sys_overrides = {"runtime_params": {"output_dir": step.fsm.root}}
     override_transform = OverrideTransform(sys_overrides)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -885,7 +885,6 @@ class RestartFile(BaseModel):
         self._ts = datetime.strptime(matches.group(2), RestartFile.FMT_TS)
         # look for segment for partition number, e.g. <base>.<ts>.000.nc vs. <base>.<ts>.nc
         self._segment = matches.group(3)
-        self._is_partitioned = self._segment is not None
         return self
 
     @property

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -2,7 +2,7 @@ import os
 import re
 import typing as t
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
@@ -40,7 +40,7 @@ class Transform(t.Protocol):
     new steps.
     """
 
-    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Sequence[LiveStep]:
         """Apply the transform to a step.
 
         Parameters
@@ -449,7 +449,7 @@ class WorkplanTransformer(LoggingMixin):
 
             for step in steps:
                 if step.application in apply_to:
-                    transformed_steps = list(self.transform_fn(step))
+                    transformed_steps = self.transform_fn(step)
                     named_dep_map[step.name] = transformed_steps[-1].name
                     split_steps.extend(transformed_steps)
                 else:
@@ -501,7 +501,7 @@ class RomsMarblTimeSplitter(Transform):
         freq_config = os.getenv(ENV_CSTAR_ORCH_TRX_FREQ, frequency)
         self.frequency = freq_config.lower()
 
-    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Sequence[LiveStep]:
         """Split a step into multiple sub-steps.
 
         Parameters
@@ -511,7 +511,7 @@ class RomsMarblTimeSplitter(Transform):
 
         Returns
         -------
-        Iterable[Step]
+        Sequence[Step]
             Steps for each subtask resulting from the split.
         """
         blueprint = deserialize(step.blueprint_path, RomsMarblBlueprint)
@@ -532,6 +532,7 @@ class RomsMarblTimeSplitter(Transform):
         last_restart_file: Path | None = None
         output_root_name = DEFAULT_OUTPUT_ROOT_NAME
 
+        results: list[LiveStep] = []
         for i, (sd, ed) in enumerate(time_slices):
             bp_copy = RomsMarblBlueprint(
                 **blueprint.model_dump(
@@ -574,8 +575,8 @@ class RomsMarblTimeSplitter(Transform):
                 "name": child_step_name,
             }
             child_step = LiveStep.from_step(step, parent=step, update=updates)
+            results.append(child_step)
 
-            yield child_step
             if i == len(time_slices) - 1:
                 break
 
@@ -591,6 +592,8 @@ class RomsMarblTimeSplitter(Transform):
 
             # use output dir of the last step as the input for the next step
             last_restart_file = restart_file_path
+
+        return tuple(results)
 
     @staticmethod
     def suffix() -> str:
@@ -654,7 +657,7 @@ class OverrideTransform(Transform):
         bp_type = type(bp)
         return bp_type(**merged)
 
-    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Sequence[LiveStep]:
         """Apply the transform to a step.
 
         Parameters
@@ -664,7 +667,7 @@ class OverrideTransform(Transform):
 
         Returns
         -------
-        Iterable[Step]
+        Sequence[Step]
             Zero-to-many steps resulting from applying the transform.
         """
         bp_path = Path(step.blueprint_path)
@@ -687,7 +690,7 @@ class OverrideTransform(Transform):
         live_step.blueprint_path = live_step.fsm.work_dir / bp_renamed
 
         serialize(live_step.blueprint_path, updated_bp)
-        return [live_step]
+        return (live_step,)
 
     @staticmethod
     def suffix() -> str:
@@ -714,9 +717,9 @@ def override_output_directory(step: LiveStep) -> LiveStep:
     """
     sys_overrides = {"runtime_params": {"output_dir": step.fsm.root}}
     override_transform = OverrideTransform(sys_overrides)
-    overridden_step_result = iter(override_transform(step))
+    overridden_step_result = override_transform(step)
 
-    return next(overridden_step_result)
+    return overridden_step_result[0]
 
 
 class Directive(Transform, t.Protocol):
@@ -824,6 +827,6 @@ class DirectiveConfig(BaseModel):
             for key, config in directives.items()
         }
         for transform in transforms:
-            step = next(iter(transform(step)))
+            step = transform(step)[0]
 
         return str(step.blueprint_path)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -818,7 +818,7 @@ class DirectiveConfig(BaseModel):
 
         step = LiveStep(
             name="directive-step",
-            application="directive",
+            application=Application.SLEEP,
             blueprint=blueprint_uri,
         )
         directive_map = DirectiveConfig.directive_map

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -593,9 +593,8 @@ class RomsMarblTimeSplitter(Transform):
             depends_on = [child_step.name]
 
             # Use the last restart file as initial conditions for the follow-up step
-            step_output_dir = child_fs.output_dir
             restart_file = RestartFile.from_parts(
-                output_root_name, ed, 0, step_output_dir
+                output_root_name, ed, 0, child_fs.output_dir
             )
 
             # use output dir of the last step as the input for the next step

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -7,7 +7,13 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    PrivateAttr,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import (
@@ -529,7 +535,7 @@ class RomsMarblTimeSplitter(Transform):
             raise ValueError(msg)
 
         depends_on = step.depends_on
-        last_restart_file: Path | None = None
+        last_restart_file: RestartFile | None = None
         output_root_name = DEFAULT_OUTPUT_ROOT_NAME
 
         results: list[LiveStep] = []
@@ -542,8 +548,9 @@ class RomsMarblTimeSplitter(Transform):
                 ),
             )
 
-            compact_sd = sd.strftime("%Y%m%d%H%M%S")
-            compact_ed = ed.strftime("%Y%m%d%H%M%S")
+            compact_fmt = "%Y%m%d%H%M%S"
+            compact_sd = sd.strftime(compact_fmt)
+            compact_ed = ed.strftime(compact_fmt)
 
             dynamic_name = f"{i + 1:03d}_{step.safe_name}_{compact_sd}_{compact_ed}"
             child_step_name = slugify(dynamic_name)
@@ -562,8 +569,10 @@ class RomsMarblTimeSplitter(Transform):
             }
 
             if last_restart_file:
-                rst_path = last_restart_file.as_posix()
-                overrides["initial_conditions"] = {"data": [{"location": rst_path}]}
+                overrides = deep_merge(
+                    overrides,
+                    ResetFileTrxAdapter.adapt(last_restart_file),
+                )
 
             child_bp_path = child_fs.work_dir / f"{child_step_name}_bp.yaml"
             serialize(child_bp_path, bp_copy)
@@ -584,14 +593,13 @@ class RomsMarblTimeSplitter(Transform):
             depends_on = [child_step.name]
 
             # Use the last restart file as initial conditions for the follow-up step
-            # - reset file names are formatted as: <stem>_rst.YYYYMMDDHHMMSS.{partition}.nc
-            reset_file_name = f"{output_root_name}_rst.{compact_ed}.000.nc"
-
             step_output_dir = child_fs.output_dir
-            restart_file_path = step_output_dir / reset_file_name
+            restart_file = RestartFile.from_parts(
+                output_root_name, ed, 0, step_output_dir
+            )
 
             # use output dir of the last step as the input for the next step
-            last_restart_file = restart_file_path
+            last_restart_file = restart_file
 
         return tuple(results)
 
@@ -736,8 +744,217 @@ class Directive(Transform, t.Protocol):
         self._config = config
 
 
+class RestartFile(BaseModel):
+    """Reference to a path that contains restart checkpoints."""
+
+    path: Path
+    """The path to a restart file."""
+    _base: str = PrivateAttr()
+    """The base name of the file."""
+    _segment: str | None = PrivateAttr(default=None)
+    """The segment identifier of the file."""
+    _ts: datetime = PrivateAttr()
+    """The timestamp parsed from the file name."""
+
+    EXT: t.ClassVar[t.Literal["nc"]] = "nc"
+    """The expected file extension for a restart file."""
+    FMT_TS: t.ClassVar[t.Literal["%Y%m%d%H%M%S"]] = "%Y%m%d%H%M%S"
+    """The expected timestamp format in the restart file name"""
+    PATTERN_RST: t.ClassVar[t.Literal[r"^(.*?)_rst\.(\d{14})(?:\.(\d{3}))?\.nc$"]] = (
+        r"^(.*?)_rst\.(\d{14})(?:\.(\d{3}))?\.nc$"
+    )
+    """A regex identifying full restart or partitioned files."""
+    SUFFIX: t.ClassVar[t.Literal["_rst"]] = "_rst"
+    """A unique suffix found in the name of restart files"""
+
+    @classmethod
+    def find(cls, search_path: Path, notfound_ok: bool = True) -> "RestartFile | None":
+        """Search for a restart file in the specified location.
+
+        Parameters
+        ----------
+        search_path : Path
+            The path to search
+        notfound_ok : bool
+            If False, raise an exception if no restart files are found.
+
+        Returns
+        -------
+        ResetFile
+
+        Raises
+        ------
+        ValueError
+            If the search path does not exist or contains no recognizable restart files.
+        """
+        search_path = search_path.expanduser().resolve()
+
+        if not search_path.exists():
+            msg = f"No directory found at path: {search_path!r}"
+            raise ValueError(msg)
+
+        if matches := sorted(search_path.rglob(f"*{cls.SUFFIX}.*.000.{cls.EXT}")):
+            # prefer use of pre-partitioned data when available
+            return RestartFile(path=matches[0])
+
+        matches = sorted(search_path.rglob(f"*{cls.SUFFIX}*.{cls.EXT}"), reverse=True)
+        if matches:
+            return RestartFile(path=matches.pop(0))
+
+        if not notfound_ok:
+            msg = f"No restart files located. Unable to continue from {search_path!r}"
+            raise CstarExpectationFailed(msg)
+        return None
+
+    @classmethod
+    def from_parts(
+        cls,
+        base: str,
+        timestamp: datetime,
+        segment: int | None = None,
+        directory: Path | None = None,
+    ) -> "RestartFile":
+        """Create a ResetFile from components.
+
+        Parameters
+        ----------
+        base : str
+            The base name for the restart file.
+        timestamp : datetime
+            The timestamp for the restart file.
+        segment : int | None
+            The segment number if partitioned, otherwise `None`.
+        directory : Path | None
+            The directory to contain the file. If not specified, defaults to cwd.
+
+        Returns
+        -------
+        ResetFile
+
+        Raises
+        ------
+        ValueError
+            If the search path does not exist or contains no recognizable restart files.
+        """
+        filename = f"{base}{cls.SUFFIX}.{timestamp.strftime(cls.FMT_TS)}"
+        if segment is not None:
+            filename = f"{filename}.{segment:03d}.{cls.EXT}"
+        else:
+            filename = f"{filename}.{cls.EXT}"
+
+        if directory:
+            return RestartFile(path=directory / filename)
+
+        return RestartFile(path=Path(filename))
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, value: Path, _info: "ValidationInfo") -> Path:
+        """Verify the supplied path meets the restart file naming convention.
+
+        Parameters
+        ----------
+        value : str
+            The value of the checkpoint frequency property
+        _info : ValidationInfo
+            Metadata for the current validation context
+        """
+        if value.suffix != f".{RestartFile.EXT}":
+            msg = f"File extension does not match expected naming convention: {value.suffix}"
+            raise ValueError(msg)
+
+        if re.fullmatch(RestartFile.PATTERN_RST, value.name, flags=re.ASCII):
+            return value
+
+        msg = f"File name does not match expected naming convention: {value}"
+        raise ValueError(msg)
+
+    @model_validator(mode="after")
+    def _model_validate(self) -> "RestartFile":
+        """Perform post-processing on the restart file path.
+
+        Returns
+        -------
+        ResetFile
+        """
+        matches = re.fullmatch(
+            RestartFile.PATTERN_RST, self.path.as_posix(), flags=re.ASCII
+        )
+        if not matches:
+            msg = f"File name does not match expected naming convention: {self.path}"
+            raise ValueError(msg)
+
+        self._base = matches.group(1)
+
+        self._ts = datetime.strptime(matches.group(2), RestartFile.FMT_TS)
+        # look for segment for partition number, e.g. <base>.<ts>.000.nc vs. <base>.<ts>.nc
+        self._segment = matches.group(3)
+        self._is_partitioned = self._segment is not None
+        return self
+
+    @property
+    def timestamp(self) -> datetime:
+        """Return a datetime derived from the timestamp in the restart file name.
+
+        Returns
+        -------
+        datetime
+        """
+        return self._ts
+
+    @property
+    def is_partitioned(self) -> bool:
+        """Return `True` if the restart file belongs to a partioned dataset.
+
+        Returns
+        -------
+        datetime
+        """
+        return self._segment is not None
+
+    @property
+    def partition(self) -> int | None:
+        if self._segment:
+            return int(self._segment)
+        return None
+
+
+class ResetFileTrxAdapter:
+    """Convert a restart file into a dictionary useful for use in an OverrideTransform."""
+
+    FMT_DATE: t.ClassVar[t.Literal["%Y-%m-%d %H:%M:%S"]] = "%Y-%m-%d %H:%M:%S"
+
+    @classmethod
+    def adapt(cls, rst_file: RestartFile) -> dict[str, t.Any]:
+        """Given a restart file, create a dictionary containing the overrides necessary to
+        execute a simulation with the restart file specified in the initial conditions.
+
+        Parameters
+        ----------
+        restart_file : ResetFile
+            The restart file metadata used to convert into an override mapping.
+
+        Returns
+        -------
+        Mapping[str, t.Any]
+        """
+        return {
+            "runtime_params": {
+                "start_date": rst_file.timestamp,
+            },
+            "initial_conditions": {
+                "data": [
+                    {
+                        "location": rst_file.path.as_posix(),
+                        "partitioned": rst_file.is_partitioned,
+                    },
+                ],
+            },
+        }
+
+
 class ContinuanceTransform(Directive, OverrideTransform):
-    """A transform that locates a reset file with an unknown path at the
+    """A transform that locates a restart file with an unknown path at the
     time the task was scheduled.
     """
 
@@ -769,22 +986,15 @@ class ContinuanceTransform(Directive, OverrideTransform):
             If unknown or invalid configuration is supplied.
         """
         if "path" not in self._config:
-            msg = "Invalid continuance transform configuration. Only reset paths are supported."
+            msg = "Invalid continuance transform configuration. Only restart paths are supported."
             raise NotImplementedError(msg)
 
-        source = Path(self._config["path"])
-        if not source.exists():
-            msg = f"No directory found at path: {source!r}"
-            raise ValueError(msg)
+        search_path = Path(self._config["path"])
+        if restart_file := RestartFile.find(search_path, notfound_ok=False):
+            return ResetFileTrxAdapter.adapt(restart_file)
 
-        matches = sorted(source.rglob("*_rst*.nc"), reverse=True)
-
-        if not matches:
-            msg = f"No reset files located. Unable to continue from {source!r}"
-            raise CstarExpectationFailed(msg)
-
-        value = matches.pop(0).as_posix()
-        return {"initial_conditions": {"data": [{"location": value}]}}
+        msg = f"No restart file located in search path: {search_path!r}"
+        raise ValueError(msg)
 
     @t.override
     @staticmethod

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -571,7 +571,7 @@ class RomsMarblTimeSplitter(Transform):
             if last_restart_file:
                 overrides = deep_merge(
                     overrides,
-                    ResetFileTrxAdapter.adapt(last_restart_file),
+                    RestartFileTrxAdapter.adapt(last_restart_file),
                 )
 
             child_bp_path = child_fs.work_dir / f"{child_step_name}_bp.yaml"
@@ -918,7 +918,7 @@ class RestartFile(BaseModel):
         return None
 
 
-class ResetFileTrxAdapter:
+class RestartFileTrxAdapter:
     """Convert a restart file into a dictionary useful for use in an OverrideTransform."""
 
     @classmethod
@@ -988,7 +988,7 @@ class ContinuanceTransform(Directive, OverrideTransform):
 
         search_path = Path(self._config["path"])
         if restart_file := RestartFile.find(search_path, notfound_ok=False):
-            return ResetFileTrxAdapter.adapt(restart_file)
+            return RestartFileTrxAdapter.adapt(restart_file)
 
         msg = f"No restart file located in search path: {search_path!r}"
         raise ValueError(msg)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -763,16 +763,28 @@ class ContinuanceTransform(Directive, OverrideTransform):
         -------
         dict[str, t.Any]
 
+        Raises
+        ------
+        ValueError
+            If unknown or invalid configuration is supplied.
         """
+        if "path" not in self._config:
+            msg = "Invalid continuance transform configuration. Only reset paths are supported."
+            raise NotImplementedError(msg)
+
         source = Path(self._config["path"])
+        if not source.exists():
+            msg = f"No directory found at path: {source!r}"
+            raise ValueError(msg)
+
         matches = sorted(source.rglob("*_rst*.nc"), reverse=True)
 
         if not matches:
             msg = f"No reset files located. Unable to continue from {source!r}"
             raise CstarExpectationFailed(msg)
 
-        match = matches.pop(0).as_posix()
-        return {"initial_conditions": {"data": [{"location": match}]}}
+        value = matches.pop(0).as_posix()
+        return {"initial_conditions": {"data": [{"location": value}]}}
 
     @t.override
     @staticmethod

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -751,11 +751,19 @@ class ContinuanceTransform(Directive, OverrideTransform):
             A dictionary containing configuration for the directive.
         """
         Directive.__init__(self, config)
-        OverrideTransform.__init__(self, self._create_reset_override())
+        OverrideTransform.__init__(self, self._create_initial_condition_overrides())
 
-    def _create_reset_override(
+    def _create_initial_condition_overrides(
         self,
     ) -> dict[str, t.Any]:
+        """Create an overrides dictionary that will result in the modified blueprint
+        using a
+
+        Returns
+        -------
+        dict[str, t.Any]
+
+        """
         source = Path(self._config["path"])
         matches = sorted(source.rglob("*_rst*.nc"), reverse=True)
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -885,7 +885,6 @@ class RestartFile(BaseModel):
             raise ValueError(msg)
 
         self._base = matches.group(1)
-
         self._ts = datetime.strptime(matches.group(2), RestartFile.FMT_TS)
         # look for segment for partition number, e.g. <base>.<ts>.000.nc vs. <base>.<ts>.nc
         self._segment = matches.group(3)
@@ -921,8 +920,6 @@ class RestartFile(BaseModel):
 
 class ResetFileTrxAdapter:
     """Convert a restart file into a dictionary useful for use in an OverrideTransform."""
-
-    FMT_DATE: t.ClassVar[t.Literal["%Y-%m-%d %H:%M:%S"]] = "%Y-%m-%d %H:%M:%S"
 
     @classmethod
     def adapt(cls, rst_file: RestartFile) -> dict[str, t.Any]:

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -836,11 +836,9 @@ class RestartFile(BaseModel):
         ValueError
             If the search path does not exist or contains no recognizable restart files.
         """
-        filename = f"{base}{cls.SUFFIX}.{timestamp.strftime(cls.FMT_TS)}"
-        if segment is not None:
-            filename = f"{filename}.{segment:03d}.{cls.EXT}"
-        else:
-            filename = f"{filename}.{cls.EXT}"
+        ts = timestamp.strftime(cls.FMT_TS)
+        parted_clause = f".{segment:03d}" if segment is not None else ""
+        filename = f"{base}{cls.SUFFIX}.{ts}{parted_clause}.{cls.EXT}"
 
         if directory:
             return RestartFile(path=directory / filename)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -592,9 +592,16 @@ class RomsMarblTimeSplitter(Transform):
             # use dependency on the prior substep to chain all the dynamic steps
             depends_on = [child_step.name]
 
+            # determine padding on partition segment of name from number of partitions
+            partition_segment: str | None = None
+            if partitioning := bp_copy.partitioning:
+                num_partitions = partitioning.n_procs_x * partitioning.n_procs_y
+                pad_size = len(str(num_partitions - 1))
+                partition_segment = "0".zfill(pad_size)
+
             # Use the last restart file as initial conditions for the follow-up step
             restart_file = RestartFile.from_parts(
-                output_root_name, ed, 0, child_fs.output_dir
+                output_root_name, ed, partition_segment, child_fs.output_dir
             )
 
             # use output dir of the last step as the input for the next step
@@ -759,8 +766,8 @@ class RestartFile(BaseModel):
     """The expected file extension for a restart file."""
     FMT_TS: t.ClassVar[t.Literal["%Y%m%d%H%M%S"]] = "%Y%m%d%H%M%S"
     """The expected timestamp format in the restart file name"""
-    PATTERN_RST: t.ClassVar[t.Literal[r"^(.*?)_rst\.(\d{14})(?:\.(\d{3}))?\.nc$"]] = (
-        r"^(.*?)_rst\.(\d{14})(?:\.(\d{3}))?\.nc$"
+    PATTERN_RST: t.ClassVar[t.Literal[r"^(.*?)_rst\.(\d{14})(?:\.(\d{1,9}))?\.nc$"]] = (
+        r"^(.*?)_rst\.(\d{14})(?:\.(\d{1,9}))?\.nc$"
     )
     """A regex identifying full restart or partitioned files."""
     SUFFIX: t.ClassVar[t.Literal["_rst"]] = "_rst"
@@ -792,7 +799,7 @@ class RestartFile(BaseModel):
             msg = f"No directory found at path: {search_path!r}"
             raise ValueError(msg)
 
-        if matches := sorted(search_path.rglob(f"*{cls.SUFFIX}.*.000.{cls.EXT}")):
+        if matches := sorted(search_path.rglob(f"*{cls.SUFFIX}.*.*.{cls.EXT}")):
             # prefer use of pre-partitioned data when available
             return RestartFile(path=matches[0])
 
@@ -810,7 +817,7 @@ class RestartFile(BaseModel):
         cls,
         base: str,
         timestamp: datetime,
-        segment: int | None = None,
+        segment: str | None = None,
         directory: Path | None = None,
     ) -> "RestartFile":
         """Create a ResetFile from components.
@@ -821,8 +828,8 @@ class RestartFile(BaseModel):
             The base name for the restart file.
         timestamp : datetime
             The timestamp for the restart file.
-        segment : int | None
-            The segment number if partitioned, otherwise `None`.
+        segment : str | None
+            The 0-padded segment number if partitioned, otherwise `None`.
         directory : Path | None
             The directory to contain the file. If not specified, defaults to cwd.
 
@@ -836,7 +843,7 @@ class RestartFile(BaseModel):
             If the search path does not exist or contains no recognizable restart files.
         """
         ts = timestamp.strftime(cls.FMT_TS)
-        parted_clause = f".{segment:03d}" if segment is not None else ""
+        parted_clause = f".{segment}" if segment is not None else ""
         filename = f"{base}{cls.SUFFIX}.{ts}{parted_clause}.{cls.EXT}"
 
         if directory:

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -369,10 +369,25 @@ def test_deep_merge(
 
 def test_deep_merge_purity() -> None:
     """Confirm the deep_merge function does not modify the input dictionaries."""
-    d0 = {"a": 1}
-    d1 = {"b": 2}
+    d0: dict[str, int | list[str]] = {"a": 0, "b": 1, "l": ["x"]}
+    d1: dict[str, int | list[str]] = {"a": 100, "c": 101, "l": ["y"]}
 
     d3 = deep_merge(d0, d1)
 
+    # confirm key moved from d1 to d3 without side-effects
+    assert "c" in d3
+    assert "c" not in d0
+
+    # confirm key moved from d0 to d3 without side-effects
     assert "b" in d3
-    assert "b" not in d0
+    assert "b" not in d1
+
+    # confirm original lists weren't changed
+    assert isinstance(d0["l"], list)
+    assert isinstance(d1["l"], list)
+    assert "x" in d0["l"]
+    assert "y" in d1["l"]
+
+    # confirm the list was merged by index
+    assert "y" in d3["l"]
+    assert "x" not in d3["l"]

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -386,7 +386,9 @@ def test_deep_merge_purity() -> None:
     assert isinstance(d0["l"], list)
     assert isinstance(d1["l"], list)
     assert "x" in d0["l"]
+    assert "x" not in d1["l"]
     assert "y" in d1["l"]
+    assert "y" not in d0["l"]
 
     # confirm the list was merged by index
     assert "y" in d3["l"]

--- a/cstar/tests/unit_tests/base/test_utils.py
+++ b/cstar/tests/unit_tests/base/test_utils.py
@@ -365,3 +365,14 @@ def test_deep_merge(
 ) -> None:
     actual = deep_merge(original, to_merge)
     assert actual == expected
+
+
+def test_deep_merge_purity() -> None:
+    """Confirm the deep_merge function does not modify the input dictionaries."""
+    d0 = {"a": 1}
+    d1 = {"b": 2}
+
+    d3 = deep_merge(d0, d1)
+
+    assert "b" in d3
+    assert "b" not in d0

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -20,6 +20,7 @@ from cstar.base.gitutils import git_location_to_raw
 from cstar.base.input_dataset import InputDataset
 from cstar.base.log import get_logger
 from cstar.base.utils import additional_files_dir
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.io.constants import SourceClassification
 from cstar.io.retriever import Retriever
 from cstar.io.source_data import SourceData, SourceDataCollection, _SourceInspector
@@ -31,6 +32,8 @@ from cstar.io.staged_data import (
 )
 from cstar.io.stager import Stager
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
+from cstar.orchestration.models import Step
+from cstar.orchestration.orchestration import LiveStep
 from cstar.tests.unit_tests.fake_abc_subclasses import (
     FakeExternalCodeBase,
     FakeInputDataset,
@@ -1772,7 +1775,7 @@ def mock_placeholder_delay() -> Generator[None, None, None]:
         yield
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def prefect_server() -> Generator[str, None, None]:
     """Starts a Prefect server and stops it when the tests are done."""
     if "PREFECT_API_URL" in os.environ:
@@ -1854,3 +1857,149 @@ def bp_templates_dir(templates_dir: Path) -> Path:
     Path
     """
     return templates_dir / "bp"
+
+
+@pytest.fixture
+def mock_sim_output_dir(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> tuple[Path, Path, Path]:
+    """This fixture creates a directory structure mocking a completed simulation.
+
+    It includes directoriess matching the expected convention for:
+    - work
+    - logs
+    - output
+    - joined output
+    - etc.
+
+    > See RomsFileSystemManager for the more information.
+
+    It includes mocked files for:
+    - a blueprint (yaml) file
+    - reset files matching glob pattern `*_rst*.nc`
+
+    Returns
+    -------
+    tuple[Path, Path, Path]
+        The tuple contains:
+        - mock user data directory (e.g. a fake "source" where user information can originate)
+        - step working directory
+        - blueprint path (path to a blueprint in user data directory)
+    """
+    info_msg = f"This file was created by the {__name__} fixture\n"
+
+    container_dir = tmp_path / "mock_sim_output_dir"
+    user_data_dir = container_dir / "userdata"
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    tpl_path = bp_templates_dir / "blueprint.yaml"
+    tpl_content = tpl_path.read_text()
+
+    bp_path = user_data_dir / "blueprint.yaml"
+    bp_path.write_text(tpl_content)
+
+    step_dir = container_dir / "step"
+    fsm = RomsFileSystemManager(step_dir)
+    fsm.prepare()
+
+    log_path = fsm.logs_dir / "cstar.out"
+    log_path.write_text(info_msg)
+    log_path.write_text("Simulation completed successfully\n")
+
+    joined_dir = fsm.joined_output_dir
+
+    reset_files = [
+        joined_dir / "output_rst.0.nc",
+        joined_dir / "output_rst.1.nc",
+        joined_dir / "output_rst.2.nc",
+    ]
+    for file in reset_files:
+        file.write_text(info_msg)
+
+    return user_data_dir, step_dir, bp_path
+
+
+@pytest.fixture
+def preprocessable_roms_step(
+    mock_sim_output_dir: tuple[Path, Path, Path],
+) -> Step:
+    """Create a valid step with an underlying RomsMarblBlueprint.
+
+    Parameters
+    ----------
+    mock_sim_output_dir: tuple[Path, Path, Path]
+        Paths to directories created to mock output of a ROMS simulation.
+    """
+    *_, step_dir, bp_path = mock_sim_output_dir
+    joined_dir = step_dir / "joined_output"
+
+    return Step(
+        name="test step",
+        application="roms_marbl",
+        blueprint=bp_path,
+        directives={
+            "continue-from": {
+                "path": joined_dir.as_posix(),
+            },
+        },
+    )
+
+
+@pytest.fixture
+def preprocessable_roms_livestep(
+    preprocessable_roms_step: Step,
+    mock_sim_output_dir: tuple[Path, Path, Path],
+) -> LiveStep:
+    """Create a valid step with an underlying RomsMarblBlueprint.
+
+    Parameters
+    ----------
+    mock_sim_output_dir: tuple[Path, Path, Path]
+        Paths to directories created to mock output of a ROMS simulation.
+
+    Returns
+    -------
+    LiveStep
+    """
+    *_, step_dir, _ = mock_sim_output_dir
+    return LiveStep.from_step(
+        preprocessable_roms_step,
+        update={"work_dir": step_dir},
+    )
+
+
+@pytest.fixture
+def preprocessable_workplan_path(
+    tmp_path: Path,
+    mock_sim_output_dir: tuple[Path, Path, Path],
+    wp_templates_dir: Path,
+) -> Path:
+    """Modify a basic workplan template to include directives in the last step.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Used to write some temporary workplans to disk
+    mock_sim_output_dir : Path
+        Used to identify a directory containing mocked restart files
+    wp_templates_dir : Path
+        Used to load a workplan template that can be modified to include directives
+    """
+    wp_template = wp_templates_dir / "workplan.yaml"
+
+    # add directives to the last step in the workplan file
+    _, continue_from_dir, _ = mock_sim_output_dir
+    content = wp_template.read_text()
+    base_indent = 6  # indentation of the "directives" element
+    directives = ["directives:", "continue-from:", f"path: {continue_from_dir}"]
+    for i in range(len(directives)):
+        line_indent_sz = base_indent + (i * 4)
+        indent = " " * line_indent_sz
+        directives[i] = f"{indent}{directives[i]}"
+    content += "\n".join(directives)
+    write_to = tmp_path / "wp_with_directives.yaml"
+    nbytes = write_to.write_text(content)
+    assert nbytes
+
+    return write_to

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1910,9 +1910,9 @@ def mock_sim_output_dir(
     joined_dir = fsm.joined_output_dir
 
     reset_files = [
-        joined_dir / "output_rst.0.nc",
-        joined_dir / "output_rst.1.nc",
-        joined_dir / "output_rst.2.nc",
+        joined_dir / "output_rst.20120101000000.000.nc",
+        joined_dir / "output_rst.20120110000000.001.nc",
+        joined_dir / "output_rst.20120120000000.002.nc",
     ]
     for file in reset_files:
         file.write_text(info_msg)

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -4,6 +4,8 @@ import logging
 import os
 import shutil
 import sys
+import textwrap
+import typing as t
 from collections.abc import Generator
 from pathlib import Path
 from unittest import mock
@@ -19,6 +21,7 @@ from cstar.entrypoint.config import (
     get_service_config,
 )
 from cstar.entrypoint.utils import (
+    ARG_DIRECTIVES_URI_LONG,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
     ARG_URI_LONG,
@@ -30,8 +33,11 @@ from cstar.entrypoint.worker.worker import (
     main,
 )
 from cstar.entrypoint.xrunner import XRunnerRequest, create_parser
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.orchestration.models import RomsMarblBlueprint
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.transforms import ContinuanceTransform
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -123,6 +129,38 @@ def sim_runner(
     runner._simulation.directory = output_path
 
     return runner
+
+
+@pytest.fixture
+def continuance_directive_path(
+    mock_sim_output_dir: tuple[Path, Path, Path],
+) -> Path:
+    """Fixture to return a Path pointing to a file containing directive
+    configuration that causes the `ContinuanceTransform` to execute.
+
+    Parameters
+    ----------
+    mock_sim_output_dir : tuple[Path, Path, Path]
+        Used to create the mock run outputs that the directive config file will
+        refer to (to locate reset files).
+
+    Returns
+    -------
+    Path
+        The path to the directive configuration file.
+    """
+    _, step_dir, _ = mock_sim_output_dir
+
+    directives = textwrap.dedent(
+        f"""\
+        directives:
+            continue-from:
+                path: {step_dir}
+        """,
+    )
+    directive_path = step_dir / "test-directives.yaml"
+    directive_path.write_text(directives)
+    return directive_path
 
 
 def test_create_parser_happy_path() -> None:
@@ -1043,6 +1081,53 @@ def test_worker_main_exec(
     assert mock_execute.call_count == 1
 
 
+def test_worker_main_exec_continue_from(
+    blueprint_path: Path,
+    continuance_directive_path: Path,
+) -> None:
+    """Verify that the continuance transform is executed when included in
+    the directives file.
+    """
+    args = [
+        "cstar.entrypoint.worker.worker",
+        ARG_URI_LONG,
+        str(blueprint_path),
+        ARG_LOGLEVEL_LONG,
+        "DEBUG",
+        ARG_DIRECTIVES_URI_LONG,
+        str(continuance_directive_path),
+    ]
+
+    # don't let it perform any real work; mock out SimulationRunner
+    with (
+        mock.patch.object(
+            SimulationRunner,
+            "execute",
+            mock.AsyncMock(),
+        ) as mock_execute,
+        mock.patch.object(
+            SimulationRunner,
+            "__init__",
+            mock.Mock(return_value=None),
+        ) as mock_init,
+        mock.patch.object(sys, "argv", args),
+    ):
+        # This should run the simulation and return a success code
+        return_code = main()
+
+    # Confirm an error code is returned
+    assert return_code == 0
+
+    # Confirm the runner ran the simulation
+    mock_init.assert_called_once()
+    mock_execute.assert_called_once()
+
+    request: XRunnerRequest[RomsMarblBlueprint] = mock_init.call_args[0][0]
+
+    # confirm directive was applied by verifying a transformed blueprint was created
+    assert ContinuanceTransform.suffix() in str(request.blueprint_uri)
+
+
 @pytest.mark.parametrize("exception_type", [CstarError, BlueprintError, Exception])
 def test_worker_main_cstar_error(
     blueprint_path: Path,
@@ -1078,3 +1163,51 @@ def test_worker_main_cstar_error(
         return_code = main()
 
     assert return_code > 0
+
+
+def test_worker_main_preprocessor_args_parsed(
+    mock_sim_output_dir: tuple[Path, Path, Path],
+    continuance_directive_path: Path,
+) -> None:
+    """Verify that the worker receives directives and they are supplied
+    to the runner.
+
+    Parameters
+    ----------
+    mock_sim_output_dir : tuple[Path, Path, Path]
+        Creates files/directories mimicking output of a prior simulation run.
+    """
+    *_, step_dir, bp_path = mock_sim_output_dir
+
+    reset_dir = RomsFileSystemManager(step_dir).joined_output_dir
+
+    args = [
+        "cstar.entrypoint.worker.worker",
+        ARG_URI_LONG,
+        str(bp_path),
+        ARG_DIRECTIVES_URI_LONG,
+        str(continuance_directive_path),
+    ]
+
+    with (
+        mock.patch(
+            "cstar.entrypoint.worker.worker.execute_runner",
+            mock.AsyncMock(),
+        ) as mock_exec_runner,
+        mock.patch.object(sys, "argv", args),
+    ):
+        _ = main()
+
+    mock_exec_runner.assert_called_once()
+
+    *_, req = mock_exec_runner.mock_calls[0].args
+
+    request = t.cast("XRunnerRequest[RomsMarblBlueprint]", req)
+
+    # verify the blueprint uri was modified by preprocessing prior to invocation
+    assert request.blueprint_uri != str(bp_path)
+    assert ContinuanceTransform.suffix() in request.blueprint_uri
+
+    # verify initial conditions now point to the --continue-from location
+    blueprint = deserialize(request.blueprint_uri, RomsMarblBlueprint)
+    assert str(reset_dir) in str(blueprint.initial_conditions.data[0].location)

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from typer.testing import CliRunner
 
 from cstar.cli.blueprint.run import app
+from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
 
 
 def test_blueprint_run_file_dne(tmp_path: Path) -> None:
@@ -63,7 +65,57 @@ def test_blueprint_run_remote_blueprint() -> None:
     mock_exec.assert_called_once()
 
 
-def test_blueprint_run_apply_directives() -> None:
+@pytest.mark.parametrize(
+    "directive_path",
+    [
+        "directive-dne.json",
+        "https://www.google.com/directive-dne.json",
+    ],
+)
+def test_blueprint_run_apply_directive_dne(tmp_path: Path, directive_path: str) -> None:
+    """Verify that an exception is raised if a path to a non-existent directive file is passed."""
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+
+    with mock.patch(
+        "cstar.cli.blueprint.run.exec_romsmarbl_runner",
+        return_value=0,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                bp_path,
+                ARG_DIRECTIVES_URI_LONG,
+                directive_path,
+            ],
+            color=False,
+        )
+
+    assert "file not found" in result.stderr
+
+
+def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
+    """Verify that an exception is raised if an empty directive file is passed."""
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    directive_file_path = tmp_path / "directive-dne.json"
+    directive_file_path.touch()
+
+    with mock.patch(
+        "cstar.cli.blueprint.run.exec_romsmarbl_runner",
+        return_value=0,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                bp_path,
+                ARG_DIRECTIVES_URI_LONG,
+                directive_file_path.as_posix(),
+            ],
+            color=False,
+        )
+
+    assert "malformed" in result.stderr
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is executed.
     """

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -6,6 +6,9 @@ from typer.testing import CliRunner
 
 from cstar.cli.blueprint.run import app
 from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
+from cstar.orchestration.converter.converter import prepare_directive_file
+from cstar.orchestration.models import Application
+from cstar.orchestration.orchestration import LiveStep
 
 
 def test_blueprint_run_file_dne(tmp_path: Path) -> None:
@@ -116,10 +119,27 @@ def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
         )
 
     assert "malformed" in result.stderr
+
+
+def test_blueprint_run_apply_directives(
+    tmp_path: Path, mock_sim_output_dir: tuple[Path, Path, Path]
+) -> None:
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is executed.
     """
     bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    _, step_dir, _ = mock_sim_output_dir
+
+    temp_step = LiveStep(
+        name="step-for-testing",
+        application=Application.ROMS_MARBL.value,
+        blueprint=bp_path,
+        work_dir=tmp_path,
+        directives={
+            "continue-from": {"path": step_dir.as_posix()},
+        },
+    )
+    directive_path = prepare_directive_file(temp_step)
 
     with mock.patch(
         "cstar.cli.blueprint.run.exec_romsmarbl_runner",
@@ -128,7 +148,11 @@ def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
         runner = CliRunner()
         _ = runner.invoke(
             app,
-            [bp_path],
+            [
+                bp_path,
+                ARG_DIRECTIVES_URI_LONG,
+                directive_path.as_posix(),
+            ],
             color=False,
         )
 

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -61,3 +61,23 @@ def test_blueprint_run_remote_blueprint() -> None:
         )
 
     mock_exec.assert_called_once()
+
+
+def test_blueprint_run_apply_directives() -> None:
+    """Verify that a URL to a remote blueprint is handled properly and the
+    blueprint is executed.
+    """
+    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+
+    with mock.patch(
+        "cstar.cli.blueprint.run.exec_romsmarbl_runner",
+        return_value=0,
+    ) as mock_exec:
+        runner = CliRunner()
+        _ = runner.invoke(
+            app,
+            [bp_path],
+            color=False,
+        )
+
+    mock_exec.assert_called_once()

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -263,7 +263,7 @@ def test_convert_step_to_preprocessed_roms_sim_no_reset_files(
 
     config = {"path": fsm.joined_output_dir}
 
-    with pytest.raises(CstarExpectationFailed, match="No reset files"):
+    with pytest.raises(CstarExpectationFailed, match="No restart files"):
         _ = ContinuanceTransform(config)
 
 

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -1,16 +1,26 @@
 import os
+import shutil
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
+from cstar.base.exceptions import CstarExpectationFailed
+from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.converter.converter import (
     app_to_cmd_map,
     get_command_mapping,
     register_command_mapping,
 )
-from cstar.orchestration.models import Application, Step
+from cstar.orchestration.models import (
+    Application,
+    RomsMarblBlueprint,
+    Step,
+)
 from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.transforms import ContinuanceTransform
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 
@@ -201,3 +211,106 @@ async def test_converter_hello_world(
     # from the function: convert_step_to_blueprint_run_command
     assert "cstar blueprint run" in command
     assert str(hello_world_bp_path) in command
+
+
+def test_convert_step_with_directives(
+    preprocessable_roms_livestep: LiveStep,
+) -> None:
+    """Verify that a Step containing directives in it's configuration results in
+    the directive file being created and passed as an argument in the command.
+
+    Parameters
+    ----------
+    preprocessable_roms_livestep: LiveStep
+        A `LiveStep` preconfigured with a continue-from preprocessing directive.
+    """
+    step = preprocessable_roms_livestep
+    bp_path = str(step.blueprint_path)
+
+    cmd_converter = get_command_mapping(Application.ROMS_MARBL)
+    result = cmd_converter(step)
+
+    # confirm the parameter is sent
+    assert ARG_DIRECTIVES_URI_LONG in result
+
+    # confirm the directive path exists
+    dir_path = result.split(ARG_DIRECTIVES_URI_LONG)[1].split(" ", maxsplit=1)[0]
+    assert bp_path in result, "The blueprint path should be unchanged"
+    assert Path(dir_path).exists()
+
+
+def test_convert_step_to_preprocessed_roms_sim_no_reset_files(
+    preprocessable_roms_livestep: LiveStep,
+) -> None:
+    """Verify that a Step containing directives in it's configuration specifying
+    a directory that does not include any reset files results in an exception.
+
+    Parameters
+    ----------
+    preprocessable_roms_livestep: LiveStep
+        A `LiveStep` preconfigured with a continue-from preprocessing directive.
+    """
+    step = preprocessable_roms_livestep
+
+    # delete any mocked reset files to trigger validation failure
+    assert step.work_dir, "Fixture failed to set work_dir on step"
+    fsm = RomsFileSystemManager(step.work_dir)
+    shutil.rmtree(fsm.joined_output_dir, ignore_errors=True)
+    fsm.joined_output_dir.mkdir(parents=True)
+
+    assert not step.blueprint_overrides, "Empty overrides expected"
+    assert step.work_dir, "Ensure fixture sets workdir"
+
+    config = {"path": fsm.joined_output_dir}
+
+    with pytest.raises(CstarExpectationFailed, match="No reset files"):
+        _ = ContinuanceTransform(config)
+
+
+def test_continuance_transform(
+    preprocessable_roms_livestep: LiveStep,
+) -> None:
+    """Verify that the `ContinuanceTransform` materially modifies blueprint content
+    to include a path to an initial conditions file located in the directory
+    passed to the transform.
+
+    Parameters
+    ----------
+    preprocessable_roms_livestep: LiveStep
+        A `LiveStep` preconfigured with a continue-from preprocessing directive.
+    """
+    step = preprocessable_roms_livestep
+    assert not step.blueprint_overrides, "Empty overrides expected"
+    assert step.work_dir, "Ensure fixture sets workdir"
+
+    bp_path_before = step.blueprint_path
+    fsm = RomsFileSystemManager(step.work_dir)
+
+    original_bp = deserialize(bp_path_before, RomsMarblBlueprint)
+    assert original_bp.initial_conditions.data, "data list is unexpectedly empty"
+    original_ic = original_bp.initial_conditions.data[0].location
+
+    trx = ContinuanceTransform(config={"path": str(fsm.joined_output_dir)})
+
+    transformed_step = next(iter(trx(step)), None)
+    assert transformed_step, "Transform didn't return a transformed step"
+
+    # confirm overrides aren empty after the transformation is applied
+    assert not transformed_step.blueprint_overrides
+
+    # confirm the blueprint path is changed
+    bp_path_after = transformed_step.blueprint_path
+    assert bp_path_after != bp_path_before, "New step must reference a new blueprint"
+
+    # confirm the path includes a suffix specified by the transform
+    assert ContinuanceTransform.suffix() in str(bp_path_after)
+
+    bp = deserialize(bp_path_after, RomsMarblBlueprint)
+    assert bp.initial_conditions.data, "data list is unexpectedly empty"
+
+    # confirm the location has been swapped to match the fixture
+    transformed_ic = Path(str(bp.initial_conditions.data[0].location))
+    assert str(original_ic) != str(transformed_ic)
+
+    # confirm the path has been expanded and resolved
+    assert transformed_ic.expanduser().resolve() == transformed_ic

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -525,6 +525,46 @@ def test_step_blueprint_overrides_set(
     assert "blueprint_overrides" in str(error)
 
 
+def test_step_directives(
+    tmp_path: Path,
+    fake_blueprint_path: pathlib.Path,
+) -> None:
+    """Verify that a `LiveBlueprint` can be instantiated from the Blueprint
+    model and dynamic directives specified on a workplan `Step`.
+
+    Parameters
+    ----------
+    tmp_path: Path
+        A temporary directory for storing testing outputs.
+    fake_blueprint_path : Path
+        A path to a file that meets minimum expectations (it exists).
+
+    """
+    directive_name = "continue-from"
+    directive_kwargs = {"path", "extra"}
+    directives: KeyValueStore = {
+        directive_name: {
+            "path": tmp_path.as_posix(),
+            "extra": 12345,
+        },
+    }
+
+    step_name = f"test-step-{uuid.uuid4()}"
+    app_name = f"test-app-{uuid.uuid4()}"
+    step = Step(
+        name=step_name,
+        application=app_name,
+        blueprint=fake_blueprint_path,
+        directives=directives,
+    )
+
+    # confirm directives are available
+    assert directive_name in step.directives
+    # confirm attributes exist
+    directive_params = t.cast("dict[str, t.Any]", step.directives[directive_name])
+    assert directive_kwargs.issubset(directive_params.keys())
+
+
 def test_workplan_defaults(
     gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -213,6 +213,40 @@ def test_serialization_workplan_runtime_vars(
     assert actual == expected
 
 
+def test_serialization_workplan_steps_with_directives(
+    tmp_path: Path,
+    preprocessable_workplan_path: Path,
+) -> None:
+    """Verify that steps containing directives are serialized correctly.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Used to write some temporary workplans to disk
+    preprocessable_workplan_path : Path
+        Path to a workplan that contains directives.
+    """
+    write_to = preprocessable_workplan_path
+
+    # load the new workplan
+    wp = deserialize(write_to, Workplan)
+
+    step = wp.steps[-1]
+
+    # confirm the directive has been loaded
+    assert step.directives
+    assert "continue-from" in step.directives
+    assert "path" in step.directives["continue-from"]
+
+    # confirm the directives can be written
+    serialize_to = tmp_path / "reserialized.yaml"
+    assert serialize(serialize_to, wp)
+
+    # confirm the serialization step wrote the directives
+    wp2 = deserialize(serialize_to, Workplan)
+    assert wp2.steps[-1].directives == wp.steps[-1].directives
+
+
 @pytest.mark.parametrize(
     "mode",
     [

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -1,12 +1,13 @@
 import os
 import typing as t
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from cstar.base.env import ENV_CSTAR_RUNID, FLAG_OFF
+from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 from cstar.orchestration.orchestration import LiveStep
@@ -14,6 +15,8 @@ from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.transforms import (
     ContinuanceTransform,
     OverrideTransform,
+    ResetFileTrxAdapter,
+    RestartFile,
     RomsMarblTimeSplitter,
     TemplateFillTransform,
     WorkplanTransformer,
@@ -551,3 +554,235 @@ def test_template_fill_combined_resolvers(
 
     assert result.blueprint_overrides["variable"] == "ALK"
     assert result.blueprint_overrides["input_dir"] == f"{upstream_dir}/joined_output"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("foo", id="no redeeming qualities"),
+        pytest.param("foo.txt", id="name-like, bad extension"),
+        pytest.param("foo.nc", id="name-like, good extension"),
+        pytest.param("foo_rst.nc", id="missing timestamp segment"),
+        pytest.param("foo_rst.0000000000000.nc", id="non-parseable timestamp (zeros)"),
+        pytest.param("foo_rst.2026040100000.nc", id="unparted::ts too short"),
+        pytest.param("foo_rst.2026040100000a..nc", id="unparted::non-numeric ts"),
+        pytest.param("foo_rst.202604010000000..nc", id="unparted::ts too long"),
+        pytest.param("foo.20260401000000_rst.nc", id="unparted::suffix on ts segment"),
+        pytest.param("foo.20260401000000_rst.000.nc", id="suffix on ts segment"),
+        pytest.param("foo.20260401000000.000_rst.nc", id="suffix on partition segment"),
+        pytest.param("foo.rst.20260401000000.000.nc", id="dot leader in suffix"),
+        pytest.param("foo.rst.20260401000000.nc", id="unparted::dot leader in suffix"),
+        pytest.param("foo_rst.20260401000000.000.nc/file.nc", id="match to dir name"),
+        pytest.param("foo_rst.20260401000000.nc/xxx.nc", id="unparted::match dir name"),
+        pytest.param("foo_rst.0000000000000.000.nc", id="ts too short"),
+        pytest.param("foo_rst.0000000000000a.000.nc", id="non-numeric ts"),
+        pytest.param("foo_rst.000000000000000.000.nc", id="ts too long"),
+        pytest.param("foo_rst.20260401000000..nc", id="partition empty"),
+        pytest.param("foo_rst.20260401000000.00.nc", id="partition too short"),
+        pytest.param("foo_rst.20260401000000.00a.nc", id="non-numeric partition"),
+        pytest.param("foo_rst.20260401000000.0000.nc", id="partition too long"),
+    ],
+)
+def test_reset_file_bad_path(tmp_path: Path, name: str) -> None:
+    """Verify that `ResetFile` reports paths that do not meet reset file naming convention."""
+    mismatched_name_path = tmp_path / name
+
+    with pytest.raises(ValueError, match="convention"):
+        _ = RestartFile(path=mismatched_name_path)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_is_parted"),
+    [
+        pytest.param("foo_rst.20260401000000.000.nc", True, id="parted"),
+        pytest.param("foo_rst.20260401000000.001.nc", True, id="non-start segment"),
+        pytest.param("foo_rst.20260401000000.nc", False, id="unparted"),
+    ],
+)
+def test_reset_file_happy_path(
+    tmp_path: Path,
+    name: str,
+    expected_is_parted: bool,
+) -> None:
+    """Verify that `ResetFile` handles good inputs correctly."""
+    path = tmp_path / name
+
+    rf = RestartFile(path=path)
+    assert rf.is_partitioned == expected_is_parted
+
+
+def test_reset_file_find(tmp_path: Path) -> None:
+    """Verify that ResetFile.find locates a reset file when expected."""
+    now = datetime.now(tz=timezone.utc)
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+    reset_path = search_path / f"foo_rst.{now.strftime('%Y%m%d%H%M%S')}.000.nc"
+    reset_path.touch()
+
+    # confirm root of search path is searched
+    reset_file = RestartFile.find(search_path)
+    assert reset_file
+    assert reset_file.path == Path(reset_path).expanduser().resolve()
+
+    # confirm search is recursive
+    reset_file = RestartFile.find(tmp_path)
+    assert reset_file
+    assert reset_file.path == Path(reset_path).expanduser().resolve()
+
+
+def test_reset_file_find_dne(tmp_path: Path) -> None:
+    """Verify that ResetFile.find returns None when no files are found."""
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+
+    reset_file = RestartFile.find(search_path)
+    assert reset_file is None
+
+
+def test_reset_file_find_dne_notok(tmp_path: Path) -> None:
+    """Verify that ResetFile.find raises an exception when no files are found
+    and find is passed `notfound_ok=False`.
+    """
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+
+    with pytest.raises(CstarExpectationFailed, match="No restart files"):
+        _ = RestartFile.find(search_path, notfound_ok=False)
+
+
+def test_reset_file_from_parts_unparted(tmp_path: Path) -> None:
+    """Verify that a ResetFile instance is created without a segment ID in the
+    path if it is not supplied.
+    """
+    now = datetime.now(tz=timezone.utc)
+    ts = now.strftime("%Y%m%d%H%M%S")
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+
+    reset_file = RestartFile.from_parts("test_reset_file_from_parts", now)
+
+    # confirm no empty segment is added
+    assert ".000." not in reset_file.path.as_posix()
+
+    # confirm full file name
+    assert reset_file.path.as_posix().endswith(f"_rst.{ts}.{RestartFile.EXT}")
+
+
+@pytest.mark.parametrize(
+    ("segment", "exp_segment"),
+    [
+        pytest.param(0, ".000.", id="edge-case, 0-th segment"),
+        pytest.param(1, ".001.", id="valid non-boundary index 1"),
+        pytest.param(123, ".123.", id="valid non-boundary index 123"),
+        pytest.param(42, ".042.", id="two-digit padding"),
+        pytest.param(999, ".999.", id="edge-case, final 3-digit segment"),
+    ],
+)
+def test_reset_file_from_parts_parted(
+    tmp_path: Path, segment: int, exp_segment: str
+) -> None:
+    """Verify that a ResetFile instance is created with a segment ID in the
+    path if it is supplied.
+    """
+    now = datetime.now(tz=timezone.utc)
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+    reset_path = search_path / f"foo_rst.{now.strftime('%Y%m%d%H%M%S')}.000.nc"
+    reset_path.touch()
+
+    reset_file = RestartFile.from_parts("test_reset_file_from_parts", now, segment)
+
+    assert exp_segment in reset_file.path.as_posix()
+
+
+def test_reset_file_from_parts_with_base(tmp_path: Path) -> None:
+    """Verify that a ResetFile instance is created with a segment ID in the
+    path if it is supplied.
+    """
+    now = datetime.now(tz=timezone.utc)
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+
+    reset_file = RestartFile.from_parts(
+        "test-base",
+        now,
+        directory=search_path,
+    )
+    assert reset_file is not None
+
+    assert reset_file.path.as_posix().startswith(
+        (search_path / "test-base_rst").as_posix(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "exp_partition", "exp_is_partitioned"),
+    [
+        pytest.param(
+            f"foo_rst.{datetime.now(tz=timezone.utc).strftime(RestartFile.FMT_TS)}.010.nc",
+            10,
+            True,
+            id="parted path",
+        ),
+        pytest.param(
+            f"foo_rst.{datetime.now(tz=timezone.utc).strftime(RestartFile.FMT_TS)}.nc",
+            None,
+            False,
+            id="unparted path",
+        ),
+    ],
+)
+def test_reset_file_from_path(
+    path: str,
+    exp_partition: int | None,
+    exp_is_partitioned: bool,
+) -> None:
+    """Verify that ResetFile.__init__ results in the correct settings on the instance."""
+    reset_path = Path(path)
+    reset_file = RestartFile(path=reset_path)
+
+    assert reset_file.is_partitioned == exp_is_partitioned
+    assert reset_file.partition == exp_partition
+
+
+def test_reset_file_adapter(tmp_path: Path) -> None:
+    """Verify that a partitioned reset file contains the correct partition information
+    when converted into an override.
+    """
+    now = datetime.now(tz=timezone.utc)
+    ts = now.strftime("%Y%m%d%H%M%S")
+    search_path = tmp_path / "test-reset-file-find"
+    search_path.mkdir(parents=True)
+    reset_path = search_path / f"foo_rst.{ts}.000.nc"
+    reset_path.touch()
+
+    reset_file = RestartFile(path=reset_path)
+    result = ResetFileTrxAdapter.adapt(reset_file)
+
+    # confirm all fields exist and the partioned flag is True
+    rp = result.get("runtime_params", None)
+    assert rp
+    assert "start_date" in rp
+    ic = result.get("initial_conditions", None)
+    assert ic
+    data = ic.get("data", None)
+    assert data
+    data0 = data[0]
+    assert data0["location"] == reset_file.path.as_posix()
+    assert data0["partitioned"]
+
+    reset_path = search_path / f"foo_rst.{ts}.nc"
+    reset_file = RestartFile(path=reset_path)
+    result = ResetFileTrxAdapter.adapt(reset_file)
+
+    # confirm all fields exist and the partioned flag is False
+    rp = result.get("runtime_params", None)
+    assert rp
+    assert "start_date" in rp
+    ic = result.get("initial_conditions", None)
+    assert ic
+    data = ic.get("data", None)
+    assert data
+    data0 = data[0]
+    assert data0["location"] == reset_file.path.as_posix()
+    assert not data0["partitioned"]

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -12,6 +12,7 @@ from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Wo
 from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.transforms import (
+    ContinuanceTransform,
     OverrideTransform,
     RomsMarblTimeSplitter,
     TemplateFillTransform,
@@ -235,6 +236,69 @@ def test_override_transform_system_precedence(
     # system level override was applied last.
     assert Path(bp_old.runtime_params.output_dir) == dir_orig
     assert Path(bp_new.runtime_params.output_dir) == sys_od
+
+
+def test_continuance_transform_not_supported(test_output_dir: Path) -> None:
+    """Verify that unknown configuration results in an exception.
+
+    Parameters
+    ----------
+    test_output_dir : Path
+        The value that replaced the static content of the blueprint template
+        and was written to the test directory, tmp_path.
+    """
+    with pytest.raises(NotImplementedError, match="supported"):
+        _ = ContinuanceTransform({"not-path": str(test_output_dir)})
+
+
+def test_continuance_transform_path_dne() -> None:
+    """Verify that sending a path to a directory that does not exist results in
+    an exception being raised.
+
+    Parameters
+    ----------
+    test_output_dir : Path
+        The value that replaced the static content of the blueprint template
+        and was written to the test directory, tmp_path.
+    """
+    with pytest.raises(ValueError, match="No directory found"):
+        _ = ContinuanceTransform({"path": "./dir-that-dne"})
+
+
+def test_continuance_transform_happy_path(
+    single_step_workplan: Workplan,
+    mock_sim_output_dir: tuple[Path, Path, Path],
+) -> None:
+    """Verify that unknown configuration results in an exception.
+
+    Parameters
+    ----------
+    single_step_workplan : Workplan
+        A workplan with a valid blueprint file on disk.
+    mock_sim_output_dir : Path
+        Paths to mocked simulation outputs; used here to pass a valid path
+        to the continuance transform (containing files meeting glob pattern *_rst.nc)
+    """
+    _, continue_from_dir, _ = mock_sim_output_dir
+
+    transform = ContinuanceTransform({"path": str(continue_from_dir)})
+    step = single_step_workplan.steps[0]
+    step.blueprint_overrides.clear()  # ensure nothing existing
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: "12345"}, clear=True):
+        steps = transform(step)
+
+    transformed = steps[0]
+
+    bp_old = deserialize(step.blueprint_path, RomsMarblBlueprint)
+    bp_new = deserialize(transformed.blueprint_path, RomsMarblBlueprint)
+
+    # confirm the old blueprint has a different initial conditions location
+    assert str(continue_from_dir) not in str(bp_old.initial_conditions.data[0].location)
+    assert str(continue_from_dir) in str(bp_new.initial_conditions.data[0].location)
+
+    # confirm the overrides were removed after being applied
+    assert not transformed.blueprint_overrides
 
 
 def test_workplan_transformer_applies_output_dir_overrides(

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -15,8 +15,8 @@ from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.transforms import (
     ContinuanceTransform,
     OverrideTransform,
-    ResetFileTrxAdapter,
     RestartFile,
+    RestartFileTrxAdapter,
     RomsMarblTimeSplitter,
     TemplateFillTransform,
     WorkplanTransformer,
@@ -757,7 +757,7 @@ def test_reset_file_adapter(tmp_path: Path) -> None:
     reset_path.touch()
 
     reset_file = RestartFile(path=reset_path)
-    result = ResetFileTrxAdapter.adapt(reset_file)
+    result = RestartFileTrxAdapter.adapt(reset_file)
 
     # confirm all fields exist and the partioned flag is True
     rp = result.get("runtime_params", None)
@@ -773,7 +773,7 @@ def test_reset_file_adapter(tmp_path: Path) -> None:
 
     reset_path = search_path / f"foo_rst.{ts}.nc"
     reset_file = RestartFile(path=reset_path)
-    result = ResetFileTrxAdapter.adapt(reset_file)
+    result = RestartFileTrxAdapter.adapt(reset_file)
 
     # confirm all fields exist and the partioned flag is False
     rp = result.get("runtime_params", None)

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -269,7 +269,8 @@ def test_continuance_transform_happy_path(
     single_step_workplan: Workplan,
     mock_sim_output_dir: tuple[Path, Path, Path],
 ) -> None:
-    """Verify that unknown configuration results in an exception.
+    """Verify that applying a well-formed continuance transform causes the
+    blueprint initial conditions to be updated.
 
     Parameters
     ----------

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -268,9 +268,11 @@ def test_continuance_transform_path_dne() -> None:
         _ = ContinuanceTransform({"path": "./dir-that-dne"})
 
 
+@pytest.mark.parametrize("pad_size", range(1, 10))
 def test_continuance_transform_happy_path(
     single_step_workplan: Workplan,
     mock_sim_output_dir: tuple[Path, Path, Path],
+    pad_size: int,
 ) -> None:
     """Verify that applying a well-formed continuance transform causes the
     blueprint initial conditions to be updated.
@@ -282,8 +284,21 @@ def test_continuance_transform_happy_path(
     mock_sim_output_dir : Path
         Paths to mocked simulation outputs; used here to pass a valid path
         to the continuance transform (containing files meeting glob pattern *_rst.nc)
+    pad_size : int
+        Used to vary the amount of zero padding in the partition segment of the file
+        name. This ensures that the restart file search can locate files regardless
+        of the number of partitions.
     """
     _, continue_from_dir, _ = mock_sim_output_dir
+
+    for seg_id in ["000", "001", "002"]:
+        rf_glob = f"*_rst.*.{seg_id}.nc"
+        reset_file_path = next(continue_from_dir.rglob(rf_glob))
+        name = reset_file_path.name.replace(
+            f"{seg_id}.nc",
+            f"{str(int(seg_id)).zfill(pad_size)}.nc",
+        )
+        reset_file_path = reset_file_path.rename(reset_file_path.with_name(name))
 
     transform = ContinuanceTransform({"path": str(continue_from_dir)})
     step = single_step_workplan.steps[0]
@@ -578,9 +593,8 @@ def test_template_fill_combined_resolvers(
         pytest.param("foo_rst.0000000000000a.000.nc", id="non-numeric ts"),
         pytest.param("foo_rst.000000000000000.000.nc", id="ts too long"),
         pytest.param("foo_rst.20260401000000..nc", id="partition empty"),
-        pytest.param("foo_rst.20260401000000.00.nc", id="partition too short"),
+        pytest.param("foo_rst.20260401000000.0000000000.nc", id="10 partition chars"),
         pytest.param("foo_rst.20260401000000.00a.nc", id="non-numeric partition"),
-        pytest.param("foo_rst.20260401000000.0000.nc", id="partition too long"),
     ],
 )
 def test_reset_file_bad_path(tmp_path: Path, name: str) -> None:
@@ -596,6 +610,8 @@ def test_reset_file_bad_path(tmp_path: Path, name: str) -> None:
     [
         pytest.param("foo_rst.20260401000000.000.nc", True, id="parted"),
         pytest.param("foo_rst.20260401000000.001.nc", True, id="non-start segment"),
+        pytest.param("foo_rst.20260401000000.1.nc", True, id="no partition padding"),
+        pytest.param("foo_rst.20260401000000.999999999.nc", True, id="max 0-padding"),
         pytest.param("foo_rst.20260401000000.nc", False, id="unparted"),
     ],
 )
@@ -671,15 +687,15 @@ def test_reset_file_from_parts_unparted(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("segment", "exp_segment"),
     [
-        pytest.param(0, ".000.", id="edge-case, 0-th segment"),
-        pytest.param(1, ".001.", id="valid non-boundary index 1"),
-        pytest.param(123, ".123.", id="valid non-boundary index 123"),
-        pytest.param(42, ".042.", id="two-digit padding"),
-        pytest.param(999, ".999.", id="edge-case, final 3-digit segment"),
+        pytest.param("0", ".0.", id="edge-case, 0-th segment"),
+        pytest.param("1", ".1.", id="valid non-boundary index 1"),
+        pytest.param("123", ".123.", id="valid non-boundary index 123"),
+        pytest.param("042", ".042.", id="two-digit padding"),
+        pytest.param("999", ".999.", id="edge-case, final 3-digit segment"),
     ],
 )
 def test_reset_file_from_parts_parted(
-    tmp_path: Path, segment: int, exp_segment: str
+    tmp_path: Path, segment: str, exp_segment: str
 ) -> None:
     """Verify that a ResetFile instance is created with a segment ID in the
     path if it is supplied.

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -597,8 +597,8 @@ def test_template_fill_combined_resolvers(
         pytest.param("foo_rst.20260401000000.00a.nc", id="non-numeric partition"),
     ],
 )
-def test_reset_file_bad_path(tmp_path: Path, name: str) -> None:
-    """Verify that `ResetFile` reports paths that do not meet reset file naming convention."""
+def test_restart_file_bad_path(tmp_path: Path, name: str) -> None:
+    """Verify that `RestartFile` reports paths that do not meet reset file naming convention."""
     mismatched_name_path = tmp_path / name
 
     with pytest.raises(ValueError, match="convention"):
@@ -615,12 +615,12 @@ def test_reset_file_bad_path(tmp_path: Path, name: str) -> None:
         pytest.param("foo_rst.20260401000000.nc", False, id="unparted"),
     ],
 )
-def test_reset_file_happy_path(
+def test_restart_file_happy_path(
     tmp_path: Path,
     name: str,
     expected_is_parted: bool,
 ) -> None:
-    """Verify that `ResetFile` handles good inputs correctly."""
+    """Verify that `RestartFile` handles good inputs correctly."""
     path = tmp_path / name
 
     rf = RestartFile(path=path)
@@ -631,8 +631,8 @@ def test_reset_file_happy_path(
     "pad_size",
     range(1, 10),
 )
-def test_reset_file_find(tmp_path: Path, pad_size: int) -> None:
-    """Verify that ResetFile.find locates a reset file when expected."""
+def test_restart_file_find(tmp_path: Path, pad_size: int) -> None:
+    """Verify that `RestartFile.find` locates a reset file when expected."""
     now = datetime.now(tz=timezone.utc)
     search_path = tmp_path / "test-reset-file-find"
     search_path.mkdir(parents=True)
@@ -651,8 +651,8 @@ def test_reset_file_find(tmp_path: Path, pad_size: int) -> None:
     assert reset_file.path == Path(reset_path).expanduser().resolve()
 
 
-def test_reset_file_find_dne(tmp_path: Path) -> None:
-    """Verify that ResetFile.find returns None when no files are found."""
+def test_restart_file_find_dne(tmp_path: Path) -> None:
+    """Verify that `RestartFile.find` returns None when no files are found."""
     search_path = tmp_path / "test-reset-file-find"
     search_path.mkdir(parents=True)
 
@@ -660,8 +660,8 @@ def test_reset_file_find_dne(tmp_path: Path) -> None:
     assert reset_file is None
 
 
-def test_reset_file_find_dne_notok(tmp_path: Path) -> None:
-    """Verify that ResetFile.find raises an exception when no files are found
+def test_restart_file_find_dne_notok(tmp_path: Path) -> None:
+    """Verify that `RestartFile.find` raises an exception when no files are found
     and find is passed `notfound_ok=False`.
     """
     search_path = tmp_path / "test-reset-file-find"
@@ -671,8 +671,8 @@ def test_reset_file_find_dne_notok(tmp_path: Path) -> None:
         _ = RestartFile.find(search_path, notfound_ok=False)
 
 
-def test_reset_file_from_parts_unparted(tmp_path: Path) -> None:
-    """Verify that a ResetFile instance is created without a segment ID in the
+def test_restart_file_from_parts_unparted(tmp_path: Path) -> None:
+    """Verify that a `RestartFile` instance is created without a segment ID in the
     path if it is not supplied.
     """
     now = datetime.now(tz=timezone.utc)
@@ -680,7 +680,7 @@ def test_reset_file_from_parts_unparted(tmp_path: Path) -> None:
     search_path = tmp_path / "test-reset-file-find"
     search_path.mkdir(parents=True)
 
-    reset_file = RestartFile.from_parts("test_reset_file_from_parts", now)
+    reset_file = RestartFile.from_parts("test_restart_file_from_parts", now)
 
     # confirm no empty segment is added
     assert ".000." not in reset_file.path.as_posix()
@@ -699,10 +699,10 @@ def test_reset_file_from_parts_unparted(tmp_path: Path) -> None:
         pytest.param("999", ".999.", id="edge-case, final 3-digit segment"),
     ],
 )
-def test_reset_file_from_parts_parted(
+def test_restart_file_from_parts_parted(
     tmp_path: Path, segment: str, exp_segment: str
 ) -> None:
-    """Verify that a ResetFile instance is created with a segment ID in the
+    """Verify that a `RestartFile` instance is created with a segment ID in the
     path if it is supplied.
     """
     now = datetime.now(tz=timezone.utc)
@@ -711,13 +711,13 @@ def test_reset_file_from_parts_parted(
     reset_path = search_path / f"foo_rst.{now.strftime('%Y%m%d%H%M%S')}.000.nc"
     reset_path.touch()
 
-    reset_file = RestartFile.from_parts("test_reset_file_from_parts", now, segment)
+    reset_file = RestartFile.from_parts("test_restart_file_from_parts", now, segment)
 
     assert exp_segment in reset_file.path.as_posix()
 
 
-def test_reset_file_from_parts_with_base(tmp_path: Path) -> None:
-    """Verify that a ResetFile instance is created with a segment ID in the
+def test_restart_file_from_parts_with_base(tmp_path: Path) -> None:
+    """Verify that a `RestartFile` instance is created with a segment ID in the
     path if it is supplied.
     """
     now = datetime.now(tz=timezone.utc)
@@ -753,12 +753,12 @@ def test_reset_file_from_parts_with_base(tmp_path: Path) -> None:
         ),
     ],
 )
-def test_reset_file_from_path(
+def test_restart_file_from_path(
     path: str,
     exp_partition: int | None,
     exp_is_partitioned: bool,
 ) -> None:
-    """Verify that ResetFile.__init__ results in the correct settings on the instance."""
+    """Verify that `RestartFile.__init__` results in the correct settings on the instance."""
     reset_path = Path(path)
     reset_file = RestartFile(path=reset_path)
 
@@ -766,7 +766,7 @@ def test_reset_file_from_path(
     assert reset_file.partition == exp_partition
 
 
-def test_reset_file_adapter(tmp_path: Path) -> None:
+def test_restart_file_adapter(tmp_path: Path) -> None:
     """Verify that a partitioned reset file contains the correct partition information
     when converted into an override.
     """

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -627,12 +627,17 @@ def test_reset_file_happy_path(
     assert rf.is_partitioned == expected_is_parted
 
 
-def test_reset_file_find(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "pad_size",
+    range(1, 10),
+)
+def test_reset_file_find(tmp_path: Path, pad_size: int) -> None:
     """Verify that ResetFile.find locates a reset file when expected."""
     now = datetime.now(tz=timezone.utc)
     search_path = tmp_path / "test-reset-file-find"
     search_path.mkdir(parents=True)
-    reset_path = search_path / f"foo_rst.{now.strftime('%Y%m%d%H%M%S')}.000.nc"
+    segment = "0".zfill(pad_size)
+    reset_path = search_path / f"foo_rst.{now.strftime('%Y%m%d%H%M%S')}.{segment}.nc"
     reset_path.touch()
 
     # confirm root of search path is searched


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change adds the ability to specify a preprocessing directive in a workplan that is JIT executed by the worker.

The proof-of-concept directive, "continue-from", searches for reset files in a directory that is empty at the time the task is scheduled.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- `deep_merge` is a pure method and no longer changes the inputs

## New Features
<!-- List any new capabilities added -->
- Add `Directives` to enable just-in-time blueprint manipulation by the runner.

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-566
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
