### PR TITLE
Fix duplicate log messages

### DIFF
--- a/cstar/entrypoint/worker/worker.py
+++ b/cstar/entrypoint/worker/worker.py
@@ -267,7 +267,7 @@ async def execute_runner(
     request : XRunnerRequest[RomsMarblBlueprint]
         A request specifying the blueprint to be executed
     """
-    log = get_logger(__name__, level=service_cfg.log_level)
+    log = get_logger(f"{__name__}.runner", level=service_cfg.log_level)
 
     log.debug(f"Job config: {job_cfg!r}")
     log.debug(f"Service config: {service_cfg!r}")


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR fixes several duplicated log messages that occur at the end of a run. The root cause is due to logger parent/child relationships based on name: because SimulationRunner is under `cstar.entrypoint.worker.worker.SimulationRunner`, it ends up propagating messages to `cstar.entrypoint.worker.worker` (which gets established by `get_logger(__name__)` in the `execute_runner` function). Adding a `.runner` to the name for that logger, it breaks the propagation chain. We could also tweak how we handle propagation, but I was worried about additional consequences w.r.t. things like file handlers. This problem might also clear up if we move `SimulationRunner` to a different location soon as part of the app refactor.

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix duplicate log messages from the worker/runner after a ROMS Simulation completes


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [x] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
