### PR TITLE
Cli callbacks

### DIFF
--- a/cstar/base/log.py
+++ b/cstar/base/log.py
@@ -189,9 +189,18 @@ class LoggingMixin:
 
 
 def parse_log_level_name(log_level: int | str) -> int:
-    level = (
+    return (
         logging.getLevelNamesMapping()[log_level.upper()]
         if isinstance(log_level, str)
         else log_level
     )
-    return level
+
+
+def reset_log_level(level: LogLevelChoices) -> None:
+    # set the level on the root logger
+    logging.getLogger().setLevel(parse_log_level_name(level))
+
+    # force loggers to delegate level to root logger
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for logger in loggers:
+        logger.setLevel(logging.NOTSET)

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -9,7 +9,7 @@ from cstar.applications.core import get_application
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLI_VERBOSE
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import is_flag_enabled
-from cstar.cli.common import dryrun_callback, verbose_callback
+from cstar.cli.common import cb_pipeline, set_env
 from cstar.entrypoint.utils import (
     ARG_DRY_RUN,
     ARG_OUTPUT_LONG,
@@ -91,8 +91,6 @@ def path_callback(value: str | None) -> str | None:
 
 def migrate_dryrun_callback(ctx: typer.Context, value: bool | None) -> bool | None:
     """Display informational message to user if a parameter conflict is found."""
-    value = dryrun_callback(ctx, value)
-
     output: str | None = ctx.params.get("output", None)
 
     if value is not None and value and output is not None:
@@ -124,7 +122,10 @@ def migrate(
         typer.Option(
             ARG_DRY_RUN,
             help="Generate the migration plan without executing it.",
-            callback=migrate_dryrun_callback,
+            callback=cb_pipeline(
+                set_env(ENV_CSTAR_CLI_DRY_RUN),
+                migrate_dryrun_callback,
+            ),
             envvar=ENV_CSTAR_CLI_DRY_RUN,
         ),
     ] = False,
@@ -133,7 +134,7 @@ def migrate(
         typer.Option(
             ARG_VERBOSE,
             help="Enable printing verbose migration outputs.",
-            callback=verbose_callback,
+            callback=set_env(ENV_CSTAR_CLI_VERBOSE),
             envvar=ENV_CSTAR_CLI_VERBOSE,
         ),
     ] = False,

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -15,7 +15,12 @@ from cstar.base.env import (
     get_env_item,
 )
 from cstar.base.log import LogLevelChoices, get_logger
-from cstar.cli.common import clobber_callback, log_level_callback
+from cstar.cli.common import (
+    cb_pipeline,
+    set_env,
+    set_flag,
+    update_loggers,
+)
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,
@@ -129,7 +134,7 @@ def run(
         typer.Option(
             ARG_LOGLEVEL_LONG,
             ARG_LOGLEVEL_SHORT,
-            callback=log_level_callback,
+            callback=cb_pipeline(set_env(ENV_CSTAR_LOG_LEVEL), update_loggers),
             help=ARG_LOGLEVEL_HELP,
             envvar=ENV_CSTAR_LOG_LEVEL,
         ),
@@ -138,7 +143,7 @@ def run(
         bool,
         typer.Option(
             ARG_CLOBBER,
-            callback=clobber_callback,
+            callback=set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),
             help=ARG_CLOBBER_HELP,
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -22,6 +22,7 @@ from cstar.entrypoint.utils import (
     ARG_CLOBBER_HELP,
     ARG_DIRECTIVES_URI_LONG,
     ARG_DIRECTIVES_URI_SHORT,
+    ARG_LOGLEVEL_HELP,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
 )
@@ -129,7 +130,7 @@ def run(
             ARG_LOGLEVEL_LONG,
             ARG_LOGLEVEL_SHORT,
             callback=log_level_callback,
-            help="Set the log level for C-Star.",
+            help=ARG_LOGLEVEL_HELP,
             envvar=ENV_CSTAR_LOG_LEVEL,
         ),
     ] = LogLevelChoices.INFO,

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -29,7 +29,6 @@ def attach_subcommands(app: typer.Typer) -> None:
                 app.add_typer(
                     command_app,
                     name=command_name,
-                    callback=common_callback,
                 )
     except Exception as ex:
         print(f"An error occurred while handling request: {ex}")

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -1,6 +1,8 @@
+from collections.abc import Callable
 import importlib
 import os
 import typing as t
+from collections.abc import Callable
 from pathlib import Path
 
 import typer
@@ -13,6 +15,7 @@ from cstar.base.env import (
     ENV_CSTAR_LOG_LEVEL,
     FLAG_ON,
 )
+from cstar.base.log import LogLevelChoices, reset_log_level
 
 app = typer.Typer()
 
@@ -72,6 +75,15 @@ def common_callback(
     ] = False,
 ) -> None:
     pass
+
+
+def update_loggers(ctx: typer.Context, value: str) -> str:
+    """Perform a log-level reset on all loggers if the log level is updated via CLI."""
+    reset_log_level(LogLevelChoices[value])
+    return value
+
+
+log_level_callback = cb_pipeline(set_env(ENV_CSTAR_LOG_LEVEL), update_loggers)
 
 
 def locate_app_modules() -> list[str]:

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 import importlib
 import os
 import typing as t
@@ -9,9 +8,6 @@ import typer
 
 import cstar
 from cstar.base.env import (
-    ENV_CSTAR_CLI_DRY_RUN,
-    ENV_CSTAR_CLI_VERBOSE,
-    ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
     FLAG_ON,
 )
@@ -22,42 +18,16 @@ app = typer.Typer()
 HELP_SHORT = "Print the current version of the C-Star package and exit."
 
 
+BoolCallback: t.TypeAlias = Callable[[typer.Context, bool], bool]
+StrCallback: t.TypeAlias = Callable[[typer.Context, str], str]
+
+
 def version_callback(value: bool) -> bool:
     """Print the version of C-Star and exit."""
     if value:
         typer.echo(cstar.__version__)
-        raise typer.Exit()
+        raise typer.Exit(0)
 
-    return value
-
-
-def log_level_callback(value: str) -> str:
-    """Set the log level in the environment for C-Star."""
-    value = value.strip().upper()
-    if value:
-        os.environ[ENV_CSTAR_LOG_LEVEL] = value
-
-    return value
-
-
-def clobber_callback(value: bool) -> bool:
-    """Callback for the clobber option."""
-    if value:
-        os.environ[ENV_CSTAR_CLOBBER_WORKING_DIR] = FLAG_ON
-    return value
-
-
-def verbose_callback(value: bool) -> bool:
-    """Callback for the verbose option."""
-    if value:
-        os.environ[ENV_CSTAR_CLI_VERBOSE] = FLAG_ON
-    return value
-
-
-def dryrun_callback(ctx: typer.Context, value: bool | None) -> bool | None:
-    """Callback for the dry-run option."""
-    if value:
-        os.environ[ENV_CSTAR_CLI_DRY_RUN] = FLAG_ON
     return value
 
 
@@ -75,6 +45,99 @@ def common_callback(
     ] = False,
 ) -> None:
     pass
+
+
+P = t.ParamSpec("P")
+A = t.TypeVar("A")
+
+
+def cb_pipeline(
+    *callbacks: Callable[[typer.Context, A], A],
+) -> Callable[[typer.Context, A], A]:
+    """Create a typer Callback function composed of a series of individual callbacks.
+
+    Parameters
+    ----------
+    callbacks : Callable[[typer.Context, A], A]
+        The sequence of callbacks to be executed
+
+    Returns
+    -------
+    Callable[[typer.Context, A], A]
+    """
+
+    def _callback(ctx: typer.Context, value: A) -> A:
+        """Callback wrapper that executes all specified callbacks."""
+        for callback in callbacks:
+            value = callback(ctx, value)
+
+        return value
+
+    return _callback
+
+
+def set_flag(
+    key: str,
+    extra: BoolCallback | None = None,
+) -> BoolCallback:
+    """Create a typer Callback function that sets the value of an environment
+    variable to the value of the argument supplied by the user.
+
+    Parameters
+    ----------
+    key : str
+        The environment variable to be set
+    extra : StrCallback
+        Additional logic called after setting the environment variable.
+
+    Returns
+    -------
+    StrCallback
+    """
+
+    def _callback(ctx: typer.Context, value: bool) -> bool:
+        """Callback that sets the specified environment variable to `FLAG_ON`
+        if `value` is `True`.
+        """
+        if value:
+            os.environ[key] = FLAG_ON
+
+        if extra:
+            value = extra(ctx, value)
+
+        return value
+
+    return _callback
+
+
+def set_env(
+    key: str,
+    extra: StrCallback | None = None,
+) -> StrCallback:
+    """Create a typer Callback function that sets the value of an environment
+    variable to the value of the argument supplied by the user.
+
+    Parameters
+    ----------
+    key : str
+        The environment variable to be set
+    extra : StrCallback
+        Additional logic called after setting the environment variable.
+
+    Returns
+    -------
+    StrCallback
+    """
+
+    def _callback(ctx: typer.Context, value: str) -> str:
+        """Callback that sets the specified environment variable to the specified value."""
+        value = value.strip()
+        os.environ[key] = value
+        if extra:
+            value = extra(ctx, value)
+        return value
+
+    return _callback
 
 
 def update_loggers(ctx: typer.Context, value: str) -> str:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -21,6 +21,7 @@ from cstar.entrypoint.utils import (
     ARG_CLOBBER,
     ARG_CLOBBER_HELP,
     ARG_DRY_RUN,
+    ARG_LOGLEVEL_HELP,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
 )
@@ -271,7 +272,7 @@ def run(
             ARG_LOGLEVEL_LONG,
             ARG_LOGLEVEL_SHORT,
             callback=log_level_callback,
-            help="Set the log level for C-Star.",
+            help=ARG_LOGLEVEL_HELP,
             envvar=ENV_CSTAR_LOG_LEVEL,
         ),
     ] = LogLevelChoices.INFO,

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -12,7 +12,12 @@ from cstar.base.env import (
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
-from cstar.cli.common import clobber_callback, log_level_callback
+from cstar.cli.common import (
+    cb_pipeline,
+    set_env,
+    set_flag,
+    update_loggers,
+)
 from cstar.cli.workplan.shared import (
     check_and_capture_kvps,
     list_runs,
@@ -271,7 +276,7 @@ def run(
         typer.Option(
             ARG_LOGLEVEL_LONG,
             ARG_LOGLEVEL_SHORT,
-            callback=log_level_callback,
+            callback=cb_pipeline(set_env(ENV_CSTAR_LOG_LEVEL), update_loggers),
             help=ARG_LOGLEVEL_HELP,
             envvar=ENV_CSTAR_LOG_LEVEL,
         ),
@@ -280,7 +285,7 @@ def run(
         bool,
         typer.Option(
             ARG_CLOBBER,
-            callback=clobber_callback,
+            callback=set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),
             help=ARG_CLOBBER_HELP,
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),

--- a/cstar/entrypoint/runner.py
+++ b/cstar/entrypoint/runner.py
@@ -14,6 +14,7 @@ from cstar.entrypoint.service import Service
 from cstar.entrypoint.utils import (
     ARG_DIRECTIVES_URI_LONG,
     ARG_DIRECTIVES_URI_SHORT,
+    ARG_LOGLEVEL_HELP,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
     ARG_URI_LONG,
@@ -205,7 +206,7 @@ def create_parser() -> argparse.ArgumentParser:
         default=get_env_item(ENV_CSTAR_LOG_LEVEL).value,
         type=str,
         required=False,
-        help="Logging level for the simulation.",
+        help=ARG_LOGLEVEL_HELP,
         choices=list(LogLevelChoices),
     )
     parser.add_argument(

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -11,6 +11,7 @@ ARG_DIRECTIVES_URI_SHORT: t.Final[str] = "-d"
 
 ARG_LOGLEVEL_LONG: t.Final[str] = "--log-level"
 ARG_LOGLEVEL_SHORT: t.Final[str] = "-l"
+ARG_LOGLEVEL_HELP: t.Final[str] = "Set the logging level for C-Star."
 
 ARG_OUTPUT_LONG: t.Final[str] = "--output"
 ARG_OUTPUT_SHORT: t.Final[str] = "-o"


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This pull request removes unnecessary per-parameter callbacks that perform the same action (in this case, setting an environment variable). To accomplish this, a utility method was added to enable creating pipelines of sequenced callbacks and it is coupled with generic environment-variable callbacks.

Additionally, I make use of the `cb_pipeline` to create a chained callback to fix a bug where loggers instantiated at import time have an inconsistent log-level when setting the level via CLI parameter.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Enable callback chaining for CLI arguments

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Enhance log-level callback to reset log levels to fix inconsistent logging levels when passing `--log-level` CLI parameter

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Removed unnecessary addition of version callback to all typer apps

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
- [X] Full type hint coverage
