### PR TITLE
Fix clear() for work dir

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -356,6 +356,7 @@ class RomsFileSystemManager(JobFileSystemManager):
             self.input_datasets_dir,
             self._codebases_dir,
             self.joined_output_dir,
+            self.work_dir,
         ]:
             if directory.exists():
                 shutil.rmtree(directory)


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- File system's `.clear()` method now correctly clears the `work` directory

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
