### PR TITLE
Parameterize extension, pattern, non-interactive mode

### DIFF
--- a/cstar/cli/workplan/generate.py
+++ b/cstar/cli/workplan/generate.py
@@ -18,16 +18,27 @@ from cstar.orchestration.models import (
 )
 from cstar.orchestration.serialization import deserialize, serialize
 
-app = typer.Typer()
-console = Console()
-
 if t.TYPE_CHECKING:
     from cstar.entrypoint.runner import BlueprintRunner
 
     BPResult: t.TypeAlias = tuple[Path, Blueprint]
 
 
-def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
+CMD_NAME = "generate"
+CMD_HELP = "Interactively generate a new workplan using pre-existing blueprints."
+
+DEFAULT_BP_EXT: t.Final[str] = ".yml"
+
+app = typer.Typer()
+console = Console()
+
+
+def _locate_blueprints(
+    search_dir: Path,
+    *,
+    extension: str = ".yaml",
+    pattern: str = "",
+) -> Iterable["BPResult"]:
     """Iterate through the contents of a directory to locate `Blueprints`.
 
     Parameters
@@ -35,7 +46,12 @@ def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
     search_dir : Path
         The directory to search for blueprints.
     """
-    files = search_dir.glob("*.yaml")
+    if not pattern:
+        pattern = f"*{extension}"
+
+    print(f"Searching {str(search_dir)!r} for files matching pattern {pattern!r}")
+    files = [f for f in search_dir.glob(pattern) if f.is_file()]
+
     valid_blueprints: list[BPResult] = []
 
     try:
@@ -50,6 +66,7 @@ def _locate_blueprints(search_dir: Path) -> Iterable["BPResult"]:
 
             valid_blueprints.append((file, bp))
     except ValueError as ex:
+        print(ex)
         msg = "File contains an invalid blueprint"
         raise typer.BadParameter(msg) from ex
 
@@ -73,7 +90,11 @@ def _display_order(blueprints: list["BPResult"]) -> None:
     console.print(table)
 
 
-def _populate_workplan(search_dir: Path, blueprints: list["BPResult"]) -> Workplan:
+def _populate_workplan(
+    search_dir: Path,
+    blueprints: list["BPResult"],
+    non_interactive: bool,
+) -> Workplan:
     """Populate a new workplan.
 
     Parameters
@@ -92,7 +113,11 @@ def _populate_workplan(search_dir: Path, blueprints: list["BPResult"]) -> Workpl
         Step(name=bp.name, application=bp.application, blueprint=p)
         for p, bp in blueprints
     ]
-    wp_name = input("Enter the name of your workplan: ")
+    if not non_interactive:
+        wp_name = input("Enter the name for your workplan: ")
+    else:
+        path0, _ = blueprints[0]
+        wp_name = "generated"
 
     return Workplan(
         name=wp_name,
@@ -102,27 +127,75 @@ def _populate_workplan(search_dir: Path, blueprints: list["BPResult"]) -> Workpl
     )
 
 
+def exclusion_callback(ctx: typer.Context, value: str) -> str:
+    """Warn the user if attempting to use the mutually-exclusive options for
+    `extension` and `pattern` simultaneously.
+
+    ctx : typer.Context
+        The typer context object
+    value : str
+        The value of the pattern parameter.
+
+    Returns
+    -------
+    str
+    """
+    ext_value = ctx.params.get("extension", DEFAULT_BP_EXT)
+    if ext_value != DEFAULT_BP_EXT and value:
+        msg = f"The following parameters cannot be combined: extension, pattern. You said: {ext_value!r} and {value!r}"
+        raise typer.BadParameter(msg)
+    return value
+
+
 @app.command(
-    name="generate",
-    help="Interactively generate a new workplan using pre-existing blueprints.",
+    name=CMD_NAME,
+    help=CMD_HELP,
 )
 def generate(
     search_directory: t.Annotated[
-        str,
-        typer.Argument(help="Specify the path to a directory containing blueprints"),
+        Path,
+        typer.Argument(
+            help="Specify the path to a directory containing blueprints",
+            dir_okay=True,
+            file_okay=False,
+            exists=True,
+            resolve_path=True,
+        ),
     ],
+    extension: t.Annotated[
+        str,
+        typer.Option(
+            "--ext",
+            help="Pass an alternative extension to search for (e.g. yaml, yml)",
+        ),
+    ] = DEFAULT_BP_EXT,
+    pattern: t.Annotated[
+        str,
+        typer.Option(
+            "--pattern",
+            help="Specify a glob pattern to use for matching blueprint file names in the search directory",
+            callback=exclusion_callback,
+        ),
+    ] = "",
+    non_interactive: t.Annotated[
+        bool,
+        typer.Option(
+            "--non-interactive",
+            help="Set this flag to enable non-interactive mode",
+        ),
+    ] = False,
 ) -> None:
     """Interactively generate a new workplan using pre-existing blueprints."""
     search_dir = Path(search_directory)
-    if not search_dir.exists():
-        print(f"No directory was found at: {search_dir!r}")
-
-    results = list(_locate_blueprints(search_dir))
+    results = list(_locate_blueprints(search_dir, extension=extension, pattern=pattern))
     if results:
         print(f"Found {len(results)} blueprints in {search_dir}")
         _display_order(results)
 
-        while "y" in input("Do you want to change the order? (yes/no): ").lower():
+        while (
+            not non_interactive
+            and "y" in input("Do you want to change the order? (yes/no): ").lower()
+        ):
             possible = list(permutations(list(range(len(results)))))
             example = list(choice(possible))
             example = [x + 1 for x in example]
@@ -150,9 +223,9 @@ def generate(
 
             _display_order(results)
 
-        wp = _populate_workplan(search_dir, results)
+        wp = _populate_workplan(search_dir, results, non_interactive)
         plan_stem = slugify(wp.name)
-        wp_path = search_dir / f"{plan_stem}.yaml"
+        wp_path = search_dir / "generated" / f"{plan_stem}{extension}"
 
         serialize(wp_path, wp)
         print(f"Your workplan has been saved to: {wp_path}")


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR improves the usability of the beta feature for generating workplan templates using the blueprints contained in a directory. It adds:

- parameter for a non-interactive mode `--non-interactive`
- parameter for the file extension `--ext`
- parameter for specifying a glob pattern instead of the extension `--pattern`

Additionally, outputs are written into a subdirectory `/<search_path>/generated` to enable repeat calls.

**Using non-interactive mode**

The CLI will use a default workplan name and accept the default step order

- `CSTAR_FF_CLI_WORKPLAN_GEN=1 cstar workplan generate /path/to/directory/ --non-interactive`

**Searching**

Use `cstar workplan generate --ext ".<extension>" ...` to search for an alternative format

- `CSTAR_FF_CLI_WORKPLAN_GEN=1 cstar workplan generate /path/to/directory/ --extension .json`

Use `cstar workplan generate --pattern "<glob-pattern>" ...` to match files with a glob pattern

- `cstar workplan generate --pattern "*.yml"`


## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- `cstar workplan generate ...` enables the user to specify a glob pattern or file extension

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
