### PR TITLE
Enable automatic schema migration on blueprint execution

### DIFF
--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -87,6 +87,16 @@ ENV_FF_ORCH_TRX_TIMESPLIT: t.Annotated[
 """Enable automatic time-splitting of simulations."""
 
 
+ENV_FF_CLI_BP_MIGRATE_AUTO: t.Annotated[
+    t.Literal["CSTAR_FF_CLI_BP_MIGRATE_AUTO"],
+    EnvVar(
+        "Enable automatic blueprint migration to the latest schema during execution.",
+        GROUP_FF,
+        default=FLAG_OFF,
+    ),
+] = "CSTAR_FF_CLI_BP_MIGRATE_AUTO"
+"""Enable automatic blueprint migration to the latest schema during execution."""
+
 ENV_FF_CLI_BP_MIGRATE_SHOW: t.Annotated[
     t.Literal["CSTAR_FF_CLI_BP_MIGRATE_SHOW"],
     EnvVar(

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 from pathlib import Path
 
@@ -11,7 +10,7 @@ from cstar.base.env import (
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
 )
-from cstar.base.log import LogLevelChoices, get_logger, parse_log_level_name
+from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
     MigrationRequest,
     cb_pipeline,
@@ -124,14 +123,6 @@ def clobber_output(ctx: typer.Context, value: bool) -> bool:
         if path.exists():
             path.unlink()
 
-    return value
-
-
-def update_logger(ctx: typer.Context, value: str) -> str:
-    logging.getLogger().setLevel(parse_log_level_name(value))
-    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
-    for logger in loggers:
-        logger.setLevel(logging.NOTSET)
     return value
 
 

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -57,6 +57,11 @@ def path_callback(value: str) -> str:
 
     Resulting path has been expanded and resolved.
 
+    Parameters
+    ----------
+    value : bool
+        The value of the path parameter.
+
     Returns
     -------
     Path
@@ -91,6 +96,13 @@ def target_callback(value: str) -> str:
 
     Resulting path has been expanded and resolved.
 
+    Parameters
+    ----------
+    ctx : typer.Context
+        The typer context object.
+    value : bool
+        The value of the output parameter.
+
     Returns
     -------
     Path
@@ -116,6 +128,13 @@ def dryrun_notify(ctx: typer.Context, value: bool) -> bool:
 def clobber_output(ctx: typer.Context, value: bool) -> bool:
     """Callback for clobber parameter that removes a pre-existing output file
     and mitigates a FileExistsError.
+
+    Parameters
+    ----------
+    ctx : typer.Context
+        The typer context object.
+    value : bool
+        The value of the clobber parameter.
     """
     output = ctx.params.get("output", "")
     if value and output:

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -1,26 +1,48 @@
+import logging
 import typing as t
 from pathlib import Path
 
 import typer
+from pydantic import ValidationError
 
-from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLI_VERBOSE
+from cstar.base.env import (
+    ENV_CSTAR_CLI_DRY_RUN,
+    ENV_CSTAR_CLI_VERBOSE,
+    ENV_CSTAR_CLOBBER_WORKING_DIR,
+    ENV_CSTAR_LOG_LEVEL,
+)
+from cstar.base.log import LogLevelChoices, get_logger, parse_log_level_name
 from cstar.cli.common import (
+    MigrationRequest,
     cb_pipeline,
     execute_migration,
+    print_validation_errors,
+    set_env,
     set_flag,
+    update_loggers,
 )
 from cstar.entrypoint.utils import (
+    ARG_CLOBBER,
+    ARG_CLOBBER_HELP,
     ARG_DRY_RUN,
+    ARG_LOGLEVEL_HELP,
+    ARG_LOGLEVEL_LONG,
+    ARG_LOGLEVEL_SHORT,
     ARG_OUTPUT_LONG,
     ARG_OUTPUT_SHORT,
     ARG_VERBOSE,
     ARG_VERBOSE_HELP,
 )
-from cstar.execution.file_system import is_remote_resource
+from cstar.execution.file_system import (
+    DirectoryManager,
+    is_remote_resource,
+    write_local_copy,
+)
 
 app = typer.Typer()
+log = get_logger(__name__)
 
-
+CMD_NAME: t.Final[str] = "migrate"
 HELP_SHORT = "Migrate the schema of a blueprint file."
 HELP_LONG = f"""\
 {HELP_SHORT}
@@ -31,46 +53,106 @@ file with the version number appended to the file name.
 """
 
 
-def path_callback(value: str | None) -> str | None:
-    """Ensure a path that was provided by a user has been expanded and resolved.
+def path_callback(value: str) -> str:
+    """Ensure the user provided a non-empty path.
+
+    Resulting path has been expanded and resolved.
 
     Returns
     -------
     Path
     """
-    if value and not is_remote_resource(value):
-        return Path(value).expanduser().resolve().as_posix()
-    return value
+    value = value.strip() if value else ""
+
+    if not value:
+        msg = "path is an empty string."
+        raise typer.BadParameter(msg)
+
+    if not is_remote_resource(value):
+        path = Path(value).expanduser().resolve()
+        if not path.exists():
+            msg = f"{str(path)!r} was not found"
+            raise typer.BadParameter(msg)
+        return path.as_posix()
+
+    try:
+        state_dir = DirectoryManager.state_home()
+        local_path = write_local_copy(value, state_dir)
+    except FileNotFoundError as ex:
+        msg = f"{ex.strerror}: {ex.filename!r}"
+        raise typer.BadParameter(msg) from ex
+    else:
+        msg = f"Remote file retrieved into: {local_path.as_posix()!r}"
+        log.debug(msg)
+        return local_path.as_posix()
 
 
-def migrate_dryrun_callback(ctx: typer.Context, value: bool | None) -> bool | None:
+def target_callback(value: str) -> str:
+    """Ensure the user provided a non-empty path.
+
+    Resulting path has been expanded and resolved.
+
+    Returns
+    -------
+    Path
+    """
+    if not value or not value.strip():
+        return value.strip()
+
+    path = Path(value)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path.as_posix()
+
+
+def dryrun_notify(ctx: typer.Context, value: bool) -> bool:
     """Display informational message to user if a parameter conflict is found."""
-    output: str | None = ctx.params.get("output", None)
+    output = ctx.params.get("output", "")
 
-    if value is not None and value and output is not None:
-        print(f"Ignoring output path {output!r} during dry-run")
+    if value and output:
+        print(f"Output path {output!r} will be ignored during dry-run")
 
     return value
 
 
-@app.command(name="migrate", help=HELP_LONG, short_help=HELP_SHORT)
+def clobber_output(ctx: typer.Context, value: bool) -> bool:
+    """Callback for clobber parameter that removes a pre-existing output file
+    and mitigates a FileExistsError.
+    """
+    output = ctx.params.get("output", "")
+    if value and output:
+        path = Path(output)
+        if path.exists():
+            path.unlink()
+
+    return value
+
+
+def update_logger(ctx: typer.Context, value: str) -> str:
+    logging.getLogger().setLevel(parse_log_level_name(value))
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for logger in loggers:
+        logger.setLevel(logging.NOTSET)
+    return value
+
+
+@app.command(name=CMD_NAME, help=HELP_LONG, short_help=HELP_SHORT)
 def migrate(
     path: t.Annotated[
         str,
         typer.Argument(
-            help="Path to a blueprint file.",
+            help="Path to a file containing a serialized blueprint.",
             callback=path_callback,
         ),
     ],
     output: t.Annotated[
-        str | None,
+        str,
         typer.Option(
             ARG_OUTPUT_LONG,
             ARG_OUTPUT_SHORT,
-            help="Path to the output file",
-            callback=path_callback,
+            help="Path where the migrated blueprint will be serialized",
+            callback=target_callback,
         ),
-    ] = None,
+    ] = "",
     dry_run: t.Annotated[
         bool,
         typer.Option(
@@ -78,7 +160,7 @@ def migrate(
             help="Generate the migration plan without executing it.",
             callback=cb_pipeline(
                 set_flag(ENV_CSTAR_CLI_DRY_RUN),
-                migrate_dryrun_callback,
+                dryrun_notify,
             ),
             envvar=ENV_CSTAR_CLI_DRY_RUN,
         ),
@@ -92,6 +174,42 @@ def migrate(
             envvar=ENV_CSTAR_CLI_VERBOSE,
         ),
     ] = False,
+    clobber: t.Annotated[
+        bool,
+        typer.Option(
+            ARG_CLOBBER,
+            help=ARG_CLOBBER_HELP,
+            callback=set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),  # extra=clobber_output),
+            envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
+        ),
+    ] = False,
+    log_level: t.Annotated[
+        LogLevelChoices,
+        typer.Option(
+            ARG_LOGLEVEL_LONG,
+            ARG_LOGLEVEL_SHORT,
+            callback=cb_pipeline(set_env(ENV_CSTAR_LOG_LEVEL), update_loggers),
+            help=ARG_LOGLEVEL_HELP,
+            envvar=ENV_CSTAR_LOG_LEVEL,
+            is_eager=True,
+        ),
+    ] = LogLevelChoices.INFO,
 ) -> None:
     """Migrate the schema of an old blueprint to the latest version."""
-    execute_migration(path, output, dry_run)
+    global log
+    log = get_logger(__name__)
+
+    try:
+        request = MigrationRequest(
+            path=Path(path),
+            output=Path(output) if output else None,
+        )
+    except ValidationError as ex:
+        print_validation_errors(ex)
+        raise typer.Exit(1) from ex
+
+    result = execute_migration(request)
+    if not result.result.plan:
+        print("Migration failed to produce a plan.")
+
+    print(f"Migrated blueprint persisted to {str(result.target)!r}")

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -64,7 +64,7 @@ def path_callback(value: str) -> str:
 
     Returns
     -------
-    Path
+    str
     """
     value = value.strip() if value else ""
 
@@ -105,7 +105,7 @@ def target_callback(value: str) -> str:
 
     Returns
     -------
-    Path
+    str
     """
     if not value or not value.strip():
         return value.strip()
@@ -116,7 +116,19 @@ def target_callback(value: str) -> str:
 
 
 def dryrun_notify(ctx: typer.Context, value: bool) -> bool:
-    """Display informational message to user if a parameter conflict is found."""
+    """Display informational message to user if a parameter conflict is found.
+
+    Parameters
+    ----------
+    ctx : typer.Context
+        The typer context object.
+    value : bool
+        The value of the dry-run parameter.
+
+    Returns
+    -------
+    bool
+    """
     output = ctx.params.get("output", "")
 
     if value and output:
@@ -135,6 +147,10 @@ def clobber_output(ctx: typer.Context, value: bool) -> bool:
         The typer context object.
     value : bool
         The value of the clobber parameter.
+
+    Returns
+    -------
+    bool
     """
     output = ctx.params.get("output", "")
     if value and output:

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -170,7 +170,10 @@ def migrate(
         typer.Option(
             ARG_CLOBBER,
             help=ARG_CLOBBER_HELP,
-            callback=set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),  # extra=clobber_output),
+            callback=cb_pipeline(
+                set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),
+                clobber_output,
+            ),
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
         ),
     ] = False,

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -7,7 +7,6 @@ from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLI_VERBOSE
 from cstar.cli.common import (
     cb_pipeline,
     execute_migration,
-    set_env,
     set_flag,
 )
 from cstar.entrypoint.utils import (
@@ -78,7 +77,7 @@ def migrate(
             ARG_DRY_RUN,
             help="Generate the migration plan without executing it.",
             callback=cb_pipeline(
-                set_env(ENV_CSTAR_CLI_DRY_RUN),
+                set_flag(ENV_CSTAR_CLI_DRY_RUN),
                 migrate_dryrun_callback,
             ),
             envvar=ENV_CSTAR_CLI_DRY_RUN,

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -2,26 +2,23 @@ import typing as t
 from pathlib import Path
 
 import typer
-from rich.console import Console
-from rich.table import Column, Table
 
-from cstar.applications.core import get_application
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLI_VERBOSE
-from cstar.base.exceptions import CstarExpectationFailed
-from cstar.base.feature import is_flag_enabled
-from cstar.cli.common import cb_pipeline, set_env
+from cstar.cli.common import (
+    cb_pipeline,
+    execute_migration,
+    set_env,
+    set_flag,
+)
 from cstar.entrypoint.utils import (
     ARG_DRY_RUN,
     ARG_OUTPUT_LONG,
     ARG_OUTPUT_SHORT,
     ARG_VERBOSE,
+    ARG_VERBOSE_HELP,
 )
-from cstar.execution.file_system import is_remote_resource, local_copy
-from cstar.orchestration.models import Blueprint
-from cstar.orchestration.serialization import serialize, validate_serialized_entity
-from cstar.system.migration import BlueprintMigration, MigrationPlan
+from cstar.execution.file_system import is_remote_resource
 
-console = Console()
 app = typer.Typer()
 
 
@@ -33,48 +30,6 @@ The schema will be updated to the latest available version. If an output
 path is not provided, it will be written next to the existing
 file with the version number appended to the file name.
 """
-
-
-def display_summary(bp_path: Path, migration_plan: MigrationPlan) -> None:
-    """Display a summary of the migration plan.
-
-    Parameters
-    ----------
-    bp_path : Path
-        The path to the blueprint being migrated.
-    migration_plan : MigrationPlan
-        Details of the planned migration.
-    """
-    source, target, plan = migration_plan
-
-    if not is_flag_enabled(ENV_CSTAR_CLI_VERBOSE):
-        print(f"Migration from {source!r} to {target!r} will take {len(plan)} steps.")
-        return
-
-    source, target, plan = migration_plan
-    padding = (0, 1)
-
-    table = Table(
-        Column(header="Step", justify="center"),
-        Column(header="From", justify="center"),
-        Column(header="To", justify="center"),
-        title=f"Migration Plan for [yellow]{bp_path.name}[/yellow]",
-        show_lines=True,
-        padding=padding,
-        pad_edge=False,
-        row_styles=["", "dim"],
-        min_width=40,
-        caption=f"Initial Schema: [green]{source}[/green]\nFinal Schema: [red]{target}[/red]",
-    )
-
-    for i, adapter in enumerate(plan):
-        table.add_row(
-            str(i + 1),
-            adapter.source(),
-            adapter.target(),
-        )
-
-    console.print(table)
 
 
 def path_callback(value: str | None) -> str | None:
@@ -133,58 +88,11 @@ def migrate(
         bool,
         typer.Option(
             ARG_VERBOSE,
-            help="Enable printing verbose migration outputs.",
-            callback=set_env(ENV_CSTAR_CLI_VERBOSE),
+            help=ARG_VERBOSE_HELP,
+            callback=set_flag(ENV_CSTAR_CLI_VERBOSE),
             envvar=ENV_CSTAR_CLI_VERBOSE,
         ),
     ] = False,
 ) -> None:
     """Migrate the schema of an old blueprint to the latest version."""
-    result = validate_serialized_entity(path, Blueprint)
-    if result.item is None:
-        raise typer.BadParameter(result.error_msg)
-
-    migrator = BlueprintMigration()
-    with local_copy(path) as local_path:
-        dumped = result.item.model_dump()
-
-        try:
-            plan = migrator.plan(dumped)
-        except CstarExpectationFailed as ex:
-            msg = f"Unable to complete migration plan: {ex}"
-            raise typer.BadParameter(msg) from ex
-
-        display_summary(local_path, plan)
-
-        if plan.source == plan.target:
-            print(f"The blueprint uses the latest schema ({plan.source})")
-            raise typer.Exit(0)
-
-        if dry_run:
-            raise typer.Exit(0)
-
-        try:
-            updated = migrator.migrate(dumped)
-        except CstarExpectationFailed as ex:
-            msg = f"Unable to complete migration: {ex}"
-            raise typer.BadParameter(msg) from ex
-        else:
-            print("Migration complete")
-
-        persist_to = (
-            Path(f"./{local_path.stem}_{plan.target}{local_path.suffix}")
-            if output is None
-            else Path(output)
-        )
-        persist_to = persist_to.expanduser().resolve()
-
-        try:
-            bp_type = get_application(result.item.application).blueprint
-            updated_bp = bp_type(**updated)
-            nbytes = serialize(persist_to, updated_bp)
-            assert nbytes, "The migrated blueprint failed to write content"
-        except SyntaxError as ex:
-            msg = f"Unable to complete migration: {ex}"
-            raise typer.BadParameter(msg) from ex
-        else:
-            print(f"Migrated blueprint persisted to {str(persist_to)!r}")
+    execute_migration(path, output, dry_run)

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -10,6 +10,7 @@ from cstar.applications.core import (
     get_application,
 )
 from cstar.base.env import (
+    ENV_CSTAR_CLI_VERBOSE,
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
     get_env_item,
@@ -17,6 +18,7 @@ from cstar.base.env import (
 from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
     cb_pipeline,
+    execute_migration,
     set_env,
     set_flag,
     update_loggers,
@@ -30,14 +32,16 @@ from cstar.entrypoint.utils import (
     ARG_LOGLEVEL_HELP,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
+    ARG_VERBOSE,
+    ARG_VERBOSE_HELP,
 )
 from cstar.execution.file_system import local_copy
-from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import deserialize, validate_serialized_entity
 from cstar.orchestration.transforms import DirectiveConfig
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.runner import BlueprintRunner
+    from cstar.orchestration.models import Blueprint
 
 app = typer.Typer()
 log = get_logger(__name__)
@@ -49,7 +53,8 @@ def path_callback(
 ) -> str:
     """Validate the blueprint content after typer has parsed the path.
 
-    Additionally, loads the blueprint and stores in the context for later use.
+    Additionally, loads the blueprint, performs automatic schema migration
+    if necessary, and stores the updated blueprint in the context for later use.
 
     Parameters
     ----------
@@ -61,25 +66,29 @@ def path_callback(
     Returns
     -------
     str
-        The path to the blueprint.
+        The path to the blueprint (or the newly migrated blueprint file).
     """
     try:
-        with local_copy(path) as local_path:
-            if not local_path.exists():
-                msg = f"Blueprint not found at path: {path}"
-                raise typer.BadParameter(msg)
+        migration_result = execute_migration(path)
+        ctx.obj = migration_result.blueprint
 
-            # use the core blueprint fields to identify the application type
-            base_bp = deserialize(local_path, Blueprint)
-            bp_type: type[Blueprint] = get_application(base_bp.application).blueprint
-
-            ctx.obj = bp_type(**base_bp.model_dump())
+        if migration_result.path:
+            return str(migration_result.path)
 
     except FileNotFoundError as ex:
         msg = f"Blueprint file not found: {path}"
         raise typer.BadParameter(msg) from ex
     except ValidationError as ex:
         msg = f"Blueprint file is malformed: {ex}"
+        raise typer.BadParameter(msg) from ex
+    except Exception as ex:
+        # If the error is essentially that the file doesn't exist (e.g. from validate_serialized_entity)
+        # we want to preserve the "not found" message for tests and user clarity.
+        if "not found" in str(ex).lower() or "no such file" in str(ex).lower():
+            msg = f"Blueprint not found at path: {path}"
+            raise typer.BadParameter(msg) from ex
+
+        msg = f"Unable to process or migrate blueprint: {ex}"
         raise typer.BadParameter(msg) from ex
 
     return path
@@ -157,6 +166,15 @@ def run(
             callback=directives_callback,
         ),
     ] = None,
+    verbose: t.Annotated[
+        bool,
+        typer.Option(
+            ARG_VERBOSE,
+            help=ARG_VERBOSE_HELP,
+            callback=set_flag(ENV_CSTAR_CLI_VERBOSE),
+            envvar=ENV_CSTAR_CLI_VERBOSE,
+        ),
+    ] = False,
 ) -> None:
     """Execute a blueprint in a local worker service."""
     bp = t.cast("Blueprint", ctx.obj)

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -1,5 +1,6 @@
 import asyncio
 import typing as t
+from pathlib import Path
 
 import typer
 from pydantic import ValidationError
@@ -15,10 +16,13 @@ from cstar.base.env import (
     ENV_CSTAR_LOG_LEVEL,
     get_env_item,
 )
+from cstar.base.feature import ENV_FF_CLI_BP_MIGRATE_AUTO, is_feature_enabled
 from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
+    MigrationRequest,
     cb_pipeline,
     execute_migration,
+    print_validation_errors,
     set_env,
     set_flag,
     update_loggers,
@@ -36,12 +40,16 @@ from cstar.entrypoint.utils import (
     ARG_VERBOSE_HELP,
 )
 from cstar.execution.file_system import local_copy
+from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import deserialize, validate_serialized_entity
 from cstar.orchestration.transforms import DirectiveConfig
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.runner import BlueprintRunner
-    from cstar.orchestration.models import Blueprint
+
+
+CMD_NAME: t.Final[str] = "run"
+CMD_HELP: t.Final[str] = "Execute a blueprint in a local worker service."
 
 app = typer.Typer()
 log = get_logger(__name__)
@@ -69,26 +77,28 @@ def path_callback(
         The path to the blueprint (or the newly migrated blueprint file).
     """
     try:
-        migration_result = execute_migration(path)
-        ctx.obj = migration_result.blueprint
+        with local_copy(path) as local_path:
+            if is_feature_enabled(ENV_FF_CLI_BP_MIGRATE_AUTO):
+                request = MigrationRequest(path=local_path)
+                result, bp_path = execute_migration(request)
 
-        if migration_result.path:
-            return str(migration_result.path)
+                if result.error:
+                    print(result.error)
+                    raise typer.Exit(1)
+            else:
+                bp_path = Path(local_path)
+
+            base_bp = deserialize(bp_path, Blueprint)
+            app = get_application(base_bp.application)
+            ctx.obj = app.blueprint(**base_bp.model_dump())
+            return str(bp_path)
 
     except FileNotFoundError as ex:
-        msg = f"Blueprint file not found: {path}"
+        msg = f"Blueprint file not found: {ex.filename}"
         raise typer.BadParameter(msg) from ex
     except ValidationError as ex:
-        msg = f"Blueprint file is malformed: {ex}"
-        raise typer.BadParameter(msg) from ex
-    except Exception as ex:
-        # If the error is essentially that the file doesn't exist (e.g. from validate_serialized_entity)
-        # we want to preserve the "not found" message for tests and user clarity.
-        if "not found" in str(ex).lower() or "no such file" in str(ex).lower():
-            msg = f"Blueprint not found at path: {path}"
-            raise typer.BadParameter(msg) from ex
-
-        msg = f"Unable to process or migrate blueprint: {ex}"
+        print_validation_errors(ex)
+        msg = f"Blueprint file is malformed: {path}"
         raise typer.BadParameter(msg) from ex
 
     return path
@@ -128,7 +138,7 @@ def directives_callback(path: str | None) -> str | None:
     return path
 
 
-@app.command(name="run", help="Execute a blueprint in a local worker service.")
+@app.command(name=CMD_NAME, help=CMD_HELP)
 def run(
     ctx: typer.Context,
     uri: t.Annotated[

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -19,6 +19,7 @@ from cstar.base.env import (
 )
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, reset_log_level
+from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import serialize, validate_serialized_entity
 from cstar.system.migration import (
@@ -26,7 +27,6 @@ from cstar.system.migration import (
     MigrateResult,
     MigrationPlan,
     MigrationRequest,
-    get_persist_to,
 )
 
 app = typer.Typer()
@@ -243,6 +243,30 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
 
 def on_migrated_callback(plan: MigrationPlan) -> None:
     print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
+
+
+def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Path:
+    """Determine the persistence path for a migrated model.
+
+    If a target is not supplied by the user, write to the `CSTAR_STATE_HOME`
+    directory.
+
+    Parameters
+    ----------
+    source : Path
+        Path to the file containing the original, serialized model.
+    target : Path | None
+        The user-supplied path
+    """
+    if target is not None:
+        output = target
+    else:
+        stem = source.stem
+        suffix = source.suffix
+        state_dir = DirectoryManager.state_home()
+        output = state_dir / f"{stem}_{plan.target}{suffix}"
+
+    return output.expanduser().resolve()
 
 
 def persist_migration(request: MigrationRequest, result: MigrateResult) -> Path:

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -1,3 +1,4 @@
+import functools
 import importlib
 import os
 import typing as t
@@ -5,6 +6,9 @@ from collections.abc import Callable
 from pathlib import Path
 
 import typer
+from pydantic import (
+    ValidationError,
+)
 
 import cstar
 from cstar.applications.core import get_application
@@ -13,17 +17,17 @@ from cstar.base.env import (
     ENV_CSTAR_LOG_LEVEL,
     FLAG_ON,
 )
-from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, reset_log_level
-from cstar.execution.file_system import local_copy
 from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import serialize, validate_serialized_entity
 from cstar.system.migration import (
     BlueprintMigration,
-    CstarMigrationError,
+    MigrateResult,
     MigrationPlan,
-    MigrationResult,
+    MigrationRequest,
+    PersistedMigrateResult,
+    get_persist_to,
 )
 
 app = typer.Typer()
@@ -185,7 +189,7 @@ def autoimport_apps(module_names: list[str]) -> None:
         importlib.import_module(module_name)
 
 
-def display_migration_plan(bp_path: Path, migration_plan: MigrationPlan) -> None:
+def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
     """Display a summary of the migration plan.
 
     Parameters
@@ -195,10 +199,18 @@ def display_migration_plan(bp_path: Path, migration_plan: MigrationPlan) -> None
     migration_plan : MigrationPlan
         Details of the planned migration.
     """
+    if not is_flag_enabled(ENV_CSTAR_CLI_VERBOSE) or not plan.adapters:
+        if plan.is_latest:
+            print(f"No migration needed for schema {plan.source!r} in {str(bp_path)!r}")
+        else:
+            num_steps = len(plan.adapters)
+            print(f"Migrating {plan.source!r}->{plan.target!r} in {num_steps} steps.")
+        return
+
     from rich.console import Console  # noqa: PLC0415
     from rich.table import Column, Table  # noqa: PLC0415
 
-    source, target, plan = migration_plan
+    source, target, adapters = plan
     padding = (0, 1)
     console = Console()
 
@@ -215,7 +227,7 @@ def display_migration_plan(bp_path: Path, migration_plan: MigrationPlan) -> None
         caption=f"Initial Schema: [green]{source}[/green]\nFinal Schema: [red]{target}[/red]",
     )
 
-    for i, adapter in enumerate(plan):
+    for i, adapter in enumerate(adapters):
         table.add_row(
             str(i + 1),
             adapter.source(),
@@ -225,82 +237,87 @@ def display_migration_plan(bp_path: Path, migration_plan: MigrationPlan) -> None
     console.print(table)
 
 
-def execute_migration(
-    path: str,
-    output: str | None = None,
-    dry_run: bool = False,
-) -> MigrationResult:
-    """Execute the schema migration for a blueprint.
+def on_migrated_callback(plan: MigrationPlan) -> None:
+    print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
 
-    Parameters
-    ----------
-    path : str
-        The path to the blueprint file.
-    output : str | None
-        The path to the output file.
-    dry_run : bool
-        If True, simulate the migration without persisting changes.
+
+def persist_migration(request: MigrationRequest, result: MigrateResult) -> Path:
+    """Serialize the migrated entity to disk.
 
     Returns
     -------
-    MigrationResult
-        NamedTuple containing the migrated blueprint and the persistence path.
+    Path
+        The path to the persisted entity file.
     """
-    result = validate_serialized_entity(path, Blueprint)
-    if result.item is None:
-        raise typer.BadParameter(result.error_msg)
+    if result.plan is None:
+        msg = "Unable to persist an unplanned migration"
+        raise ValueError(msg)
 
-    migrator = BlueprintMigration()
-    with local_copy(path) as local_path:
-        dumped = result.item.model_dump()
+    persist_to = get_persist_to(request.source, request.target, result.plan)
 
     try:
-        plan = migrator.plan(dumped)
-    except (CstarExpectationFailed, CstarMigrationError) as ex:
-        msg = f"Unable to complete migration plan: {ex}"
-        raise typer.BadParameter(msg) from ex
-
-    # The summary/latest-check logic must be inside the local_copy context
-    # to ensure the local file is available if needed by the summary function.
-    if plan.source == plan.target:
-        print(f"The blueprint uses the latest schema ({plan.source})")
-        bp_type = get_application(result.item.application).blueprint
-        return MigrationResult(bp_type(**dumped), None)
-
-    if is_flag_enabled(ENV_CSTAR_CLI_VERBOSE):
-        display_migration_plan(local_path, plan)
-    else:
-        num_steps = len(plan.adapters)
-        print(f"Migrating {plan.source!r}->{plan.target!r} in {num_steps} steps.")
-
-    if dry_run:
-        bp_type = get_application(result.item.application).blueprint
-        return MigrationResult(bp_type(**dumped), None)
-
-    try:
-        updated = migrator.migrate(dumped)
-    except (CstarExpectationFailed, CstarMigrationError) as ex:
-        msg = f"Unable to complete migration: {ex}"
-        raise typer.BadParameter(msg) from ex
-    else:
-        print("Migration complete")
-
-    persist_to = (
-        Path(f"./{local_path.stem}_{plan.target}{local_path.suffix}")
-        if output is None
-        else Path(output)
-    )
-    persist_to = persist_to.expanduser().resolve()
-
-    try:
-        bp_type = get_application(result.item.application).blueprint
-        updated_bp = bp_type(**updated)
+        bp_type = get_application(result.application).blueprint
+        updated_bp = bp_type(**result.migrated)
         nbytes = serialize(persist_to, updated_bp)
         assert nbytes, "The migrated blueprint failed to write content"
     except SyntaxError as ex:
         msg = f"Unable to complete migration: {ex}"
         raise typer.BadParameter(msg) from ex
-    else:
-        print(f"Migrated blueprint persisted to {str(persist_to)!r}")
 
-    return MigrationResult(updated_bp, persist_to)
+    return persist_to
+
+
+def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
+    """Execute the schema migration for a blueprint.
+
+    Parameters
+    ----------
+    request : MigrationRequest
+        Parameters to pass to the migrator.
+
+    Returns
+    -------
+    PersistedMigrationResult
+        Named tuple containing the migration result and path where it was persisted.
+    """
+    validation_result = validate_serialized_entity(request.source, Blueprint)
+    if validation_result.item is None:
+        raise typer.BadParameter(validation_result.error_msg)
+
+    dumped = validation_result.item.model_dump()
+
+    migrator = BlueprintMigration(
+        on_planned=functools.partial(on_planned_callback, request.source),
+        on_migrated=on_migrated_callback,
+    )
+
+    if request.dry_run():
+        migrator.plan(dumped)
+        raise typer.Exit(0)
+
+    migration_result = migrator.plan_and_migrate(dumped)
+    if migration_result.error:
+        print(migration_result.error)
+        raise typer.Exit(1)
+
+    plan = migration_result.plan
+    if not plan:
+        print("Migration failed to produce a plan.")
+        raise typer.Exit(2)
+
+    persisted_to = persist_migration(request, migration_result)
+
+    return PersistedMigrateResult(migration_result, persisted_to)
+
+
+def print_validation_errors(ex: ValidationError) -> None:
+    """Display the contents of a validation error in a user-friendly format."""
+    error_format: t.Final[str] = "Invalid {0} value ({1}): {2}"
+
+    for error in ex.errors():
+        msg = error_format.format(
+            f"{error['loc'][0]!r}",
+            f"{error['input']!r}",
+            f"{error['msg']}",
+        )
+        print(msg)

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -26,7 +26,6 @@ from cstar.system.migration import (
     MigrateResult,
     MigrationPlan,
     MigrationRequest,
-    PersistedMigrateResult,
     get_persist_to,
 )
 
@@ -187,6 +186,11 @@ def locate_app_modules() -> list[str]:
 def autoimport_apps(module_names: list[str]) -> None:
     for module_name in module_names:
         importlib.import_module(module_name)
+
+
+class PersistedMigrateResult(t.NamedTuple):
+    result: MigrateResult
+    target: str | Path
 
 
 def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -300,8 +300,7 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
         print(migration_result.error)
         raise typer.Exit(1)
 
-    plan = migration_result.plan
-    if not plan:
+    if not migration_result.plan:
         print("Migration failed to produce a plan.")
         raise typer.Exit(2)
 

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -7,11 +7,24 @@ from pathlib import Path
 import typer
 
 import cstar
+from cstar.applications.core import get_application
 from cstar.base.env import (
+    ENV_CSTAR_CLI_VERBOSE,
     ENV_CSTAR_LOG_LEVEL,
     FLAG_ON,
 )
+from cstar.base.exceptions import CstarExpectationFailed
+from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, reset_log_level
+from cstar.execution.file_system import local_copy
+from cstar.orchestration.models import Blueprint
+from cstar.orchestration.serialization import serialize, validate_serialized_entity
+from cstar.system.migration import (
+    BlueprintMigration,
+    CstarMigrationError,
+    MigrationPlan,
+    MigrationResult,
+)
 
 app = typer.Typer()
 
@@ -170,3 +183,124 @@ def locate_app_modules() -> list[str]:
 def autoimport_apps(module_names: list[str]) -> None:
     for module_name in module_names:
         importlib.import_module(module_name)
+
+
+def display_migration_plan(bp_path: Path, migration_plan: MigrationPlan) -> None:
+    """Display a summary of the migration plan.
+
+    Parameters
+    ----------
+    bp_path : Path
+        The path to the blueprint being migrated.
+    migration_plan : MigrationPlan
+        Details of the planned migration.
+    """
+    from rich.console import Console  # noqa: PLC0415
+    from rich.table import Column, Table  # noqa: PLC0415
+
+    source, target, plan = migration_plan
+    padding = (0, 1)
+    console = Console()
+
+    table = Table(
+        Column(header="Step", justify="center"),
+        Column(header="From", justify="center"),
+        Column(header="To", justify="center"),
+        title=f"Migration Plan for [yellow]{bp_path.name}[/yellow]",
+        show_lines=True,
+        padding=padding,
+        pad_edge=False,
+        row_styles=["", "dim"],
+        min_width=40,
+        caption=f"Initial Schema: [green]{source}[/green]\nFinal Schema: [red]{target}[/red]",
+    )
+
+    for i, adapter in enumerate(plan):
+        table.add_row(
+            str(i + 1),
+            adapter.source(),
+            adapter.target(),
+        )
+
+    console.print(table)
+
+
+def execute_migration(
+    path: str,
+    output: str | None = None,
+    dry_run: bool = False,
+) -> MigrationResult:
+    """Execute the schema migration for a blueprint.
+
+    Parameters
+    ----------
+    path : str
+        The path to the blueprint file.
+    output : str | None
+        The path to the output file.
+    dry_run : bool
+        If True, simulate the migration without persisting changes.
+
+    Returns
+    -------
+    MigrationResult
+        NamedTuple containing the migrated blueprint and the persistence path.
+    """
+    result = validate_serialized_entity(path, Blueprint)
+    if result.item is None:
+        raise typer.BadParameter(result.error_msg)
+
+    migrator = BlueprintMigration()
+    with local_copy(path) as local_path:
+        dumped = result.item.model_dump()
+
+    try:
+        plan = migrator.plan(dumped)
+    except (CstarExpectationFailed, CstarMigrationError) as ex:
+        msg = f"Unable to complete migration plan: {ex}"
+        raise typer.BadParameter(msg) from ex
+
+    # The summary/latest-check logic must be inside the local_copy context
+    # to ensure the local file is available if needed by the summary function.
+    if plan.source == plan.target:
+        print(f"The blueprint uses the latest schema ({plan.source})")
+        bp_type = get_application(result.item.application).blueprint
+        return MigrationResult(bp_type(**dumped), None)
+
+    if is_flag_enabled(ENV_CSTAR_CLI_VERBOSE):
+        display_migration_plan(local_path, plan)
+    else:
+        num_steps = len(plan.adapters)
+        print(f"Migrating {plan.source!r}->{plan.target!r} in {num_steps} steps.")
+
+    if dry_run:
+        bp_type = get_application(result.item.application).blueprint
+        return MigrationResult(bp_type(**dumped), None)
+
+    try:
+        updated = migrator.migrate(dumped)
+    except (CstarExpectationFailed, CstarMigrationError) as ex:
+        msg = f"Unable to complete migration: {ex}"
+        raise typer.BadParameter(msg) from ex
+    else:
+        print("Migration complete")
+
+    persist_to = (
+        Path(f"./{local_path.stem}_{plan.target}{local_path.suffix}")
+        if output is None
+        else Path(output)
+    )
+    persist_to = persist_to.expanduser().resolve()
+
+    try:
+        bp_type = get_application(result.item.application).blueprint
+        updated_bp = bp_type(**updated)
+        nbytes = serialize(persist_to, updated_bp)
+        assert nbytes, "The migrated blueprint failed to write content"
+    except SyntaxError as ex:
+        msg = f"Unable to complete migration: {ex}"
+        raise typer.BadParameter(msg) from ex
+    else:
+        print(f"Migrated blueprint persisted to {str(persist_to)!r}")
+
+    return MigrationResult(updated_bp, persist_to)

--- a/cstar/entrypoint/utils.py
+++ b/cstar/entrypoint/utils.py
@@ -20,3 +20,4 @@ ARG_URI_LONG: t.Final[str] = "--blueprint-uri"
 ARG_URI_SHORT: t.Final[str] = "-b"
 
 ARG_VERBOSE: t.Final[str] = "--verbose"
+ARG_VERBOSE_HELP: t.Final[str] = "Set this flag to print verbose CLI outputs."

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import typing as t
+from collections.abc import AsyncGenerator, Generator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,7 +46,7 @@ class XdgMetaContainer:
     state: "EnvItem"
     """Metadata used to identify the state directory."""
 
-    def __iter__(self) -> t.Iterator["EnvItem"]:
+    def __iter__(self) -> Iterator["EnvItem"]:
         """Return an iterable containing all settings contained in the instance."""
         yield self.cache
         yield self.config
@@ -311,7 +312,7 @@ class RomsFileSystemManager(JobFileSystemManager):
                     self.input_datasets_dir,
                     self._codebases_dir,
                     self.joined_output_dir,
-                }
+                },
             )
         )
 
@@ -462,7 +463,7 @@ def write_local_copy(url: str, directory: Path) -> Path:
 
 
 @contextmanager
-def local_copy(uri: str) -> t.Generator[Path, None, None]:
+def local_copy(uri: str) -> Generator[Path, None, None]:
     """Context manager used to create a local copy of a remote resource.
 
     When the uri references a local resource, it is used without being copied.
@@ -486,7 +487,7 @@ def local_copy(uri: str) -> t.Generator[Path, None, None]:
 
 
 @asynccontextmanager
-async def local_copy_async(uri: str) -> t.AsyncGenerator[Path, None]:
+async def local_copy_async(uri: str) -> AsyncGenerator[Path, None]:
     """Asynchronous context manager used to create a local copy of a remote resource.
 
     When the uri references a local resource, it is used without being copied.

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import functools
 import os
 import shutil
@@ -438,16 +439,21 @@ def write_local_copy(url: str, directory: Path) -> Path:
     -------
     Path
         The local path where the remote resource was copied
+
+    Raises
+    ------
+    FileNotFoundError
+        If the remote URL cannot be retrieved.
     """
     parsed_url = urlsplit(url)
     resource_path = Path(parsed_url.path)
     resource_name = resource_path.name
     http_ok: t.Final[int] = 200
 
-    get_request = request("GET", url, timeout=2.0)
+    get_request = request("GET", url, timeout=1.0)
     if get_request.status_code != http_ok:
-        msg = f"Unable to retrieve file from: {url}"
-        raise FileNotFoundError(msg)
+        msg = "Unable to retrieve remote file"
+        raise FileNotFoundError(errno.ENOENT, msg, url)
 
     local_path = directory / resource_name
     local_path.write_text(get_request.text)

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -479,7 +479,7 @@ def local_copy(uri: str) -> Generator[Path, None, None]:
         A path to a local copy of the resource
     """
     if is_remote_resource(uri):
-        with TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory(delete=False) as tmp_dir:
             bp_path = write_local_copy(uri, Path(tmp_dir))
             yield bp_path
     else:

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import sys
 import typing as t
-from collections.abc import AsyncGenerator, Generator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,7 +45,7 @@ class XdgMetaContainer:
     state: "EnvItem"
     """Metadata used to identify the state directory."""
 
-    def __iter__(self) -> Iterator["EnvItem"]:
+    def __iter__(self) -> t.Iterator["EnvItem"]:
         """Return an iterable containing all settings contained in the instance."""
         yield self.cache
         yield self.config
@@ -312,7 +311,7 @@ class RomsFileSystemManager(JobFileSystemManager):
                     self.input_datasets_dir,
                     self._codebases_dir,
                     self.joined_output_dir,
-                },
+                }
             )
         )
 
@@ -440,11 +439,6 @@ def write_local_copy(url: str, directory: Path) -> Path:
     -------
     Path
         The local path where the remote resource was copied
-
-    Raises
-    ------
-    FileNotFoundError
-        If the remote URL cannot be retrieved.
     """
     parsed_url = urlsplit(url)
     resource_path = Path(parsed_url.path)
@@ -463,7 +457,7 @@ def write_local_copy(url: str, directory: Path) -> Path:
 
 
 @contextmanager
-def local_copy(uri: str) -> Generator[Path, None, None]:
+def local_copy(uri: str) -> t.Generator[Path, None, None]:
     """Context manager used to create a local copy of a remote resource.
 
     When the uri references a local resource, it is used without being copied.
@@ -487,7 +481,7 @@ def local_copy(uri: str) -> Generator[Path, None, None]:
 
 
 @asynccontextmanager
-async def local_copy_async(uri: str) -> AsyncGenerator[Path, None]:
+async def local_copy_async(uri: str) -> t.AsyncGenerator[Path, None]:
     """Asynchronous context manager used to create a local copy of a remote resource.
 
     When the uri references a local resource, it is used without being copied.

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -1,13 +1,24 @@
 import abc
 import typing as t
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
 
-from cstar.base.adapter import ModelAdapter
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FilePath,
+    NewPath,
+    ValidationInfo,
+    field_validator,
+)
 
-if t.TYPE_CHECKING:
-    from cstar.orchestration.models import Blueprint
+from cstar.base.adapter import ModelAdapter
+from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLOBBER_WORKING_DIR
+from cstar.base.feature import is_flag_enabled
+from cstar.base.log import LoggingMixin
+from cstar.execution.file_system import DirectoryManager
 
 APP_ROMS_MARBL: t.Literal["roms_marbl"] = "roms_marbl"
 APP_ROMS_MARBL_SCHEMA_1_0_0: t.Literal["1.0.0"] = "1.0.0"
@@ -125,6 +136,56 @@ ConverterMap: t.TypeAlias = Mapping[tuple[str, str, str], type[SchemaAdapter]]
 """A mapping of (application, source version, target version) keys to adapters."""
 
 
+class MigrationRequest(BaseModel):
+    source: FilePath = Field(
+        frozen=True,
+        description="Path to a file containing a serialized blueprint",
+        alias="path",
+    )
+    target: NewPath | None = Field(
+        default=None,
+        description="Path where the migrated blueprint will be serialized",
+        frozen=True,
+        alias="output",
+    )
+
+    config: t.ClassVar[ConfigDict] = ConfigDict(str_strip_whitespace=True)
+    """Model configuration ensuring attributes have whitespace stripped."""
+
+    @classmethod
+    def dry_run(cls) -> bool:
+        """Return `True` if dry-run is enabled."""
+        return is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN)
+
+    @classmethod
+    def clobber(cls) -> bool:
+        """Return `True` if clobber is enabled."""
+        return is_flag_enabled(ENV_CSTAR_CLOBBER_WORKING_DIR)
+
+    @field_validator("target", mode="before")
+    @classmethod
+    def _clobber_target(
+        cls,
+        value: str,
+        _info: "ValidationInfo",
+    ) -> str:
+        """Remove a pre-existing target file if clobber is enabled.
+
+        Parameters
+        ----------
+        value : str
+            The value of the target property
+        _info : ValidationInfo
+            Metadata for the current validation context
+        """
+        if cls.clobber() and value:
+            path = Path(value)
+            if path.exists() and path.is_file():
+                path.unlink()
+
+        return value
+
+
 class MigrationPlan(t.NamedTuple):
     """Results describing the plan that will be used to complete a migration."""
 
@@ -135,17 +196,34 @@ class MigrationPlan(t.NamedTuple):
     adapters: Sequence[type[SchemaAdapter]]
     """An ordered list of adapters that will complete the migration when applied."""
 
+    @property
+    def is_latest(self) -> bool:
+        return self.source == self.target
 
-class MigrationResult(t.NamedTuple):
+
+class MigrateResult(t.NamedTuple):
     """The results of an executed migration."""
 
-    blueprint: "Blueprint"
-    """The migrated blueprint (or original if up-to-date)."""
-    path: Path | None
-    """The path where the migrated blueprint was saved (if applicable)."""
+    original: dict[str, t.Any]
+    """The original model content."""
+    migrated: dict[str, t.Any]
+    """The migrated model content."""
+    error: str = ""
+    """Error(s) causing the migration to fail."""
+    plan: MigrationPlan | None = None
+    """The migration plan if migration was possible, otherwise `None`."""
+
+    @property
+    def application(self) -> str:
+        return self.migrated.get("application", "")
 
 
-class Migration(abc.ABC):
+class PersistedMigrateResult(t.NamedTuple):
+    result: MigrateResult
+    target: str | Path
+
+
+class Migration(abc.ABC, LoggingMixin):
     """Base class for types that will execute a version migration by executing
     one to many SchemaAdapters.
     """
@@ -156,7 +234,19 @@ class Migration(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def migrate(self, dumped: dict[str, t.Any]) -> dict[str, t.Any]:
+    def migrate(
+        self,
+        dumped: dict[str, t.Any],
+        plan: MigrationPlan,
+    ) -> dict[str, t.Any]:
+        """Execute the upgrade path."""
+        ...
+
+    @abc.abstractmethod
+    def plan_and_migrate(
+        self,
+        dumped: dict[str, t.Any],
+    ) -> MigrateResult:
         """Execute the upgrade path."""
         ...
 
@@ -208,6 +298,10 @@ class HelloWorldSchemaAdapter2025v1(SchemaAdapter):
         return {**model}
 
 
+OnPlannedCallback: t.TypeAlias = Callable[[MigrationPlan], None]
+OnMigratedCallback: t.TypeAlias = Callable[[MigrationPlan], None]
+
+
 class BlueprintMigration(Migration):
     """A migration controller for RomsMarblBlueprints."""
 
@@ -218,14 +312,23 @@ class BlueprintMigration(Migration):
     schema_bounds: Mapping[str, SchemaBounds]
     """A mapping of unique app names to their minimum and maximum schema version."""
 
+    on_planned_callback: Callable[[MigrationPlan], None] | None = None
+    """Callback executed when the migrator completes a plan."""
+    on_migrated_callback: Callable[[MigrationPlan], None] | None = None
+    """Callback executed when the migrator completes a migration."""
+
     def __init__(
         self,
         adapters: Sequence[type[SchemaAdapter]] | None = None,
         schema_bounds: Mapping[str, SchemaBounds] | None = None,
+        on_planned: OnPlannedCallback | None = None,
+        on_migrated: OnMigratedCallback | None = None,
     ) -> None:
         self.adapters = adapters or [RomsMarblSchemaAdapter2025v1]
         self.schema_bounds = schema_bounds or default_schema_bounds
         self.adapter_lookup = self._build_adapter_lookup()
+        self.on_planned_callback = on_planned
+        self.on_migrated_callback = on_migrated
 
     def _build_adapter_lookup(self) -> ConverterMap:
         """Build the mapping that enables the lookup of adapters.
@@ -256,7 +359,7 @@ class BlueprintMigration(Migration):
         CstarUnsupportedMigrationError
             If unable to identify a complete migration upgrade path.
         """
-        plan: list[type[SchemaAdapter]] = []
+        adapters: list[type[SchemaAdapter]] = []
         application = dumped["application"]
 
         if application not in self.schema_bounds:
@@ -283,16 +386,23 @@ class BlueprintMigration(Migration):
                 raise CstarUnsupportedMigrationError(msg)
 
             # store adapter and prepare to traverse the next edge
-            plan.append(self.adapter_lookup[key])
+            adapters.append(self.adapter_lookup[key])
             _, _, version = key
 
         if version != goal:
             msg = f"Incomplete migration from {initial_version!r} to {goal!r}"
             raise CstarUnsupportedMigrationError(msg)
 
-        return MigrationPlan(initial_version, goal, plan)
+        migration_plan = MigrationPlan(initial_version, goal, adapters)
+        if self.on_planned_callback:
+            self.on_planned_callback(migration_plan)
+        return migration_plan
 
-    def migrate(self, dumped: dict[str, t.Any]) -> dict[str, t.Any]:
+    def migrate(
+        self,
+        dumped: dict[str, t.Any],
+        plan: MigrationPlan,
+    ) -> dict[str, t.Any]:
         """Execute the plan to upgrade the blueprint to the latest version.
 
         Returns
@@ -305,14 +415,68 @@ class BlueprintMigration(Migration):
         CstarMigrationError
             If the migration cannot be completed.
         """
-        source, target, plan = self.plan(dumped)
+        # source, target, plan = self.plan(dumped)
         model = deepcopy(dumped)
 
-        for klass in plan:
+        for klass in plan.adapters:
             if model := klass(model).adapt():
                 continue
 
-            msg = f"Schema migration from {source!r} to {target!r} failed."
+            msg = f"Schema migration from {plan.source!r} to {plan.target!r} failed."
             raise CstarMigrationError(msg)
 
+        if self.on_migrated_callback:
+            self.on_migrated_callback(plan)
         return model
+
+    def plan_and_migrate(self, dumped: dict[str, t.Any]) -> MigrateResult:
+        """Create a migration plan and execute it."""
+        try:
+            plan = self.plan(dumped)
+        except CstarUnsupportedMigrationError as ex:
+            msg = f"Unable to plan migration: {ex}"
+            # raise typer.BadParameter(msg) from ex
+            return MigrateResult(dumped, {}, error=msg)
+
+        if plan.is_latest:
+            # msg = f"The blueprint already uses the latest schema: {plan.source}"
+            # print(msg)
+            return MigrateResult(dumped, dumped, plan=plan)
+
+        try:
+            migrated = self.migrate(dumped, plan)
+        # except (CstarExpectationFailed, CstarMigrationError) as ex:
+        except CstarMigrationError as ex:
+            msg = f"Unable to complete migration: {ex}"
+            # raise typer.BadParameter(msg) from ex
+            return MigrateResult(dumped, {}, plan=plan, error=msg)
+
+        return MigrateResult(
+            dumped,
+            migrated,
+            plan=plan,
+        )
+
+
+def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Path:
+    """Determine the persistence path for a migrated model.
+
+    If a target is not supplied by the user, write to the `CSTAR_STATE_HOME`
+    directory.
+
+    Parameters
+    ----------
+    source : Path
+        Path to the file containing the original, serialized model.
+    target : Path | None
+        The user-supplied path
+    """
+    if target is not None:
+        output = target
+    else:
+        stem = source.stem
+        suffix = source.suffix
+        state_dir = DirectoryManager.state_home()
+        output = state_dir / f"{stem}_{plan.target}{suffix}"
+
+    return output.expanduser().resolve()

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -2,7 +2,6 @@ import abc
 import typing as t
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
-from pathlib import Path
 
 from pydantic import (
     BaseModel,
@@ -16,7 +15,6 @@ from cstar.base.adapter import ModelAdapter
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_CLOBBER_WORKING_DIR
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LoggingMixin
-from cstar.execution.file_system import DirectoryManager
 
 APP_ROMS_MARBL: t.Literal["roms_marbl"] = "roms_marbl"
 APP_ROMS_MARBL_SCHEMA_1_0_0: t.Literal["1.0.0"] = "1.0.0"
@@ -420,27 +418,3 @@ class BlueprintMigration(Migration):
             migrated,
             plan=plan,
         )
-
-
-def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Path:
-    """Determine the persistence path for a migrated model.
-
-    If a target is not supplied by the user, write to the `CSTAR_STATE_HOME`
-    directory.
-
-    Parameters
-    ----------
-    source : Path
-        Path to the file containing the original, serialized model.
-    target : Path | None
-        The user-supplied path
-    """
-    if target is not None:
-        output = target
-    else:
-        stem = source.stem
-        suffix = source.suffix
-        state_dir = DirectoryManager.state_home()
-        output = state_dir / f"{stem}_{plan.target}{suffix}"
-
-    return output.expanduser().resolve()

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -2,8 +2,12 @@ import abc
 import typing as t
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from pathlib import Path
 
 from cstar.base.adapter import ModelAdapter
+
+if t.TYPE_CHECKING:
+    from cstar.orchestration.models import Blueprint
 
 APP_ROMS_MARBL: t.Literal["roms_marbl"] = "roms_marbl"
 APP_ROMS_MARBL_SCHEMA_1_0_0: t.Literal["1.0.0"] = "1.0.0"
@@ -130,6 +134,15 @@ class MigrationPlan(t.NamedTuple):
     """The version of the schema that the document will be upgraded to."""
     adapters: Sequence[type[SchemaAdapter]]
     """An ordered list of adapters that will complete the migration when applied."""
+
+
+class MigrationResult(t.NamedTuple):
+    """The results of an executed migration."""
+
+    blueprint: "Blueprint"
+    """The migrated blueprint (or original if up-to-date)."""
+    path: Path | None
+    """The path where the migrated blueprint was saved (if applicable)."""
 
 
 class Migration(abc.ABC):

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -435,20 +435,15 @@ class BlueprintMigration(Migration):
             plan = self.plan(dumped)
         except CstarUnsupportedMigrationError as ex:
             msg = f"Unable to plan migration: {ex}"
-            # raise typer.BadParameter(msg) from ex
             return MigrateResult(dumped, {}, error=msg)
 
         if plan.is_latest:
-            # msg = f"The blueprint already uses the latest schema: {plan.source}"
-            # print(msg)
             return MigrateResult(dumped, dumped, plan=plan)
 
         try:
             migrated = self.migrate(dumped, plan)
-        # except (CstarExpectationFailed, CstarMigrationError) as ex:
         except CstarMigrationError as ex:
             msg = f"Unable to complete migration: {ex}"
-            # raise typer.BadParameter(msg) from ex
             return MigrateResult(dumped, {}, plan=plan, error=msg)
 
         return MigrateResult(

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -193,11 +193,6 @@ class MigrateResult(t.NamedTuple):
         return self.migrated.get("application", "")
 
 
-class PersistedMigrateResult(t.NamedTuple):
-    result: MigrateResult
-    target: str | Path
-
-
 class Migration(abc.ABC, LoggingMixin):
     """Base class for types that will execute a version migration by executing
     one to many SchemaAdapters.

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -10,8 +10,6 @@ from pydantic import (
     Field,
     FilePath,
     NewPath,
-    ValidationInfo,
-    field_validator,
 )
 
 from cstar.base.adapter import ModelAdapter
@@ -161,29 +159,6 @@ class MigrationRequest(BaseModel):
     def clobber(cls) -> bool:
         """Return `True` if clobber is enabled."""
         return is_flag_enabled(ENV_CSTAR_CLOBBER_WORKING_DIR)
-
-    @field_validator("target", mode="before")
-    @classmethod
-    def _clobber_target(
-        cls,
-        value: str,
-        _info: "ValidationInfo",
-    ) -> str:
-        """Remove a pre-existing target file if clobber is enabled.
-
-        Parameters
-        ----------
-        value : str
-            The value of the target property
-        _info : ValidationInfo
-            Metadata for the current validation context
-        """
-        if cls.clobber() and value:
-            path = Path(value)
-            if path.exists() and path.is_file():
-                path.unlink()
-
-        return value
 
 
 class MigrationPlan(t.NamedTuple):

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -390,7 +390,6 @@ class BlueprintMigration(Migration):
         CstarMigrationError
             If the migration cannot be completed.
         """
-        # source, target, plan = self.plan(dumped)
         model = deepcopy(dumped)
 
         for klass in plan.adapters:

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -287,9 +287,9 @@ class BlueprintMigration(Migration):
     schema_bounds: Mapping[str, SchemaBounds]
     """A mapping of unique app names to their minimum and maximum schema version."""
 
-    on_planned_callback: Callable[[MigrationPlan], None] | None = None
+    on_planned_callback: OnPlannedCallback | None = None
     """Callback executed when the migrator completes a plan."""
-    on_migrated_callback: Callable[[MigrationPlan], None] | None = None
+    on_migrated_callback: OnMigratedCallback | None = None
     """Callback executed when the migrator completes a migration."""
 
     def __init__(

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
 from cstar.cli.blueprint.migrate import app
 from cstar.entrypoint.utils import ARG_DRY_RUN, ARG_OUTPUT_LONG, ARG_OUTPUT_SHORT
+from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.serialization import deserialize
 from cstar.system.migration import hw_bounds, rm_bounds
 
@@ -54,7 +55,8 @@ def test_blueprint_migrate_file_dne(tmp_path: Path) -> None:
         color=False,
     )
 
-    assert "not found" in result.stderr
+    assert "Invalid value for 'PATH'" in result.stderr
+    assert "was not found" in result.stderr
 
 
 def test_blueprint_migrate_remote_blueprint_dne() -> None:
@@ -68,9 +70,10 @@ def test_blueprint_migrate_remote_blueprint_dne() -> None:
         color=False,
     )
 
-    assert "not found" in result.stderr
+    assert "Unable to retrieve remote file" in result.stderr
 
 
+@pytest.mark.usefixtures("mock_state_dir")
 def test_blueprint_migrate_default_output(blueprint_1_0_0_sleep: Path) -> None:
     """Verify that a request to migrate a blueprint without specifying an output
     path explicitly results in the creation of a file matching the expected naming
@@ -78,7 +81,8 @@ def test_blueprint_migrate_default_output(blueprint_1_0_0_sleep: Path) -> None:
     """
     latest = rm_bounds["max"]
     bp_path = blueprint_1_0_0_sleep
-    expected_output_path = Path(f"./{bp_path.stem}_{latest}.yaml")
+    state_dir = DirectoryManager.state_home()
+    expected_output_path = state_dir / f"{bp_path.stem}_{latest}.yaml"
 
     runner = CliRunner()
     result = runner.invoke(
@@ -110,7 +114,7 @@ def test_blueprint_migrate_unnecessary(hello_world_bp_path: Path) -> None:
         [bp_path.as_posix()],
         color=False,
     )
-    assert "uses the latest" in result.stdout
+    assert "No migration needed" in result.stdout
     assert latest in result.stdout
 
 

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -169,6 +169,4 @@ def test_blueprint_migrate_dry_run(
 
     assert not result.stderr, result.stderr
     assert not expected_output_path.exists()
-    assert "Migration from" in result.stdout
-    assert source in result.stdout
-    assert target in result.stdout
+    assert f"Migrating {source!r}->{target!r}" in result.stdout

--- a/cstar/tests/unit_tests/orchestration/test_migration.py
+++ b/cstar/tests/unit_tests/orchestration/test_migration.py
@@ -51,10 +51,10 @@ def test_migration_version(model: dict[str, t.Any], exp_version: str) -> None:
     bp0 = model
     migrator = BlueprintMigration()
 
-    migrated = migrator.migrate(bp0)
+    result = migrator.plan_and_migrate(bp0)
 
-    assert "schema_version" in migrated
-    assert exp_version == migrated["schema_version"]
+    assert "schema_version" in result.migrated
+    assert exp_version == result.migrated["schema_version"]
 
 
 def test_migration_simple_plan() -> None:
@@ -108,7 +108,8 @@ def test_migration_no_plan_no_changes(hello_world_bp_path: Path) -> None:
     assert not adapters
 
     dumped.pop(KEY_SV, None)  # remove version inserted by the fixture.
-    migrated = migrator.migrate(dumped)
+    plan = migrator.plan(dumped)
+    migrated = migrator.migrate(dumped, plan)
 
     assert KEY_SV not in migrated
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR enables automatic schema migration on blueprint execution, though it defaults to disabled using the feature flag `CSTAR_FF_CLI_BP_MIGRATE_AUTO`.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Execution of `cstar blueprint run` with any out-of-date blueprint automatically triggers a schema migration
- Add `--clobber` flag to `cstar blueprint migrate ...` to allow overwriting prior migrations

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Minor de-duplication of help text in CLI via adding constants
- Refactored as needed to share migration code with manual migration triggered via `cstar blueprint migrate ...`

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-895
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [ ] New functionality has documentation
