### PR TITLE
Shared job config

### DIFF
--- a/cstar/entrypoint/config.py
+++ b/cstar/entrypoint/config.py
@@ -1,0 +1,130 @@
+import logging
+import os
+import typing as t
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+from cstar.base.env import get_env_item
+from cstar.base.log import parse_log_level_name
+from cstar.orchestration.utils import (
+    ENV_CSTAR_SLURM_ACCOUNT,
+    ENV_CSTAR_SLURM_MAX_WALLTIME,
+    ENV_CSTAR_SLURM_QUEUE,
+)
+
+JOBFILE_DATE_FORMAT: t.Final[str] = "%Y%m%d_%H%M%S"
+
+
+def _generate_job_name() -> str:
+    """Generate a unique job name based on the current date and time."""
+    now_utc = datetime.now(timezone.utc)
+    formatted_now_utc = now_utc.strftime(JOBFILE_DATE_FORMAT)
+    return f"cstar_worker_{formatted_now_utc}"
+
+
+class JobConfig(BaseModel):
+    """Configuration required to submit HPC jobs."""
+
+    account_id: t.Annotated[str, Field(frozen=True)]
+    """HPC account used for billing."""
+    walltime: t.Annotated[str, Field(frozen=True)]
+    """Maximum walltime allowed for job."""
+    priority: t.Annotated[str, Field(frozen=True)]
+    """Job priority."""
+    job_name: t.Annotated[str, Field(frozen=True)] = _generate_job_name()
+    """User-friendly job name."""
+
+
+class ServiceConfiguration(BaseModel):
+    """Configuration options for a Service."""
+
+    as_service: bool = False
+    """Determines lifetime of the service.
+
+    When `True`, calling `execute` on the service will run continuously until
+    shutdown criteria are met. When `False`, the service completes a single
+    pass through the service lifecycle and automatically exits.
+    """
+    loop_delay: float = Field(default=0.0, ge=0.0)
+    """Duration (in seconds) of a delay between iterations of the main event loop."""
+    health_check_frequency: float | None = Field(default=None, ge=0.0)
+    """Time (in seconds) between calls to a health check handler.
+
+    NOTE:
+    - A value of `None` disables health checks.
+    - A value of `0` triggers the health check on every iteration.
+    """
+    log_level: int = logging.INFO
+    """The logging level used by the service."""
+    health_check_log_threshold: int = Field(default=10, ge=3)
+    """The number of health-checks that may be missed before logging."""
+    name: str = "Service"
+    """A user-friendly name for logging."""
+
+    @property
+    def healthcheck_enabled(self) -> bool:
+        """Return `True` when the health check frequency is non-null.
+
+        Returns
+        -------
+        bool
+        """
+        return self.health_check_frequency is not None
+
+
+def get_service_config(
+    log_level: int | str, name: str = "Runner"
+) -> ServiceConfiguration:
+    """Create a ServiceConfiguration instance using CLI arguments.
+
+    Parameters
+    ----------
+    log_level : int or str
+        The log level to be used by the worker
+
+    Returns
+    -------
+    ServiceConfiguration
+    """
+    level = parse_log_level_name(log_level)
+
+    return ServiceConfiguration(
+        as_service=True,
+        loop_delay=5,
+        health_check_frequency=None,
+        log_level=level,
+        health_check_log_threshold=10,
+        name=name,
+    )
+
+
+def get_job_config() -> JobConfig:
+    """Create and configure a `JobConfig` instance from environment variables.
+
+    Returns
+    -------
+    JobConfig
+    """
+    account_id: str = get_env_item(ENV_CSTAR_SLURM_ACCOUNT).value
+    walltime: str = get_env_item(ENV_CSTAR_SLURM_MAX_WALLTIME).value
+    priority: str = get_env_item(ENV_CSTAR_SLURM_QUEUE).value
+
+    return JobConfig(account_id=account_id, walltime=walltime, priority=priority)
+
+
+def configure_environment(log: logging.Logger) -> None:
+    """Configure the environment variables required by the worker.
+
+    Parameters
+    ----------
+    log : logging.Logger
+        A logger to log configuration details.
+
+    Returns
+    -------
+    None
+    """
+    # ensure git works on distributed file-system, e.g. lustre
+    os.environ["GIT_DISCOVERY_ACROSS_FILESYSTEM"] = "1"
+    log.debug("Git discovery across file-system enabled.")

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import signal
 import time
 from abc import ABC, abstractmethod
