### PR TITLE
Add CLI parameters for log level and clobber

### DIFF
--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 import sys
 import typing as t
@@ -11,6 +12,18 @@ DEFAULT_LOG_FORMAT = (
 )
 TRACE_LOG_LEVEL: t.Final[int] = 5
 TRACE_LOG_NAME: t.Final[str] = "TRACE"
+
+
+class LogLevelChoices(enum.StrEnum):
+    """Log levels for C-Star. Used by CLI and entrypoints to display and validate
+    a set of fixed choices.
+    """
+
+    TRACE = "TRACE"
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
 
 
 class TraceLogger(logging.Logger):

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -2,6 +2,7 @@ import asyncio
 import typing as t
 
 import typer
+
 from cstar.base.env import (
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -2,8 +2,13 @@ import asyncio
 import typing as t
 
 import typer
-
-from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
+from cstar.base.env import (
+    ENV_CSTAR_CLOBBER_WORKING_DIR,
+    ENV_CSTAR_LOG_LEVEL,
+    get_env_item,
+)
+from cstar.base.log import LogLevelChoices
+from cstar.cli.common import clobber_callback, log_level_callback
 from cstar.entrypoint.worker.worker import (
     SimulationStages,
     execute_runner,
@@ -30,6 +35,25 @@ def run(
             case_sensitive=False,
         ),
     ] = None,
+    log_level: t.Annotated[
+        LogLevelChoices,
+        typer.Option(
+            "--log-level",
+            "-l",
+            callback=log_level_callback,
+            help="Set the log level for C-Star.",
+            envvar=ENV_CSTAR_LOG_LEVEL,
+        ),
+    ] = LogLevelChoices.INFO,
+    clobber: t.Annotated[
+        bool,
+        typer.Option(
+            "--clobber",
+            callback=clobber_callback,
+            help="Clobber the working directory if it exists.",
+            envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
+        ),
+    ] = False,
 ) -> None:
     """Execute a blueprint in a local worker service."""
     result = validate_serialized_entity(path, RomsMarblBlueprint)

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -11,6 +11,9 @@ from cstar.base.env import (
 from cstar.base.log import LogLevelChoices
 from cstar.cli.common import clobber_callback, log_level_callback
 from cstar.entrypoint.worker.worker import (
+    ARG_CLOBBER,
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
     SimulationStages,
     execute_runner,
     get_job_config,
@@ -39,8 +42,8 @@ def run(
     log_level: t.Annotated[
         LogLevelChoices,
         typer.Option(
-            "--log-level",
-            "-l",
+            ARG_LOGLEVEL_LONG,
+            ARG_LOGLEVEL_SHORT,
             callback=log_level_callback,
             help="Set the log level for C-Star.",
             envvar=ENV_CSTAR_LOG_LEVEL,
@@ -49,7 +52,7 @@ def run(
     clobber: t.Annotated[
         bool,
         typer.Option(
-            "--clobber",
+            ARG_CLOBBER,
             callback=clobber_callback,
             help="Clobber the working directory if it exists.",
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 import typer
 
+from cstar.base.env import ENV_CSTAR_CLOBBER_WORKING_DIR, ENV_CSTAR_LOG_LEVEL
 from cstar.base.exceptions import CstarExpectationFailed
-from cstar.base.log import get_logger
+from cstar.base.log import LogLevelChoices, get_logger
+from cstar.cli.common import clobber_callback, log_level_callback
 from cstar.cli.workplan.shared import (
     check_and_capture_kvps,
     list_runs,
@@ -246,6 +248,25 @@ def run(
             "--dry-run",
             "-d",
             help="Generate the execution plan without executing the workplan.",
+        ),
+    ] = False,
+    log_level: t.Annotated[
+        LogLevelChoices,
+        typer.Option(
+            "--log-level",
+            "-l",
+            callback=log_level_callback,
+            help="Set the log level for C-Star.",
+            envvar=ENV_CSTAR_LOG_LEVEL,
+        ),
+    ] = LogLevelChoices.INFO,
+    clobber: t.Annotated[
+        bool,
+        typer.Option(
+            "--clobber",
+            callback=clobber_callback,
+            help="Clobber the working directory if it exists.",
+            envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,
 ) -> None:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -13,6 +13,11 @@ from cstar.cli.workplan.shared import (
     check_and_capture_kvps,
     list_runs,
 )
+from cstar.entrypoint.worker.worker import (
+    ARG_CLOBBER,
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
+)
 from cstar.execution.file_system import local_copy
 from cstar.orchestration.dag_runner import build_and_run_dag
 from cstar.orchestration.models import Workplan
@@ -253,8 +258,8 @@ def run(
     log_level: t.Annotated[
         LogLevelChoices,
         typer.Option(
-            "--log-level",
-            "-l",
+            ARG_LOGLEVEL_LONG,
+            ARG_LOGLEVEL_SHORT,
             callback=log_level_callback,
             help="Set the log level for C-Star.",
             envvar=ENV_CSTAR_LOG_LEVEL,
@@ -263,7 +268,7 @@ def run(
     clobber: t.Annotated[
         bool,
         typer.Option(
-            "--clobber",
+            ARG_CLOBBER,
             callback=clobber_callback,
             help="Clobber the working directory if it exists.",
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -36,6 +36,8 @@ ARG_LOGLEVEL_SHORT: Literal["-l"] = "-l"
 ARG_STAGE_LONG: Literal["--stage"] = "--stage"
 ARG_STAGE_SHORT: Literal["-g"] = "-g"
 
+ARG_CLOBBER: Literal["--clobber"] = "--clobber"
+
 
 def _generate_job_name() -> str:
     """Generate a unique job name based on the current date and time."""


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change enables a user to set the values of the log level and clobber environment variables indirectly via `typer`.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Add `--log-level` and `--clobber` parameters to CLI methods for running blueprints and workplans.

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Subtask of #CSD-681
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
