### PR TITLE
Promote env show and workplan status features to always-on

### DIFF
--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -16,15 +16,6 @@ ENV_FF_DEVELOPER_MODE: t.Annotated[
 ] = "CSTAR_FF_DEVELOPER_MODE"
 """Enable developer mode to enable all feature flags (not recommended)."""
 
-ENV_FF_CLI_ENV_SHOW: t.Annotated[
-    t.Literal["CSTAR_FF_CLI_ENV_SHOW"],
-    EnvVar(
-        "Enable CLI for displaying environment configuration.",
-        GROUP_FF,
-        default=FLAG_OFF,
-    ),
-] = "CSTAR_FF_CLI_ENV_SHOW"
-"""Enable CLI for displaying environment configuration."""
 
 ENV_FF_CLI_TEMPLATE_CREATE: t.Annotated[
     t.Literal["CSTAR_FF_CLI_TEMPLATE_CREATE"],
@@ -65,16 +56,6 @@ ENV_FF_CLI_WORKPLAN_PLAN: t.Annotated[
     ),
 ] = "CSTAR_FF_CLI_WORKPLAN_PLAN"
 """Enable CLI for generating the execution plan of a workplan."""
-
-ENV_FF_CLI_WORKPLAN_STATUS: t.Annotated[
-    t.Literal["CSTAR_FF_CLI_WORKPLAN_STATUS"],
-    EnvVar(
-        "Enable CLI for retrieving status about a workplan run.",
-        GROUP_FF,
-        default=FLAG_OFF,
-    ),
-] = "CSTAR_FF_CLI_WORKPLAN_STATUS"
-"""Enable CLI for retrieving status about a workplan run."""
 
 ENV_FF_ORCH_TRX_TIMESPLIT: t.Annotated[
     t.Literal["CSTAR_FF_ORCH_TRX_TIMESPLIT"],

--- a/cstar/cli/environment/__init__.py
+++ b/cstar/cli/environment/__init__.py
@@ -1,6 +1,5 @@
 import typer
 
-from cstar.base.feature import is_feature_enabled
 from cstar.cli.environment.show import app as app_show
 
 app = typer.Typer(
@@ -8,5 +7,4 @@ app = typer.Typer(
     help="Manage the environment variables consumed by C-Star.",
 )
 
-if is_feature_enabled("CSTAR_FF_CLI_ENV_SHOW"):
-    app.add_typer(app_show)
+app.add_typer(app_show)

--- a/cstar/cli/workplan/__init__.py
+++ b/cstar/cli/workplan/__init__.py
@@ -4,7 +4,6 @@ from cstar.base.feature import (
     ENV_FF_CLI_WORKPLAN_COMPOSE,
     ENV_FF_CLI_WORKPLAN_GEN,
     ENV_FF_CLI_WORKPLAN_PLAN,
-    ENV_FF_CLI_WORKPLAN_STATUS,
     is_feature_enabled,
 )
 from cstar.cli.workplan.check import app as app_check
@@ -30,9 +29,7 @@ if is_feature_enabled(ENV_FF_CLI_WORKPLAN_PLAN):
     app.add_typer(app_plan)
 
 app.add_typer(app_run)
-
-if is_feature_enabled(ENV_FF_CLI_WORKPLAN_STATUS):
-    app.add_typer(app_status)
+app.add_typer(app_status)
 
 if is_feature_enabled(ENV_FF_CLI_WORKPLAN_COMPOSE):
     app.add_typer(app_compose)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,7 +12,7 @@ The following environment variables can be set by the user to control C-Star beh
 Frequent users may want to set preferred values for these variables in their ``.bash_profile`` or ``.zshrc`` files.
 
 .. tip::
-    Use ``CSTAR_FF_CLI_ENV_SHOW=1 cstar env show --display export`` to generate a starter script.
+    Use ``cstar env show --display export`` to generate a starter script.
 
 .. envvar-table::
     cstar.base.env


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR promotes two stable features to always-on. The following CLI commands will be available without enabling a feature-flag:

- `cstar env show`
- `cstar workplan status`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Promote `env show` and `workplan status` to always-on & deprecate feature flags

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-795
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
- [X] New functionality has documentation
