### PR TITLE
Relocate suffix creation to RomsPartitioning; reuse min-padded-index

### DIFF
--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -164,8 +164,7 @@ class RomsMarblTimeSplitter(Transform[LiveStep]):
             partition_segment: str | None = None
             if partitioning := bp_copy.partitioning:
                 num_partitions = partitioning.n_procs_x * partitioning.n_procs_y
-                pad_size = len(str(num_partitions - 1))
-                partition_segment = "0".zfill(pad_size)
+                partition_segment = min_padded_index(0, num_partitions)
 
             # Use the last restart file as initial conditions for the follow-up step
             restart_file = RestartFile.from_parts(

--- a/cstar/roms/input_dataset.py
+++ b/cstar/roms/input_dataset.py
@@ -2,13 +2,21 @@ import datetime as dt
 import shutil
 import tempfile
 from abc import ABC
+from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, ClassVar
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.input_dataset import InputDataset
 from cstar.base.log import LoggingMixin
-from cstar.base.utils import _list_to_concise_str, coerce_datetime, lazy_import
+from cstar.base.utils import (
+    _list_to_concise_str,
+    coerce_datetime,
+    lazy_import,
+    min_padded_index,
+    min_padded_indices,
+)
 from cstar.io.constants import FileEncoding
 from cstar.io.source_data import SourceData, SourceDataCollection
 from cstar.io.staged_data import StagedDataCollection, StagedFile
@@ -44,6 +52,8 @@ class ROMSPartitioning:
         Paths to the partitioned files.
     """
 
+    SUFFIX_FMT: ClassVar[str] = ".{0}.nc"
+
     def __init__(self, np_xi: int, np_eta: int, files: list[Path]) -> None:
         self.np_xi = np_xi
         self.np_eta = np_eta
@@ -54,6 +64,20 @@ class ROMSPartitioning:
 
     def __len__(self) -> int:
         return len(self.files)
+
+    @classmethod
+    def suffix(cls, i: int, num_partitions: int) -> str:
+        """Return a minimally padded suffix."""
+        padded_idx = min_padded_index(i, num_partitions)
+        return cls.SUFFIX_FMT.format(padded_idx)
+
+    @classmethod
+    def suffixes(cls, num_partitions: int) -> Generator[str, None, None]:
+        """Return an iterator producing all minimally padded suffixes
+        for a given partitition size.
+        """
+        for padded_idx in min_padded_indices(num_partitions):
+            yield cls.SUFFIX_FMT.format(padded_idx)
 
 
 @dataclass
@@ -137,12 +161,12 @@ class ROMSInputDataset(InputDataset, ABC):
                 raise rte
 
             n_source_partitions = self.source_np_xi * self.source_np_eta  # type: ignore[operator]
-            ndigits = len(str(n_source_partitions - 1))
-            locations = []
-            for i in range(n_source_partitions):
-                old_suffix = f".{0:0{ndigits}d}.nc"
-                new_suffix = f".{i:0{ndigits}d}.nc"
-                locations.append(location.replace(old_suffix, new_suffix))
+
+            suffixes = ROMSPartitioning.suffixes(n_source_partitions)
+            suffix0 = ROMSPartitioning.suffix(0, n_source_partitions)
+
+            locations = [location.replace(suffix0, suffix) for suffix in suffixes]
+
             self.partitioned_source = SourceDataCollection.from_locations(locations)
             # muting the linter because we only enter this block if np_xi and np_eta are not None
             self.partitioning = ROMSPartitioning(
@@ -159,7 +183,7 @@ class ROMSInputDataset(InputDataset, ABC):
             return self.source_np_xi, self.source_np_eta
         return None
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         input_dataset_dict = super().to_dict()
         if self.source_partitioning is not None:
             input_dataset_dict["source_np_xi"] = self.source_np_xi

--- a/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
+++ b/cstar/tests/unit_tests/roms/test_roms_input_dataset.py
@@ -801,3 +801,53 @@ class TestDatasetLinker:
         symlink = workdir / "cdr.nc"
         assert symlink.is_symlink()
         assert symlink.resolve() == target.resolve()
+
+
+@pytest.mark.parametrize(
+    ("num_partitions", "exp_length", "exp_max_suffix"),
+    [(2, 1, "1"), (10, 1, "9"), (100, 2, "99"), (101, 3, "100"), (1000, 3, "999")],
+)
+def test_suffix_generation(
+    num_partitions: int,
+    exp_length: int,
+    exp_max_suffix: str,
+) -> None:
+    """Verify suffix creation adds the minimal amount of padding."""
+    # suffix format: ".xxx.nc" - add 3 to exp_length for alpha chars.
+    num_extra_chars = 4
+    total_length = exp_length + num_extra_chars
+
+    # verify correct padding on 0-th index
+    suffix = ROMSPartitioning.suffix(0, num_partitions)
+    assert suffix.startswith(".")
+    assert suffix.endswith(".nc")
+    assert len(suffix) == total_length
+
+    # verify correct padding on last index
+    suffix = ROMSPartitioning.suffix(num_partitions - 1, num_partitions)
+    assert suffix.startswith(".")
+    assert suffix.endswith(".nc")
+    assert len(suffix) == total_length
+
+    exp_suffix = f".{exp_max_suffix}.nc"
+    assert exp_suffix == suffix
+
+
+def test_suffix_collection_generation() -> None:
+    """Verify suffix creation adds the minimal amount of padding."""
+    # suffix format: ".xxx.nc" - add 3 to exp_length for alpha chars.
+    suffixes = list(ROMSPartitioning.suffixes(100))
+
+    for i in range(0, 100, 10):
+        assert f".{i:02d}.nc" in suffixes
+
+    # test edge case
+    assert f".{9:02d}.nc" in suffixes
+
+    suffixes = list(ROMSPartitioning.suffixes(1000))
+
+    for i in range(0, 1000, 100):
+        assert f".{i:03d}.nc" in suffixes
+
+    # test edge case
+    assert f".{999:02d}.nc" in suffixes


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Minor QoL PR to re-use the calculation for minimally-padded indices from both the `ROMSInputDataset` and `Orchestrator`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce code duplication for producing minimally-padded indices

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage

