### PR TITLE
minor linting and type hinting fixes

### DIFF
--- a/cstar/base/input_dataset.py
+++ b/cstar/base/input_dataset.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from abc import ABC
 from pathlib import Path
+from typing import Any
 
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import coerce_datetime
@@ -11,21 +12,16 @@ from cstar.io.staged_data import StagedDataCollection, StagedFile
 class InputDataset(ABC, LoggingMixin):
     """Describes spatiotemporal data needed to run a unique instance of a model
     simulation.
-
-    Attributes:
-    -----------
-    source: SourceData
-        Describes the location of and classifies the source data
-    working_copy: StagedFile or StagedDataCollection or None
-        Describes the locally staged version (if any) of the data
-    exists_locally: bool
-        True if this InputDataset has been staged for use locally
-
-    Methods:
-    --------
-    get(local_dir) -> StagedFile | StagedDataCollection
-        Stage this InputDataset for local use by C-Star
     """
+
+    source: SourceData
+    """The location of and classifies the source data"""
+    start_date: dt.datetime | None = None
+    """The minimum date in the dataset."""
+    end_date: dt.datetime | None = None
+    """The maximum date in the dataset."""
+    _working_copy: StagedFile | StagedDataCollection | None = None
+    """The locally staged version (if any) of the data"""
 
     def __init__(
         self,
@@ -33,7 +29,7 @@ class InputDataset(ABC, LoggingMixin):
         file_hash: str | None = None,
         start_date: str | dt.datetime | None = None,
         end_date: str | dt.datetime | None = None,
-    ):
+    ) -> None:
         """Initialize an InputDataset object associated with a model simulation.
 
         Parameters:
@@ -54,7 +50,7 @@ class InputDataset(ABC, LoggingMixin):
         # Subclass-specific  confirmation that everything is set up correctly:
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         pass
 
     @property
@@ -76,9 +72,7 @@ class InputDataset(ABC, LoggingMixin):
         -------
         bool: True if all files are known to exist locally, otherwise False
         """
-        if (self.working_copy) and not (self.working_copy.changed_from_source):
-            return True
-        return False
+        return bool(self.working_copy and not self.working_copy.changed_from_source)
 
     @property
     def _local(self) -> list[Path]:
@@ -86,9 +80,7 @@ class InputDataset(ABC, LoggingMixin):
         if self.working_copy:
             if isinstance(self.working_copy, StagedDataCollection):
                 return self.working_copy.paths
-            return [
-                self.working_copy.path,
-            ]
+            return [self.working_copy.path]
         return []
 
     def __str__(self) -> str:
@@ -126,7 +118,7 @@ class InputDataset(ABC, LoggingMixin):
 
         return repr_str
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Represent this InputDataset object as a dictionary of kwargs.
 
         Returns:
@@ -135,14 +127,14 @@ class InputDataset(ABC, LoggingMixin):
            A dictionary of kwargs that can be used to initialize the
            InputDataset object.
         """
-        input_dataset_dict = {}
-        input_dataset_dict["location"] = self.source.location
+        input_dataset_dict = {"location": self.source.location}
+
         if self.source.file_hash is not None:
             input_dataset_dict["file_hash"] = self.source.file_hash
         if self.start_date is not None:
-            input_dataset_dict["start_date"] = self.start_date.__str__()
+            input_dataset_dict["start_date"] = str(self.start_date)
         if self.end_date is not None:
-            input_dataset_dict["end_date"] = self.end_date.__str__()
+            input_dataset_dict["end_date"] = str(self.end_date)
 
         return input_dataset_dict
 
@@ -159,10 +151,12 @@ class InputDataset(ABC, LoggingMixin):
         target_path = Path(local_dir).expanduser().resolve() / self.source.basename
 
         if self.exists_locally:
-            self.log.info(f"⏭️ {target_path} already exists, skipping.")
+            msg = f"⏭️ {target_path} already exists, skipping."
+            self.log.info(msg)
             return
+
         staged = self.source.stage(target_dir=local_dir)
-        assert isinstance(staged, StagedFile) or isinstance(
-            staged, StagedDataCollection
-        )
+        if not isinstance(staged, (StagedFile, StagedDataCollection)):
+            msg = f"Require StagedFile or StagedDataCollection; received {type(staged)}"
+            raise TypeError(msg)
         self._working_copy = staged

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -44,7 +44,7 @@ class ROMSPartitioning:
         Paths to the partitioned files.
     """
 
-    def __init__(self, np_xi: int, np_eta: int, files: list[Path]):
+    def __init__(self, np_xi: int, np_eta: int, files: list[Path]) -> None:
         self.np_xi = np_xi
         self.np_eta = np_eta
         self.files = files
@@ -52,7 +52,7 @@ class ROMSPartitioning:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(np_xi={self.np_xi}, np_eta={self.np_eta}, files={_list_to_concise_str(self.files, pad=43)})"
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.files)
 
 
@@ -71,20 +71,20 @@ class DatasetLinker(LoggingMixin):
 
     def validate_opt(
         self,
-    ):
+    ) -> None:
         """Validate that the opt file exists in the work directory and that it contains the conventional symlink name."""
         opt_file = self.opt_file_dir / self.opt_file_name
 
         if not opt_file.exists():
-            raise FileNotFoundError(f"Opt file {opt_file} does not exist")
+            msg = f"Opt file {opt_file} does not exist"
+            raise FileNotFoundError(msg)
 
         opt_content = opt_file.read_text()
         if self.symlink_name not in opt_content:
-            raise CstarExpectationFailed(
-                f"{self.opt_file_name} must contain the string {self.symlink_name}."
-            )
+            msg = f"{self.opt_file_name} must contain the string {self.symlink_name}."
+            raise CstarExpectationFailed(msg)
 
-    def link(self, dataset_path: Path):
+    def link(self, dataset_path: Path) -> None:
         """Create symlink to dataset_path in the work directory.
         Parameters
         ----------
@@ -94,21 +94,14 @@ class DatasetLinker(LoggingMixin):
         symlink_path = self.workdir / self.symlink_name
         symlink_path.unlink(missing_ok=True)
         symlink_path.symlink_to(dataset_path)
-        self.log.info(f"🔗 Created symlink: {symlink_path} → {dataset_path}")
+        msg = f"🔗 Created symlink: {symlink_path} → {dataset_path}"
+        self.log.info(msg)
 
 
 class ROMSInputDataset(InputDataset, ABC):
-    (
-        (
-            """
-    ROMS-specific implementation of `InputDataset` (doc below)
-
-    Docstring for InputDataset:
-    ---------------------------
+    """Describes spatiotemporal data needed to run a unique instance of a ROMS model
+    simulation.
     """
-        )
-        + (InputDataset.__doc__ or "")
-    )
 
     partitionable: bool = True
     """Set to False if the input dataset should not be partitioned."""
@@ -122,7 +115,7 @@ class ROMSInputDataset(InputDataset, ABC):
         source_np_xi: int | None = None,
         source_np_eta: int | None = None,
         linker: DatasetLinker | None = None,
-    ):
+    ) -> None:
         self.start_date = coerce_datetime(start_date) if start_date else None
         self.end_date = coerce_datetime(end_date) if end_date else None
 
@@ -134,9 +127,15 @@ class ROMSInputDataset(InputDataset, ABC):
 
         if self.source_partitioning:
             if file_hash:
-                raise NotImplementedError(
-                    "Cannot use hash verification with partitioned source files"
-                )
+                msg = "Cannot use hash verification with partitioned source files"
+                raise NotImplementedError(msg)
+
+            if self.source_np_eta is None or self.source_np_xi is None:
+                rte = RuntimeError("Partitioning requires non-null partition size")
+                rte.add_note(f"{self.source_np_eta=}")
+                rte.add_note(f"{self.source_np_xi=}")
+                raise rte
+
             n_source_partitions = self.source_np_xi * self.source_np_eta  # type: ignore[operator]
             ndigits = len(str(n_source_partitions - 1))
             locations = []
