### PR TITLE
Add initial hw app and blueprint app-host

### DIFF
--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -2,7 +2,8 @@ import typing as t
 
 import typer
 
-from cstar.orchestration.models import RomsMarblBlueprint
+from cstar.cli.workplan.shared import get_registered_bp
+from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import validate_serialized_entity
 
 app = typer.Typer()
@@ -22,9 +23,14 @@ def check(
     bool
         `True` if valid
     """
-    result = validate_serialized_entity(path, RomsMarblBlueprint)
+    result = validate_serialized_entity(path, Blueprint)
     if result.item is None:
-        print(result.error_msg)
-        return
+        raise typer.BadParameter(result.error_msg)
+
+    bp_type = get_registered_bp(result.item.application)
+    result = validate_serialized_entity(path, bp_type)
+
+    if result.item is None:
+        raise typer.BadParameter(result.error_msg)
 
     print(f"The blueprint `{result.item.name}` is valid")

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -2,14 +2,16 @@ import asyncio
 import typing as t
 
 import typer
+from pydantic import ValidationError
 
 from cstar.base.env import (
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
     get_env_item,
 )
-from cstar.base.log import LogLevelChoices
+from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import clobber_callback, log_level_callback
+from cstar.cli.workplan.shared import create_xrunner, get_registered_bp
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,
     ARG_LOGLEVEL_LONG,
@@ -17,22 +19,71 @@ from cstar.entrypoint.utils import (
 )
 from cstar.entrypoint.worker.worker import (
     SimulationStages,
-    execute_runner,
     get_job_config,
     get_request,
     get_service_config,
 )
-from cstar.orchestration.models import RomsMarblBlueprint
-from cstar.orchestration.serialization import validate_serialized_entity
+from cstar.entrypoint.worker.worker import execute_runner as exec_romsmarbl_runner
+from cstar.entrypoint.xrunner import XRunnerRequest
+from cstar.execution.file_system import local_copy
+from cstar.orchestration.models import Blueprint
+from cstar.orchestration.serialization import deserialize, validate_serialized_entity
 
 app = typer.Typer()
+log = get_logger(__name__)
+
+
+def path_callback(
+    ctx: typer.Context,
+    path: str,
+) -> str:
+    """Validate the blueprint content after typer has parsed the path.
+
+    Additionally, loads the blueprint and stores in the context for later use.
+
+    Parameters
+    ----------
+    ctx : typer.Context
+        The context of the command.
+    path : str
+        The path to the blueprint.
+
+    Returns
+    -------
+    str
+        The path to the blueprint.
+    """
+    try:
+        with local_copy(path) as local_path:
+            if not local_path.exists():
+                msg = f"Blueprint not found at path: {path}"
+                raise typer.BadParameter(msg)
+
+            # use the core blueprint fields to identify the application type
+            bp_core = deserialize(local_path, Blueprint)
+            bp_type = get_registered_bp(bp_core.application)
+
+            ctx.obj = bp_type(**bp_core.model_dump())
+
+    except FileNotFoundError as ex:
+        msg = f"Blueprint file not found: {path}"
+        raise typer.BadParameter(msg) from ex
+    except ValidationError as ex:
+        msg = f"Blueprint file is malformed: {ex}"
+        raise typer.BadParameter(msg) from ex
+
+    return path
 
 
 @app.command(name="run", help="Execute a blueprint in a local worker service.")
 def run(
-    path: t.Annotated[
+    ctx: typer.Context,
+    uri: t.Annotated[
         str,
-        typer.Argument(help="The path to the blueprint to execute"),
+        typer.Argument(
+            help="The URI (or path) to the blueprint to execute",
+            callback=path_callback,
+        ),
     ],
     stage: t.Annotated[
         list[SimulationStages] | None,
@@ -62,17 +113,34 @@ def run(
     ] = False,
 ) -> None:
     """Execute a blueprint in a local worker service."""
-    result = validate_serialized_entity(path, RomsMarblBlueprint)
+    bp = t.cast("Blueprint", ctx.obj)
+    name = f"{bp.application}_runner"
+
+    job_cfg = get_job_config()
+    service_cfg = get_service_config(get_env_item(ENV_CSTAR_LOG_LEVEL).value, name=name)
+
+    msg = f"Executing {bp.application!r} blueprint in a {type(bp)} service"
+    log.debug(msg)
+
+    result = validate_serialized_entity(uri, type(bp))
     if not result.is_valid:
         print(result.error_msg)
         return
 
-    print("Executing blueprint in a worker service")
-    job_cfg = get_job_config()
-    service_cfg = get_service_config(get_env_item(ENV_CSTAR_LOG_LEVEL).value)
-    request = get_request(path, stage)
+    if bp.application == "roms_marbl":
+        # NOTE: temporary conditional to use old runner until it is converted to XRunner
+        rm_request = get_request(uri, stage)
+        rc = asyncio.run(exec_romsmarbl_runner(job_cfg, service_cfg, rm_request))
+    else:
+        request = XRunnerRequest(uri, type(bp))
 
-    rc = asyncio.run(execute_runner(job_cfg, service_cfg, request))
+        runner = create_xrunner(request, service_cfg, job_cfg)
+        xresult = asyncio.run(runner.execute_xrunner())
+
+        if errors := xresult.errors:
+            print(f"Errors occurred: {', '.join(errors)}")
+
+        rc = len(errors)
 
     if rc:
         print("Blueprint execution failed")

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -60,10 +60,10 @@ def path_callback(
                 raise typer.BadParameter(msg)
 
             # use the core blueprint fields to identify the application type
-            bp_core = deserialize(local_path, Blueprint)
-            bp_type = get_registered_bp(bp_core.application)
+            base_bp = deserialize(local_path, Blueprint)
+            bp_type = get_registered_bp(base_bp.application)
 
-            ctx.obj = bp_type(**bp_core.model_dump())
+            ctx.obj = bp_type(**base_bp.model_dump())
 
     except FileNotFoundError as ex:
         msg = f"Blueprint file not found: {path}"

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -26,7 +26,7 @@ from cstar.entrypoint.worker.worker import (
 from cstar.entrypoint.worker.worker import execute_runner as exec_romsmarbl_runner
 from cstar.entrypoint.xrunner import XRunnerRequest
 from cstar.execution.file_system import local_copy
-from cstar.orchestration.models import Blueprint
+from cstar.orchestration.models import Application, Blueprint
 from cstar.orchestration.serialization import deserialize, validate_serialized_entity
 
 app = typer.Typer()
@@ -127,7 +127,7 @@ def run(
         print(result.error_msg)
         return
 
-    if bp.application == "roms_marbl":
+    if bp.application == Application.ROMS_MARBL.value:
         # NOTE: temporary conditional to use old runner until it is converted to XRunner
         rm_request = get_request(uri, stage)
         rc = asyncio.run(exec_romsmarbl_runner(job_cfg, service_cfg, rm_request))

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -10,10 +10,12 @@ from cstar.base.env import (
 )
 from cstar.base.log import LogLevelChoices
 from cstar.cli.common import clobber_callback, log_level_callback
-from cstar.entrypoint.worker.worker import (
+from cstar.entrypoint.utils import (
     ARG_CLOBBER,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
+)
+from cstar.entrypoint.worker.worker import (
     SimulationStages,
     execute_runner,
     get_job_config,

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -5,6 +5,7 @@ from cstar.cli.common import common_callback
 from cstar.cli.environment import app as app_env
 from cstar.cli.template import app as app_template
 from cstar.cli.workplan import app as app_workplan
+from cstar.entrypoint.worker import hello_app, worker  # noqa: F401
 
 
 def attach_subcommands(app: typer.Typer) -> None:

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -32,14 +32,13 @@ def attach_subcommands(app: typer.Typer) -> None:
 
 app = typer.Typer(
     callback=common_callback,
-    help="The C-Star CLI (installed as `cstar`) enables command-line management and execution of C-Star workplans and blueprints.",
+    help="The C-Star CLI enables command-line management and execution of C-Star workplans and blueprints.",
 )
 attach_subcommands(app)
 
 
 def main() -> None:
     """Main entrypoint for the complete C-Star CLI."""
-    global app
     app()
 
 

--- a/cstar/cli/workplan/check.py
+++ b/cstar/cli/workplan/check.py
@@ -24,7 +24,6 @@ def check(
     """
     result = validate_serialized_entity(path, Workplan)
     if result.item is None:
-        print(result.error_msg)
-        return
+        raise typer.BadParameter(result.error_msg)
 
     print(f"The workplan `{result.item.name}` is valid")

--- a/cstar/cli/workplan/generate.py
+++ b/cstar/cli/workplan/generate.py
@@ -1,5 +1,8 @@
 import typing as t
+from collections.abc import Iterable
+from itertools import permutations
 from pathlib import Path
+from random import choice
 
 import typer
 from rich.console import Console
@@ -16,7 +19,7 @@ if t.TYPE_CHECKING:
     BPResult: t.TypeAlias = tuple[Path, RomsMarblBlueprint]
 
 
-def _locate_blueprints(search_dir: Path) -> t.Iterable["BPResult"]:
+def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
     """Iterate through the contents of a directory to locate `Blueprints`.
 
     Parameters
@@ -104,9 +107,6 @@ def generate(
         _display_order(results)
 
         while "y" in input("Do you want to change the order? (yes/no): ").lower():
-            from itertools import permutations
-            from random import choice
-
             possible = list(permutations(list(range(len(results)))))
             example = list(choice(possible))
             example = [x + 1 for x in example]
@@ -115,8 +115,8 @@ def generate(
                 f"Specify the new order by providing the current order numbers in a new arrangement, (e.g. {', '.join(str(ex) for ex in example)}): "
             )
             order = order_input.replace(" ", "").split(",")
-            provided = set(int(x) for x in order)
-            required = set(x + 1 for x in range(len(results)))
+            provided = {int(x) for x in order}
+            required = {x + 1 for x in range(len(results))}
 
             diff = required.difference(provided)
 

--- a/cstar/cli/workplan/generate.py
+++ b/cstar/cli/workplan/generate.py
@@ -9,14 +9,20 @@ from rich.console import Console
 from rich.table import Table
 
 from cstar.base.utils import slugify
-from cstar.orchestration.models import RomsMarblBlueprint, Step, Workplan, WorkplanState
+from cstar.cli.workplan.shared import get_registered_bp
+from cstar.orchestration.models import (
+    Blueprint,
+    Step,
+    Workplan,
+    WorkplanState,
+)
 from cstar.orchestration.serialization import deserialize, serialize
 
 app = typer.Typer()
 console = Console()
 
 if t.TYPE_CHECKING:
-    BPResult: t.TypeAlias = tuple[Path, RomsMarblBlueprint]
+    BPResult: t.TypeAlias = tuple[Path, Blueprint]
 
 
 def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
@@ -30,12 +36,17 @@ def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
     files = search_dir.glob("*.yaml")
     valid_blueprints: list[BPResult] = []
 
-    for file in files:
-        try:
-            bp = deserialize(file, RomsMarblBlueprint)
+    try:
+        for file in files:
+            base_bp = deserialize(file, Blueprint)
+
+            bp_type = get_registered_bp(base_bp.application)
+            bp = bp_type(**base_bp.model_dump())
+
             valid_blueprints.append((file, bp))
-        except Exception:
-            print(f"File {file} is not a valid RomsMarblBlueprint")
+    except ValueError as ex:
+        msg = "File contains an invalid blueprint"
+        raise typer.BadParameter(msg) from ex
 
     return valid_blueprints
 

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -24,6 +24,9 @@ from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import validate_serialized_entity
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
+
 app = typer.Typer()
 log = get_logger(__name__)
 
@@ -292,7 +295,7 @@ def run(
                 build_and_run_dag(
                     wp_path,
                     run_id,
-                    user_variables=t.cast("t.Mapping[str, str]", ctx.obj),
+                    user_variables=t.cast("Mapping[str, str]", ctx.obj),
                     dry_run=dry_run,
                 ),
             )

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -13,7 +13,7 @@ from cstar.cli.workplan.shared import (
     check_and_capture_kvps,
     list_runs,
 )
-from cstar.entrypoint.worker.worker import (
+from cstar.entrypoint.utils import (
     ARG_CLOBBER,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -8,9 +8,12 @@ from rich.console import Console
 from rich.table import Column, Table
 
 from cstar.base.log import get_logger
+from cstar.orchestration.application import APP_CAT_BLUEPRINTS
 from cstar.orchestration.dag_runner import DagStatus
+from cstar.orchestration.models import Blueprint
 from cstar.orchestration.orchestration import Status
 from cstar.orchestration.tracking import TrackingRepository
+from cstar.system.registration import Registrar
 
 console = Console()
 log = get_logger(__name__)
@@ -168,3 +171,19 @@ def check_and_capture_kvps(entries: list[str]) -> Mapping[str, str] | None:
         raise typer.BadParameter(msg)
 
     return variables
+
+
+def get_registered_bp(application: str) -> type[Blueprint]:
+    """Retrieve the Blueprint type registered for the given application.
+
+    Parameters
+    ----------
+    application
+        The application name
+
+    Returns
+    -------
+    type[Blueprint]
+    """
+    reg_bp = Registrar[Blueprint](APP_CAT_BLUEPRINTS)
+    return reg_bp.get(application)

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -8,7 +8,9 @@ from rich.console import Console
 from rich.table import Column, Table
 
 from cstar.base.log import get_logger
-from cstar.orchestration.application import APP_CAT_BLUEPRINTS
+from cstar.entrypoint.config import get_job_config, get_service_config
+from cstar.entrypoint.xrunner import XBlueprintRunner, XRunnerRequest
+from cstar.orchestration.application import APP_CAT_BLUEPRINTS, APP_CAT_RUNNERS
 from cstar.orchestration.dag_runner import DagStatus
 from cstar.orchestration.models import Blueprint
 from cstar.orchestration.orchestration import Status
@@ -17,6 +19,9 @@ from cstar.system.registration import Registrar
 
 console = Console()
 log = get_logger(__name__)
+
+if t.TYPE_CHECKING:
+    from cstar.entrypoint.config import JobConfig, ServiceConfiguration
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:
@@ -171,6 +176,38 @@ def check_and_capture_kvps(entries: list[str]) -> Mapping[str, str] | None:
         raise typer.BadParameter(msg)
 
     return variables
+
+
+def create_xrunner(
+    request: XRunnerRequest[Blueprint],
+    service_cfg: "ServiceConfiguration | None" = None,
+    job_cfg: "JobConfig | None" = None,
+    log_level: int | str = "INFO",
+) -> XBlueprintRunner[Blueprint]:
+    """Dynamically create a runner using the application to look up the
+    registered handler.
+
+    Parameters
+    ----------
+    job_cfg : JobConfig
+        Configuration applied to the scheduler.
+    service_cfg : ServiceConfiguration
+        Configuration applied to the service.
+    request : XRunnerRequest
+        A request specifying the blueprint to be executed.
+    """
+    if job_cfg is None:
+        job_cfg = get_job_config()
+    if service_cfg is None:
+        service_cfg = get_service_config(
+            log_level,
+            name=f"{request.application}_runner",
+        )
+
+    runner_registry = Registrar[XBlueprintRunner[Blueprint]](APP_CAT_RUNNERS)
+    klass = runner_registry.get(request.application)
+
+    return klass(request, job_cfg, service_cfg)
 
 
 def get_registered_bp(application: str) -> type[Blueprint]:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -1,5 +1,7 @@
 import asyncio
 import typing as t
+from collections import Counter
+from collections.abc import Mapping
 
 import typer
 from rich.console import Console
@@ -131,7 +133,7 @@ def check_and_capture_kvp(entry: str) -> tuple[str, str]:
     return k, v
 
 
-def check_and_capture_kvps(entries: list[str]) -> t.Mapping[str, str] | None:
+def check_and_capture_kvps(entries: list[str]) -> Mapping[str, str] | None:
     """Capture all unique keyj-value pairs from user-supplied configuration
     supplied as a list of key-value pairs in the format ["key1=value", "key2=value"]
 
@@ -160,7 +162,7 @@ def check_and_capture_kvps(entries: list[str]) -> t.Mapping[str, str] | None:
     variables = dict(captured_kvps)
 
     if len(variables) < len(captured_kvps):
-        counter = t.Counter(k for k, _ in captured_kvps)
+        counter = Counter(k for k, _ in captured_kvps)
         k, _ = counter.most_common(1)[0]
         msg = f"Found variable with multiple values: {k}"
         raise typer.BadParameter(msg)

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -204,9 +204,7 @@ def create_xrunner(
             name=f"{request.application}_runner",
         )
 
-    runner_registry = Registrar[XBlueprintRunner[Blueprint]](APP_CAT_RUNNERS)
-    klass = runner_registry.get(request.application)
-
+    klass = get_registered_runner(request.application)
     return klass(request, job_cfg, service_cfg)
 
 
@@ -222,5 +220,21 @@ def get_registered_bp(application: str) -> type[Blueprint]:
     -------
     type[Blueprint]
     """
-    reg_bp = Registrar[Blueprint](APP_CAT_BLUEPRINTS)
-    return reg_bp.get(application)
+    registrar = Registrar[Blueprint](APP_CAT_BLUEPRINTS)
+    return registrar.get(application)
+
+
+def get_registered_runner(application: str) -> type[XBlueprintRunner[Blueprint]]:
+    """Retrieve the Runner type registered for the given application.
+
+    Parameters
+    ----------
+    application
+        The application name
+
+    Returns
+    -------
+    type[XBlueprintRunner[Blueprint]]
+    """
+    registrar = Registrar[XBlueprintRunner[Blueprint]](APP_CAT_RUNNERS)
+    return registrar.get(application)

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -1,0 +1,9 @@
+import typing as t
+
+ARG_URI_LONG: t.Literal["--blueprint-uri"] = "--blueprint-uri"
+ARG_URI_SHORT: t.Literal["-b"] = "-b"
+
+ARG_LOGLEVEL_LONG: t.Literal["--log-level"] = "--log-level"
+ARG_LOGLEVEL_SHORT: t.Literal["-l"] = "-l"
+
+ARG_CLOBBER: t.Literal["--clobber"] = "--clobber"

--- a/cstar/entrypoint/worker/hello_app.py
+++ b/cstar/entrypoint/worker/hello_app.py
@@ -1,0 +1,40 @@
+import typing as t
+
+from cstar.entrypoint.xrunner import XBlueprintRunner, XRunnerResult
+from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.application import register_blueprint, register_runner
+from cstar.orchestration.models import Application, Blueprint
+
+
+@register_blueprint(Application.HELLO_WORLD)
+class HelloWorldBlueprint(Blueprint):
+    """A simple blueprint demonstrating the integration of a Blueprint and it's
+    runner application.
+    """
+
+    application: str = Application.HELLO_WORLD
+    """The application identifier."""
+    target: str
+    """The person to say hello to."""
+
+
+@register_runner(Application.HELLO_WORLD)
+class HelloWorldRunner(XBlueprintRunner[HelloWorldBlueprint]):
+    """Worker class to execute a simple "Hello, world" application specified via blueprint."""
+
+    application: str = Application.HELLO_WORLD
+    """The application identifier."""
+
+    @t.override
+    def __call__(self) -> XRunnerResult[HelloWorldBlueprint]:
+        """Process the blueprint.
+
+        Returns
+        -------
+        RunnerResult
+            The result of the blueprint processing.
+        """
+        self.log.debug("Executing handler function on blueprint runner")
+
+        print(f"Hello, {self.blueprint.target}")
+        return self.set_result(ExecutionStatus.COMPLETED)

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -19,22 +19,21 @@ from cstar.entrypoint.config import (
     get_service_config,
 )
 from cstar.entrypoint.service import Service
+from cstar.entrypoint.utils import (
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
+    ARG_URI_LONG,
+    ARG_URI_SHORT,
+)
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.roms import ROMSSimulation
 
 if TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
 
-ARG_URI_LONG: Literal["--blueprint-uri"] = "--blueprint-uri"
-ARG_URI_SHORT: Literal["-b"] = "-b"
-
-ARG_LOGLEVEL_LONG: Literal["--log-level"] = "--log-level"
-ARG_LOGLEVEL_SHORT: Literal["-l"] = "-l"
 
 ARG_STAGE_LONG: Literal["--stage"] = "--stage"
 ARG_STAGE_SHORT: Literal["-g"] = "-g"
-
-ARG_CLOBBER: Literal["--clobber"] = "--clobber"
 
 
 class SimulationStages(enum.StrEnum):

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -1,8 +1,6 @@
 import argparse
 import asyncio
-import dataclasses as dc
 import enum
-import logging
 import os
 import pathlib
 import sys
@@ -11,7 +9,7 @@ from typing import TYPE_CHECKING, Final, Literal, override
 
 from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
 from cstar.base.exceptions import BlueprintError, CstarError
-from cstar.base.log import get_logger
+from cstar.base.log import LogLevelChoices, get_logger
 from cstar.base.utils import slugify
 from cstar.entrypoint.config import (
     configure_environment,
@@ -25,7 +23,9 @@ from cstar.entrypoint.utils import (
     ARG_URI_LONG,
     ARG_URI_SHORT,
 )
+from cstar.entrypoint.xrunner import XRunnerRequest
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
+from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.roms import ROMSSimulation
 
 if TYPE_CHECKING:
@@ -51,17 +51,19 @@ class SimulationStages(enum.StrEnum):
     """Execute hooks after the simulation completes. See `Simulation.post_run`"""
 
 
-@dc.dataclass(frozen=True)
-class BlueprintRequest:
-    """Represents a request to run a c-star simulation."""
+class BlueprintRequest(XRunnerRequest[RomsMarblBlueprint]):
+    stages: list[SimulationStages]
+    """The simulation stages to execute."""
 
-    blueprint_uri: str
-    """The path to the blueprint."""
-    stages: list[SimulationStages] = dc.field(default_factory=list)
-    """The simulation stages to execute.
-
-    Defaults to all stages.
-    """
+    def __init__(
+        self,
+        uri: str,
+        bp_type: type[RomsMarblBlueprint],
+        name: str = "",
+        stages: list[SimulationStages] | None = None,
+    ) -> None:
+        super().__init__(uri, bp_type, name)
+        self.stages = stages or []
 
 
 class SimulationRunner(Service):
@@ -316,15 +318,7 @@ def create_simrunner_parser() -> argparse.ArgumentParser:
         type=str,
         required=False,
         help="Logging level for the simulation.",
-        choices=[
-            logging.getLevelName(i)
-            for i in [
-                logging.DEBUG,
-                logging.INFO,
-                logging.WARNING,
-                logging.ERROR,
-            ]
-        ],
+        choices=list(LogLevelChoices),
     )
     parser.add_argument(
         ARG_STAGE_SHORT,
@@ -360,7 +354,8 @@ def get_request(
         stages = list(SimulationStages)
 
     return BlueprintRequest(
-        blueprint_uri=blueprint_uri,
+        blueprint_uri,
+        RomsMarblBlueprint,
         stages=stages,
     )
 

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -289,7 +289,7 @@ class SimulationRunner(Service):
         return False
 
 
-def create_parser() -> argparse.ArgumentParser:
+def create_simrunner_parser() -> argparse.ArgumentParser:
     """Create a parser for CLI arguments expected by a SimulationRunner.
 
     Returns
@@ -416,11 +416,11 @@ def main() -> int:
     int
         The exit code of the worker script. Returns 0 on success, 1 on failure.
     """
-    parser = create_parser()
+    parser = create_simrunner_parser()
     args = parser.parse_args()
 
     job_cfg = get_job_config()
-    service_cfg = get_service_config(args.log_level)
+    service_cfg = get_service_config(args.log_level, name="SimulationRunner")
     request = get_request(args.blueprint_uri, args.stages)
 
     return asyncio.run(execute_runner(job_cfg, service_cfg, request))

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -51,7 +51,7 @@ class SimulationStages(enum.StrEnum):
     """Execute hooks after the simulation completes. See `Simulation.post_run`"""
 
 
-class BlueprintRequest(XRunnerRequest[RomsMarblBlueprint]):
+class RomsMarblRunnerRequest(XRunnerRequest[RomsMarblBlueprint]):
     stages: list[SimulationStages]
     """The simulation stages to execute."""
 
@@ -84,7 +84,7 @@ class SimulationRunner(Service):
 
     def __init__(
         self,
-        request: BlueprintRequest,
+        request: RomsMarblRunnerRequest,
         service_cfg: "ServiceConfiguration",
         job_cfg: "JobConfig",
     ) -> None:
@@ -335,7 +335,7 @@ def create_simrunner_parser() -> argparse.ArgumentParser:
 
 def get_request(
     blueprint_uri: str, stages: list[SimulationStages] | None = None
-) -> BlueprintRequest:
+) -> RomsMarblRunnerRequest:
     """Create a BlueprintRequest instance from CLI arguments.
 
     Parameters
@@ -353,7 +353,7 @@ def get_request(
     if not stages:
         stages = list(SimulationStages)
 
-    return BlueprintRequest(
+    return RomsMarblRunnerRequest(
         blueprint_uri,
         RomsMarblBlueprint,
         stages=stages,
@@ -363,7 +363,7 @@ def get_request(
 async def execute_runner(
     job_cfg: "JobConfig",
     service_cfg: "ServiceConfiguration",
-    request: BlueprintRequest,
+    request: RomsMarblRunnerRequest,
 ) -> int:
     """Execute a blueprint with a SimulationRunner.
 

--- a/cstar/entrypoint/xrunner.py
+++ b/cstar/entrypoint/xrunner.py
@@ -1,0 +1,407 @@
+import argparse
+import os
+import typing as t
+from datetime import datetime, timezone
+
+from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
+from cstar.base.exceptions import CstarError
+from cstar.base.log import LogLevelChoices, get_logger
+from cstar.entrypoint.config import (
+    JOBFILE_DATE_FORMAT,
+    configure_environment,
+)
+from cstar.entrypoint.service import Service
+from cstar.entrypoint.utils import (
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
+    ARG_URI_LONG,
+    ARG_URI_SHORT,
+)
+from cstar.execution.file_system import local_copy
+from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.serialization import SerializableModel, deserialize
+
+if t.TYPE_CHECKING:
+    from cstar.entrypoint.config import JobConfig, ServiceConfiguration
+
+
+class HasApplication(SerializableModel, t.Protocol):
+    application: str
+
+
+TBlueprint = t.TypeVar("TBlueprint", bound=HasApplication)
+
+
+class XRunnerRequest(t.Generic[TBlueprint]):
+    """Generic request containing configuration required to execute an application
+    via Blueprint.
+    """
+
+    name: str | None = None
+    """User-friendly name for the process (or job) handling the request."""
+    blueprint_uri: str
+    """The URI of a blueprint to be used to parameterize the application."""
+    bp_type: type[TBlueprint]
+    """The type of blueprint that the URI will be deserialized into."""
+    _bp: TBlueprint | None = None
+    """The deserialized blueprint."""
+
+    def __init__(self, uri: str, bp_type: type[TBlueprint], name: str = "") -> None:
+        """Initialize the request instance.
+
+        Parameters
+        ----------
+        name : str
+            User-friendly name for the process (or job) handling the request.
+        path : Path
+            The URI of a blueprint to be used to parameterize the application.
+        bp_type : type[TBlueprint]
+            The type of blueprint that the path will be deserialized into.
+        """
+        self.blueprint_uri = uri
+        self.bp_type = bp_type
+        self.name = name.strip() or XRunnerRequest._generate_job_name()
+
+    @property
+    def application(self) -> str:
+        """Return the string identifying the application that will be executed.
+
+        Returns
+        -------
+        str
+        """
+        return self.blueprint.application
+
+    @property
+    def blueprint(self) -> TBlueprint:
+        """Return the deserialized blueprint instance.
+
+        Returns
+        -------
+        TBlueprint
+        """
+        if self._bp is None:
+            with local_copy(str(self.blueprint_uri)) as local_path:
+                self._bp = deserialize(local_path, self.bp_type)
+        return self._bp
+
+    @classmethod
+    def _generate_job_name(cls) -> str:
+        """Generate a unique job name based on the current date and time.
+
+        Returns
+        -------
+        str
+        """
+        now_utc = datetime.now(timezone.utc)
+        formatted_now_utc = now_utc.strftime(JOBFILE_DATE_FORMAT)
+        return f"cstar_worker_{formatted_now_utc}"
+
+
+class XRunnerResult(t.Generic[TBlueprint]):
+    """Specifies details about the result of running an application."""
+
+    request: XRunnerRequest[TBlueprint]
+    """The request that was handled and produced the result."""
+    status: t.Final[ExecutionStatus | None]
+    """The final status of the application."""
+    _errors: t.Final[list[str]]
+    """The error messages produced by the application."""
+
+    def __init__(
+        self,
+        request: XRunnerRequest[TBlueprint],
+        status: (
+            ExecutionStatus | None
+        ) = None,  # TODO: review this... it should be able to be non-nullable.
+        errors: list[str] | None = None,
+    ) -> None:
+        """Initialize the result instance.
+
+        Parameters
+        ----------
+        request : XRunnerRequest[TBlueprint]
+            The request that was handled and produced the result.
+        status : ExecutionStatus | None
+            The final status of the application.
+        errors : list[str] | None
+            The error messages produced by the appplication.
+        """
+        self.request = request
+        self._errors = errors or []
+        self.status = status
+
+    @property
+    def errors(self) -> tuple[str, ...]:
+        return tuple(self._errors)
+
+
+class XRunner(t.Protocol, t.Generic[TBlueprint]):
+    """Core API required to be a hosted BlueprintRunner."""
+
+    def __init__(
+        self,
+        request: XRunnerRequest[TBlueprint],
+        job_cfg: "JobConfig",
+        service_config: "ServiceConfiguration",
+    ) -> None:
+        """Initialize a runner instance.
+
+        Parameters
+        ----------
+        request : XRunnerRequest[TBlueprint]
+            The request containing configuration for executing an application.
+        job_cfg : JobConfig
+            Configuration required to submit jobs on an HPC.
+        service_config : ServiceConfiguration
+            Configuration options for the execution of an application in a service.
+        """
+
+    @property
+    def blueprint(self) -> TBlueprint:
+        """Return the deserialized blueprint instance.
+
+        Returns
+        -------
+        TBlueprint
+        """
+        ...
+
+    @property
+    def request(self) -> XRunnerRequest[TBlueprint]:
+        """Return the request containing configuration for executing the application.
+
+        Returns
+        -------
+        XRunnerRequest[TBlueprint]
+        """
+        ...
+
+    @property
+    def result(self) -> XRunnerResult[TBlueprint] | None:
+        """Return the result produced by executing the application.
+
+        Returns
+        -------
+        XRunnerResult[TBlueprint]
+        """
+        ...
+
+    def __call__(self) -> XRunnerResult[TBlueprint]:
+        """Execute the application.
+
+        Returns
+        -------
+        XRunnerResult[TBlueprint]
+        """
+        ...
+
+    def set_result(
+        self, status: ExecutionStatus, errors: list[str] | None = None
+    ) -> XRunnerResult[TBlueprint]:
+        """Set the status and resulting errors after executing the application.
+
+        Returns
+        -------
+        XRunnerResult[TBlueprint]
+        """
+        ...
+
+
+class XBlueprintRunner(XRunner[TBlueprint], Service):
+    """A service that executes a blueprint."""
+
+    _request: XRunnerRequest[TBlueprint]
+    """The instigating request."""
+    _result: XRunnerResult[TBlueprint] | None = None
+    """The result produced by the application."""
+    _job_cfg: "JobConfig"
+    """Configuration required to submit jobs on an HPC."""
+
+    def __init__(
+        self,
+        request: XRunnerRequest[TBlueprint],
+        job_cfg: "JobConfig",
+        service_cfg: "ServiceConfiguration",
+    ) -> None:
+        """Initialize the `XBlueprintRunner` with the supplied configuration.
+
+        Parameters
+        ----------
+        request: BlueprintRequest
+            A request containing information about the blueprint to run.
+        job_cfg: JobConfig
+            Configuration for submitting jobs to an HPC, such as account ID,
+            walltime, job name, and priority.
+        service_cfg: ServiceConfiguration
+            Configuration for modifying behavior of the service process.
+        """
+        Service.__init__(self, service_cfg)
+        self._request = request
+        self._job_cfg = job_cfg
+
+    @property
+    def request(self) -> XRunnerRequest[TBlueprint]:
+        return self._request
+
+    @property
+    def result(self) -> XRunnerResult[TBlueprint] | None:
+        return self._result
+
+    @property
+    def blueprint(self) -> TBlueprint:
+        return self._request.blueprint
+
+    @property
+    def blueprint_uri(self) -> str:
+        """Return the URI of the blueprint to run."""
+        return self._request.blueprint_uri
+
+    @property
+    def status(self) -> ExecutionStatus:
+        """Return the status of the runner's work."""
+        if self._result and self._result.status:
+            return self._result.status
+
+        return ExecutionStatus.UNKNOWN
+
+    def __call__(self) -> XRunnerResult[TBlueprint]:
+        return XRunnerResult(self.request, ExecutionStatus.COMPLETED)
+
+    def is_done(self) -> bool:
+        """Return `True` if the blueprint has completed execution.
+
+        Returns
+        -------
+        bool
+        """
+        return ExecutionStatus.is_terminal(self.status)
+
+    def _log_disposition(self) -> None:
+        """Log the status of the runner's work at the current time."""
+        msg = (
+            "Final disposition of task executed by service "
+            f"{self._config.name!r} is {self.status.name!r}"
+        )
+        self.log.debug(msg)
+
+    @t.override
+    def _can_shutdown(self) -> bool:
+        """Determine if the service can shutdown.
+
+        Returns
+        -------
+        bool
+            `True` if the service can shutdown, `False` otherwise.
+        """
+        if self.is_done():
+            self.log.info(f"Shutdown is allowed ({self.status}).")
+            return True
+
+        return False
+
+    @t.override
+    def _on_start(self) -> None:
+        """Prepare the runner for execution.
+
+        Performs validation of arguments received via CLI.
+        """
+        if not self.blueprint_uri:
+            msg = "No blueprint URI provided"
+            raise ValueError(msg)
+
+    @t.override
+    async def _on_iteration(self) -> None:
+        """Execute an application as specified in the blueprint."""
+        try:
+            self._result = self()
+        except Exception:
+            msg = f"An error occurred while running blueprint: {self.blueprint_uri}"
+            self.log.exception(msg)
+            self.set_result(ExecutionStatus.FAILED, [msg])
+
+    @t.override
+    def _on_shutdown(self) -> None:
+        """Perform actions required when shutting down the service.
+
+        By default, a `BlueprintRunner` logs the work disposition before shutdown.
+        """
+        self._log_disposition()
+
+    def set_result(
+        self,
+        status: ExecutionStatus,
+        errors: list[str] | None = None,
+    ) -> XRunnerResult[TBlueprint]:
+        """Create a RunnerResult instance and store the value.
+
+        Uses
+
+        Returns
+        -------
+        RunnerResult
+        """
+        if self._result is None:
+            self._result = XRunnerResult(self._request, status, errors)
+        return self._result
+
+    async def execute_xrunner(self) -> XRunnerResult[TBlueprint]:
+        """Execute a blueprint with a BlueprintRunner.
+
+        Parameters
+        ----------
+        klass : type[BlueprintRunner]
+            The BlueprintRunner to use for execution.
+        """
+        log = get_logger(__name__, level=self._config.log_level)
+
+        log.debug(f"Job config: {self._job_cfg!r}")
+        log.debug(f"Service config: {self._config!r}")
+        log.debug(f"Request: {self.request!r}")
+        log.trace(f"Environment: {os.environ}")
+
+        try:
+            configure_environment(log)
+
+            return self()
+
+        except CstarError as ex:
+            msg = "An error occurred while processing the blueprint"
+            log.exception(msg, exc_info=ex)
+            return self.set_result(ExecutionStatus.FAILED, [msg, str(ex)])
+        except Exception as ex:
+            msg = "An unexpected exception occurred while processing the blueprint"
+            log.exception(msg, exc_info=ex)
+            return self.set_result(ExecutionStatus.FAILED, [msg, str(ex)])
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create a parser for CLI arguments expected by a SimulationRunner.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        An argument parser configured with the expected arguments for the
+        SimulationRunner service.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run a c-star simulation.",
+        exit_on_error=True,
+    )
+    parser.add_argument(
+        ARG_URI_SHORT,
+        ARG_URI_LONG,
+        type=str,
+        required=True,
+        help="The URI of a blueprint.",
+    )
+    parser.add_argument(
+        ARG_LOGLEVEL_SHORT,
+        ARG_LOGLEVEL_LONG,
+        default=get_env_item(ENV_CSTAR_LOG_LEVEL).value,
+        type=str,
+        required=False,
+        help="Logging level for the simulation.",
+        choices=list(LogLevelChoices),
+    )
+    return parser

--- a/cstar/orchestration/application.py
+++ b/cstar/orchestration/application.py
@@ -1,0 +1,43 @@
+import typing as t
+from collections.abc import Callable
+
+from cstar.system.registration import register_handler
+
+THandler = t.TypeVar("THandler")
+
+APP_CAT_BLUEPRINTS: t.Literal["blueprints"] = "blueprints"
+APP_CAT_RUNNERS: t.Literal["runners"] = "runners"
+
+
+def register_blueprint(
+    application: str,
+) -> Callable[[type[THandler]], type[THandler]]:
+    """Decorator used to register a Blueprint for a given application.
+
+    Parameters
+    ----------
+    application : str
+        The name of the application the handler will be registered for, e.g. "roms_marbl"
+
+    Returns
+    -------
+        A decorator that registers the decorated class as a Blueprint
+    """
+    return register_handler(APP_CAT_BLUEPRINTS, application)
+
+
+def register_runner(
+    application: str,
+) -> Callable[[type[THandler]], type[THandler]]:
+    """Decorator used to register a Runner for a given application.
+
+    Parameters
+    ----------
+    application : str
+        The name of the application the handler will be registered for, e.g. "roms_marbl"
+
+    Returns
+    -------
+        A decorator that registers the decorated class as a Runner
+    """
+    return register_handler(APP_CAT_RUNNERS, application)

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -3,17 +3,16 @@ import random
 import sys
 import textwrap
 import typing as t
-from collections import defaultdict
 
 from cstar.base.log import get_logger
-from cstar.entrypoint.worker.worker import ARG_URI_LONG
+from cstar.entrypoint.utils import ARG_URI_LONG
 from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
-    from cstar.orchestration.orchestration import Launcher, LiveStep
+    from cstar.orchestration.orchestration import LiveStep
 
 log = get_logger(__name__)
 
@@ -88,40 +87,31 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     return f"sh {script_path}"
 
 
-launcher_aware_app_to_cmd_map: dict[
-    type["Launcher"],
-    dict[str, StepToCommandConversionFn],
-] = defaultdict(
-    lambda: {
-        Application.SLEEP.value: convert_step_to_placeholder,
-        Application.ROMS_MARBL.value: convert_roms_step_to_command,
-    },
-)
+app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
+    Application.SLEEP: convert_step_to_placeholder,
+    Application.ROMS_MARBL: convert_roms_step_to_command,
+}
 """Map application types to a function that converts a step to a CLI command."""
 
 
 def register_command_mapping(
-    application: Application,
-    launcher: type["Launcher"],
+    application: str,
     mapping_func: StepToCommandConversionFn,
 ) -> None:
-    launcher_map = launcher_aware_app_to_cmd_map[launcher]
-    launcher_map[application] = mapping_func
+    app_to_cmd_map[application] = mapping_func
 
 
 def get_command_mapping(
-    application: Application,
-    launcher: type["Launcher"],
+    application: str,
 ) -> StepToCommandConversionFn:
-    launcher_map = launcher_aware_app_to_cmd_map[launcher]
-    step_converter = launcher_map[application.value]
+    step_converter = app_to_cmd_map[application]
 
     if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
-        if converter_override not in launcher_map:
+        if converter_override not in app_to_cmd_map:
             msg = f"Override in env var `{ENV_CSTAR_CMD_CONVERTER_OVERRIDE}` has invalid value: {converter_override}"
             raise ValueError(msg)
 
-        converter = launcher_map[converter_override]
+        converter = app_to_cmd_map[converter_override]
         msg = f"Overriding step converter `{step_converter}` with `{converter}` for `{application}` commands."
         step_converter = converter
     else:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -11,11 +11,13 @@ from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 if t.TYPE_CHECKING:
+    from collections.abc import Callable
+
     from cstar.orchestration.orchestration import Launcher, LiveStep
 
 log = get_logger(__name__)
 
-StepToCommandConversionFn: t.TypeAlias = "t.Callable[[LiveStep], str]"
+StepToCommandConversionFn: t.TypeAlias = "Callable[[LiveStep], str]"
 """Convert a `Step` into a command to be executed.
 
 Parameters

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -116,22 +116,28 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
 
 
 app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
-    Application.SLEEP: convert_step_to_placeholder,
-    Application.ROMS_MARBL: convert_roms_step_to_command,
+    Application.SLEEP.value: convert_step_to_placeholder,
+    Application.ROMS_MARBL.value: convert_roms_step_to_command,
+    Application.HELLO_WORLD.value: convert_step_to_blueprint_run_command,
 }
 """Map application types to a function that converts a step to a CLI command."""
 
 
 def register_command_mapping(
-    application: str,
+    application: Application | str,
     mapping_func: StepToCommandConversionFn,
 ) -> None:
+    if isinstance(application, Application):
+        application = application.value
     app_to_cmd_map[application] = mapping_func
 
 
 def get_command_mapping(
     application: str,
 ) -> StepToCommandConversionFn:
+    if isinstance(application, Application):
+        application = application.value
+
     step_converter = app_to_cmd_map[application]
 
     if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -109,7 +109,7 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     )
 
     # write it to a script asset
-    script_path = step.fsm.work_dir / "script.sh"
+    script_path = step.fsm.work_dir / "placeholder_script.sh"
     script_path.write_text(script)
 
     return f"sh {script_path}"

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -3,8 +3,10 @@ import random
 import sys
 import textwrap
 import typing as t
+from collections import defaultdict
 
 from cstar.base.env import ENV_CSTAR_CLOBBER_WORKING_DIR
+from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
 from cstar.entrypoint.utils import ARG_CLOBBER, ARG_URI_LONG
@@ -115,11 +117,13 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     return f"sh {script_path}"
 
 
-app_to_cmd_map: dict[str, StepToCommandConversionFn] = {
-    Application.SLEEP.value: convert_step_to_placeholder,
-    Application.ROMS_MARBL.value: convert_roms_step_to_command,
-    Application.HELLO_WORLD.value: convert_step_to_blueprint_run_command,
-}
+app_to_cmd_map: dict[str, StepToCommandConversionFn] = defaultdict(
+    lambda: convert_step_to_blueprint_run_command,
+    {
+        Application.SLEEP.value: convert_step_to_placeholder,
+        Application.ROMS_MARBL.value: convert_roms_step_to_command,
+    },
+)
 """Map application types to a function that converts a step to a CLI command."""
 
 
@@ -139,6 +143,9 @@ def get_command_mapping(
         application = application.value
 
     step_converter = app_to_cmd_map[application]
+    if step_converter is None:
+        msg = f"No command converter found for application: {application!r}"
+        raise CstarExpectationFailed(msg)
 
     if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
         if converter_override not in app_to_cmd_map:

--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -4,8 +4,10 @@ import sys
 import textwrap
 import typing as t
 
+from cstar.base.env import ENV_CSTAR_CLOBBER_WORKING_DIR
+from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
-from cstar.entrypoint.utils import ARG_URI_LONG
+from cstar.entrypoint.utils import ARG_CLOBBER, ARG_URI_LONG
 from cstar.orchestration.models import Application
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
@@ -48,7 +50,33 @@ def convert_roms_step_to_command(step: "LiveStep") -> str:
         The complete CLI command.
     """
     worker_module = "cstar.entrypoint.worker.worker"
-    return f"{sys.executable} -m {worker_module} {ARG_URI_LONG} {step.blueprint_path}"
+    return f"{sys.executable} -m {worker_module}  {ARG_URI_LONG} {step.blueprint_path}"
+
+
+def convert_step_to_blueprint_run_command(step: "LiveStep") -> str:
+    """Convert a generic blueprint execution step to a CLI command.
+
+    Parameters
+    ----------
+    step : LiveStep
+        The step to be converted.
+
+    Returns
+    -------
+    str
+        The complete CLI command.
+    """
+    cmd_array = [
+        "cstar",
+        "blueprint",
+        "run",
+        str(step.blueprint_path),
+    ]
+
+    if is_flag_enabled(ENV_CSTAR_CLOBBER_WORKING_DIR):
+        cmd_array.append(ARG_CLOBBER)
+
+    return " ".join(cmd_array)
 
 
 def convert_step_to_placeholder(step: "LiveStep") -> str:

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import typing as t
+from collections.abc import Generator, Iterable, Mapping
 from dataclasses import dataclass, field
 from itertools import cycle
 from pathlib import Path
@@ -46,12 +47,12 @@ class DagStatus:
     ]
 
     @property
-    def open_items(self) -> t.Iterable[str]:
+    def open_items(self) -> Iterable[str]:
         """Return the name of all items that have not completed."""
         return (k for k, v in self.details.items() if not Status.is_terminal(v))
 
     @property
-    def closed_items(self) -> t.Iterable[str]:
+    def closed_items(self) -> Iterable[str]:
         """Return the name of all items that have completed."""
         return (k for k, v in self.details.items() if Status.is_terminal(v))
 
@@ -63,14 +64,14 @@ def get_launcher() -> "Launcher":
     return launcher
 
 
-def incremental_delays() -> t.Generator[float, None, None]:
+def incremental_delays() -> Generator[float, None, None]:
     """Return a value from an infinite cycle of incremental delays.
 
     Returns
     -------
     Generator[float]
     """
-    delays = [0.1, 1, 2, 5, 15, 30, 60]
+    delays: list[float] = [0.1, 1, 2, 5, 15, 30, 60]
 
     if custom_delays := os.getenv(ENV_CSTAR_ORCH_DELAYS, ""):
         try:
@@ -184,7 +185,7 @@ async def prepare_workplan(
     wp_path: Path,
     output_dir: Path,
     run_id: str,
-    user_variables: t.Mapping | None = None,
+    user_variables: Mapping[str, str] | None = None,
 ) -> tuple[Workplan, Path]:
     """Load the workplan and apply any applicable transforms.
 
@@ -246,7 +247,7 @@ async def build_and_run_dag(
     wp_path: Path,
     run_id: str = "",
     output_dir: Path | None = None,
-    user_variables: t.Mapping[str, str] | None = None,
+    user_variables: Mapping[str, str] | None = None,
     dry_run: bool = False,
 ) -> Path:
     """Execute the steps in the workplan.

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -12,8 +12,6 @@ from pydantic import PrivateAttr
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import get_logger
 from cstar.base.utils import slugify
-from cstar.orchestration.converter.converter import get_command_mapping
-from cstar.orchestration.models import Application
 from cstar.orchestration.orchestration import (
     Launcher,
     LiveStep,
@@ -104,11 +102,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         LocalHandle | None
             A ProcessHandle identifying the newly submitted job.
         """
-        step_converter = get_command_mapping(
-            Application(step.application),
-            LocalLauncher,
-        )
-        cmd = step_converter(step)
+        cmd = step.command
 
         step.fsm.prepare()
         log_file = step.fsm.logs_dir / f"{step.safe_name}.out"

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -12,6 +12,7 @@ from cstar.base.env import (
     ENV_CSTAR_SLURM_POST_SUBMIT_DELAY,
     get_env_item,
 )
+from cstar.base.exceptions import CstarError
 from cstar.base.log import get_logger
 from cstar.base.utils import _run_cmd, slugify
 from cstar.execution.handler import ExecutionStatus
@@ -20,14 +21,12 @@ from cstar.execution.scheduler_job import (
     get_slurm_batch,
     get_slurm_batches,
 )
-from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.orchestration import (
     Launcher,
     ProcessHandle,
     Status,
     Task,
 )
-from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.state import (
     get_sentinel,
     load_sentinels,
@@ -181,8 +180,11 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         SlurmHandle
             A ProcessHandle identifying the newly submitted job.
         """
+        if not step.blueprint:
+            msg = f"Step cannot resolve blueprint from: {step.blueprint_path}"
+            raise CstarError(msg)
+
         job_name = step.safe_name
-        bp = deserialize(step.blueprint_path, RomsMarblBlueprint)
         job_dep_ids = [d.pid for d in dependencies]
 
         script_path = step.fsm.work_dir / "script.sh"
@@ -199,7 +201,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         job = create_scheduler_job(
             commands=command,
             account_key=SlurmLauncher.configured_account(),
-            cpus=bp.cpus_needed,
+            cpus=step.blueprint.cpus_needed,
             nodes=None,  # let existing logic handle this
             cpus_per_node=None,  # let existing logic handle this
             script_path=script_path,

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import typing as t
+from collections.abc import Mapping
 
 from prefect import State, task
 from prefect import Task as PrefectTask
@@ -250,7 +251,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         return batch.status
 
     @staticmethod
-    async def _locate_priors() -> t.Mapping[str, SlurmHandle]:
+    async def _locate_priors() -> Mapping[str, SlurmHandle]:
         """Retrieve all task sentinels discovered in the output path.
 
 

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -20,8 +20,7 @@ from cstar.execution.scheduler_job import (
     get_slurm_batch,
     get_slurm_batches,
 )
-from cstar.orchestration.converter.converter import get_command_mapping
-from cstar.orchestration.models import Application, RomsMarblBlueprint
+from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.orchestration import (
     Launcher,
     ProcessHandle,
@@ -186,11 +185,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         bp = deserialize(step.blueprint_path, RomsMarblBlueprint)
         job_dep_ids = [d.pid for d in dependencies]
 
-        step_converter = get_command_mapping(
-            Application(step.application),
-            SlurmLauncher,
-        )
-
         script_path = step.fsm.work_dir / "script.sh"
         output_file = step.fsm.logs_dir / f"{job_name}.out"
 
@@ -201,7 +195,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             output_file.parent.mkdir(parents=True)
             output_file.write_text("ready\n")
 
-        command = step_converter(step)
+        command = step.command
         job = create_scheduler_job(
             commands=command,
             account_key=SlurmLauncher.configured_account(),

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -212,10 +212,12 @@ class BlueprintState(StrEnum):
 class Application(StrEnum):
     """The supported application types."""
 
-    ROMS_MARBL = auto()
+    ROMS_MARBL = "roms_marbl"
     """A UCLA-ROMS simulation coupled with a MARBL biogeochemical component."""
-    SLEEP = auto()
+    SLEEP = "sleep"
     """A call to the hostname executable to simplify testing."""
+    HELLO_WORLD = "hello_world"
+    """Sample custom application."""
 
 
 class ParameterSet(DocLocMixin, ConfiguredBaseModel):
@@ -338,7 +340,7 @@ class Blueprint(ConfiguredBaseModel, ABC):
     description: RequiredString
     """A user-friendly description of the scenario to be executed by the blueprint."""
 
-    application: Application = Application.ROMS_MARBL
+    application: str
     """The process type to be executed by the blueprint."""
 
     state: BlueprintState = BlueprintState.NotSet
@@ -355,6 +357,9 @@ class Blueprint(ConfiguredBaseModel, ABC):
 
 class RomsMarblBlueprint(Blueprint, ConfiguredBaseModel):
     """Blueprint schema for running a ROMS-MARBL simulation."""
+
+    application: str = Application.ROMS_MARBL
+    """The process type to be executed by the blueprint."""
 
     valid_start_date: datetime
     """Beginning of the time range for the available data."""

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -24,6 +24,7 @@ from pydantic import (
 from pytimeparse import parse
 
 from cstar.base.utils import slugify
+from cstar.orchestration.application import register_blueprint
 from cstar.orchestration.serialization import register_representer, strenum_representer
 
 if t.TYPE_CHECKING:
@@ -61,7 +62,7 @@ class ConfiguredBaseModel(BaseModel):
     for subclasses.
     """
 
-    model_config = ConfigDict(extra="forbid", from_attributes=True)
+    model_config = ConfigDict(extra="allow", from_attributes=True)
     """Pydantic ConfigDict with options we want changed."""
 
 
@@ -355,6 +356,7 @@ class Blueprint(ConfiguredBaseModel, ABC):
         return 1
 
 
+@register_blueprint(Application.ROMS_MARBL)
 class RomsMarblBlueprint(Blueprint, ConfiguredBaseModel):
     """Blueprint schema for running a ROMS-MARBL simulation."""
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -18,6 +18,7 @@ from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
 )
+from cstar.orchestration.converter.converter import get_command_mapping
 from cstar.orchestration.models import Step, Workplan
 from cstar.orchestration.serialization import (
     intenum_representer,
@@ -237,6 +238,17 @@ class LiveStep(Step):
         if self._fsm is None:
             self._fsm = JobFileSystemManager(self.get_working_dir)
         return self._fsm
+
+    @property
+    def command(self) -> str:
+        """Generate the shell command that will execute the underlying application.
+
+        Returns
+        -------
+        str
+        """
+        step_converter = get_command_mapping(self.application)
+        return step_converter(self)
 
     @classmethod
     def from_step(

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -18,12 +18,15 @@ from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
 )
+from cstar.orchestration.application import APP_CAT_BLUEPRINTS
 from cstar.orchestration.converter.converter import get_command_mapping
-from cstar.orchestration.models import Step, Workplan
+from cstar.orchestration.models import Blueprint, Step, Workplan
 from cstar.orchestration.serialization import (
+    deserialize,
     intenum_representer,
     register_representer,
 )
+from cstar.system.registration import Registrar
 
 nx = lazy_import("networkx")
 
@@ -238,6 +241,14 @@ class LiveStep(Step):
         if self._fsm is None:
             self._fsm = JobFileSystemManager(self.get_working_dir)
         return self._fsm
+
+    @property
+    def blueprint(self) -> Blueprint:
+        """Load and return the blueprint associated with this step."""
+        base_bp = deserialize(self.blueprint_path, Blueprint)
+        reg_bp = Registrar[Blueprint](APP_CAT_BLUEPRINTS)
+        bp_type = reg_bp.get(base_bp.application)
+        return bp_type(**base_bp.model_dump())
 
     @property
     def command(self) -> str:

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import typing as t
+from collections.abc import Callable, Iterable, Mapping
 from enum import IntEnum, StrEnum, auto
 from pathlib import Path
 
@@ -242,7 +243,7 @@ class LiveStep(Step):
         cls,
         step: Step,
         parent: "LiveStep | Step | None" = None,
-        update: t.Mapping[str, t.Any] | None = None,
+        update: Mapping[str, t.Any] | None = None,
     ) -> "LiveStep":
         """Convert a step from orchestration planning into a LiveStep.
 
@@ -317,7 +318,7 @@ class Planner(LoggingMixin):
         DiGraph
             A graph of the execution plan.
         """
-        data: t.Mapping[str, list[str]] = {s.name: [] for s in workplan.steps}
+        data: Mapping[str, list[str]] = {s.name: [] for s in workplan.steps}
         for step in workplan.steps:
             for prereq in step.depends_on:
                 data[prereq].append(step.name)
@@ -334,7 +335,7 @@ class Planner(LoggingMixin):
         nx.set_node_attributes(g, values=defaults)
         return g
 
-    def flatten(self) -> t.Iterable[Step]:
+    def flatten(self) -> Iterable[Step]:
         """Return the planned steps in execution order.
 
         Returns
@@ -433,31 +434,31 @@ class Planner(LoggingMixin):
         self,
         key: t.Literal["status"],
         default: Status | None = None,
-        filter_fn: t.Callable[[Status], bool] | None = None,
-    ) -> t.Mapping[str, Status]: ...
+        filter_fn: Callable[[Status], bool] | None = None,
+    ) -> Mapping[str, Status]: ...
 
     @t.overload
     def retrieve_all(
         self,
         key: t.Literal["step"],
         default: Step | None = None,
-        filter_fn: t.Callable[[Step], bool] | None = None,
-    ) -> t.Mapping[str, Step]: ...
+        filter_fn: Callable[[Step], bool] | None = None,
+    ) -> Mapping[str, Step]: ...
 
     @t.overload
     def retrieve_all(
         self,
         key: t.Literal["task"],
-        default: Task | None = None,
-        filter_fn: t.Callable[[Task], bool] | None = None,
-    ) -> t.Mapping[str, Task]: ...
+        default: Task[t.Any] | None = None,
+        filter_fn: Callable[[Task[t.Any]], bool] | None = None,
+    ) -> Mapping[str, Task[t.Any]]: ...
 
     def retrieve_all(
         self,
         key: str,
         default: t.Any | None = None,
-        filter_fn: t.Callable[[t.Any], bool] | None = None,
-    ) -> t.Mapping[str, t.Any]:
+        filter_fn: Callable[[t.Any], bool] | None = None,
+    ) -> Mapping[str, t.Any]:
         """Retrieve a user-defined value for every node in the plan.
 
         Parameters
@@ -585,7 +586,7 @@ class Orchestrator(LoggingMixin):
         self.planner = planner
         self.launcher = launcher
 
-    def get_open_nodes(self, *, mode: RunMode) -> t.Mapping[str, Status] | None:
+    def get_open_nodes(self, *, mode: RunMode) -> Mapping[str, Status] | None:
         """Retrieve the set of task nodes with a non-terminal state that are
         executing or ready to execute.
 
@@ -636,7 +637,7 @@ class Orchestrator(LoggingMixin):
 
         return None
 
-    def get_closed_nodes(self, *, mode: RunMode) -> t.Mapping[str, Status]:
+    def get_closed_nodes(self, *, mode: RunMode) -> Mapping[str, Status]:
         """Retrieve the set of task nodes with a terminal state.
 
         Returns
@@ -738,7 +739,7 @@ class Orchestrator(LoggingMixin):
             self.planner.store(n, KEY_STATUS, Status.Failed)
             raise CstarExpectationFailed(f"Node {n} task failed.")
 
-    async def run(self, mode: RunMode) -> t.Mapping[str, Status]:
+    async def run(self, mode: RunMode) -> Mapping[str, Status]:
         """Execute tasks that are ready and query status on running tasks.
 
         Parameters
@@ -784,7 +785,7 @@ class Orchestrator(LoggingMixin):
 
         return {k: v.status if v else Status.Unsubmitted for k, v in kvp.items()}
 
-    async def _cancel(self, cancellations: t.Iterable[Task]) -> None:
+    async def _cancel(self, cancellations: Iterable[Task]) -> None:
         """Request the cancellation of running tasks.
 
         Parameters
@@ -827,7 +828,7 @@ def check_environment() -> None:
 def configure_environment(
     output_dir: Path | None = None,
     run_id: str | None = None,
-    updates: t.Mapping[str, str] | None = None,
+    updates: Mapping[str, str] | None = None,
 ) -> None:
     """Configure environment variables required by the runner.
 
@@ -837,7 +838,7 @@ def configure_environment(
         The directory where outputs will be written.
     run_id : str | None
         The unique identifier for an execution of the workplan.
-    updates : t.Mapping[str, str] | None
+    updates : Mapping[str, str] | None
         Additional environment variable updates.
     """
     if output_dir:

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -54,7 +54,7 @@ _T = t.TypeVar("_T", bound=SerializableModel)
 class ValidationResult(t.Generic[_T]):
     """Disposition and reason for a validation failure."""
 
-    error_msg: str | None = None
+    error_msg: str = ""
     """An error message that is populated if validation fails."""
     item: _T | None = None
     """The deserialized workplan if validation succeeds."""

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -274,22 +274,38 @@ class WorkplanTransformer(LoggingMixin):
         if self._transformed:
             return self._transformed
 
+        apply_to = {Application.ROMS_MARBL, Application.SLEEP}
+
         # ensure consistent output targets for all steps in the workplan
         live_steps = [LiveStep.from_step(s) for s in self.original.steps]
-        steps: Iterable[LiveStep] = list(
-            map(override_output_directory, live_steps),
-        )
+        steps: list[LiveStep] = []
+        for step in live_steps:
+            if step.application in apply_to:
+                override_output_directory(step)
+            steps.append(step)
 
         if is_feature_enabled(ENV_FF_ORCH_TRX_TIMESPLIT):
             split_steps: list[LiveStep] = []
             named_dep_map: dict[str, str] = {}
 
             for step in steps:
-                transformed_steps = list(self.transform_fn(step))
-                named_dep_map[step.name] = transformed_steps[-1].name
-                split_steps.extend(transformed_steps)
+                if step.application in apply_to:
+                    transformed_steps = list(self.transform_fn(step))
+                    named_dep_map[step.name] = transformed_steps[-1].name
+                    split_steps.extend(transformed_steps)
+                else:
+                    split_steps.append(step)
+
+            # apply any overrides produced in the transform function
+            override_transform = OverrideTransform()
+
+            steps = []
 
             for step in split_steps:
+                if step.application not in apply_to:
+                    steps.append(step)
+                    continue
+
                 depends_on = {str(d) for d in step.depends_on}
 
                 if to_update := depends_on.intersection(named_dep_map):
@@ -299,7 +315,7 @@ class WorkplanTransformer(LoggingMixin):
                     step.depends_on.clear()
                     step.depends_on.extend(depends_on)
 
-            steps = split_steps
+                steps.extend(override_transform(step))
 
         # apply any overrides produced in the transform function
         override_transform = OverrideTransform()
@@ -541,6 +557,3 @@ def override_output_directory(step: LiveStep) -> LiveStep:
     overridden_step_result = iter(override_transform(step))
 
     return next(overridden_step_result)
-
-
-register_transform(Application.ROMS_MARBL.value, RomsMarblTimeSplitter())

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -2,6 +2,7 @@ import itertools
 import os
 import typing as t
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
@@ -31,7 +32,7 @@ class Transform(t.Protocol):
     new steps.
     """
 
-    def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
         """Apply the transform to a step.
 
         Parameters
@@ -89,7 +90,7 @@ def get_transforms(application: str) -> list[Transform]:
 
 def _dailies(
     start_date: datetime, end_date: datetime
-) -> t.Iterable[tuple[datetime, datetime]]:
+) -> Iterable[tuple[datetime, datetime]]:
     """Get daily time slices for the given start and end dates."""
     current_date = datetime(start_date.year, start_date.month, start_date.day)
     while current_date < end_date:
@@ -101,7 +102,7 @@ def _dailies(
 
 def _weeklies(
     start_date: datetime, end_date: datetime
-) -> t.Iterable[tuple[datetime, datetime]]:
+) -> Iterable[tuple[datetime, datetime]]:
     """Get weekly time slices for the given start and end dates."""
     current_date = datetime(start_date.year, start_date.month, start_date.day)
     while current_date < end_date:
@@ -113,7 +114,7 @@ def _weeklies(
 
 def _monthlies(
     start_date: datetime, end_date: datetime
-) -> t.Iterable[tuple[datetime, datetime]]:
+) -> Iterable[tuple[datetime, datetime]]:
     """Get monthly time slices for the given start and end dates."""
     current_date = datetime(start_date.year, start_date.month, 1)
     while current_date < end_date:
@@ -148,7 +149,7 @@ def get_time_slices(
     start_date: datetime,
     end_date: datetime,
     frequency: str = SplitFrequency.Monthly.value,
-) -> t.Iterable[tuple[datetime, datetime]]:
+) -> Iterable[tuple[datetime, datetime]]:
     """Get the time slices for the given start and end dates.
 
     Parameters
@@ -275,7 +276,7 @@ class WorkplanTransformer(LoggingMixin):
 
         # ensure consistent output targets for all steps in the workplan
         live_steps = [LiveStep.from_step(s) for s in self.original.steps]
-        steps: t.Iterable[LiveStep] = list(
+        steps: Iterable[LiveStep] = list(
             map(override_output_directory, live_steps),
         )
 
@@ -327,7 +328,7 @@ class RomsMarblTimeSplitter(Transform):
         freq_config = os.getenv(ENV_CSTAR_ORCH_TRX_FREQ, frequency)
         self.frequency = freq_config.lower()
 
-    def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
         """Split a step into multiple sub-steps.
 
         Parameters
@@ -376,7 +377,7 @@ class RomsMarblTimeSplitter(Transform):
             child_fs = step.fsm.get_subtask_manager(child_step_name)
 
             description = f"Subtask {i + 1} of {n_slices}; Timespan: {sd} to {ed}; {bp_copy.description}"
-            overrides = {
+            overrides: dict[str, t.Any] = {
                 "name": dynamic_name,
                 "description": description,
                 "runtime_params": {
@@ -393,7 +394,7 @@ class RomsMarblTimeSplitter(Transform):
             child_bp_path = child_fs.work_dir / f"{child_step_name}_bp.yaml"
             serialize(child_bp_path, bp_copy)
 
-            updates = {
+            updates: dict[str, t.Any] = {
                 "blueprint": child_bp_path.as_posix(),
                 "blueprint_overrides": overrides,
                 "depends_on": depends_on,
@@ -480,7 +481,7 @@ class OverrideTransform(Transform):
 
         return RomsMarblBlueprint(**merged)
 
-    def __call__(self, step: LiveStep) -> t.Iterable[LiveStep]:
+    def __call__(self, step: LiveStep) -> Iterable[LiveStep]:
         """Apply the transform to a step.
 
         Parameters

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import typing as t
 from collections import defaultdict
@@ -316,10 +315,6 @@ class WorkplanTransformer(LoggingMixin):
                     step.depends_on.extend(depends_on)
 
                 steps.extend(override_transform(step))
-
-        # apply any overrides produced in the transform function
-        override_transform = OverrideTransform()
-        steps = list(itertools.chain.from_iterable(map(override_transform, steps)))
 
         self._transformed = self.original.model_copy(
             update={

--- a/cstar/system/registration.py
+++ b/cstar/system/registration.py
@@ -106,8 +106,8 @@ class Registrar(LoggingMixin, t.Generic[TValue]):
             for cat in categories
             if cls._storage[cat].get(key)
         ]
-        missing = set(categories).difference(x[0] for x in results)
-        if missing:
+
+        if missing := set(categories).difference(x[0] for x in results):
             msg = f"Unable to locate categorical registrations: {key}, {','.join(missing)}"
             raise ValueError(msg)
         return tuple(x[1] for x in results if x[1])

--- a/cstar/system/registration.py
+++ b/cstar/system/registration.py
@@ -1,0 +1,143 @@
+import typing as t
+from collections import defaultdict
+from collections.abc import Callable
+
+from cstar.base.exceptions import CstarError
+from cstar.base.log import LoggingMixin
+
+TValue = t.TypeVar("TValue")
+
+
+class Registrar(LoggingMixin, t.Generic[TValue]):
+    """An in-memory cache of key-value pairs used to identify a type used for
+    a specific role.
+    """
+
+    """The role of the item being registered, e.g. `blueprint`."""
+    _storage: t.ClassVar[dict[str, dict[str, t.Any]]]
+    """The internal memory of the registry.
+
+    The registry is nested so that a single class can be re-used to perform registration
+    for many different reasons. The role (or category) specifies which sub-mapping to
+    place a given registration into.
+    """
+
+    def __init__(self, role: str) -> None:
+        """Initialize a registry instance.
+
+        Parameters
+        ----------
+        role : str
+            A unique role name that is used to store a collection of related registry entries.
+        """
+        if not hasattr(Registrar, "_storage"):
+            Registrar._storage = defaultdict(dict)
+        self._role = role
+        self._lookup = Registrar._storage[role]
+
+    def put(self, key: str, klass: type) -> bool:
+        """Register a key-to-class lookup.
+
+        Parameters
+        ----------
+        key : str
+            The key used when looking up the type.
+        klass : type
+            The type held as the value in the key-value pair.
+
+        Returns
+        -------
+        bool
+            `True` if registry is updated, `False` if mapping exists.
+        """
+        current = self._lookup.get(key, None)
+
+        if current and current == klass:
+            msg = f"Attempted to re-register the {self._role!r} for: {key}"
+            self.log.debug(msg)
+            return False
+
+        self._lookup[key] = klass
+
+        msg = f"Registry `{self._role}::{key}` updated {klass.__name__!r}"
+        self.log.debug(msg)
+        return True
+
+    def get(self, key: str) -> type[TValue]:
+        """Retrieve the type referenced by the key.
+
+        Parameters
+        ----------
+        key : str
+            The key to look up.
+        klass : type
+            The type held as the value in the key-value pair.
+
+        Returns
+        -------
+        type
+            The type held in the mapping
+
+        Raises
+        ------
+        CStarError
+            If the lookup fails to find a mapping.
+        """
+        key = key.strip() if key else ""
+        if not key:
+            msg = "A registry key must be specified"
+            raise ValueError(msg)
+
+        found_type = self._lookup.get(key, None)
+        if not found_type:
+            msg = f"No {self._role!r} is registered for the key: {key!r}"
+            raise CstarError(msg)
+        return found_type
+
+    @classmethod
+    def get_categorical(cls, key: str, *categories: str) -> tuple[type[TValue], ...]:
+        """Retrieve the same key across multiple categories."""
+        results = [
+            (cat, cls._storage[cat].get(key))
+            for cat in categories
+            if cls._storage[cat].get(key)
+        ]
+        missing = set(categories).difference(x[0] for x in results)
+        if missing:
+            msg = f"Unable to locate categorical registrations: {key}, {','.join(missing)}"
+            raise ValueError(msg)
+        return tuple(x[1] for x in results if x[1])
+
+
+def register_handler(
+    role: str,
+    application: str,
+) -> Callable[[type[TValue]], type[TValue]]:
+    """Decorator used to register a type as a handler for some process.
+
+    Parameters
+    ----------
+    category : str
+        A string identifying the handler category, e.g. "blueprint" or "runner".
+    application : str
+        The name of the application the handler will be registered for, e.g. "roms_marbl"
+
+    Returns
+    -------
+        A function that will add the handler to the registry then return it.
+    """
+
+    def register_handler_direct(klass: type[TValue]) -> type[TValue]:
+        """Register the specified type as a blueprint.
+
+        Parameters
+        ----------
+        klass : type[THandler]
+            The type to be registered
+        """
+        registry = Registrar[TValue](role)
+        registry.put(application, klass)
+
+        return klass
+
+    return register_handler_direct

--- a/cstar/system/registration.py
+++ b/cstar/system/registration.py
@@ -21,6 +21,10 @@ class Registrar(LoggingMixin, t.Generic[TValue]):
     for many different reasons. The role (or category) specifies which sub-mapping to
     place a given registration into.
     """
+    _role: str
+    """The registry role the instance will retrieve records for."""
+    _lookup: dict[str, t.Any]
+    """The branch of the registry used for the target role."""
 
     def __init__(self, role: str) -> None:
         """Initialize a registry instance.

--- a/cstar/system/registration.py
+++ b/cstar/system/registration.py
@@ -132,12 +132,17 @@ def register_handler(
     """
 
     def register_handler_direct(klass: type[TValue]) -> type[TValue]:
-        """Register the specified type as a blueprint.
+        """Register the handler in the registry for the specified role.
 
         Parameters
         ----------
         klass : type[THandler]
             The type to be registered
+
+        Returns
+        -------
+        type[TValue]
+            The unmodified, original type.
         """
         registry = Registrar[TValue](role)
         registry.put(application, klass)

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -18,11 +18,13 @@ from cstar.entrypoint.config import (
     get_job_config,
     get_service_config,
 )
-from cstar.entrypoint.worker.worker import (
+from cstar.entrypoint.utils import (
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
     ARG_URI_LONG,
     ARG_URI_SHORT,
+)
+from cstar.entrypoint.worker.worker import (
     BlueprintRequest,
     SimulationRunner,
     SimulationStages,

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -1025,7 +1025,7 @@ async def test_runner_setup_stage(
     """
     mock_prep_fs = mock.Mock()
 
-    stages = []
+    stages: list[SimulationStages] = []
     if setup:
         stages.append(SimulationStages.SETUP)
     if build:

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -25,7 +25,7 @@ from cstar.entrypoint.utils import (
     ARG_URI_SHORT,
 )
 from cstar.entrypoint.worker.worker import (
-    BlueprintRequest,
+    RomsMarblRunnerRequest,
     SimulationRunner,
     SimulationStages,
     create_simrunner_parser,
@@ -102,7 +102,7 @@ def sim_runner(
     SimulationRunner
         An initialized instance of SimulationRunner, configured via blueprint.
     """
-    request = BlueprintRequest(
+    request = RomsMarblRunnerRequest(
         str(blueprint_path),
         RomsMarblBlueprint,
         stages=list(SimulationStages),
@@ -345,7 +345,7 @@ def test_start_runner(
     blueprint_path: Path
         The path to the blueprint yaml file created by the fixture.
     """
-    request = BlueprintRequest(
+    request = RomsMarblRunnerRequest(
         str(blueprint_path),
         RomsMarblBlueprint,
     )
@@ -1040,7 +1040,7 @@ async def test_runner_setup_stage(
     if post_run:
         stages.append(SimulationStages.POST_RUN)
 
-    request = BlueprintRequest(
+    request = RomsMarblRunnerRequest(
         str(blueprint_path),
         RomsMarblBlueprint,
         stages=list(stages),

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -28,7 +28,7 @@ from cstar.entrypoint.worker.worker import (
     BlueprintRequest,
     SimulationRunner,
     SimulationStages,
-    create_parser,
+    create_simrunner_parser,
     get_request,
     main,
 )
@@ -129,7 +129,7 @@ def sim_runner(
 
 def test_create_parser_happy_path() -> None:
     """Verify that a help argument is present in the parser."""
-    parser = create_parser()
+    parser = create_simrunner_parser()
 
     # ruff: noqa: SLF001
     assert ARG_URI_LONG in parser._option_string_actions
@@ -166,7 +166,7 @@ def test_parser_good_log_level(
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
 
-    parser = create_parser()
+    parser = create_simrunner_parser()
     parsed_args = parser.parse_args(args)
 
     assert getattr(parsed_args, "log_level", None) == logging.getLevelName(
@@ -195,7 +195,7 @@ def test_parser_lowercase_log_level(
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
 
-    parser = create_parser()
+    parser = create_simrunner_parser()
 
     # unable to parse the lower-case log levels
     with pytest.raises(SystemExit):
@@ -210,7 +210,7 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     valid_args_tuples = ((k, v) for k, v in valid_args.items())
     args = list(itertools.chain.from_iterable(valid_args_tuples))
 
-    parser = create_parser()
+    parser = create_simrunner_parser()
 
     with pytest.raises(SystemExit):
         _ = parser.parse_args(args)
@@ -245,7 +245,7 @@ def test_get_service_config(
     arg_b, val_b = blueprint_uri.split(" ", maxsplit=1)
     arg_l, val_l = log_level.split(" ", maxsplit=1)
 
-    parser = create_parser()
+    parser = create_simrunner_parser()
     parsed_args = parser.parse_args(
         [
             arg_b,
@@ -278,7 +278,7 @@ def test_get_request(
     blueprint_uri: str,
 ) -> None:
     """Verify that the expected values are set on the blueprint request."""
-    parser = create_parser()
+    parser = create_simrunner_parser()
     parsed_args = parser.parse_args(
         [
             ARG_URI_LONG,

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -33,6 +33,7 @@ from cstar.entrypoint.worker.worker import (
     main,
 )
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
+from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -103,6 +104,7 @@ def sim_runner(
     """
     request = BlueprintRequest(
         str(blueprint_path),
+        RomsMarblBlueprint,
         stages=list(SimulationStages),
     )
 
@@ -345,6 +347,7 @@ def test_start_runner(
     """
     request = BlueprintRequest(
         str(blueprint_path),
+        RomsMarblBlueprint,
     )
 
     service_config = ServiceConfiguration(
@@ -1039,6 +1042,7 @@ async def test_runner_setup_stage(
 
     request = BlueprintRequest(
         str(blueprint_path),
+        RomsMarblBlueprint,
         stages=list(stages),
     )
 

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_check_blueprint.py
@@ -22,7 +22,7 @@ def test_blueprint_check_file_dne(
     runner = CliRunner()
     result = runner.invoke(app, args, color=False)
 
-    assert "not found" in result.stdout
+    assert "not found" in result.stderr
 
 
 def test_blueprint_check_file_no_content(
@@ -42,7 +42,7 @@ def test_blueprint_check_file_no_content(
     runner = CliRunner()
     result = runner.invoke(app, args, color=False)
 
-    assert "is invalid" in result.stdout
+    assert "is invalid" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_blueprint_check_file_bad_content(
     runner = CliRunner()
     result = runner.invoke(app, args, color=False)
 
-    assert "is invalid" in result.stdout
+    assert "is invalid" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -130,7 +130,7 @@ def test_blueprint_valid_input(
 )
 def test_blueprint_incomplete_input(
     start_removal: str,
-    end_removal: str,
+    end_removal: str | None,
     tests_path: Path,
     tmp_path: Path,
 ) -> None:
@@ -152,7 +152,7 @@ def test_blueprint_incomplete_input(
     blueprint_path = tests_path / "integration_tests/blueprints/blueprint_complete.yaml"
 
     content = blueprint_path.read_text().splitlines()
-    remaining_content = []
+    remaining_content: list[str] = []
     cutting = False
     cut_once = False
 
@@ -178,7 +178,7 @@ def test_blueprint_incomplete_input(
     result = runner.invoke(app, args, color=False)
 
     err_msg = f"{bp_path} should not pass validation"
-    assert "is invalid" in result.stdout, err_msg
+    assert "is invalid" in result.stderr, err_msg
 
 
 @pytest.mark.parametrize(
@@ -191,7 +191,7 @@ def test_blueprint_incomplete_input(
 )
 def test_blueprint_optional_input(
     start_removal: str,
-    end_removal: str,
+    end_removal: str | None,
     tests_path: Path,
     tmp_path: Path,
 ) -> None:
@@ -214,7 +214,7 @@ def test_blueprint_optional_input(
     blueprint_path = tests_path / "integration_tests/blueprints/blueprint_complete.yaml"
 
     content = blueprint_path.read_text().splitlines()
-    remaining_content = []
+    remaining_content: list[str] = []
     cutting, cut_once = False, False
 
     for line in content:
@@ -251,7 +251,7 @@ def test_blueprint_check_remote_blueprint_dne() -> None:
     runner = CliRunner()
     result = runner.invoke(app, args, color=False)
 
-    assert "not found" in result.stdout
+    assert "not found" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -269,8 +269,6 @@ def test_blueprint_check_remote_blueprint(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     bp_uri : str
         A working URL referencing a valid blueprint
     """

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -1,23 +1,17 @@
 from pathlib import Path
 from unittest import mock
 
-import pytest
 from typer.testing import CliRunner
 
 from cstar.cli.blueprint.run import app
 
 
-def test_blueprint_run_file_dne(
-    capsys: pytest.CaptureFixture,
-    tmp_path: Path,
-) -> None:
+def test_blueprint_run_file_dne(tmp_path: Path) -> None:
     """Verify that a path to a non-existent blueprint fails to be started due
     to validation.
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     tmp_path : Path
         Temporary directory to read/write test inputs and outputs
     """
@@ -30,19 +24,12 @@ def test_blueprint_run_file_dne(
         color=False,
     )
 
-    assert "not found" in result.stdout
+    assert "not found" in result.stderr
 
 
-def test_blueprint_run_remote_blueprint_dne(
-    capsys: pytest.CaptureFixture,
-) -> None:
+def test_blueprint_run_remote_blueprint_dne() -> None:
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is not executed if the URL is invalid.
-
-    Parameters
-    ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     """
     bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint-X.yaml"
 
@@ -53,7 +40,7 @@ def test_blueprint_run_remote_blueprint_dne(
         color=False,
     )
 
-    assert "not found" in result.stdout
+    assert "not found" in result.stderr
 
 
 def test_blueprint_run_remote_blueprint() -> None:
@@ -63,7 +50,7 @@ def test_blueprint_run_remote_blueprint() -> None:
     bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
 
     with mock.patch(
-        "cstar.cli.blueprint.run.execute_runner",
+        "cstar.cli.blueprint.run.exec_romsmarbl_runner",
         return_value=0,
     ) as mock_exec:
         runner = CliRunner()

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_check_workplan.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
-from cstar.cli.workplan.check import check
+from cstar.cli.workplan.check import app
 
 
 @pytest.mark.parametrize(
@@ -12,7 +13,6 @@ from cstar.cli.workplan.check import check
 def test_cli_workplan_check_action_tpl(
     tmp_path: Path,
     workplan_name: str,
-    capsys: pytest.CaptureFixture,
     wp_templates_dir: Path,
 ) -> None:
     """Verify that CLI check action validates the stored templates.
@@ -32,14 +32,14 @@ def test_cli_workplan_check_action_tpl(
     wp_path = tmp_path / template_file
     wp_path.write_text(template_path.read_text())
 
-    check(wp_path.as_posix())
-    captured = capsys.readouterr().out
-    assert " valid" in captured
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
+
+    assert " valid" in result.stdout
 
 
 def test_cli_workplan_check_dne(
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
 ) -> None:
     """Verify that an invalid path fails a validity check.
 
@@ -54,30 +54,29 @@ def test_cli_workplan_check_dne(
     """
     wp_path = tmp_path / "workplan-dne.yaml"
 
-    check(wp_path.as_posix())
-    captured = capsys.readouterr().out
-    assert " not found" in captured
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
+
+    assert " not found" in result.stderr
 
 
 def test_cli_workplan_check_file_no_content(
-    capsys: pytest.CaptureFixture,
     tmp_path: Path,
 ) -> None:
     """Verify that an empty workplan file fails a validity check.
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     tmp_path : Path
         Temporary directory to read/write test inputs and outputs
     """
     wp_path = tmp_path / "empty_workplan.yml"
     wp_path.touch()
 
-    check(wp_path.as_posix())
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
 
-    assert "is invalid" in capsys.readouterr().out
+    assert "is invalid" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -85,7 +84,6 @@ def test_cli_workplan_check_file_no_content(
     [" ", "", "\n", '{"foo": "bar"}', "name: Sample Workplan\n"],
 )
 def test_cli_workplan_check_file_bad_content(
-    capsys: pytest.CaptureFixture,
     tmp_path: Path,
     content: str,
 ) -> None:
@@ -93,17 +91,16 @@ def test_cli_workplan_check_file_bad_content(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     tmp_path : Path
         Temporary directory to read/write test inputs and outputs
     """
     wp_path = tmp_path / "invalid_workplan.yml"
     wp_path.write_text(content)
 
-    check(wp_path.as_posix())
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
 
-    assert "is invalid" in capsys.readouterr().out
+    assert "is invalid" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -114,7 +111,6 @@ def test_cli_workplan_check_file_bad_content(
     ],
 )
 def test_cli_workplan_check_valid_input(
-    capsys: pytest.CaptureFixture,
     repo_relative_path: Path,
     package_path: Path,
 ) -> None:
@@ -125,8 +121,6 @@ def test_cli_workplan_check_valid_input(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     repo_relative_path : Path
         Relative path to a workplan within the c-star repo
     package_path : Path
@@ -134,10 +128,11 @@ def test_cli_workplan_check_valid_input(
     """
     wp_path = package_path / repo_relative_path
 
-    check(wp_path.as_posix())
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
 
     msg = f"`{wp_path}` does not contain a valid workplan"
-    assert "is valid" in capsys.readouterr().out, msg
+    assert "is valid" in result.stdout, msg
 
 
 @pytest.mark.parametrize(
@@ -154,9 +149,8 @@ def test_cli_workplan_check_valid_input(
     ],
 )
 def test_workplan_incomplete_input(
-    capsys: pytest.CaptureFixture,
     start_removal: str,
-    end_removal: str,
+    end_removal: str | None,
     tmp_path: Path,
     package_path: Path,
 ) -> None:
@@ -166,8 +160,6 @@ def test_workplan_incomplete_input(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     start_removal : Path
         A string that will trigger content skipping to begin when building a test workplan
     end_removal : Path
@@ -180,7 +172,7 @@ def test_workplan_incomplete_input(
     wp_path = package_path / "cstar/additional_files/templates/wp/workplan.yaml"
 
     content = wp_path.read_text().splitlines()
-    remaining_content = []
+    remaining_content: list[str] = []
     cutting = False
     cut_once = False
 
@@ -200,10 +192,11 @@ def test_workplan_incomplete_input(
     wp_path = tmp_path / "wp.yaml"
     wp_path.write_text("\n".join(remaining_content))
 
-    check(wp_path.as_posix())
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
 
     err_msg = f"{wp_path} should not pass validation"
-    assert "is invalid" in capsys.readouterr().out, err_msg
+    assert "is invalid" in result.stderr, err_msg
 
 
 @pytest.mark.parametrize(
@@ -224,7 +217,6 @@ def test_workplan_incomplete_input(
     ],
 )
 def test_workplan_optional_input(
-    capsys: pytest.CaptureFixture,
     start_removal: str,
     end_removal: str | None,
     tmp_path: Path,
@@ -236,8 +228,6 @@ def test_workplan_optional_input(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     start_removal : Path
         A string that will trigger content skipping to begin when building a test workplan
     end_removal : Path
@@ -250,7 +240,7 @@ def test_workplan_optional_input(
     wp_path = package_path / "cstar/additional_files/templates/wp/workplan.yaml"
 
     content = wp_path.read_text().splitlines()
-    remaining_content = []
+    remaining_content: list[str] = []
     cutting = False
     cut_once = False
 
@@ -270,28 +260,23 @@ def test_workplan_optional_input(
     wp_path = tmp_path / "bp.yaml"
     wp_path.write_text("\n".join(remaining_content))
 
-    check(wp_path.as_posix())
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_path.as_posix()], color=False)
 
     err_msg = f"{wp_path} should not pass validation"
-    assert "is valid" in capsys.readouterr().out, err_msg
+    assert "is valid" in result.stdout, err_msg
 
 
-def test_workplan_check_remote_workplan_dne(
-    capsys: pytest.CaptureFixture,
-) -> None:
+def test_workplan_check_remote_workplan_dne() -> None:
     """Verify that a URL to a remote workplan is handled properly and the
     workplan is not executed if the URL is invalid.
-
-    Parameters
-    ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     """
-    wp_path = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml_XXX"
+    wp_uri = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml_XXX"
 
-    check(wp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_uri], color=False)
 
-    assert "not found" in capsys.readouterr().out
+    assert "not found" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -302,7 +287,6 @@ def test_workplan_check_remote_workplan_dne(
     ],
 )
 def test_workplan_check_remote_workplan(
-    capsys: pytest.CaptureFixture,
     wp_uri: str,
 ) -> None:
     """Verify that a URL to a remote workplan is handled properly and the
@@ -310,11 +294,10 @@ def test_workplan_check_remote_workplan(
 
     Parameters
     ----------
-    capsys : pytest.CaptureFixture
-        Used to verify outputs from the CLI
     wp_uri : str
         A working URL referencing a valid workplan
     """
-    check(wp_uri)
+    runner = CliRunner()
+    result = runner.invoke(app, [wp_uri], color=False)
 
-    assert "is valid" in capsys.readouterr().out
+    assert "is valid" in result.stdout

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -148,7 +148,7 @@ def fill_workplan_template(
         list_form: int = 0,
     ) -> str:
         """Populate the template with the supplied data."""
-        dedent = "            "  # depth of populated dedent below...
+        dedent = "                "  # depth of populated dedent below...
         l1_indent = " " * 4
         # l2_indent = l1_indent * 2
 
@@ -183,17 +183,8 @@ def fill_workplan_template(
             )
 
         # NOTE: using __file__ for blueprint path to give an existing path to pass validator
-        populated = textwrap.dedent(
+        steps_str = textwrap.dedent(
             f"""\
-            # yaml-language-server: $schema={workplan_schema_path.as_posix()}
-            name: {fill_vals["name"]}
-            description: {fill_vals["description"]}
-            state: {fill_vals["state"]}
-            compute_environment: {fill_vals["compute_environment"]}
-                # num_nodes: 4
-                # num_cpus_per_process: 16
-
-            runtime_vars: {fill_vals.get("runtime_vars", "")}
             steps:
                 - name: Test Step
                   application: sleep
@@ -213,9 +204,38 @@ def fill_workplan_template(
                   workflow_overrides:
                       segment_length: 16
                   compute_overrides:
-                      walltime: 00:10:00
-                      num_nodes: 4
+                      walltime: 00:05:00
+                      num_nodes: 2
             """,
+        )
+
+        if input_data.get("steps", ""):
+            steps: list[dict[str, t.Any]] = input_data["steps"]
+            steps_str = "steps:\n" if steps else "steps: []\n"
+
+            for step in steps:
+                steps_str += textwrap.dedent(f"""\
+                    - name: {step["name"]}
+                      application: {step["application"]}
+                      depends_on: []
+                      blueprint: {step["blueprint"]}
+                      blueprint_overrides: {{}}
+                """)
+
+        populated = (
+            textwrap.dedent(
+                f"""\
+                # yaml-language-server: $schema={workplan_schema_path.as_posix()}
+                name: {fill_vals["name"]}
+                description: {fill_vals["description"]}
+                state: {fill_vals["state"]}
+                compute_environment: {fill_vals["compute_environment"]}
+                    # num_nodes: 4
+                    # num_cpus_per_process: 16
+                runtime_vars: {fill_vals.get("runtime_vars", "")}
+                """,
+            )
+            + steps_str
         )
 
         print(f"populated workplan template:\n{populated}\n")
@@ -422,3 +442,35 @@ def single_step_workplan(
 def remote_workplan_uri() -> str:
     """Fixture for returning a URL to a valid remote workplan for testing."""
     return "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
+
+
+@pytest.fixture
+def hello_world_default_target() -> str:
+    """Return the default target for the hello world blueprint."""
+    return "@ankona"
+
+
+@pytest.fixture
+def hello_world_bp_content(hello_world_default_target: str) -> str:
+    """Return the minimal content for a HW blueprint.
+
+    Parameters
+    ----------
+    hello_world_default_target : str
+        The default target for the hello world blueprint.
+    """
+    return textwrap.dedent(f"""\
+        name: Say hello to my little friend!
+        description: This blueprint says hello to a very nice guy
+        application: hello_world
+        state: draft
+        target: '{hello_world_default_target}'
+        """)
+
+
+@pytest.fixture
+def hello_world_bp_path(tmp_path: Path, hello_world_bp_content: str) -> Path:
+    """Return a fresh copy of the HW blueprint in the current test's temp dir."""
+    path = tmp_path / "helloworld.yaml"
+    path.write_text(hello_world_bp_content)
+    return path

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -411,7 +411,7 @@ def single_step_workplan(
         steps=[
             Step(
                 name="s-00",
-                application=Application.SLEEP.value,
+                application=Application.SLEEP,
                 blueprint=bp_path.as_posix(),
             ),
         ],

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -1,6 +1,7 @@
 import json
 import textwrap
 import typing as t
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,7 @@ def fake_blueprint_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def gen_fake_steps(tmp_path: Path) -> t.Callable[[int], t.Generator[Step, None, None]]:
+def gen_fake_steps(tmp_path: Path) -> Callable[[int], Generator[Step, None, None]]:
     """Create fake steps for testing purposes.
 
     Parameters
@@ -32,7 +33,7 @@ def gen_fake_steps(tmp_path: Path) -> t.Callable[[int], t.Generator[Step, None, 
         Unique path for test-specific files
     """
 
-    def _gen_fake_steps(num_steps: int) -> t.Generator[Step, None, None]:
+    def _gen_fake_steps(num_steps: int) -> Generator[Step, None, None]:
         """Create `num_steps` fake steps."""
         for i in range(num_steps):
             step_name = f"step-{i:03d}"
@@ -139,7 +140,7 @@ def blueprint_schema_path(tmp_path: Path) -> Path:
 def fill_workplan_template(
     empty_workplan_template_input: dict[str, t.Any],
     workplan_schema_path: Path,
-) -> t.Callable[[dict[str, t.Any]], str]:
+) -> Callable[[dict[str, t.Any]], str]:
     """Create a function to populate a raw workplan yaml document template."""
 
     def _get_workplan_template(
@@ -228,7 +229,7 @@ def fill_workplan_template(
 def fill_blueprint_template(
     empty_workplan_template_input: dict[str, t.Any],
     blueprint_schema_path: Path,
-) -> t.Callable[[dict[str, t.Any]], str]:
+) -> Callable[[dict[str, t.Any]], str]:
     """Create a function to populate a raw workplan yaml document template."""
 
     def _get_blueprint_template(

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -402,7 +402,7 @@ def single_step_workplan(
     bp_content = bp_content.replace(
         default_output_dir, f"output_dir: {tmp_path.as_posix()}"
     )
-    bp_content.replace(Application.SLEEP.value, Application.ROMS_MARBL.value)
+    bp_content.replace(Application.SLEEP, Application.ROMS_MARBL)
     bp_path.write_text(bp_content)
 
     return Workplan(

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -5,14 +5,12 @@ from unittest import mock
 import pytest
 
 from cstar.orchestration.converter.converter import (
+    app_to_cmd_map,
     get_command_mapping,
-    launcher_aware_app_to_cmd_map,
     register_command_mapping,
 )
-from cstar.orchestration.launch.local import LocalLauncher
-from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import Application, Step
-from cstar.orchestration.orchestration import Launcher, LiveStep
+from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 
@@ -22,18 +20,16 @@ def custom_map_function(step: Step) -> str:
 
 
 @pytest.mark.parametrize(
-    ("target_application", "launcher_type"),
+    ("target_application"),
     [
-        (Application.ROMS_MARBL, LocalLauncher),
-        (Application.ROMS_MARBL, SlurmLauncher),
-        (Application.SLEEP, LocalLauncher),
-        (Application.SLEEP, SlurmLauncher),
+        Application.ROMS_MARBL,
+        Application.SLEEP,
+        Application.HELLO_WORLD,
     ],
 )
 def test_converter_defaults(
     tmp_path: Path,
-    target_application: Application,
-    launcher_type: type[Launcher],
+    target_application: str,
 ) -> None:
     """Verify that the registration of a converter is not required for the default apps.
 
@@ -43,38 +39,30 @@ def test_converter_defaults(
         Temporary path fixture for writing per-test outputs.
     target_application: Application
         The application type to locate a mapping for
-    launcher_type: type[Launcher]
-        The type of launcher that will consume the command
     """
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
     step = LiveStep(
         name="test step",
-        application=target_application.value,
+        application=target_application,
         blueprint=bp_path,
         work_dir=tmp_path / "unit-test-work-dir",
     )
 
-    mapped_fn = get_command_mapping(target_application, launcher_type)
+    mapped_fn = get_command_mapping(target_application)
 
     # confirm a mapping function was returned
     assert mapped_fn(step)
 
 
 @pytest.mark.parametrize(
-    ("target_application", "launcher_type"),
-    [
-        (Application.ROMS_MARBL, LocalLauncher),
-        (Application.ROMS_MARBL, SlurmLauncher),
-        (Application.SLEEP, LocalLauncher),
-        (Application.SLEEP, SlurmLauncher),
-    ],
+    ("target_application"),
+    [Application.ROMS_MARBL, Application.SLEEP],
 )
 def test_converter_registration(
     tmp_path: Path,
-    target_application: Application,
-    launcher_type: type[Launcher],
+    target_application: str,
 ) -> None:
     """Verify that the registration of a converter is not required for the default apps.
 
@@ -84,26 +72,24 @@ def test_converter_registration(
         Temporary path fixture for writing per-test outputs
     target_application: Application
         The application type to locate a mapping for
-    launcher_type: type[Launcher]
-        The type of launcher that will consume the command
     """
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
     step = LiveStep(
         name="test step",
-        application=target_application.value,
+        application=target_application,
         blueprint=bp_path,
         work_dir=tmp_path / "unit-test-work-dir",
     )
 
     # ensure registration doesn't persist after test completes.
-    with mock.patch.dict(launcher_aware_app_to_cmd_map[launcher_type], {}):
-        original_fn = get_command_mapping(target_application, launcher_type)
+    with mock.patch.dict(app_to_cmd_map, {}):
+        original_fn = get_command_mapping(target_application)
 
-        register_command_mapping(target_application, launcher_type, custom_map_function)
+        register_command_mapping(target_application, custom_map_function)
 
-        mapped_fn = get_command_mapping(target_application, launcher_type)
+        mapped_fn = get_command_mapping(target_application)
 
     # confirm the function is a mapping function
     assert mapped_fn(step)
@@ -114,18 +100,12 @@ def test_converter_registration(
 
 
 @pytest.mark.parametrize(
-    ("target_application", "launcher_type"),
-    [
-        (Application.ROMS_MARBL, LocalLauncher),
-        (Application.ROMS_MARBL, SlurmLauncher),
-        (Application.SLEEP, LocalLauncher),
-        (Application.SLEEP, SlurmLauncher),
-    ],
+    ("target_application"),
+    [Application.ROMS_MARBL, Application.SLEEP],
 )
 def test_converter_override_invalid(
     tmp_path: Path,
     target_application: Application,
-    launcher_type: type[Launcher],
 ) -> None:
     """Verify that an invalid converter override results in an error.
 
@@ -135,8 +115,6 @@ def test_converter_override_invalid(
         Temporary path fixture for writing per-test outputs
     target_application: Application
         The application type to locate a mapping for
-    launcher_type: type[Launcher]
-        The type of launcher that will consume the command
     """
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
@@ -145,25 +123,22 @@ def test_converter_override_invalid(
         mock.patch.dict(os.environ, {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "DNE-key"}),
         pytest.raises(ValueError) as error,
     ):
-        _ = get_command_mapping(target_application, launcher_type)
+        _ = get_command_mapping(target_application)
 
     assert ENV_CSTAR_CMD_CONVERTER_OVERRIDE in str(error)
 
 
 @pytest.mark.parametrize(
-    ("target_application", "overridden_target", "launcher_type"),
+    ("target_application", "overridden_target"),
     [
-        (Application.ROMS_MARBL, Application.SLEEP, LocalLauncher),
-        (Application.ROMS_MARBL, Application.SLEEP, SlurmLauncher),
-        (Application.SLEEP, Application.ROMS_MARBL, LocalLauncher),
-        (Application.SLEEP, Application.ROMS_MARBL, SlurmLauncher),
+        (Application.ROMS_MARBL, Application.SLEEP),
+        (Application.SLEEP, Application.ROMS_MARBL),
     ],
 )
 def test_converter_override_capability(
     tmp_path: Path,
-    target_application: Application,
-    overridden_target: Application,
-    launcher_type: type[Launcher],
+    target_application: str,
+    overridden_target: str,
 ) -> None:
     """Verify that the the override specified in an environment variable takes precedence
     over defaults.
@@ -175,19 +150,54 @@ def test_converter_override_capability(
     target_application: Application
         The application type to locate a mapping for
     overridden_target: Application
-        The application type to use in place of the original target application
-    launcher_type: type[Launcher]
-        The type of launcher that will consume the command
+        The key to use to locate the override
     """
     bp_path = tmp_path / "blueprint.yaml"
     bp_path.touch()
 
-    original_fn = get_command_mapping(target_application, launcher_type)
+    original_fn = get_command_mapping(target_application)
 
     with mock.patch.dict(
         os.environ,
-        {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: overridden_target.value},
+        {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: overridden_target},
     ):
-        overridden_fn = get_command_mapping(target_application, launcher_type)
+        overridden_fn = get_command_mapping(target_application)
 
     assert original_fn != overridden_fn
+
+
+@pytest.mark.asyncio
+async def test_converter_hello_world(
+    tmp_path: Path,
+    hello_world_bp_path: Path,
+) -> None:
+    """Verify that the command converter produces a working CLI
+    command.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test blueprint.
+    hello_world_bp_path : Path
+        Path to the hello world blueprint.
+    """
+    work_dir = tmp_path / "work"
+
+    step = LiveStep(
+        name=f"{__name__}",
+        application=Application.HELLO_WORLD,
+        blueprint=hello_world_bp_path.as_posix(),
+        work_dir=work_dir,
+    )
+
+    # find the registered command converter for this application and launcher type
+    cmd_converter = get_command_mapping(Application.HELLO_WORLD)
+    assert cmd_converter is not None, "Command converter not found"
+
+    # use the converter function to generate the command
+    command = cmd_converter(step)
+
+    # confirm the retrieved converter produces the output expected
+    # from the function: convert_step_to_blueprint_run_command
+    assert "cstar blueprint run" in command
+    assert str(hello_world_bp_path) in command

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -29,7 +29,7 @@ def custom_map_function(step: Step) -> str:
 )
 def test_converter_defaults(
     tmp_path: Path,
-    target_application: str,
+    target_application: Application,
 ) -> None:
     """Verify that the registration of a converter is not required for the default apps.
 
@@ -62,7 +62,7 @@ def test_converter_defaults(
 )
 def test_converter_registration(
     tmp_path: Path,
-    target_application: str,
+    target_application: Application,
 ) -> None:
     """Verify that the registration of a converter is not required for the default apps.
 

--- a/cstar/tests/unit_tests/orchestration/test_hello_app.py
+++ b/cstar/tests/unit_tests/orchestration/test_hello_app.py
@@ -1,0 +1,167 @@
+# ruff: noqa: S101
+from pathlib import Path
+
+import pytest
+
+from cstar.base.exceptions import CstarError
+from cstar.base.log import LogLevelChoices
+from cstar.entrypoint.config import (
+    ServiceConfiguration,
+    get_job_config,
+    get_service_config,
+)
+from cstar.entrypoint.worker.hello_app import (
+    HelloWorldBlueprint,
+    HelloWorldRunner,
+)
+from cstar.entrypoint.xrunner import XRunnerRequest
+from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.models import Application
+from cstar.orchestration.serialization import deserialize, serialize
+
+
+@pytest.mark.asyncio
+async def test_hello_world_blueprint_serialization(
+    tmp_path: Path,
+    hello_world_bp_content: str,
+) -> None:
+    """Verify that a well-formed HW blueprint is serialized and
+    deserialized correctly.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test blueprint.
+    hello_world_bp_content : str
+        Valid yaml for a hello world blueprint.
+    """
+    target = "@ankona"
+    bp_path = tmp_path / "helloworld.yaml"
+    bp_path.write_text(hello_world_bp_content)
+
+    bp = deserialize(bp_path.as_posix(), HelloWorldBlueprint)
+    assert bp.application == Application.HELLO_WORLD
+    assert bp.target == target
+    assert bp.name == "Say hello to my little friend!"
+    assert bp.description == "This blueprint says hello to a very nice guy"
+    assert bp.state == "draft"
+    assert bp.cpus_needed == 1  # until it's moved, cpus_needed is hardcoded
+
+    persist_to = tmp_path / "hwserialized.yaml"
+    assert serialize(persist_to, bp), "Failed to serialize blueprint"
+    assert persist_to.exists(), "Serialized blueprint not found"
+
+    bp2 = deserialize(persist_to, HelloWorldBlueprint)
+    assert bp2.name == bp.name
+    assert bp2.description == bp.description
+    assert bp2.application == bp.application
+    assert bp2.state == bp.state
+    assert bp2.target == bp.target
+    assert bp2.cpus_needed == bp.cpus_needed
+
+
+@pytest.mark.asyncio
+async def test_hello_world_runner_execute_xrunner(
+    capsys: pytest.CaptureFixture[str],
+    hello_world_bp_path: Path,
+    hello_world_default_target: str,
+) -> None:
+    """Verify that a well-formed HW blueprint executes correctly.
+
+    This tests the integration of `BlueprintRunner` and `HelloWorldRunner` classes
+    without the service lifecycle being invoked.
+
+    Parameters
+    ----------
+    capsys : CaptureFixture
+        Fixture for capturing stdout and stderr.
+    hello_world_bp_path : Path
+        Path to the hello world blueprint.
+    """
+    request = XRunnerRequest(str(hello_world_bp_path), HelloWorldBlueprint)
+    svc_cfg = ServiceConfiguration()
+    job_cfg = get_job_config()
+
+    runner = HelloWorldRunner(request, job_cfg, svc_cfg)
+    result = await runner.execute_xrunner()
+
+    assert result is not None
+    # Confirm the success disposition is set
+    assert result.status == ExecutionStatus.COMPLETED
+
+    captured = capsys.readouterr()
+    assert f"hello, {hello_world_default_target}".lower() in captured.out.lower()
+
+
+@pytest.mark.asyncio
+async def test_hello_world_runner_execute_runner(
+    capsys: pytest.CaptureFixture[str],
+    hello_world_bp_path: Path,
+    hello_world_default_target: str,
+) -> None:
+    """Verify that a well-formed HW blueprint executes correctly.
+
+    This tests the integration of `BlueprintRunner` and `HelloWorldRunner` classes
+    by triggering the service lifecycle.
+
+    Parameters
+    ----------
+    capsys : CaptureFixture
+        Fixture for capturing stdout and stderr.
+    hello_world_bp_path : Path
+        Path to the hello world blueprint.
+    """
+    request = XRunnerRequest(str(hello_world_bp_path), HelloWorldBlueprint)
+    svc_cfg = ServiceConfiguration()
+    job_cfg = get_job_config()
+
+    runner = HelloWorldRunner(request, job_cfg, svc_cfg)
+    await runner.execute()
+
+    if not runner.result:
+        msg = "Failed to set result on runner"
+        raise CstarError(msg)
+
+    result = runner.result
+
+    assert result is not None
+
+    # Confirm the success disposition is set and no errors are returned
+    assert result.status == ExecutionStatus.COMPLETED
+    assert not result.errors
+
+    captured = capsys.readouterr()
+    assert f"hello, {hello_world_default_target}".lower() in captured.out.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_runner_happy_path(
+    capsys: pytest.CaptureFixture[str],
+    hello_world_bp_path: Path,
+    hello_world_default_target: str,
+) -> None:
+    """Verify that a well-formed HW blueprint executes correctly.
+
+    This tests the `BlueprintRunner` and `HelloWorldRunner` classes.
+
+    Parameters
+    ----------
+    capsys : CaptureFixture
+        Fixture for capturing stdout and stderr.
+    hello_world_bp_path : Path
+        Path to the hello world blueprint.
+    """
+    request = XRunnerRequest(str(hello_world_bp_path), HelloWorldBlueprint)
+    job_cfg = get_job_config()
+    svc_cfg = get_service_config(
+        log_level=LogLevelChoices.INFO,
+    )
+
+    runner = HelloWorldRunner(request, job_cfg, svc_cfg)
+    await runner.execute()
+
+    # Confirm the success disposition is set
+    assert runner.status == ExecutionStatus.COMPLETED
+
+    captured = capsys.readouterr()
+    assert f"hello, {hello_world_default_target}".lower() in captured.out.lower()

--- a/cstar/tests/unit_tests/orchestration/test_helloworldrunner.py
+++ b/cstar/tests/unit_tests/orchestration/test_helloworldrunner.py
@@ -1,0 +1,413 @@
+# ruff: noqa: S101
+import os
+import typing as t
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from cstar.base.env import ENV_CSTAR_STATE_HOME
+from cstar.cli.blueprint.run import app as app_run_blueprint
+from cstar.cli.workplan.run import app as app_run_workplan
+from cstar.entrypoint.config import get_job_config, get_service_config
+from cstar.entrypoint.worker.hello_app import (
+    HelloWorldBlueprint,
+    HelloWorldRunner,
+)
+from cstar.entrypoint.xrunner import XRunnerRequest
+from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.models import Workplan, WorkplanState
+from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.utils import (
+    ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
+    ENV_CSTAR_ORCH_DELAYS,
+    ENV_CSTAR_SLURM_MAX_WALLTIME,
+    ENV_CSTAR_SLURM_QUEUE,
+)
+
+
+@pytest.fixture
+def hw_single_step_wp_path(
+    tmp_path: Path,
+    hello_world_bp_content: str,
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
+) -> Path:
+    """Return the path to a workplan containing a single step that runs the hello_world application.
+
+    Returns
+    -------
+    Path
+    """
+    bp_content = hello_world_bp_content
+    bp_path = tmp_path / "hw.yaml"
+    bp_path.write_text(bp_content)
+
+    expected_name = "hw-workplan"
+    expected_description = "This is a test workplan using the hello_world application"
+
+    step_name = "Hello Devloper!"
+    app_name = "hello_world"
+    draft_state = "draft"
+
+    wp_yaml = fill_workplan_template(
+        {
+            "name": expected_name,
+            "description": expected_description,
+            "state": draft_state,
+            "steps": [
+                {
+                    "name": step_name,
+                    "application": app_name,
+                    "blueprint": bp_path.as_posix(),
+                },
+            ],
+        }
+    )
+    wp_path = tmp_path / "hw-workplan.yaml"
+    assert wp_path.write_text(wp_yaml)
+
+    return wp_path
+
+
+@pytest.fixture
+def hw_single_step_wp(
+    hw_single_step_wp_path: Path,
+) -> Workplan:
+    """Return a workplan containing a single step that runs the hello_world application.
+
+    Returns
+    -------
+    Workplan
+    """
+    return deserialize(hw_single_step_wp_path, Workplan)
+
+
+@pytest.fixture
+def heterogeneous_workplan_path(
+    tmp_path: Path,
+    hw_single_step_wp: Workplan,
+    single_step_workplan: Workplan,
+) -> Path:
+    """Return the path to a workplan containing steps triggering different applications.
+
+    Uses pre-existing fixtures and combines their steps into a new workplan.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Path where temporary workplans and blueprints will be written during the test.
+    hw_single_step_wp : Path
+        Path to a workplan that contains a single hello_world step.
+    single_step_workplan : Path
+        Path to a workplan that contains a single roms_marbl/sleep step.
+
+    Returns
+    -------
+    Path
+    """
+    wp = Workplan(
+        name="heterogeneous-workplan",
+        description="This is a test workplan containing steps triggering different applications",
+        state=WorkplanState.Draft,
+        compute_environment={
+            "num_nodes": 4,
+            "num_cpus_per_process": 16,
+        },
+        runtime_vars=["var1", "var2"],
+        steps=[
+            hw_single_step_wp.steps[0],
+            single_step_workplan.steps[0],
+        ],
+    )
+    wp_path = tmp_path / f"{wp.name}.yaml"
+    assert serialize(wp_path, wp)
+
+    return wp_path
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "@ankona",
+        "@ScottEilerman",
+        "@NoraLoose",
+    ],
+)
+@pytest.mark.asyncio
+async def test_hello_world_runner_happy_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    target: str,
+    hello_world_bp_content: str,
+) -> None:
+    """Test the execution of the "hello, {world}!" application
+
+    This test verifies that the runner receives and parses the Blueprint, and
+    executes the `Service` lifecycle.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test blueprint.
+    target : str
+        Target to say hello to. Used to verify the runner triggers the
+        `on_iteration` callback and that target is correctly parsed.
+    hello_world_bp_content : str
+        The content of a `HelloWorldBlueprint`.
+    """
+    bp_content = hello_world_bp_content.replace("@ankona", target)
+    bp_path = tmp_path / "hw.yaml"
+    bp_path.write_text(bp_content)
+
+    request = XRunnerRequest(str(bp_path), HelloWorldBlueprint)
+    job_cfg = get_job_config()
+    svc_cfg = get_service_config(log_level="INFO")
+
+    runner = HelloWorldRunner(request, job_cfg, svc_cfg)
+
+    await runner.execute()
+
+    # Confirm the success disposition is set
+    assert runner.status == ExecutionStatus.COMPLETED
+
+    captured = capsys.readouterr()
+    assert f"hello, {target}".lower() in captured.out.lower()
+
+
+@pytest.mark.asyncio
+async def test_hello_world_workplan(
+    tmp_path: Path,
+    hello_world_bp_content: str,
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
+) -> None:
+    """Test deserialization of a workplan containing a non ROMS-MARBL application.
+
+    Consider moving to a parametrized test that executes the same evaluation on all
+    known application types.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test blueprint.
+    hello_world_bp_content : str
+        The content of a `HelloWorldBlueprint`.
+    """
+    bp_content = hello_world_bp_content
+    bp_path = tmp_path / "hw.yaml"
+    bp_path.write_text(bp_content)
+
+    expected_name = "hw-workplan"
+    expected_description = "This is a test workplan using the hello_world application"
+
+    step_name = "Hello Devloper!"
+    app_name = "hello_world"
+    draft_state = "draft"
+
+    wp_yaml = fill_workplan_template(
+        {
+            "name": expected_name,
+            "description": expected_description,
+            "state": draft_state,
+            "steps": [
+                {
+                    "name": step_name,
+                    "application": app_name,
+                    "blueprint": bp_path.as_posix(),
+                },
+            ],
+        }
+    )
+    wp_path = tmp_path / "hw-workplan.yaml"
+    wp_path.write_text(wp_yaml)
+
+    # ensure the read succeeds
+    workplan = deserialize(wp_path, Workplan)
+    assert workplan.name == expected_name
+    assert workplan.description == expected_description
+    assert workplan.state == draft_state
+    assert len(workplan.steps) == 1
+    assert workplan.steps[0].name == step_name
+    assert workplan.steps[0].application == app_name
+    assert workplan.steps[0].blueprint_path == bp_path.as_posix()
+
+    # ensure a write succeeds
+    wp_copy = tmp_path / "hw-workplan-copy.yaml"
+    assert serialize(wp_copy, workplan), "Failed to serialize workplan"
+
+    # and sanity check the copy that was loaded
+    workplan_copy = deserialize(wp_copy, Workplan)
+    assert workplan_copy.name == workplan_copy.name
+    assert workplan_copy.description == workplan_copy.description
+    assert workplan_copy.state == workplan_copy.state
+    assert workplan_copy.steps[0].name == workplan_copy.steps[0].name
+    assert workplan_copy.steps[0].application == workplan_copy.steps[0].application
+    assert (
+        workplan_copy.steps[0].blueprint_path == workplan_copy.steps[0].blueprint_path
+    )
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    [
+        pytest.param(True, id="dry-run only"),
+        pytest.param(False, id="full execution"),
+    ],
+)
+def test_hello_world_workplan_dry_run(
+    tmp_path: Path,
+    hw_single_step_wp_path: Path,
+    dry_run: bool,
+    prefect_server_url: str,
+) -> None:
+    """Test the preparation of a workplan containing a non ROMS-MARBL application (--dry-run).
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test workplan and outputs from the run.
+    hw_single_step_wp_path : Path
+        The path to the workplan containing a single step that runs the hello_world application.
+    dry_run : bool
+        Whether to run the workplan in dry-run mode.
+    prefect_server_url: str
+        Implicitly declare dependence on the prefect server
+    """
+    state_dir = tmp_path / "state"
+    runner = CliRunner()
+    custom_env = {
+        ENV_CSTAR_ORCH_DELAYS: "0.01",
+        ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
+        ENV_CSTAR_SLURM_QUEUE: "debug",
+        ENV_CSTAR_STATE_HOME: state_dir.as_posix(),
+        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
+    }
+
+    run_id = str(uuid.uuid4())
+    with (
+        mock.patch.dict(os.environ, custom_env),
+        mock.patch(
+            "cstar.system.manager.CStarSystemManager.scheduler",
+            mock.PropertyMock(return_value=None),
+        ),
+    ):
+        args = [hw_single_step_wp_path.as_posix(), "--run-id", run_id]
+        if dry_run:
+            args.append("--dry-run")
+
+        result = runner.invoke(
+            app_run_workplan,
+            args,
+            color=False,
+        )
+
+    assert result.exit_code == 0
+    assert run_id in result.stdout
+    assert "completed" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    [
+        pytest.param(True, id="dry-run only"),
+        pytest.param(False, id="full execution"),
+    ],
+)
+def test_heterogeneous_workplan(
+    tmp_path: Path,
+    heterogeneous_workplan_path: Path,
+    dry_run: bool,
+    prefect_server_url: str,
+) -> None:
+    """Test the preparation of a workplan containing multiple applications (--dry-run).
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test workplan and outputs from the run.
+    heterogeneous_workplan_path : Path
+        The path to the workplan containing a step relying on the hello_world application
+        and a step relying on the ROMS-MARBL application.
+    dry_run : bool
+        Whether to run the workplan in dry-run mode.
+    prefect_server_url: str
+        Implicitly declare dependence on the prefect server
+    """
+    state_dir = tmp_path / "state"
+    runner = CliRunner()
+    custom_env = {
+        ENV_CSTAR_ORCH_DELAYS: "0.01",
+        ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
+        ENV_CSTAR_SLURM_QUEUE: "debug",
+        ENV_CSTAR_STATE_HOME: state_dir.as_posix(),
+        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
+    }
+    run_id = str(uuid.uuid4())
+    with (
+        mock.patch.dict(os.environ, custom_env),
+        mock.patch(
+            "cstar.system.manager.CStarSystemManager.scheduler",
+            mock.PropertyMock(return_value=None),
+        ),
+    ):
+        args = [heterogeneous_workplan_path.as_posix(), "--run-id", run_id]
+        if dry_run:
+            args.append("--dry-run")
+
+        result = runner.invoke(
+            app_run_workplan,
+            args,
+            color=False,
+        )
+
+    assert result.exit_code == 0
+    assert run_id in result.stdout
+    assert "completed" in result.stdout
+
+
+def test_hw_runner_bp_only(
+    tmp_path: Path,
+    hello_world_bp_path: Path,
+    prefect_server_url: str,
+) -> None:
+    """Verify that a blueprint containing the sample application is executed
+    correctly by the `cstar blueprint run` command.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary output location for writing the test workplan and outputs from the run.
+    hello_world_bp_path : Path
+        A fixture that stores an HW blueprint and returns the path.
+    prefect_server_url: str
+        Implicitly declare dependence on the prefect server
+    """
+    state_dir = tmp_path / "state"
+    runner = CliRunner()
+    custom_env = {
+        ENV_CSTAR_ORCH_DELAYS: "0.01",
+        ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
+        ENV_CSTAR_SLURM_QUEUE: "debug",
+        ENV_CSTAR_STATE_HOME: state_dir.as_posix(),
+        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
+    }
+    with (
+        mock.patch.dict(os.environ, custom_env),
+        mock.patch(
+            "cstar.system.manager.CStarSystemManager.scheduler",
+            mock.PropertyMock(return_value=None),
+        ),
+    ):
+        args = [str(hello_world_bp_path)]
+
+        print(f"Executing CliRunner with: {args}")
+        result = runner.invoke(
+            app_run_blueprint,
+            args,
+            color=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Hello," in result.stdout


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This is the MVP for adding new blueprint-driven applications into a `Workplan`. It adds and integrates a simple `HelloWorldBlueprint` and `HelloWorldRunner` as a reference for further application additions.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- `BlueprintRequest` deprecated in favor of `XRunnerRequest`

## New Features
<!-- List any new capabilities added -->
- Added capability to add custom blueprints and orchestrate within a `Workplan`

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Improved consistency in CLI outputs and error handling

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-681
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [X] New functionality has documentation
