### PR TITLE
Fix automatic output directory overrides

### DIFF
--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -278,9 +278,10 @@ class WorkplanTransformer(LoggingMixin):
         # ensure consistent output targets for all steps in the workplan
         live_steps = [LiveStep.from_step(s) for s in self.original.steps]
         steps: list[LiveStep] = []
-        for step in live_steps:
+        for i in range(len(live_steps)):
+            step = live_steps[i]
             if step.application in apply_to:
-                override_output_directory(step)
+                step = override_output_directory(step)
             steps.append(step)
 
         if is_feature_enabled(ENV_FF_ORCH_TRX_TIMESPLIT):

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -1,18 +1,24 @@
 import os
+import typing as t
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_RUNID
-from cstar.orchestration.models import Application, RomsMarblBlueprint, Workplan
+from cstar.base.env import ENV_CSTAR_RUNID, FLAG_OFF
+from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
+from cstar.orchestration.models import Application, RomsMarblBlueprint, Step, Workplan
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.transforms import (
     OverrideTransform,
     RomsMarblTimeSplitter,
+    WorkplanTransformer,
     get_transforms,
 )
+
+if t.TYPE_CHECKING:
+    from cstar.orchestration.orchestration import LiveStep
 
 
 @pytest.fixture
@@ -230,3 +236,62 @@ def test_override_transform_system_precedence(
     # system level override was applied last.
     assert Path(bp_old.runtime_params.output_dir) == dir_orig
     assert Path(bp_new.runtime_params.output_dir) == sys_od
+
+
+def test_workplan_transformer_applies_output_dir_overrides(
+    step_overiding_wp: Workplan,
+    test_output_dir: Path,
+    test_output_dir_override: Path,
+) -> None:
+    """Verify that the workplan transformer applies a transform to override
+    the output directory for all steps.
+
+    Parameters
+    ----------
+    step_overiding_wp : Workplan
+        A workplan copied from a template with paths referencing tmp_path.
+    test_output_dir : Path
+        The value that replaced the static content of the blueprint template
+        and was written to the test directory, tmp_path.
+    test_output_dir_override : Path
+        An override that was already on the step before the WP transformer is invoked
+    """
+    wp_transformer = WorkplanTransformer(step_overiding_wp, OverrideTransform())
+    original_bp_path = step_overiding_wp.steps[0].blueprint_path
+    step_orig: Step = step_overiding_wp.steps[0]
+    bp_orig = deserialize(step_orig.blueprint_path, RomsMarblBlueprint)
+
+    with mock.patch.dict(
+        os.environ,
+        {ENV_CSTAR_RUNID: "12345", ENV_FF_ORCH_TRX_TIMESPLIT: FLAG_OFF},
+        clear=True,
+    ):
+        wp_trx = wp_transformer.apply()
+
+    step_trx = t.cast("LiveStep", wp_trx.steps[0])
+
+    # sanity-check expectations for the original blueprint output location and override
+    dir_orig = bp_orig.runtime_params.output_dir
+    original_override = t.cast(
+        "str",
+        step_orig.blueprint_overrides["runtime_params"]["output_dir"],  # type: ignore[reportArgumentType,index,call-overload]
+    )
+    assert dir_orig == test_output_dir
+    assert original_override == str(test_output_dir_override)
+
+    # confirm no override remains on the step
+    assert "runtime_params" not in step_trx.blueprint_overrides
+
+    # confirm the transformed step includes an updated blueprint path.
+    trx_bp_path = step_trx.blueprint_path
+    assert str(trx_bp_path) != str(original_bp_path)
+
+    # confirm the original and updated blueprint have different output directories
+    blueprint = deserialize(trx_bp_path, RomsMarblBlueprint)
+    assert blueprint.runtime_params.output_dir != dir_orig
+
+    # confirm the workplan override took precedence over any original override or output_dir
+    exp_dir = step_trx.fsm.root
+    assert blueprint.runtime_params.output_dir == exp_dir
+    assert blueprint.runtime_params.output_dir != dir_orig
+    assert blueprint.runtime_params.output_dir != original_override


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a regression when applying automatic output directory overrides to a step. Previously, the transformation applied the transform but failed to update the workplan with the transformed step.

The result of the bug is that the override would not be applied until a new override transform was applied, which can occurred after time splitting. This gave the erroneous sense that there was a dependency on time splitting.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug where automatic output directory overrides appeared dependent on time-splitting

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-829
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [X] New functionality has documentation
