### PR TITLE
Fix runner error handling

### DIFF
--- a/cstar/applications/roms_marbl/app.py
+++ b/cstar/applications/roms_marbl/app.py
@@ -161,8 +161,8 @@ def main() -> int:
 
     try:
         asyncio.run(runner.execute())
-        if runner.state.errors:
-            print(f"Errors occurred: {', '.join(runner.state.errors)}")
+        if runner.result.errors:
+            print(f"Errors occurred: {', '.join(runner.result.errors)}")
             return 1
     except CstarError as ex:
         print(f"An error occurred during the simulation: {ex}")

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -177,10 +177,10 @@ def run(
     runner = app_config.runner(request, service_cfg, job_cfg)
     asyncio.run(runner.execute())
 
-    if runner.state and runner.state.errors:
-        print(f"Errors occurred: {', '.join(runner.state.errors)}")
+    if runner.result and runner.result.errors:
+        print(f"Errors occurred: {', '.join(runner.result.errors)}")
 
-    rc = len(runner.state.errors) if runner.state else 0
+    rc = len(runner.result.errors) if runner.result else 0
 
     if rc:
         print("Blueprint execution failed")

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -173,6 +173,7 @@ def preprocess_path(workplan_path: str | None) -> str | None:
 
                 validation_result = validate_serialized_entity(local_path, Workplan)
                 if not validation_result.item:
+                    log.error(validation_result.error_msg)
                     msg = f"The workplan file in `{workplan_path}` is improperly formatted"
                     raise typer.BadParameter(msg)
 


### PR DESCRIPTION
# Summary
This fixes (I think? I haven't done a super clean test) a bug where a ROMS crash did not end up triggering a non-zero exit of the runner. The bug resulted in slurm reporting successful completion of a step when it should have registered a failure.

TODO: Add test case that exemplifies the bug and the fix.


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug in runner error handling


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
