### PR TITLE
Shutdown prefect server after tests complete

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -47,6 +47,7 @@ jobs:
            prefect server start --port 4200 --no-ui --analytics-off --background
            export PREFECT_API_URL=http://127.0.0.1:4200/api
            coverage run --rcfile=coverage.toml -m pytest -s --verbose cstar/tests/unit_tests/*
+           prefect server stop
            
       - name: Get coverage report
         shell: micromamba-shell {0}                


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change modifies the _unit test_ action to ensure the prefect server is shutdown after tests complete. The prefect server appears to keep the build agent alive indefinitely after the tests complete.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- Ensure shutdown of prefect to release build agent after tests complete

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-828
- [ ] Tests added
- [X] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
