### PR TITLE
Allow exist-ok when making workdir

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1275,7 +1275,9 @@ class ROMSSimulation(Simulation):
             compile_time_code_dir.mkdir(parents=True)
             runtime_code_dir.mkdir(parents=True)
             input_datasets_dir.mkdir(parents=True)
-            work_dir.mkdir(parents=True)
+            work_dir.mkdir(
+                parents=True, exist_ok=True
+            )  # this one gets made by C-Star FSM
         except OSError as e:
             msg = (
                 f"The input directory is not empty. Re-run with {ENV_CSTAR_CLOBBER_WORKING_DIR}={FLAG_ON} "


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Re-fixing this after reverting... what is happening is that when we rely on `super().clear()` to clear the workdir, it actually recreates it at the end of `.clear()` (kind of odd...). So, the previous fix to also delete it in the subclass's `.clear()` ended up being necessary, but only for workdir... instead, I'm just going to allow exist_ok=True for the workdir rather than delete and recreate it all over again.


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
