### PR TITLE
Mitigate linter warnings for deprecated generic use in CSD-566

### DIFF
--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -1,6 +1,8 @@
 import itertools
 import typing as t
 from abc import ABC
+from collections import Counter
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime
 from enum import StrEnum, auto
@@ -506,7 +508,7 @@ class Workplan(BaseModel):
     description: RequiredString
     """A user-friendly description of the workplan."""
 
-    steps: t.Sequence[SerializeAsAny[Step]] = Field(
+    steps: Sequence[SerializeAsAny[Step]] = Field(
         min_length=1,
         frozen=True,
     )
@@ -556,7 +558,7 @@ class Workplan(BaseModel):
         value : list[str]
             Variable names used at runtime
         """
-        var_counter = t.Counter(value)
+        var_counter = Counter(value)
         most_common = var_counter.most_common(1)
         var_name, var_count = most_common[0] if most_common else ("", 0)
 
@@ -576,7 +578,7 @@ class Workplan(BaseModel):
         value : list[Step]
             The steps in the workplan.
         """
-        name_counter = t.Counter(step.name for step in value)
+        name_counter = Counter(step.name for step in value)
         most_common = name_counter.most_common(1)
         step_name, step_count = most_common[0] if most_common else ("", 0)
 
@@ -621,7 +623,7 @@ class UserDefinedVariables(BaseModel):
 
     keys: set[str] = Field(default_factory=set)
     """The set of valid keys available for runtime replacement."""
-    mapping: t.Mapping[str, str] = Field(default_factory=dict)
+    mapping: Mapping[str, str] = Field(default_factory=dict)
     """Key-value pairs specifying the value to be used for a key replacement."""
 
     require_coverage: bool = Field(default=False, frozen=True)

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import typing as t
 import uuid
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pytest
@@ -525,13 +526,13 @@ def test_step_blueprint_overrides_set(
 
 
 def test_workplan_defaults(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify attributes and default values are set as expected.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     """
     steps = list(gen_fake_steps(5))
@@ -566,14 +567,14 @@ def test_workplan_defaults(
     ],
 )
 def test_workplan_name_validation(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
     invalid_value: str | None,
 ) -> None:
     """Verify name validation works as expected.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     invalid_value : str
         A test value that should trigger a validation error
@@ -600,14 +601,14 @@ def test_workplan_name_validation(
     ],
 )
 def test_workplan_description_validation(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
     invalid_value: str | None,
 ) -> None:
     """Verify description validation works as expected.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     invalid_value : str
         A test value that should trigger a validation error
@@ -626,13 +627,13 @@ def test_workplan_description_validation(
 
 
 def test_workplan_state_validation(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify description validation works as expected.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     """
     steps = list(gen_fake_steps(5))
@@ -658,12 +659,12 @@ def test_workplan_state_validation(
         [None],
     ],
 )
-def test_workplan_steps_validation(invalid_value: list | None) -> None:
+def test_workplan_steps_validation(invalid_value: list[str | None] | None) -> None:
     """Verify steps validation works as expected.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     """
     name = f"test-plan-{uuid.uuid4()}"
@@ -690,7 +691,7 @@ def test_workplan_steps_validation(invalid_value: list | None) -> None:
 )
 def test_workplan_compute_environment(
     compute_env: KeyValueStore,
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify the compute environment of the workplan is set as expected.
 
@@ -698,7 +699,7 @@ def test_workplan_compute_environment(
     ----------
     overrides: dict[str, str | int]
         A set of overrides for the step
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     """
     steps = list(gen_fake_steps(5))
@@ -713,13 +714,13 @@ def test_workplan_compute_environment(
 
 
 def test_workplan_json_serialize(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the model is json serializable.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -746,14 +747,14 @@ def test_workplan_json_serialize(
 
 
 def test_workplan_yaml_serialize(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
     tmp_path: pathlib.Path,
 ) -> None:
     """Verify that the model serializes to YAML without errors.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     tmp_path : Path
         Temporarily write a yaml document to disk for manual test review of failures.
@@ -791,14 +792,14 @@ def test_workplan_yaml_serialize(
 
 
 def test_workplan_yaml_deserialize(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
     tmp_path: pathlib.Path,
 ) -> None:
     """Verify that the model deserializes from YAML without errors.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
     tmp_path : Path
         Temporarily write a yaml document to disk to ensure deserialization.
@@ -822,13 +823,13 @@ def test_workplan_yaml_deserialize(
 
 
 def test_workplan_step_copy(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan deep-copies steps.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -858,13 +859,13 @@ def test_workplan_step_copy(
 
 
 def test_workplan_step_set(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan does not allow the steps list reference to change.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -882,13 +883,13 @@ def test_workplan_step_set(
 
 
 def test_workplan_runtimevars_copy(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan copy of runtime_vars is distinct
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -917,13 +918,13 @@ def test_workplan_runtimevars_copy(
 
 
 def test_workplan_runtimevars_set(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan does not allow the runtime_vars list reference to change.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -942,13 +943,13 @@ def test_workplan_runtimevars_set(
 
 
 def test_workplan_runtimevars_duplicates(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan identifies duplicate runtime_vars
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -966,13 +967,13 @@ def test_workplan_runtimevars_duplicates(
 
 
 def test_workplan_computeenv_copy(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan copy of compute_environment is distinct
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -1001,13 +1002,13 @@ def test_workplan_computeenv_copy(
 
 
 def test_workplan_computeenv_set(
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that the Workplan does not allow the compute env reference to change.
 
     Parameters
     ----------
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -27,6 +27,9 @@ from cstar.orchestration.transforms import (
     get_time_slices,
 )
 
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 @pytest.fixture
 def diamond_graph(tmp_path: Path) -> nx.DiGraph:
@@ -60,14 +63,14 @@ def tree_graph(tmp_path: Path) -> nx.DiGraph:
     -------
     nx.DiGraph
     """
-    data: dict[str, t.Iterable[str]] = {
+    data: dict[str, Iterable[str]] = {
         "0": ["1", "2"],
         "1": ["3", "4"],
         "2": ["5", "6"],
     }
     bp_path = tmp_path / "blueprint.yaml"
-    g: nx.DiGraph = nx.DiGraph(data)
-    initial_stats = {
+    g = nx.DiGraph(data)
+    initial_stats: dict[str, dict[str, Step | Status]] = {
         key: {
             KEY_STEP: Step(name=key, application="sleep", blueprint=bp_path.as_posix()),
             KEY_STATUS: Status.Unsubmitted,

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -1,5 +1,6 @@
 import typing as t
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -57,7 +58,7 @@ def test_serialization_workplan_no_data(
 )
 def test_serialization_workplan_required_fields(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     attr_to_exclude: str,
     complete_workplan_template_input: dict[str, t.Any],
     empty_workplan_template_input: dict[str, t.Any],
@@ -92,7 +93,7 @@ def test_serialization_workplan_required_fields(
 )
 def test_serialization_workplan_optional_fields(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     attr_to_empty: str,
     complete_workplan_template_input: dict[str, t.Any],
     empty_workplan_template_input: dict[str, t.Any],
@@ -119,7 +120,7 @@ def test_serialization_workplan_optional_fields(
 
 def test_serialization_workplan_happy_path(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
 ) -> None:
     """Verify that a fully-populated workplan can be deserialized."""
@@ -148,7 +149,7 @@ def test_serialization_workplan_happy_path(
 
 def test_serialization_workplan_compute_env(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
 ) -> None:
     """Verify that dynamically added compute environment attributes are parsed."""
@@ -184,7 +185,7 @@ def test_serialization_workplan_compute_env(
 
 def test_serialization_workplan_runtime_vars(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
 ) -> None:
     """Verify that dynamically added runtime vars are parsed."""
@@ -219,7 +220,7 @@ def test_serialization_workplan_runtime_vars(
         PersistenceMode.yaml,
     ],
 )
-def test_serialization_handle(tmp_path: Path, mode: PersistenceMode) -> None:
+def test_serialization_handle(mode: PersistenceMode) -> None:
     """Verify that a task can be properly serialized to disk and reloaded."""
     pid, job_name = "test-pid", "abc123"
     handle = SlurmHandle(pid=pid, name=job_name)


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change includes resolution of minor linting issues encountered while completing CSD-566.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Mitigated linter warnings from using deprecated collections (e.g. t.Mapping, t.Iterable)

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Subtask of #CSD-566
- [ ] Tests added
- [ ] Tests passing
- [X] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
