### PR TITLE
Handle slurm timeout

### DIFF
--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -22,6 +22,8 @@ class ExecutionStatus(Enum):
         The task is currently executing.
     COMPLETED : ExecutionStatus
         The task finished successfully.
+    TIMEOUT : ExecutionStatus
+        The task was cancelled by the system for exceeding it's walltime allotment.
     CANCELLED : ExecutionStatus
         The task was cancelled before completion.
     FAILED : ExecutionStatus
@@ -38,6 +40,7 @@ class ExecutionStatus(Enum):
     PENDING = auto()
     RUNNING = auto()
     COMPLETED = auto()
+    TIMEOUT = auto()
     CANCELLED = auto()
     FAILED = auto()
     HELD = auto()

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -339,7 +339,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 return Status.Running
             case ExecutionStatus.COMPLETED:
                 return Status.Done
-            case ExecutionStatus.CANCELLED:
+            case ExecutionStatus.CANCELLED | ExecutionStatus.TIMEOUT:
                 return Status.Cancelled
             case ExecutionStatus.FAILED:
                 return Status.Failed


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change fixes a bug where a SLURM timeout is not handled. This defect may result in an orchestrator failing to exit correctly.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix failure to handle SLURM timeout status

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-486
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [X] New functionality has documentation
