### PR TITLE
Add `cstar workplan log` command

### DIFF
--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -19,6 +19,7 @@ from cstar.cli.common import clobber_callback, log_level_callback
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,
+    ARG_CLOBBER_HELP,
     ARG_DIRECTIVES_URI_LONG,
     ARG_DIRECTIVES_URI_SHORT,
     ARG_LOGLEVEL_LONG,
@@ -137,7 +138,7 @@ def run(
         typer.Option(
             ARG_CLOBBER,
             callback=clobber_callback,
-            help="Set this flag to remove any pre-existing files in the working directory.",
+            help=ARG_CLOBBER_HELP,
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -137,7 +137,7 @@ def run(
         typer.Option(
             ARG_CLOBBER,
             callback=clobber_callback,
-            help="Clobber the working directory if it exists.",
+            help="Set this flag to remove any pre-existing files in the working directory.",
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,

--- a/cstar/cli/workplan/__init__.py
+++ b/cstar/cli/workplan/__init__.py
@@ -10,6 +10,7 @@ from cstar.base.feature import (
 from cstar.cli.workplan.check import app as app_check
 from cstar.cli.workplan.compose import app as app_compose
 from cstar.cli.workplan.generate import app as app_gen
+from cstar.cli.workplan.log import app as app_log
 from cstar.cli.workplan.plan import app as app_plan
 from cstar.cli.workplan.run import app as app_run
 from cstar.cli.workplan.status import app as app_status
@@ -20,6 +21,7 @@ app = typer.Typer(
 )
 
 app.add_typer(app_check)
+app.add_typer(app_log)
 
 if is_feature_enabled(ENV_FF_CLI_WORKPLAN_GEN):
     app.add_typer(app_gen)

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -12,6 +12,7 @@ log = get_logger(__name__)
 app = typer.Typer()
 
 _MONITOR_POLL_INTERVAL: t.Final[float] = 0.25
+ARG_MONITOR: t.Final[str] = "--monitor"
 
 
 @app.command(name="log", help="Print the log for a workplan step.")
@@ -32,8 +33,7 @@ def workplan_log(
     monitor: t.Annotated[
         bool,
         typer.Option(
-            "--monitor",
-            "-m",
+            ARG_MONITOR,
             help="Set this flag to stream updates from the log file indefinitely (like tail -f). "
             "Waits for the file to appear if it does not yet exist.",
         ),

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -45,7 +45,7 @@ def workplan_log(
     log_path = step_fsm.logs_dir / f"{slugify(step_name)}.out"
 
     if not monitor and not log_path.exists():
-        print(f"No log file found for step '{step_name}' in run '{run_id}'.")
+        print(f"No log file found for step {step_name!r} in run {run_id!r}.")
         print(f"Expected path: {log_path}")
         raise typer.Exit(1)
 

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -5,7 +5,7 @@ import typer
 
 from cstar.base.log import get_logger
 from cstar.base.utils import slugify
-from cstar.cli.workplan.shared import list_runs, list_steps
+from cstar.cli.workplan.shared import autocomplete_step_list, list_runs
 from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
 
 log = get_logger(__name__)
@@ -37,7 +37,7 @@ def workplan_log(
         str,
         typer.Argument(
             help="The name of the step whose log should be printed.",
-            autocompletion=list_steps,
+            autocompletion=autocomplete_step_list,
         ),
     ],
     monitor: t.Annotated[

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -1,0 +1,73 @@
+import time
+import typing as t
+
+import typer
+
+from cstar.base.log import get_logger
+from cstar.base.utils import slugify
+from cstar.cli.workplan.shared import list_runs
+from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+
+log = get_logger(__name__)
+app = typer.Typer()
+
+_MONITOR_POLL_INTERVAL: t.Final[float] = 0.25
+
+
+@app.command(name="log", help="Print the log for a workplan step.")
+def workplan_log(
+    run_id: t.Annotated[
+        str,
+        typer.Argument(
+            help="The unique identifier of a specific workplan execution.",
+            autocompletion=list_runs,
+        ),
+    ],
+    step_name: t.Annotated[
+        str,
+        typer.Argument(
+            help="The name of the step whose log should be printed.",
+        ),
+    ],
+    monitor: t.Annotated[
+        bool,
+        typer.Option(
+            "--monitor",
+            "-m",
+            help="Stream new output as the log file is updated (like tail -f). "
+            "Waits for the file to appear if it does not yet exist.",
+        ),
+    ] = False,
+) -> None:
+    """Print the log for a workplan step."""
+    root_fsm = JobFileSystemManager(DirectoryManager.data_home() / run_id)
+    step_fsm = root_fsm.get_subtask_manager(step_name)
+    log_path = step_fsm.logs_dir / f"{slugify(step_name)}.out"
+
+    if not monitor and not log_path.exists():
+        print(f"No log file found for step '{step_name}' in run '{run_id}'.")
+        print(f"Expected path: {log_path}")
+        raise typer.Exit(1)
+
+    if not monitor:
+        print(log_path.read_text(), end="")
+        return
+
+    # --monitor: wait for the file to appear, then stream new content
+    try:
+        while not log_path.exists():
+            time.sleep(_MONITOR_POLL_INTERVAL)
+
+        with log_path.open("r") as fp:
+            while True:
+                chunk = fp.read()
+                if chunk:
+                    print(chunk, end="", flush=True)
+                else:
+                    time.sleep(_MONITOR_POLL_INTERVAL)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    typer.run(workplan_log)

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -5,7 +5,7 @@ import typer
 
 from cstar.base.log import get_logger
 from cstar.base.utils import slugify
-from cstar.cli.workplan.shared import list_runs
+from cstar.cli.workplan.shared import list_runs, list_steps
 from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
 
 log = get_logger(__name__)
@@ -37,6 +37,7 @@ def workplan_log(
         str,
         typer.Argument(
             help="The name of the step whose log should be printed.",
+            autocompletion=list_steps,
         ),
     ],
     monitor: t.Annotated[

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -34,7 +34,7 @@ def workplan_log(
         typer.Option(
             "--monitor",
             "-m",
-            help="Stream new output as the log file is updated (like tail -f). "
+            help="Set this flag to stream updates from the log file indefinitely (like tail -f). "
             "Waits for the file to appear if it does not yet exist.",
         ),
     ] = False,

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -12,10 +12,19 @@ log = get_logger(__name__)
 app = typer.Typer()
 
 _MONITOR_POLL_INTERVAL: t.Final[float] = 0.25
+
+
+HELP_SHORT = "Print the log for a workplan step."
+HELP_LONG = f"""\
+{HELP_SHORT}
+
+The `run_id` may be from an in-progress or completed run.
+"""
+
 ARG_MONITOR: t.Final[str] = "--monitor"
 
 
-@app.command(name="log", help="Print the log for a workplan step.")
+@app.command(name="log", help=HELP_LONG, short_help=HELP_SHORT)
 def workplan_log(
     run_id: t.Annotated[
         str,

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -19,6 +19,7 @@ from cstar.cli.workplan.shared import (
 )
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,
+    ARG_CLOBBER_HELP,
     ARG_DRY_RUN,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
@@ -278,7 +279,7 @@ def run(
         typer.Option(
             ARG_CLOBBER,
             callback=clobber_callback,
-            help="Set this flag to remove any pre-existing files in the working directory.",
+            help=ARG_CLOBBER_HELP,
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -259,7 +259,7 @@ def run(
         bool,
         typer.Option(
             ARG_DRY_RUN,
-            help="Generate the execution plan without executing the workplan.",
+            help="Set this flag to generate an execution plan without executing the workplan.",
             envvar=ENV_CSTAR_CLI_DRY_RUN,
         ),
     ] = False,
@@ -278,7 +278,7 @@ def run(
         typer.Option(
             ARG_CLOBBER,
             callback=clobber_callback,
-            help="Clobber the working directory if it exists.",
+            help="Set this flag to remove any pre-existing files in the working directory.",
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -115,6 +115,13 @@ def autocomplete_step_list(ctx: typer.Context, incomplete: str) -> list[str]:
 
     Use the parameters on `ctx` to locate the run-id supplied by the user.
 
+    Parameters
+    ----------
+    ctx : typer.Context
+        The typer context
+    incomplete : str
+        A string used to filter the step list to step names that start with the value.
+
     Returns
     -------
     list[str]

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -30,8 +30,8 @@ if t.TYPE_CHECKING:
     from cstar.orchestration.tracking import WorkplanRun
 
 
-def list_runs(incomplete: str) -> list[tuple[str, str]]:
-    """Retrieve a list of all recorded run-ids.
+async def list_runs(incomplete: str) -> list[tuple[str, str]]:
+    """Retrieve a list of all recorded run-ids asynchronously.
 
     Parameters
     ----------
@@ -43,8 +43,9 @@ def list_runs(incomplete: str) -> list[tuple[str, str]]:
     list[tuple[str, str]]
         A tuple for each run-id discovered containing [run-id, workplan-path]
     """
+    incomplete = incomplete.lower()
     repo = TrackingRepository()
-    run_list = asyncio.run(repo.list_latest_runs(incomplete))
+    run_list = await repo.list_latest_runs(incomplete)
 
     if not run_list:
         if incomplete:
@@ -55,22 +56,37 @@ def list_runs(incomplete: str) -> list[tuple[str, str]]:
     return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
 
 
-def list_steps(ctx: typer.Context, incomplete: str) -> list[str]:
-    """Return step names for the already-typed run_id, for shell autocompletion."""
-    run_id = ctx.params.get("run_id")
+async def list_steps(run_id: str, incomplete: str) -> list[str]:
+    """Return step names for the already-typed run_id, for shell autocompletion.
+
+    Applies the `incomplete` parameter as a filter, when supplied.
+
+    Parameters
+    ----------
+    run_id : str
+        The run-id for which steps will be retrieved.
+    incomplete : str
+        A string used to filter results by matching to the start of the
+        discovered step names
+
+    Returns
+    -------
+    list[str]
+    """
     if not run_id:
         return []
 
+    incomplete = incomplete.lower()
     wp_run: WorkplanRun | None = None
     try:
         repo = TrackingRepository()
 
-        if wp_run := asyncio.run(repo.get_workplan_run(run_id)):
+        if wp_run := await repo.get_workplan_run(run_id):
             wp = deserialize(wp_run.trx_workplan_path, Workplan)
             step_names = [str(s.name) for s in wp.steps]
 
             if incomplete:
-                step_names = [s for s in step_names if s.startswith(incomplete)]
+                step_names = [s for s in step_names if s.lower().startswith(incomplete)]
 
             return step_names
     except FileNotFoundError:
@@ -90,8 +106,26 @@ def list_steps(ctx: typer.Context, incomplete: str) -> list[str]:
     return [
         d.name
         for d in sorted(tasks_dir.iterdir())
-        if d.is_dir() and d.name.startswith(incomplete)
+        if d.is_dir() and d.name.lower().startswith(incomplete)
     ]
+
+
+def autocomplete_step_list(ctx: typer.Context, incomplete: str) -> list[str]:
+    """Return an auto-completed list of step names.
+
+    Use the parameters on `ctx` to locate the run-id supplied by the user.
+
+    Returns
+    -------
+    list[str]
+    """
+    run_id: str = ctx.params.get("run_id", "")
+
+    if not run_id:
+        msg = "run-id is required to autocomplete steps"
+        raise typer.BadParameter(msg)
+
+    return asyncio.run(list_steps(run_id, incomplete))
 
 
 def checkmark(color: str) -> str:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -15,6 +15,7 @@ from cstar.applications.core import (
 from cstar.base.log import get_logger
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
+from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
 from cstar.orchestration.dag_runner import DagStatus
 from cstar.orchestration.models import Blueprint
 from cstar.orchestration.orchestration import Status
@@ -50,6 +51,23 @@ def list_runs(incomplete: str) -> list[tuple[str, str]]:
         return [("run-id", "no results found")]
 
     return [(r.run_id, f"Workplan path: {r.workplan_path}") for r in run_list if r]
+
+
+def list_steps(ctx: typer.Context, incomplete: str) -> list[str]:
+    """Return step names for the already-typed run_id, for shell autocompletion."""
+    run_id = ctx.params.get("run_id")
+    if not run_id:
+        return []
+
+    tasks_dir = JobFileSystemManager(DirectoryManager.data_home() / run_id).tasks_dir
+    if not tasks_dir.exists():
+        return []
+
+    return [
+        d.name
+        for d in sorted(tasks_dir.iterdir())
+        if d.is_dir() and d.name.startswith(incomplete)
+    ]
 
 
 def checkmark(color: str) -> str:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -17,8 +17,9 @@ from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
 from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
 from cstar.orchestration.dag_runner import DagStatus
-from cstar.orchestration.models import Blueprint
+from cstar.orchestration.models import Blueprint, Workplan
 from cstar.orchestration.orchestration import Status
+from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.tracking import TrackingRepository
 
 console = Console()
@@ -26,6 +27,7 @@ log = get_logger(__name__)
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
+    from cstar.orchestration.tracking import WorkplanRun
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:
@@ -59,8 +61,30 @@ def list_steps(ctx: typer.Context, incomplete: str) -> list[str]:
     if not run_id:
         return []
 
-    tasks_dir = JobFileSystemManager(DirectoryManager.data_home() / run_id).tasks_dir
+    wp_run: WorkplanRun | None = None
+    try:
+        repo = TrackingRepository()
+
+        if wp_run := asyncio.run(repo.get_workplan_run(run_id)):
+            wp = deserialize(wp_run.trx_workplan_path, Workplan)
+            step_names = [str(s.name) for s in wp.steps]
+
+            if incomplete:
+                step_names = [s for s in step_names if s.startswith(incomplete)]
+
+            return step_names
+    except FileNotFoundError:
+        if wp_run:
+            msg = f"Workplan run contains a dead path: {wp_run.trx_workplan_path} was not found"
+            log.debug(msg)
+
+    # run state may be cleaned up. fallback to directory search
+    run_dir = DirectoryManager.data_home() / run_id
+    tasks_dir = JobFileSystemManager(run_dir).tasks_dir
+
     if not tasks_dir.exists():
+        msg = f"tasks_dir {str(tasks_dir)!r} was not found"
+        log.debug(msg)
         return []
 
     return [

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -31,7 +31,7 @@ if t.TYPE_CHECKING:
 
 
 def list_runs(incomplete: str) -> list[tuple[str, str]]:
-    """Retrieve a list of all recorded run-ids asynchronously.
+    """Retrieve a list of all recorded run-ids.
 
     Parameters
     ----------

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
     from cstar.orchestration.tracking import WorkplanRun
 
 
-async def list_runs(incomplete: str) -> list[tuple[str, str]]:
+def list_runs(incomplete: str) -> list[tuple[str, str]]:
     """Retrieve a list of all recorded run-ids asynchronously.
 
     Parameters
@@ -45,7 +45,7 @@ async def list_runs(incomplete: str) -> list[tuple[str, str]]:
     """
     incomplete = incomplete.lower()
     repo = TrackingRepository()
-    run_list = await repo.list_latest_runs(incomplete)
+    run_list = asyncio.run(repo.list_latest_runs(incomplete))
 
     if not run_list:
         if incomplete:

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -26,8 +26,8 @@ def status(
 ) -> None:
     """Retrieve the current status of a workplan."""
     if not run_id:
-        print("A run-id must be provided.")
-        raise typer.Exit(1)
+        msg = "A run-id must be provided."
+        raise typer.BadParameter(msg)
 
     repo = TrackingRepository()
     workplan_run = asyncio.run(repo.get_workplan_run(run_id))

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -17,15 +17,15 @@ console = Console()
 @app.command(name="status", help="Retrieve the current status of a workplan.")
 def status(
     run_id: t.Annotated[
-        str | None,
+        str,
         typer.Argument(
             help="The unique identifier of a specific workplan execution.",
             autocompletion=list_runs,
         ),
-    ] = None,
+    ],
 ) -> None:
     """Retrieve the current status of a workplan."""
-    if run_id is None:
+    if not run_id:
         print("A run-id must be provided.")
         raise typer.Exit(1)
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -17,16 +17,30 @@ console = Console()
 @app.command(name="status", help="Retrieve the current status of a workplan.")
 def status(
     run_id: t.Annotated[
-        str,
-        typer.Option(
+        str | None,
+        typer.Argument(
             help="The unique identifier of a specific workplan execution.",
             autocompletion=list_runs,
         ),
-    ] = "...",
+    ] = None,
+    run_id_flag: t.Annotated[
+        str | None,
+        typer.Option(
+            "--run-id",
+            help="The unique identifier of a specific workplan execution.",
+            autocompletion=list_runs,
+        ),
+    ] = None,
 ) -> None:
     """Retrieve the current status of a workplan."""
+    effective_run_id = run_id or run_id_flag
+
+    if effective_run_id is None:
+        print("A run-id must be provided.")
+        raise typer.Exit(1)
+
     repo = TrackingRepository()
-    workplan_run = asyncio.run(repo.get_workplan_run(run_id))
+    workplan_run = asyncio.run(repo.get_workplan_run(effective_run_id))
 
     if workplan_run is None:
         print("An unknown run-id was supplied.")
@@ -35,8 +49,8 @@ def status(
     launcher = get_launcher()
 
     try:
-        status = asyncio.run(load_run_state(run_id, launcher))
-        display_summary(run_id, status)
+        status = asyncio.run(load_run_state(effective_run_id, launcher))
+        display_summary(effective_run_id, status)
     except FileNotFoundError:  # blueprint not found.
         console.print_exception()
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -25,10 +25,6 @@ def status(
     ],
 ) -> None:
     """Retrieve the current status of a workplan."""
-    if not run_id:
-        msg = "A run-id must be provided."
-        raise typer.BadParameter(msg)
-
     repo = TrackingRepository()
     workplan_run = asyncio.run(repo.get_workplan_run(run_id))
 

--- a/cstar/cli/workplan/status.py
+++ b/cstar/cli/workplan/status.py
@@ -23,24 +23,14 @@ def status(
             autocompletion=list_runs,
         ),
     ] = None,
-    run_id_flag: t.Annotated[
-        str | None,
-        typer.Option(
-            "--run-id",
-            help="The unique identifier of a specific workplan execution.",
-            autocompletion=list_runs,
-        ),
-    ] = None,
 ) -> None:
     """Retrieve the current status of a workplan."""
-    effective_run_id = run_id or run_id_flag
-
-    if effective_run_id is None:
+    if run_id is None:
         print("A run-id must be provided.")
         raise typer.Exit(1)
 
     repo = TrackingRepository()
-    workplan_run = asyncio.run(repo.get_workplan_run(effective_run_id))
+    workplan_run = asyncio.run(repo.get_workplan_run(run_id))
 
     if workplan_run is None:
         print("An unknown run-id was supplied.")
@@ -49,8 +39,8 @@ def status(
     launcher = get_launcher()
 
     try:
-        status = asyncio.run(load_run_state(effective_run_id, launcher))
-        display_summary(effective_run_id, status)
+        status = asyncio.run(load_run_state(run_id, launcher))
+        display_summary(run_id, status)
     except FileNotFoundError:  # blueprint not found.
         console.print_exception()
 

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -1,6 +1,9 @@
 import typing as t
 
 ARG_CLOBBER: t.Literal["--clobber"] = "--clobber"
+ARG_CLOBBER_HELP: t.Final[str] = (
+    "Set this flag to remove any pre-existing files in the working directory."
+)
 ARG_DRY_RUN: t.Literal["--dry-run"] = "--dry-run"
 
 ARG_DIRECTIVES_URI_LONG: t.Literal["--directives"] = "--directives"

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -1,21 +1,21 @@
 import typing as t
 
-ARG_CLOBBER: t.Literal["--clobber"] = "--clobber"
+ARG_CLOBBER: t.Final[str] = "--clobber"
 ARG_CLOBBER_HELP: t.Final[str] = (
     "Set this flag to remove any pre-existing files in the working directory."
 )
-ARG_DRY_RUN: t.Literal["--dry-run"] = "--dry-run"
+ARG_DRY_RUN: t.Final[str] = "--dry-run"
 
-ARG_DIRECTIVES_URI_LONG: t.Literal["--directives"] = "--directives"
-ARG_DIRECTIVES_URI_SHORT: t.Literal["-d"] = "-d"
+ARG_DIRECTIVES_URI_LONG: t.Final[str] = "--directives"
+ARG_DIRECTIVES_URI_SHORT: t.Final[str] = "-d"
 
-ARG_LOGLEVEL_LONG: t.Literal["--log-level"] = "--log-level"
-ARG_LOGLEVEL_SHORT: t.Literal["-l"] = "-l"
+ARG_LOGLEVEL_LONG: t.Final[str] = "--log-level"
+ARG_LOGLEVEL_SHORT: t.Final[str] = "-l"
 
-ARG_OUTPUT_LONG: t.Literal["--output"] = "--output"
-ARG_OUTPUT_SHORT: t.Literal["-o"] = "-o"
+ARG_OUTPUT_LONG: t.Final[str] = "--output"
+ARG_OUTPUT_SHORT: t.Final[str] = "-o"
 
-ARG_URI_LONG: t.Literal["--blueprint-uri"] = "--blueprint-uri"
-ARG_URI_SHORT: t.Literal["-b"] = "-b"
+ARG_URI_LONG: t.Final[str] = "--blueprint-uri"
+ARG_URI_SHORT: t.Final[str] = "-b"
 
-ARG_VERBOSE: t.Literal["--verbose"] = "--verbose"
+ARG_VERBOSE: t.Final[str] = "--verbose"

--- a/cstar/tests/unit_tests/orchestration/cli/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/cli/conftest.py
@@ -1,0 +1,146 @@
+import os
+from collections.abc import Generator
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_STATE_HOME
+from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
+
+
+@pytest.fixture
+def mock_state_dir(
+    tmp_path: Path,
+) -> Generator[Path, None, None]:
+    """Verify that CLI plan action generates an output image from a workplan.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs; used to create a temporary location
+        for writing state directory content.
+
+    """
+    mock_state_dir = tmp_path / "mock-state-dir"
+    mock_state_dir.mkdir(exist_ok=True)
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: mock_state_dir.as_posix()}):
+        yield mock_state_dir
+
+
+@pytest.fixture
+def mock_data_dir(
+    tmp_path: Path,
+) -> Generator[Path, None, None]:
+    """Verify that CLI plan action generates an output image from a workplan.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs; used to create a temporary location
+        for writing data directory content.
+
+    """
+    mock_data_dir = tmp_path / "mock-data-dir"
+    mock_data_dir.mkdir(exist_ok=True)
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_DATA_HOME: mock_data_dir.as_posix()}):
+        yield mock_data_dir
+
+
+@pytest.fixture(params=["fanout", "linear", "parallel", "single_step"])
+def prepared_workplan(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    wp_templates_dir: Path,
+    default_blueprint_path: str,
+    bp_templates_dir: Path,
+) -> tuple[Path, Workplan]:
+    """Verify that CLI plan action generates an output image from a workplan.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    workplan_name : str
+        The name of a workplan fixture to use for workplan creation
+    wp_templates_dir: Path
+        Fixture returning the path to the directory containing workplan template files
+    default_blueprint_path : str
+        Fixture returning the default blueprint path contained in template workplans
+    # mock_state_dir: Path
+    #     Path to a temporary state directory for the test.
+    """
+    workplan_name = request.param
+    template_file = f"{workplan_name}.yaml"  # "single_step.yaml"
+    template_path = wp_templates_dir / template_file
+
+    bp_template_path = bp_templates_dir / "blueprint.yaml"
+    bp_content = bp_template_path.read_text()
+
+    test_bp_path = tmp_path / "blueprint.yaml"
+    test_bp_path.write_text(bp_content)
+
+    content = template_path.read_text()
+    content = content.replace(default_blueprint_path, test_bp_path.as_posix())
+
+    wp_path = tmp_path / template_file
+    wp_path.write_text(content)
+
+    wp = deserialize(wp_path, Workplan)
+
+    return wp_path, wp
+
+
+@pytest.fixture
+async def executed_workplan(
+    tmp_path: Path,
+    prepared_workplan: tuple[Path, Workplan],
+    mock_state_dir: Path,  # noqa: ARG001
+) -> tuple[Path, Workplan, str]:
+    """Create a WorkplanRun record for the prepared workplan."""
+    wp_path, wp = prepared_workplan
+    fake_run_id = "fake-run-id"
+
+    repo = TrackingRepository()
+    wp_run = WorkplanRun(
+        workplan_path=wp_path,
+        trx_workplan_path=wp_path,
+        output_path=tmp_path / "mock-output",
+        run_id=fake_run_id,
+    )
+    await repo.put_workplan_run(wp_run)
+
+    mock_get_wp = mock.Mock(return_value=wp_run)
+
+    with (
+        mock.patch(
+            "cstar.orchestration.tracking.TrackingRepository.get_workplan_run",
+            mock_get_wp,
+        ),
+    ):
+        return wp_path, wp, fake_run_id
+
+
+@pytest.fixture
+async def executed_workplan_with_sideeffects(
+    executed_workplan: tuple[Path, Workplan, str],
+    mock_data_dir: Path,  # noqa: ARG001
+) -> tuple[Path, Workplan, str]:
+    """Create a WorkplanRun record for the prepared workplan and populate
+    the run directories with logs.
+    """
+    wp_path, wp, fake_run_id = executed_workplan
+    root_fsm = JobFileSystemManager(DirectoryManager.data_home() / fake_run_id)
+
+    for i, step in enumerate(wp.steps):
+        step_fsm = root_fsm.get_subtask_manager(step.safe_name)
+        step_fsm.prepare()
+        log_path = step_fsm.logs_dir / f"{step.safe_name}.out"
+        log_path.write_text(f"{step.name} message {i}")
+
+    return wp_path, wp, fake_run_id

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_shared.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_shared.py
@@ -1,9 +1,17 @@
-import typing as t
+from collections.abc import Mapping
+from pathlib import Path
+from unittest import mock
 
 import pytest
 import typer
 
-from cstar.cli.workplan.shared import check_and_capture_kvp, check_and_capture_kvps
+from cstar.cli.workplan.shared import (
+    autocomplete_step_list,
+    check_and_capture_kvp,
+    check_and_capture_kvps,
+    list_steps,
+)
+from cstar.orchestration.models import Workplan
 
 
 @pytest.mark.parametrize(
@@ -89,7 +97,7 @@ def test_capture_kvp_invalid_inputs(entry: str, error: str) -> None:
 )
 def test_capture_kvps_happy_path(
     entries: list[str],
-    expected: t.Mapping[str, str],
+    expected: Mapping[str, str],
 ) -> None:
     """Verify that valid inputs produce the expected output.
 
@@ -142,3 +150,134 @@ def test_capture_kvps_duplicate(
     """
     with pytest.raises(typer.BadParameter, match="multiple"):
         _ = check_and_capture_kvps(entries)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_list_steps_empty_run_id() -> None:
+    """Verify that listing steps with no filter returns all available steps
+    in the results.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    steps = await list_steps(run_id="", incomplete="")
+
+    # confirm that an empty list is returned
+    assert not steps
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_list_steps_unfiltered(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that listing steps with no filter returns all available steps
+    in the results.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+    num_steps = len(wp.steps)
+
+    # confirm that a step is discovered when not using a filter
+    steps = await list_steps(fake_run_id, incomplete="")
+    assert len(steps) == num_steps
+    assert set(steps) == {s.name for s in wp.steps}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_list_steps_filtered(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that listing steps with a filter returns a subset of available results.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    for step in wp.steps:
+        # confirm that using a step name as the filter returns that single result
+        steps = await list_steps(fake_run_id, step.name)
+        assert len(steps) == 1
+        assert step.name in steps
+
+        # confirm case-insensitivity
+        steps = await list_steps(fake_run_id, step.name.lower())
+        assert len(steps) == 1
+        assert step.name in steps
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_list_steps_filter_all(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that listing steps with an filter that has no matches results in
+    no results.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, _, fake_run_id = executed_workplan
+
+    # confirm a nonsense name is not found
+    steps = await list_steps(fake_run_id, incomplete="xyzpqr")
+    assert not steps
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_autocomplete_step_list_no_run_id() -> None:
+    """Verify that a missing run-id parameter raises a typer exception."""
+    mock_typer_ctx = mock.Mock(params={"no-run-id-param-to-locate": 0})
+
+    with (
+        mock.patch("typer.Context", mock_typer_ctx),
+        pytest.raises(typer.BadParameter, match="run-id is required"),
+    ):
+        autocomplete_step_list(mock_typer_ctx, incomplete="")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_state_dir")
+async def test_autocomplete_step_list_empty_run_id() -> None:
+    """Verify that a missing run-id parameter raises a typer exception."""
+    mock_typer_ctx = mock.Mock(params={"run-id": ""})
+
+    with (
+        mock.patch("typer.Context", mock_typer_ctx),
+        pytest.raises(typer.BadParameter, match="run-id is required"),
+    ):
+        autocomplete_step_list(mock_typer_ctx, incomplete="")
+
+
+@pytest.mark.usefixtures("mock_state_dir")
+def test_autocomplete_step_list_happy_path(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that a valid run-id locates a run.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    mock_typer_ctx = mock.Mock(params={"run_id": fake_run_id})
+
+    with mock.patch("typer.Context", mock_typer_ctx):
+        steps = autocomplete_step_list(mock_typer_ctx, incomplete="")
+        assert len(steps) == len(wp.steps)

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
@@ -66,7 +66,7 @@ async def test_cli_workplan_log_step_with_logs(
 
     Parameters
     ----------
-    executed_workplan : tuple[Path, Workplan, str]
+    executed_workplan_with_sideeffects : tuple[Path, Workplan, str]
         The path to a workplan YAML file, the workplan instance, and a run-id.
     """
     _, wp, fake_run_id = executed_workplan_with_sideeffects

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cstar.cli.workplan.log import app
+from cstar.orchestration.models import Workplan
+
+
+@pytest.mark.asyncio
+async def test_cli_workplan_log_step_dne(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that an invalid step name results in an error message.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    *_, fake_run_id = executed_workplan
+
+    runner = CliRunner()
+    invalid_step_name = "step-DNE"
+
+    result = runner.invoke(
+        app,
+        [fake_run_id, invalid_step_name],
+        color=False,
+    )
+
+    assert f"No log file found for step {invalid_step_name!r}" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_cli_workplan_log_step_no_logs(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that a step where no logs have been created results in an error message.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    runner = CliRunner()
+    step_name = wp.steps[0].name
+
+    result = runner.invoke(
+        app,
+        [fake_run_id, step_name],
+        color=False,
+        catch_exceptions=False,
+    )
+
+    assert f"No log file found for step {step_name!r}" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_cli_workplan_log_step_with_logs(
+    executed_workplan_with_sideeffects: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that logs are loaded successfully.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan_with_sideeffects
+
+    runner = CliRunner()
+
+    for step in wp.steps:
+        result = runner.invoke(
+            app,
+            [fake_run_id, step.name],
+            color=False,
+            catch_exceptions=False,
+        )
+
+        assert f"{step.name} message" in result.stdout


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Add `cstar workplan log <run-id> <step>` command to easily view logs from a workplan step. It looks for the `<step_name>.out` file in the `logs` directory and prints it to screen. An optional `--monitor` flag will continuously stream updates from that file. The monitor feature doesn't currently have auto-exit functionality if the step completes, you always have to Ctrl-C to escape it.

## New Features
<!-- List any new capabilities added -->
- Add `cstar workplan log <run-id> <step>` command to easily view logs from a workplan step.

## Bug Fixes
- Fix a case-sensitivity bug in run-id autocompletion

## Improvements
- Remove unnecessary use of `Literal` types


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [X] New functionality has documentation
