### PR TITLE
Fix regression in file-system clear unit test

### DIFF
--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -73,12 +73,30 @@ def test_file_system_clear(
         Fixture providing tmp_path and fake files
 
     """
-    output_dir, output_files = populated_output_dir
+    output_dir, _ = populated_output_dir
 
     fs = RomsFileSystemManager(output_dir)
+    fs.prepare()
+
+    (fs.compile_time_code_dir / "a.txt").touch()
+    (fs.runtime_code_dir / "b.txt").touch()
+    (fs.input_datasets_dir / "c.txt").touch()
+    (fs.joined_output_dir / "d.txt").touch()
+    (fs.work_dir / "e.txt").touch()
+    (fs.work_dir / "f.yaml").touch()
+    (fs.work_dir / "g.yml").touch()
+
     fs.clear()
 
-    assert all(not f.exists() for f in output_files)
+    assert not fs.compile_time_code_dir.exists()
+    assert not fs.runtime_code_dir.exists()
+    assert not fs.input_datasets_dir.exists()
+    assert not fs.joined_output_dir.exists()
+
+    # confirm yaml in work_dir is not removed.
+    assert not (fs.work_dir / "e.txt").exists()
+    assert (fs.work_dir / "f.yaml").exists()
+    assert (fs.work_dir / "g.yml").exists()
 
 
 def test_file_system_pickle_job_fs(tmp_path: Path) -> None:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Fix a regression in the unit tests due to updated behavior in `RomsFileSystemManager.clear`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix failing unit test causing new feature branches to fail

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
