### PR TITLE
Fix workdir clear() behavior (again)

### DIFF
--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -350,8 +350,6 @@ class RomsFileSystemManager(JobFileSystemManager):
 
     def clear(self) -> None:
         """Ensure the job's working directories are empty."""
-        super().clear()
-
         for directory in [
             self.compile_time_code_dir,
             self.runtime_code_dir,
@@ -361,6 +359,12 @@ class RomsFileSystemManager(JobFileSystemManager):
         ]:
             if directory.exists():
                 shutil.rmtree(directory)
+
+        # clear everything from workdir except blueprints
+        if self.work_dir.exists():
+            for f in self.work_dir.iterdir():
+                if not f.name.endswith(".yml") and not f.name.endswith(".yaml"):
+                    f.unlink()
 
 
 class StateDirectoryManager:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
As previously discussed, we probably shouldn't have been calling `super().clear()` here -- that was resulting in the logs dir being trashed, among other things, which got rid of important cstar logs.

We _do_ need to clear some things from the `work` (or `run` dir in a newer PR). However, we also store overridden blueprints there, and we _don't_ want to wipe those.

This fix gets rid of the`super().clear()` and adds a sorta-messy conditional clear of the work dir (everything except  yamls).

At some point we may want to put workflow artifacts in a different location that the step's run-artifact dir.

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug where CSTAR_CLOBBER_WORK_DIR would also delete important workplan artifacts

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
