### PR TITLE
Move roms.in, symlink roms exe in work dir

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -356,7 +356,6 @@ class RomsFileSystemManager(JobFileSystemManager):
             self.input_datasets_dir,
             self._codebases_dir,
             self.joined_output_dir,
-            self.work_dir,
         ]:
             if directory.exists():
                 shutil.rmtree(directory)

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1610,7 +1610,7 @@ class ROMSSimulation(Simulation):
         # symlink roms exe into work dir for ability to easily rerun from the correct
         # location if debugging
 
-        roms_symlink_path = self.fs_manager.work_dir / "roms"
+        roms_symlink_path = self.fs_manager.work_dir / self.exe_path.name
         roms_symlink_path.symlink_to(self.exe_path)
 
         ## 2: RUN ROMS

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1596,23 +1596,22 @@ class ROMSSimulation(Simulation):
 
         # we run ROMS in the work dir
         run_path = self.fs_manager.work_dir
+        runtime_settings_fname = "cstar_generated_roms.in"
 
-        # save modified roms.in and rename original for clarity
-        old_runtime_settings_path = self.fs_manager.runtime_code_dir / self._in_file
-        final_runtime_settings_file = (
-            old_runtime_settings_path.parent / f"{self.name}_PATCHED.in"
-        )
+        # save modified roms.in in the work directory
+        final_runtime_settings_file = self.fs_manager.work_dir / runtime_settings_fname
         self.roms_runtime_settings.to_file(final_runtime_settings_file)
-
-        old_runtime_settings_path.rename(
-            old_runtime_settings_path.parent
-            / f"{old_runtime_settings_path.stem}_ORIGINAL.in"
-        )
 
         script_name = job_name or self.name
         safe_name = slugify(script_name)
         script_path = self.fs_manager.work_dir / f"{safe_name}.sh"
         output_file = self.fs_manager.logs_dir / f"{safe_name}.out"
+
+        # symlink roms exe into work dir for ability to easily rerun from the correct
+        # location if debugging
+
+        roms_symlink_path = self.fs_manager.work_dir / "roms"
+        roms_symlink_path.symlink_to(self.exe_path)
 
         ## 2: RUN ROMS
 
@@ -1621,8 +1620,8 @@ class ROMSSimulation(Simulation):
                 f"{cstar_sysmgr.environment.mpi_exec_prefix}",
                 "-n",
                 f"{self.discretization.n_procs_tot}",
-                f"{self.exe_path}",
-                f"{final_runtime_settings_file}",
+                "./roms",
+                f"{runtime_settings_fname}",
             ]
         )
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -1590,7 +1590,7 @@ class TestProcessingAndExecution:
 
             # Check LocalProcess was instantiated correctly
             mock_local_process.assert_called_once_with(
-                commands=f"{cstar_sysmgr.environment.mpi_exec_prefix} -n {sim.discretization.n_procs_tot} {sim.exe_path} {runtime_code_dir}/ROMSTest_PATCHED.in",
+                commands=f"{cstar_sysmgr.environment.mpi_exec_prefix} -n {sim.discretization.n_procs_tot} ./roms cstar_generated_roms.in",
                 run_path=sim.fs_manager.work_dir,
                 output_file=sim.fs_manager.logs_dir / "romstest.out",
             )
@@ -1679,7 +1679,7 @@ class TestProcessingAndExecution:
             # Call `run()` without explicitly passing `queue_name` and `walltime`
             execution_handler = sim.run(account_key="some_key")
             mock_create_job.assert_called_once_with(
-                commands=f"{exp_mpi_prefix} -n 6 {build_dir / 'roms'} {runtime_code_dir}/ROMSTest_PATCHED.in",
+                commands=f"{exp_mpi_prefix} -n 6 ./roms cstar_generated_roms.in",
                 job_name=None,
                 cpus=6,
                 account_key="some_key",


### PR DESCRIPTION
# Summary
This PR consolidates artifacts needed at roms runtime in the `work` directory. Instead of saving the modified roms.in back to `input/runtime_code` with a modified filename, we now save it with a consistent `cstar_generated_roms.in` in the work directory. We also symlink the built roms executable into the work directory, so a user who is debugging can rerun `mpirun ./roms cstar_generated_roms.in` from the `work` dir and it will have everything it needs (including symlinks to cdr.nc or nesting.nc for certain input files).

We could consider moving the roms executable and other compiled artifacts to the `work` dir, but we are rapidly moving toward a future where we may not need to recompile very often and could simply be referencing these executables that live pre-compiled in some other location.


## Improvements
<!-- List any improvements made to existing code or processes  -->
- Save the generated roms.in to the work directory, where roms is run.
- Symlink the roms executable to the work directory, where roms is run.


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [x] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
