### PR TITLE
Remove stages parameter and undifferentiated request type

### DIFF
--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -17,13 +17,12 @@ from cstar.entrypoint.utils import (
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
 )
+from cstar.entrypoint.worker.worker import execute_runner as exec_romsmarbl_runner
 from cstar.entrypoint.worker.worker import (
-    SimulationStages,
     get_job_config,
     get_request,
     get_service_config,
 )
-from cstar.entrypoint.worker.worker import execute_runner as exec_romsmarbl_runner
 from cstar.entrypoint.xrunner import XRunnerRequest
 from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import Application, Blueprint
@@ -85,13 +84,6 @@ def run(
             callback=path_callback,
         ),
     ],
-    stage: t.Annotated[
-        list[SimulationStages] | None,
-        typer.Option(
-            help="The stages to execute. If not specified, all stages will be executed.",
-            case_sensitive=False,
-        ),
-    ] = None,
     log_level: t.Annotated[
         LogLevelChoices,
         typer.Option(
@@ -129,7 +121,7 @@ def run(
 
     if bp.application == Application.ROMS_MARBL.value:
         # NOTE: temporary conditional to use old runner until it is converted to XRunner
-        rm_request = get_request(uri, stage)
+        rm_request = get_request(uri)
         rc = asyncio.run(exec_romsmarbl_runner(job_cfg, service_cfg, rm_request))
     else:
         request = XRunnerRequest(uri, type(bp))

--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -1,15 +1,12 @@
-import argparse
 import asyncio
-import enum
 import os
 import pathlib
 import sys
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Final, Literal, override
+from typing import TYPE_CHECKING, Final, override
 
-from cstar.base.env import ENV_CSTAR_LOG_LEVEL, get_env_item
 from cstar.base.exceptions import BlueprintError, CstarError
-from cstar.base.log import LogLevelChoices, get_logger
+from cstar.base.log import get_logger
 from cstar.base.utils import slugify
 from cstar.entrypoint.config import (
     configure_environment,
@@ -17,53 +14,13 @@ from cstar.entrypoint.config import (
     get_service_config,
 )
 from cstar.entrypoint.service import Service
-from cstar.entrypoint.utils import (
-    ARG_LOGLEVEL_LONG,
-    ARG_LOGLEVEL_SHORT,
-    ARG_URI_LONG,
-    ARG_URI_SHORT,
-)
-from cstar.entrypoint.xrunner import XRunnerRequest
+from cstar.entrypoint.xrunner import XRunnerRequest, create_parser
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.roms import ROMSSimulation
 
 if TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
-
-
-ARG_STAGE_LONG: Literal["--stage"] = "--stage"
-ARG_STAGE_SHORT: Literal["-g"] = "-g"
-
-
-class SimulationStages(enum.StrEnum):
-    """The stages in the simulation pipeline."""
-
-    SETUP = enum.auto()
-    """Execute simulation setup. See `Simulation.setup`"""
-    BUILD = enum.auto()
-    """Execute builds of simulation dependencies. See `Simulation.build`"""
-    PRE_RUN = enum.auto()
-    """Execute hooks before the simulation starts. See `Simulation.pre_run`"""
-    RUN = enum.auto()
-    """Execute the simulation. See `Simulation.run`"""
-    POST_RUN = enum.auto()
-    """Execute hooks after the simulation completes. See `Simulation.post_run`"""
-
-
-class RomsMarblRunnerRequest(XRunnerRequest[RomsMarblBlueprint]):
-    stages: list[SimulationStages]
-    """The simulation stages to execute."""
-
-    def __init__(
-        self,
-        uri: str,
-        bp_type: type[RomsMarblBlueprint],
-        name: str = "",
-        stages: list[SimulationStages] | None = None,
-    ) -> None:
-        super().__init__(uri, bp_type, name)
-        self.stages = stages or []
 
 
 class SimulationRunner(Service):
@@ -75,8 +32,6 @@ class SimulationRunner(Service):
     """The root directory where simulation outputs will be written."""
     _simulation: Final[ROMSSimulation]
     """The simulation instance created from the blueprint."""
-    _stages: Final[tuple[SimulationStages, ...]]
-    """The simulation stages that should be executed."""
     _handler: ExecutionHandler | None
     """The execution handler for the simulation."""
     _job_config: Final["JobConfig"]
@@ -84,7 +39,7 @@ class SimulationRunner(Service):
 
     def __init__(
         self,
-        request: RomsMarblRunnerRequest,
+        request: XRunnerRequest[RomsMarblBlueprint],
         service_cfg: "ServiceConfiguration",
         job_cfg: "JobConfig",
     ) -> None:
@@ -92,7 +47,7 @@ class SimulationRunner(Service):
 
         Parameters
         ----------
-        request: BlueprintRequest
+        request: XRunnerRequest[RomsMarblBlueprint]
             A request containing information about the simulation to run
 
         service_cfg: ServiceConfiguration
@@ -109,7 +64,6 @@ class SimulationRunner(Service):
         self._simulation = ROMSSimulation.from_blueprint(self._blueprint_uri)
         self._simulation.name = slugify(self._simulation.name)
         self._output_root = self._simulation.directory.expanduser()
-        self._stages = tuple(request.stages)
 
         roms_root = os.environ.get("ROMS_ROOT", None)
         self._simulation.exe_path = pathlib.Path(roms_root) if roms_root else None
@@ -165,23 +119,14 @@ class SimulationRunner(Service):
             raise BlueprintError(msg)
 
         try:
-            if SimulationStages.SETUP in self._stages:
-                self.log.trace("Setting up simulation")
-                self._simulation.setup()
-            else:
-                self.log.trace("Skipping simulation setup")
+            self.log.trace("Setting up simulation")
+            self._simulation.setup()
 
-            if SimulationStages.BUILD in self._stages:
-                self.log.trace("Building simulation")
-                self._simulation.build()
-            else:
-                self.log.trace("Skipping simulation build")
+            self.log.trace("Building simulation")
+            self._simulation.build()
 
-            if SimulationStages.PRE_RUN in self._stages:
-                self.log.trace("Executing simulation pre-run")
-                self._simulation.pre_run()
-            else:
-                self.log.trace("Skipping simulation pre_run")
+            self.log.trace("Executing simulation pre-run")
+            self._simulation.pre_run()
 
         except RuntimeError as ex:
             msg = "Failed to build simulation"
@@ -198,7 +143,6 @@ class SimulationRunner(Service):
         simulation.
         """
         # perform simulation cleanup activities only when required
-        stage_enabled = SimulationStages.POST_RUN in self._stages
         treat_as_failure = False
         try:
             if not self._simulation:
@@ -216,11 +160,8 @@ class SimulationRunner(Service):
                 )
                 return
 
-            if stage_enabled:
-                self._simulation.post_run()
-                self.log.debug("Executing simulation post-run")
-            else:
-                self.log.debug("Skipping simulation post-run")
+            self._simulation.post_run()
+            self.log.debug("Executing simulation post-run")
         except RuntimeError:
             treat_as_failure = True
             self.log.exception("Simulation post_run failed.")
@@ -239,11 +180,8 @@ class SimulationRunner(Service):
                     "job_name": self._job_config.job_name,
                 }
 
-                if SimulationStages.RUN in self._stages:
-                    self.log.trace("Running simulation.")
-                    self._handler = self._simulation.run(**run_params)
-                else:
-                    self.log.trace("Skipping simulation run")
+                self.log.trace("Running simulation.")
+                self._handler = self._simulation.run(**run_params)
             else:
                 await self._handler.updates(seconds=1.0)
         except Exception:
@@ -291,79 +229,31 @@ class SimulationRunner(Service):
         return False
 
 
-def create_simrunner_parser() -> argparse.ArgumentParser:
-    """Create a parser for CLI arguments expected by a SimulationRunner.
-
-    Returns
-    -------
-    argparse.ArgumentParser
-        An argument parser configured with the expected arguments for the
-        SimulationRunner service.
-    """
-    parser = argparse.ArgumentParser(
-        description="Run a c-star simulation.",
-        exit_on_error=True,
-    )
-    parser.add_argument(
-        ARG_URI_SHORT,
-        ARG_URI_LONG,
-        type=str,
-        required=True,
-        help="The URI of a blueprint.",
-    )
-    parser.add_argument(
-        ARG_LOGLEVEL_SHORT,
-        ARG_LOGLEVEL_LONG,
-        default=get_env_item(ENV_CSTAR_LOG_LEVEL).value,
-        type=str,
-        required=False,
-        help="Logging level for the simulation.",
-        choices=list(LogLevelChoices),
-    )
-    parser.add_argument(
-        ARG_STAGE_SHORT,
-        ARG_STAGE_LONG,
-        choices=[x.value for x in SimulationStages],
-        type=str,
-        required=False,
-        action="append",
-        dest="stages",
-        help=("Simulation stages to execute."),
-    )
-    return parser
-
-
 def get_request(
-    blueprint_uri: str, stages: list[SimulationStages] | None = None
-) -> RomsMarblRunnerRequest:
-    """Create a BlueprintRequest instance from CLI arguments.
+    blueprint_uri: str,
+) -> XRunnerRequest[RomsMarblBlueprint]:
+    """Create a XRunnerRequest[RomsMarblBlueprint] instance from CLI arguments.
 
     Parameters
     ----------
     blueprint_uri : str
         The path to a blueprint file
-    stages : list[SimulationStages] | None
-        The set of stages to be executed. Defaults to all stages, if empty or None.
 
     Returns
     -------
-    BlueprintRequest
+    XRunnerRequest[RomsMarblBlueprint]
         A request configured to run a c-star simulation via a blueprint.
     """
-    if not stages:
-        stages = list(SimulationStages)
-
-    return RomsMarblRunnerRequest(
+    return XRunnerRequest(
         blueprint_uri,
         RomsMarblBlueprint,
-        stages=stages,
     )
 
 
 async def execute_runner(
     job_cfg: "JobConfig",
     service_cfg: "ServiceConfiguration",
-    request: RomsMarblRunnerRequest,
+    request: XRunnerRequest[RomsMarblBlueprint],
 ) -> int:
     """Execute a blueprint with a SimulationRunner.
 
@@ -373,7 +263,7 @@ async def execute_runner(
         Configuration applied to the scheduler
     service_cfg : ServiceConfiguration
         Configuration applied to the service
-    request : BlueprintRequest
+    request : XRunnerRequest[RomsMarblBlueprint]
         A request specifying the blueprint to be executed
     """
     log = get_logger(__name__, level=service_cfg.log_level)
@@ -411,12 +301,12 @@ def main() -> int:
     int
         The exit code of the worker script. Returns 0 on success, 1 on failure.
     """
-    parser = create_simrunner_parser()
+    parser = create_parser()
     args = parser.parse_args()
 
     job_cfg = get_job_config()
     service_cfg = get_service_config(args.log_level, name="SimulationRunner")
-    request = get_request(args.blueprint_uri, args.stages)
+    request = get_request(args.blueprint_uri)
 
     return asyncio.run(execute_runner(job_cfg, service_cfg, request))
 

--- a/cstar/entrypoint/xrunner.py
+++ b/cstar/entrypoint/xrunner.py
@@ -228,7 +228,7 @@ class XBlueprintRunner(XRunner[TBlueprint], Service):
 
         Parameters
         ----------
-        request: BlueprintRequest
+        request: XRunnerRequest[TBlueprint]
             A request containing information about the blueprint to run.
         job_cfg: JobConfig
             Configuration for submitting jobs to an HPC, such as account ID,

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -25,13 +25,11 @@ from cstar.entrypoint.utils import (
     ARG_URI_SHORT,
 )
 from cstar.entrypoint.worker.worker import (
-    RomsMarblRunnerRequest,
     SimulationRunner,
-    SimulationStages,
-    create_simrunner_parser,
     get_request,
     main,
 )
+from cstar.entrypoint.xrunner import XRunnerRequest, create_parser
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
 from cstar.orchestration.models import RomsMarblBlueprint
 from cstar.orchestration.utils import (
@@ -39,7 +37,6 @@ from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_MAX_WALLTIME,
     ENV_CSTAR_SLURM_QUEUE,
 )
-from cstar.simulation import Simulation
 
 DEFAULT_LOOP_DELAY = 5
 DEFAULT_HEALTH_CHECK_FREQUENCY: int | None = None
@@ -102,10 +99,9 @@ def sim_runner(
     SimulationRunner
         An initialized instance of SimulationRunner, configured via blueprint.
     """
-    request = RomsMarblRunnerRequest(
+    request = XRunnerRequest(
         str(blueprint_path),
         RomsMarblBlueprint,
-        stages=list(SimulationStages),
     )
 
     service_config = ServiceConfiguration(
@@ -131,7 +127,7 @@ def sim_runner(
 
 def test_create_parser_happy_path() -> None:
     """Verify that a help argument is present in the parser."""
-    parser = create_simrunner_parser()
+    parser = create_parser()
 
     # ruff: noqa: SLF001
     assert ARG_URI_LONG in parser._option_string_actions
@@ -168,7 +164,7 @@ def test_parser_good_log_level(
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
 
-    parser = create_simrunner_parser()
+    parser = create_parser()
     parsed_args = parser.parse_args(args)
 
     assert getattr(parsed_args, "log_level", None) == logging.getLevelName(
@@ -197,7 +193,7 @@ def test_parser_lowercase_log_level(
     arg_tuples = [(k, v) for k, v in valid_args.items()]
     args = list(itertools.chain.from_iterable(arg_tuples))
 
-    parser = create_simrunner_parser()
+    parser = create_parser()
 
     # unable to parse the lower-case log levels
     with pytest.raises(SystemExit):
@@ -212,7 +208,7 @@ def test_parser_bad_log_level(valid_args: dict[str, str]) -> None:
     valid_args_tuples = ((k, v) for k, v in valid_args.items())
     args = list(itertools.chain.from_iterable(valid_args_tuples))
 
-    parser = create_simrunner_parser()
+    parser = create_parser()
 
     with pytest.raises(SystemExit):
         _ = parser.parse_args(args)
@@ -247,7 +243,7 @@ def test_get_service_config(
     arg_b, val_b = blueprint_uri.split(" ", maxsplit=1)
     arg_l, val_l = log_level.split(" ", maxsplit=1)
 
-    parser = create_simrunner_parser()
+    parser = create_parser()
     parsed_args = parser.parse_args(
         [
             arg_b,
@@ -280,7 +276,7 @@ def test_get_request(
     blueprint_uri: str,
 ) -> None:
     """Verify that the expected values are set on the blueprint request."""
-    parser = create_simrunner_parser()
+    parser = create_parser()
     parsed_args = parser.parse_args(
         [
             ARG_URI_LONG,
@@ -290,7 +286,7 @@ def test_get_request(
         ]
     )
 
-    config = get_request(parsed_args.blueprint_uri, parsed_args.stages)
+    config = get_request(parsed_args.blueprint_uri)
 
     assert config.blueprint_uri == blueprint_uri
 
@@ -345,7 +341,7 @@ def test_start_runner(
     blueprint_path: Path
         The path to the blueprint yaml file created by the fixture.
     """
-    request = RomsMarblRunnerRequest(
+    request = XRunnerRequest(
         str(blueprint_path),
         RomsMarblBlueprint,
     )
@@ -975,100 +971,6 @@ async def test_runner_on_iteration(
         assert mock_simulation.pre_run.call_count == 1
         assert mock_simulation.run.call_count == 1
         assert mock_shutdown.call_count == 1
-
-
-@pytest.mark.xfail(
-    reason="some of these fail now that we raise an error on unknown return status"
-)
-@pytest.mark.parametrize(
-    ("setup", "build", "pre_run", "run", "post_run"),
-    [
-        (0, 0, 0, 0, 0),
-        (1, 0, 0, 0, 0),
-        (0, 1, 0, 0, 0),
-        (0, 0, 1, 0, 0),
-        (0, 0, 0, 1, 0),
-        (0, 0, 0, 1, 1),
-        (1, 1, 0, 0, 0),
-        (0, 0, 1, 1, 0),
-        (1, 0, 1, 0, 0),
-        (1, 0, 0, 1, 0),
-        (0, 1, 1, 0, 0),
-        (0, 1, 0, 1, 0),
-        (0, 1, 0, 1, 1),
-        (0, 1, 1, 1, 0),
-        (0, 1, 1, 1, 1),
-        (1, 0, 0, 1, 1),
-        (1, 1, 0, 1, 1),
-        (1, 0, 1, 1, 1),
-        (1, 1, 1, 1, 1),
-    ],
-)
-@pytest.mark.asyncio
-async def test_runner_setup_stage(
-    sim_runner: SimulationRunner,
-    blueprint_path: Path,
-    setup: bool,
-    build: bool,
-    pre_run: bool,
-    run: bool,
-    post_run: bool,
-) -> None:
-    """Test conditional stage execution.
-
-    Verifies that each conditionally stage is executed when configured to do so.
-
-    WARNING: executing post-run without run is currently not tested/supported due to
-    the way the simulation creates and relies on a stateful execution handler.
-
-    Parameters
-    ----------
-    sim_runner: SimulationRunner
-        An instance of SimulationRunner to be used for the test.
-    """
-    mock_prep_fs = mock.Mock()
-
-    stages: list[SimulationStages] = []
-    if setup:
-        stages.append(SimulationStages.SETUP)
-    if build:
-        stages.append(SimulationStages.BUILD)
-    if pre_run:
-        stages.append(SimulationStages.PRE_RUN)
-    if run:
-        stages.append(SimulationStages.RUN)
-    if post_run:
-        stages.append(SimulationStages.POST_RUN)
-
-    request = RomsMarblRunnerRequest(
-        str(blueprint_path),
-        RomsMarblBlueprint,
-        stages=list(stages),
-    )
-
-    setattr(sim_runner, "_stages", tuple(request.stages))
-    mock_simulation = mock.Mock(spec=Simulation)
-
-    def _mock_run(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
-        return mock.Mock(spec=ExecutionHandler, status=ExecutionStatus.COMPLETED)
-
-    mock_simulation.run.configure_mock(side_effect=_mock_run)
-
-    # don't let it perform any real work
-    with (
-        mock.patch.object(sim_runner, "_start_healthcheck", mock.Mock()),
-        mock.patch.object(sim_runner, "_simulation", mock_simulation),
-    ):
-        # Trigger a run through the lifecycle as a task.
-        await sim_runner.execute()
-
-        # Now confirm that my target lifecycle behaviors were conditionally executed
-        assert mock_prep_fs.call_count == 1
-        assert mock_simulation.setup.call_count == (1 if setup else 0)
-        assert mock_simulation.build.call_count == (1 if build else 0)
-        assert mock_simulation.pre_run.call_count == (1 if pre_run else 0)
-        assert mock_simulation.run.call_count == (1 if run else 0)
-        assert mock_simulation.post_run.call_count == (1 if post_run else 0)
 
 
 def test_worker_main(tmp_path: Path, sim_runner: SimulationRunner) -> None:

--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -220,12 +220,13 @@ Use the ``run`` command from the ``cstar`` CLI to execute a blueprint.
       :caption: Executing a blueprint YAML file in python.
 
         from cstar.entrypoint.config import JobConfig, ServiceConfiguration, SimulationRunner
-        from cstar.entrypoint.worker.worker import BlueprintRequest
+        from cstar.entrypoint.xrunner import XRunnerRequest
+        from cstar.orchestration.models import RomsMarblBlueprint
 
         account_id = "your-account-id"
         queue_id = "wholenode"
         
-        request = BlueprintRequest("my_blueprint.yaml")
+        request = XRunnerRequest("my_blueprint.yaml", RomsMarblBlueprint)
         service_cfg = ServiceConfiguration()
         job_cfg = JobConfig(account_id, priority=queue_id)
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change deprecates the `SimulationStages` parameter. After removing the attribute, the remaining `BlueprintRequest` is undifferentiated from the base class so it is also removed.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- `BlueprintRequest` has been deprecated and removed.
- `--stage` CLI parameter for `cstar blueprint run` is no longer supported

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-710
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [X] New functionality has documentation