@@ -7,49 +6,12 @@ from queue import Empty, Full, Queue
 from threading import Event, Thread
 from typing import TYPE_CHECKING, ClassVar, Final, Literal
 
-from pydantic import BaseModel, Field
-
 from cstar.base.log import LoggingMixin
 
 if TYPE_CHECKING:
     from types import FrameType
 
-
-class ServiceConfiguration(BaseModel):
-    """Configuration options for a Service."""
-
-    as_service: bool = False
-    """Determines lifetime of the service.
-
-    When `True`, calling `execute` on the service will run continuously until
-    shutdown criteria are met. When `False`, the service completes a single
-    pass through the service lifecycle and automatically exits.
-    """
-    loop_delay: float = Field(default=0.0, ge=0.0)
-    """Duration (in seconds) of a delay between iterations of the main event loop."""
-    health_check_frequency: float | None = Field(default=None, ge=0.0)
-    """Time (in seconds) between calls to a health check handler.
-
-    NOTE:
-    - A value of `None` disables health checks.
-    - A value of `0` triggers the health check on every iteration.
-    """
-    log_level: int = logging.INFO
-    """The logging level used by the service."""
-    health_check_log_threshold: int = Field(default=10, ge=3)
-    """The number of health-checks that may be missed before logging."""
-    name: str = "Service"
-    """A user-friendly name for logging."""
-
-    @property
-    def healthcheck_enabled(self) -> bool:
-        """Return `True` when the health check frequency is non-null.
-
-        Returns
-        -------
-        bool
-        """
-        return self.health_check_frequency is not None
+    from cstar.entrypoint.config import ServiceConfiguration
 
 
 class Service(ABC, LoggingMixin):
@@ -62,7 +24,7 @@ class Service(ABC, LoggingMixin):
     CMD_HEARTBEAT: Literal["heartbeat"] = "heartbeat"
     MIN_HCF: ClassVar[float] = 0.01
 
-    _config: Final[ServiceConfiguration]
+    _config: Final["ServiceConfiguration"]
     """Runtime configuration of the `Service`"""
     _hc_thread: Thread | None = None
     """A thread for executing an unblocked healthcheck callback."""
@@ -73,7 +35,7 @@ class Service(ABC, LoggingMixin):
 
     def __init__(
         self,
-        config: ServiceConfiguration,
+        config: "ServiceConfiguration",
     ) -> None:
         """Initialize the Service.
 
@@ -232,7 +194,7 @@ class Service(ABC, LoggingMixin):
 
     def _healthcheck(
         self,
-        config: ServiceConfiguration,
+        config: "ServiceConfiguration",
         msg_queue: Queue,
     ) -> None:
         """Run the health-check event loop.

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -7,25 +7,23 @@ import os
 import pathlib
 import sys
 from datetime import datetime, timezone
-from typing import Final, Literal, override
+from typing import TYPE_CHECKING, Final, Literal, override
 
 from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
 from cstar.base.exceptions import BlueprintError, CstarError
-from cstar.base.log import get_logger, parse_log_level_name
+from cstar.base.log import get_logger
 from cstar.base.utils import slugify