@@ -187,7 +186,7 @@ class ROMSInputDataset(InputDataset, ABC):
 
     def partition(
         self, np_xi: int, np_eta: int, overwrite_existing_files: bool = False
-    ):
+    ) -> None:
         """Partition a netCDF dataset into tiles to run ROMS in parallel.
 
         Takes a local InputDataset and parallelisation parameters and uses
@@ -220,26 +219,28 @@ class ROMSInputDataset(InputDataset, ABC):
         def validate_partitioning_request() -> bool:
             """Helper function to skip, raise, or proceed with partitioning request."""
             if (self.partitioning is not None) and (not overwrite_existing_files):
-                if (self.partitioning.np_xi == np_xi) and (
-                    self.partitioning.np_eta == np_eta
+                if (
+                    self.partitioning.np_xi == np_xi
+                    and self.partitioning.np_eta == np_eta
                 ):
-                    self.log.info(
-                        f"⏭️  {self.__class__.__name__} already partitioned, skipping"
-                    )
+                    msg = f"⏭️  {self.__class__.__name__} already partitioned, skipping"
+                    self.log.info(msg)
                     return False
-                else:
-                    raise FileExistsError(
-                        f"The file has already been partitioned into a different arrangement "
-                        f"({self.partitioning.np_xi},{self.partitioning.np_eta}). "
-                        "To overwrite these files, try again with overwrite_existing_files=True"
-                    )
+
+                msg = (
+                    f"The file has already been partitioned into a different arrangement "
+                    f"({self.partitioning.np_xi},{self.partitioning.np_eta}). "
+                    "To overwrite these files, try again with overwrite_existing_files=True"
+                )
+                raise FileExistsError(msg)
 
             if not self.exists_locally:
-                raise ValueError(
+                msg = (
                     f"local path(s) to InputDataset \n {self._local}, "
-                    + "refers to a non-existent file(s)"
-                    + "\n call InputDataset.get() and try again."
+                    "refers to a non-existent file(s)"
+                    "\n call InputDataset.get() and try again."
                 )
+                raise ValueError(msg)
             return True
 
         def list_files_to_partition() -> list[Path]:
@@ -249,14 +250,11 @@ class ROMSInputDataset(InputDataset, ABC):
             if isinstance(self.working_copy, StagedDataCollection):
                 # if single InputDataset corresponds to many files, check they're colocated
                 if not all(
-                    [
-                        d.parent == self.working_copy.common_parent
-                        for d in self.working_copy.paths
-                    ]
+                    d.parent == self.working_copy.common_parent
+                    for d in self.working_copy.paths
                 ):
-                    raise ValueError(
-                        f"A single input dataset exists in multiple directories: {self.working_copy.paths}."
-                    )
+                    msg = f"A single input dataset exists in multiple directories: {self.working_copy.paths}."
+                    raise ValueError(msg)
 
                 # If they are, we want to partition them all in the same place
                 id_files_to_partition = self.working_copy.paths
@@ -271,12 +269,14 @@ class ROMSInputDataset(InputDataset, ABC):
             """Helper function that wraps the actual roms_tools.partition_netcdf
             call.
             """
-            new_parted_files = []
+            new_parted_files: list[Path] = []
 
             include_coarse_dims = True
 
             for idfile in files:
-                self.log.info(f"Partitioning {idfile} into ({np_xi},{np_eta})")
+                msg = f"Partitioning {idfile} into ({np_xi},{np_eta})"
+                self.log.info(msg)
+
                 try:
                     result = roms_tools.partition_netcdf(
                         idfile,
@@ -286,10 +286,11 @@ class ROMSInputDataset(InputDataset, ABC):
                     )
 
                 except Exception as e:
-                    self.log.warning(
+                    msg = (
                         f"Encountered error partitioning {idfile} with coarse dims; "
                         f"retrying without coarse dims. Exception: {e}"
                     )
+                    self.log.warning(msg)
                     include_coarse_dims = False
                     try:
                         result = roms_tools.partition_netcdf(
@@ -321,7 +322,7 @@ class ROMSInputDataset(InputDataset, ABC):
 
         def restore_existing_partitioned_files(
             backup_dir: Path, restore_paths: list[Path]
-        ):
+        ) -> None:
             """Helper function to restore existing parted files if partitioning
             fails.
             """
@@ -383,9 +384,8 @@ class ROMSInputDataset(InputDataset, ABC):
             self.linker.validate_opt()
             working_copy = self.working_copy
             if not isinstance(working_copy, StagedFile):
-                raise CstarExpectationFailed(
-                    "Cannot use a linker for non-file datasets"
-                )
+                msg = "Cannot use a linker for non-file datasets"
+                raise CstarExpectationFailed(msg)
             self.linker.link(working_copy.path)
 
     def _get_from_partitioned_source(self, local_dir: Path) -> None:
@@ -395,18 +395,18 @@ class ROMSInputDataset(InputDataset, ABC):
             for i, s in enumerate(self.partitioned_source):
                 target_path = local_dir / s.basename
                 if self.working_copy and self.working_copy[i].path == target_path:  # type: ignore[index]
-                    self.log.info(f"⏭️ {target_path} already exists, skipping.")
+                    msg = f"⏭️ {target_path} already exists, skipping."
+                    self.log.info(msg)
                     continue
-                else:
-                    self._working_copy.append(s.stage(local_dir))  # type: ignore[union-attr]
+
+                self._working_copy.append(s.stage(local_dir))  # type: ignore[union-attr]
             return
         # Otherwise stage them all:
-        else:
-            self._working_copy = self.partitioned_source.stage(local_dir)
+        self._working_copy = self.partitioned_source.stage(local_dir)
 
     def _update_partitioning_attribute(
         self, new_np_xi: int, new_np_eta: int, parted_files: list[Path]
-    ):
+    ) -> None:
         self.partitioning = ROMSPartitioning(
             np_xi=new_np_xi, np_eta=new_np_eta, files=parted_files
         )
@@ -427,17 +427,16 @@ class ROMSInputDataset(InputDataset, ABC):
             zero_files = [f for f in self.partitioning.files if zero_str in str(f)]
             return [Path(str(f).replace(zero_str, ".nc")) for f in zero_files]
 
-        raise FileNotFoundError(
+        msg = (
             "ROMS requires files to be partitioned for use. "
             "Call ROMSInputDataset.partition() or ROMSSimulation.pre_run() "
             "and try again"
         )
+        raise FileNotFoundError(msg)
 
 
 class ROMSModelGrid(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model grid files."""
