### PR TITLE
Add utility for env var flag checks

### DIFF
--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -87,6 +87,21 @@ ENV_FF_ORCH_TRX_TIMESPLIT: t.Annotated[
 """Enable automatic time-splitting of simulations."""
 
 
+def is_flag_enabled(flag: str) -> bool:
+    """Determine if a boolean environment varible is enabled.
+
+    Parameters
+    ----------
+    flag : str
+        The name of an environment variable to check.
+
+    Returns
+    -------
+    bool
+    """
+    return os.getenv(flag, FLAG_OFF) == FLAG_ON
+
+
 def is_feature_enabled(flag: str) -> bool:
     """Determine if an environment variable for a feature is set.
 
@@ -101,7 +116,7 @@ def is_feature_enabled(flag: str) -> bool:
         pass only the <FLAG_NAME> and exclude the `CSTAR_FF_` prefix.
     """
     # developer mode enables all feature flags
-    if os.getenv(ENV_FF_DEVELOPER_MODE, FLAG_OFF) == FLAG_ON:
+    if is_flag_enabled(ENV_FF_DEVELOPER_MODE):
         return True
 
     # enable omitting the CSTAR_FF_ prefix at the call-site
@@ -119,7 +134,7 @@ def is_feature_enabled(flag: str) -> bool:
         for i in range(2, len(flag_parts)):
             segment_id = "_".join(flag_parts[:i])
 
-            if os.getenv(segment_id, FLAG_OFF) == FLAG_ON:
+            if is_flag_enabled(segment_id):
                 return True
 
-    return os.getenv(flag, FLAG_OFF) == FLAG_ON
+    return is_flag_enabled(flag)

--- a/cstar/tests/unit_tests/system/test_environment.py
+++ b/cstar/tests/unit_tests/system/test_environment.py
@@ -10,13 +10,17 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from cstar.base.env import (
     ENV_CSTAR_CACHE_HOME,
+    ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_CONFIG_HOME,
     ENV_CSTAR_DATA_HOME,
     ENV_CSTAR_NPROCS_POST,
     ENV_CSTAR_STATE_HOME,
+    FLAG_OFF,
+    FLAG_ON,
     get_env_item,
     hpc_data_directory,
 )
+from cstar.base.feature import is_flag_enabled
 from cstar.system.environment import CStarEnvironment
 
 
@@ -161,9 +165,7 @@ class TestSetupEnvironmentFromFiles:
         )
 
         # Patch the root path and expanduser to point to our temporary files
-        with (
-            patch.object(CStarEnvironment, "package_root", new=tmp_path),
-        ):
+        with patch.object(CStarEnvironment, "package_root", new=tmp_path):
             # Instantiate the environment to trigger loading the environment variables
             env = MockEnvironment()
             # Define expected final environment variables after merging and expansion
@@ -912,3 +914,19 @@ def test_env_show_default(
         from cstar.cli.environment.show import show
 
         show("file")
+
+
+def test_is_flag_enabled() -> None:
+    """Verify the utility `is_flag_enabled` determines the correct value for
+    a flag when it is set to on, set to off, and not set at all.
+    """
+    key = ENV_CSTAR_CLOBBER_WORKING_DIR
+
+    with mock.patch.dict(os.environ, {key: FLAG_ON}, clear=True):
+        assert is_flag_enabled(key)
+
+    with mock.patch.dict(os.environ, {key: FLAG_OFF}, clear=True):
+        assert not is_flag_enabled(key)
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert not is_flag_enabled(key)


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change adds a utility for simplifying the checking of flags held in environment variables without importing all relative constants.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Simplified env-var flag evaluation

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Subtask of CSD-681
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