-from cstar.entrypoint.service import Service, ServiceConfiguration
-from cstar.execution.handler import ExecutionHandler, ExecutionStatus
-from cstar.orchestration.utils import (
-    ENV_CSTAR_SLURM_ACCOUNT,
-    ENV_CSTAR_SLURM_MAX_WALLTIME,
-    ENV_CSTAR_SLURM_QUEUE,
+from cstar.entrypoint.config import (
+    configure_environment,
+    get_job_config,
+    get_service_config,
 )
+from cstar.entrypoint.service import Service
+from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.roms import ROMSSimulation
 
-DATE_FORMAT: Final[str] = "%Y-%m-%d %H:%M:%S"
-WORKER_LOG_FILE_TPL: Final[str] = "cstar-worker.{0}.log"
-JOBFILE_DATE_FORMAT: Final[str] = "%Y%m%d_%H%M%S"
-LOGS_DIRECTORY: Final[str] = "logs"
+if TYPE_CHECKING:
+    from cstar.entrypoint.config import JobConfig, ServiceConfiguration
 
 ARG_URI_LONG: Literal["--blueprint-uri"] = "--blueprint-uri"
 ARG_URI_SHORT: Literal["-b"] = "-b"
@@ -37,13 +35,6 @@ ARG_STAGE_LONG: Literal["--stage"] = "--stage"
 ARG_STAGE_SHORT: Literal["-g"] = "-g"
 
 ARG_CLOBBER: Literal["--clobber"] = "--clobber"
-
-
-def _generate_job_name() -> str:
-    """Generate a unique job name based on the current date and time."""
-    now_utc = datetime.now(timezone.utc)
-    formatted_now_utc = now_utc.strftime(JOBFILE_DATE_FORMAT)
-    return f"cstar_worker_{formatted_now_utc}"
 
 
 class SimulationStages(enum.StrEnum):
@@ -74,20 +65,6 @@ class BlueprintRequest:
     """
 
 
-@dc.dataclass(frozen=True)
-class JobConfig:
-    """Configuration required to submit HPC jobs."""
-
-    account_id: str
-    """HPC account used for billing."""
-    walltime: str
-    """Maximum walltime allowed for job."""
-    priority: str
-    """Job priority."""
-    job_name: str = _generate_job_name()
-    """User-friendly job name."""
-
-
 class SimulationRunner(Service):
     """Worker class to run c-star simulations."""
 
@@ -101,14 +78,14 @@ class SimulationRunner(Service):
     """The simulation stages that should be executed."""
     _handler: ExecutionHandler | None
     """The execution handler for the simulation."""
-    _job_config: Final[JobConfig]
+    _job_config: Final["JobConfig"]
     """Configuration for submitting jobs to an HPC."""
 
     def __init__(
         self,
         request: BlueprintRequest,
-        service_cfg: ServiceConfiguration,
-        job_cfg: JobConfig,
+        service_cfg: "ServiceConfiguration",
+        job_cfg: "JobConfig",
     ) -> None:
         """Initialize the SimulationRunner with the supplied configuration.
 
@@ -363,30 +340,6 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_service_config(log_level: int | str) -> ServiceConfiguration:
-    """Create a ServiceConfiguration instance using CLI arguments.
-
-    Parameters
-    ----------
-    log_level : int or str
-        The log level to be used by the worker
-
-    Returns
-    -------
-    ServiceConfiguration
-    """
-    level = parse_log_level_name(log_level)
-
-    return ServiceConfiguration(
-        as_service=True,
-        loop_delay=5,
-        health_check_frequency=None,
-        log_level=level,
-        health_check_log_threshold=10,
-        name="SimulationRunner",
-    )
-
-
 def get_request(
     blueprint_uri: str, stages: list[SimulationStages] | None = None
 ) -> BlueprintRequest:
@@ -413,39 +366,10 @@ def get_request(
     )
 
 
-def get_job_config() -> JobConfig:
-    """Create and configure a `JobConfig` instance from environment variables.
-
-    Returns
-    -------
-    JobConfig
-    """
-    account_id: str = get_env_item(ENV_CSTAR_SLURM_ACCOUNT).value
-    walltime: str = get_env_item(ENV_CSTAR_SLURM_MAX_WALLTIME).value
-    priority: str = get_env_item(ENV_CSTAR_SLURM_QUEUE).value
-
-    return JobConfig(account_id, walltime, priority)
-
-
-def configure_environment(log: logging.Logger) -> None:
-    """Configure the environment variables required by the worker.
-
-    Parameters
-    ----------
-    log : logging.Logger
-        A logger to log configuration details.
-
-    Returns
-    -------
-    None
-    """
-    # ensure git works on distributed file-system, e.g. lustre
-    os.environ["GIT_DISCOVERY_ACROSS_FILESYSTEM"] = "1"
-    log.debug("Git discovery configured.")
-
-
 async def execute_runner(
-    job_cfg: JobConfig, service_cfg: ServiceConfiguration, request: BlueprintRequest
+    job_cfg: "JobConfig",
+    service_cfg: "ServiceConfiguration",
+    request: BlueprintRequest,
 ) -> int:
     """Execute a blueprint with a SimulationRunner.
 
@@ -460,10 +384,10 @@ async def execute_runner(
     """
     log = get_logger(__name__, level=service_cfg.log_level)
 
-    log.debug(f"Job config: {job_cfg}")
-    log.debug(f"Simulation runner service config: {service_cfg}")
-    log.debug(f"Simulation request: {request}")
-    log.debug(f"os.environ: {os.environ}")
+    log.debug(f"Job config: {job_cfg!r}")
+    log.debug(f"Service config: {service_cfg!r}")
+    log.debug(f"Request: {request!r}")
+    log.trace(f"Environment: {os.environ}")
 
     try:
         configure_environment(log)

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -12,7 +12,8 @@ from unittest import mock
 import pytest
 from pydantic import ValidationError
 
-from cstar.entrypoint.service import Service, ServiceConfiguration
+from cstar.entrypoint.config import ServiceConfiguration
+from cstar.entrypoint.service import Service
 
 
 class PrintingService(Service):

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -11,21 +11,23 @@ from unittest import mock
 import pytest
 
 from cstar.base.exceptions import BlueprintError, CstarError
-from cstar.entrypoint.service import ServiceConfiguration
+from cstar.entrypoint.config import (
+    JobConfig,
+    ServiceConfiguration,
+    configure_environment,
+    get_job_config,
+    get_service_config,
+)
 from cstar.entrypoint.worker.worker import (
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
     ARG_URI_LONG,
     ARG_URI_SHORT,
     BlueprintRequest,
-    JobConfig,
     SimulationRunner,
     SimulationStages,
-    configure_environment,
     create_parser,
-    get_job_config,
     get_request,
-    get_service_config,
     main,
 )
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
@@ -251,7 +253,7 @@ def test_get_service_config(
         ],
     )
 
-    config = get_service_config(parsed_args.log_level)
+    config = get_service_config(parsed_args.log_level, name="SimulationRunner")
 
     # some values are currently hardcoded for the worker service
     assert config.as_service

--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -219,8 +219,8 @@ Use the ``run`` command from the ``cstar`` CLI to execute a blueprint.
     .. code-block:: python
       :caption: Executing a blueprint YAML file in python.
 
-        from cstar.entrypoint.service import ServiceConfiguration
-        from cstar.entrypoint.worker.worker import BlueprintRequest, JobConfig, SimulationRunner
+        from cstar.entrypoint.config import JobConfig, ServiceConfiguration, SimulationRunner
+        from cstar.entrypoint.worker.worker import BlueprintRequest
 
         account_id = "your-account-id"
         queue_id = "wholenode"


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change extracts the job configuration classes for services from the `worker` module to avoid circular references when they are re-used by new applications.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- `ServiceConfiguration`, `JobConfig` have been relocated to `cstar.entrypoint.config` from `cstar.entrypoint.worker.worker`

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Subtask of #CSD-681
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