-
-    pass
 
 
 class ROMSInitialConditions(ROMSInputDataset):
@@ -445,13 +444,9 @@ class ROMSInitialConditions(ROMSInputDataset):
     files.
     """
 
-    pass
-
 
 class ROMSTidalForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model tidal forcing files."""
-
-    pass
 
 
 class ROMSBoundaryForcing(ROMSInputDataset):
@@ -459,21 +454,15 @@ class ROMSBoundaryForcing(ROMSInputDataset):
     files.
     """
 
-    pass
-
 
 class ROMSSurfaceForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for model surface forcing
     files.
     """
 
-    pass
-
 
 class ROMSRiverForcing(ROMSInputDataset):
     """An implementation of the ROMSInputDataset class for river forcing files."""
-
-    pass
 
 
 class ROMSForcingCorrections(ROMSInputDataset):
@@ -485,12 +474,13 @@ class ROMSForcingCorrections(ROMSInputDataset):
     a NetCDF or similar file.
     """
 
-    def validate(self):
-        if self.source._classification.value.file_encoding == FileEncoding.TEXT:
-            raise TypeError(
+    def validate(self) -> None:
+        if self.source.classification.value.file_encoding == FileEncoding.TEXT:
+            msg = (
                 f"{self.__class__.__name__} cannot be initialized with a source YAML file. "
                 "Please provide a direct path or URL to a dataset (e.g., NetCDF)."
             )
+            raise TypeError(msg)
 
 
 class ROMSCdrForcing(ROMSInputDataset):

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -16,6 +17,8 @@ from cstar.orchestration.transforms import (
     get_time_slices,
     get_transforms,
 )
+
+N_MONTHS: t.Final[int] = 12
 
 
 def test_time_splitting() -> None:
@@ -47,7 +50,7 @@ def test_time_splitting() -> None:
     ],
 )
 def test_roms_marbl_transform_registry(
-    application: str, transform_fn: t.Callable[[Step], t.Iterable[Step]]
+    application: str, transform_fn: Callable[[Step], Iterable[Step]]
 ) -> None:
     """Verify that the transform registry returns the expected transform."""
     with mock.patch.dict(
@@ -95,7 +98,7 @@ def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
         transformed_steps = list(transform(original_step))
 
         # one step transforms into 12 monthly steps
-        assert len(transformed_steps) == 12
+        assert len(transformed_steps) == N_MONTHS
 
         output_directories: list[str] = []
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request contains minor type-hint, linting, and formatting mitigations. 

Linter mitigations include:
- declare attributes in class
- return direct value from boolean expression
- avoid direct calls to dunder methods
- remove unnecessary `pass`
- avoid magic numbers


Type-hint mitigations include:
- missing return types
- missing generic type arguments
- fix instantiation(s) resulting in partially known type
- avoid use of deprecated type hints (t.Iterable, t.Callable)

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Improved type-hints for `InputDataset` and `RomsInputDataset`
- Mitigated linter warnings

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Full type hint coverage
