### PR TITLE
Add methods supporting deserialization to intermediate dicts

### DIFF
--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -137,7 +137,7 @@ def directives_callback(path: str | None) -> str | None:
     except FileNotFoundError as ex:
         msg = f"Directive file not found: {path}"
         raise typer.BadParameter(msg) from ex
-    except (RuntimeError, ValidationError) as ex:
+    except (ValueError, ValidationError) as ex:
         msg = f"Directive file {path!r} is malformed: {ex}"
         raise typer.BadParameter(msg) from ex
 

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -137,7 +137,7 @@ def directives_callback(path: str | None) -> str | None:
     except FileNotFoundError as ex:
         msg = f"Directive file not found: {path}"
         raise typer.BadParameter(msg) from ex
-    except ValidationError as ex:
+    except (RuntimeError, ValidationError) as ex:
         msg = f"Directive file {path!r} is malformed: {ex}"
         raise typer.BadParameter(msg) from ex
 

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -85,7 +85,14 @@ def read_json_to_raw(path: Path) -> dict[str, t.Any]:
     """
     with path.open("r", encoding="utf-8") as fp:
         json_data = fp.read()
-        return from_json(json_data)
+        try:
+            return from_json(json_data)
+        except ValueError as ex:
+            msg = (
+                f"Failed to load json from {str(path)!r}. If are loading a remote document, your URL "
+                f"may point to an HTML page instead of the raw YAML content."
+            )
+            raise RuntimeError(msg) from ex
 
 
 def read_yaml_to_raw(path: Path) -> dict[str, t.Any]:
@@ -105,8 +112,8 @@ def read_yaml_to_raw(path: Path) -> dict[str, t.Any]:
             model_dict = yaml.safe_load(fp)
         except ScannerError as e:
             msg = (
-                f"Failed to load yaml from {path}. If are loading a remote YAML, your URL "
-                f"may point to a HTML page instead of the raw YAML content."
+                f"Failed to load yaml from {str(path)!r}. If are loading a remote document, your URL "
+                f"may point to an HTML page instead of the raw YAML content."
             )
             raise RuntimeError(msg) from e
         return model_dict
@@ -136,9 +143,18 @@ def read_raw(
         mode = _mode_detect(path)
 
     if mode == PersistenceMode.json:
-        return read_json_to_raw(path)
+        reader = read_json_to_raw
+        alt = read_yaml_to_raw
+    else:
+        reader = read_yaml_to_raw
+        alt = read_json_to_raw
 
-    return read_yaml_to_raw(path)
+    try:
+        return reader(path)
+    except (RuntimeError, ValueError):
+        msg = f"Deserialization failed with {mode!r} for {str(path)!r}. Using alternate reader"
+        log.debug(msg)
+        return alt(path)
 
 
 def _read_json(path: Path, klass: type[_T]) -> _T:
@@ -155,7 +171,7 @@ def _read_json(path: Path, klass: type[_T]) -> _T:
     -------
     _T
     """
-    model_dict = read_raw(path, PersistenceMode.json)
+    model_dict = read_json_to_raw(path)
     return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 
@@ -173,7 +189,7 @@ def _read_yaml(path: Path, klass: type[_T]) -> _T:
     -------
     _T
     """
-    model_dict = read_raw(path, PersistenceMode.yaml)
+    model_dict = read_yaml_to_raw(path)
     return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 
@@ -318,6 +334,10 @@ def deserialize(
         model = _read_json(path, klass)
     else:
         model = _read_yaml(path, klass)
+
+    # if model is None:
+    #     msg = f"Unable to deserialize a `{klass.__name__}` at `{path}` as `{mode}` from: \n{path.read_text()}"
+    #     raise ValueError(msg)
 
     msg = f"Deserialized {str(path)!r} into: {model}"
     log.trace(msg)

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -85,14 +85,7 @@ def read_json_to_raw(path: Path) -> dict[str, t.Any]:
     """
     with path.open("r", encoding="utf-8") as fp:
         json_data = fp.read()
-        try:
-            return from_json(json_data)
-        except ValueError as ex:
-            msg = (
-                f"Failed to load json from {str(path)!r}. If are loading a remote document, your URL "
-                f"may point to an HTML page instead of the raw YAML content."
-            )
-            raise RuntimeError(msg) from ex
+        return from_json(json_data)
 
 
 def read_yaml_to_raw(path: Path) -> dict[str, t.Any]:
@@ -108,15 +101,7 @@ def read_yaml_to_raw(path: Path) -> dict[str, t.Any]:
     dict[str, t.Any]
     """
     with path.open("r", encoding="utf-8") as fp:
-        try:
-            model_dict = yaml.safe_load(fp)
-        except ScannerError as e:
-            msg = (
-                f"Failed to load yaml from {str(path)!r}. If are loading a remote document, your URL "
-                f"may point to an HTML page instead of the raw YAML content."
-            )
-            raise RuntimeError(msg) from e
-        return model_dict
+        return yaml.safe_load(fp)
 
 
 def read_raw(
@@ -142,19 +127,25 @@ def read_raw(
     if mode == PersistenceMode.auto:
         mode = _mode_detect(path)
 
+    readers = [read_json_to_raw]
     if mode == PersistenceMode.json:
-        reader = read_json_to_raw
-        alt = read_yaml_to_raw
+        readers.append(read_yaml_to_raw)
     else:
-        reader = read_yaml_to_raw
-        alt = read_json_to_raw
+        readers.insert(0, read_yaml_to_raw)
 
-    try:
-        return reader(path)
-    except (RuntimeError, ValueError):
-        msg = f"Deserialization failed with {mode!r} for {str(path)!r}. Using alternate reader"
-        log.debug(msg)
-        return alt(path)
+    for reader_fn in readers:
+        try:
+            return reader_fn(path)
+        except (ScannerError, ValueError):
+            msg = f"Deserialization failed with {mode!r} for {str(path)!r}"
+            log.debug(msg)
+
+    msg = (
+        f"Failed to deserialize {str(path)!r}. If are loading a remote document, your URL "
+        "may point to an HTML page instead of the raw YAML content."
+    )
+    raise RuntimeError(msg)
+    # log.warning(msg)
 
 
 def _read_json(path: Path, klass: type[_T]) -> _T:

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path, PosixPath
 
 import yaml
-from yaml import safe_load
+from pydantic_core import from_json
 from yaml.scanner import ScannerError
 
 from cstar.base.log import get_logger
@@ -71,6 +71,76 @@ class ValidationResult(t.Generic[_T]):
         return self.item is not None
 
 
+def read_json_to_raw(path: Path) -> dict[str, t.Any]:
+    """Read and process content as a JSON file.
+
+    Parameters
+    ----------
+    path : Path
+        The path to a file containing JSON.
+
+    Returns
+    -------
+    dict[str, t.Any]
+    """
+    with path.open("r", encoding="utf-8") as fp:
+        json_data = fp.read()
+        return from_json(json_data)
+
+
+def read_yaml_to_raw(path: Path) -> dict[str, t.Any]:
+    """Read and process content as a YAML file.
+
+    Parameters
+    ----------
+    path : Path
+        The path to a file containing YAML.
+
+    Returns
+    -------
+    dict[str, t.Any]
+    """
+    with path.open("r", encoding="utf-8") as fp:
+        try:
+            model_dict = yaml.safe_load(fp)
+        except ScannerError as e:
+            msg = (
+                f"Failed to load yaml from {path}. If are loading a remote YAML, your URL "
+                f"may point to a HTML page instead of the raw YAML content."
+            )
+            raise RuntimeError(msg) from e
+        return model_dict
+
+
+def read_raw(
+    path: Path,
+    mode: PersistenceMode = PersistenceMode.auto,
+) -> dict[str, t.Any]:
+    """Given a path to a persisted model, use the file extension to identify
+    the data format and load the model data into a raw dictionary.
+
+    Parameters
+    ----------
+    path : Path
+        The path to the persisted entity.
+
+    Returns
+    -------
+    dict[str, t.Any]
+    """
+    if not path.exists():
+        msg = f"Unable to read raw model from path: {path}"
+        raise FileNotFoundError(msg)
+
+    if mode == PersistenceMode.auto:
+        mode = _mode_detect(path)
+
+    if mode == PersistenceMode.json:
+        return read_json_to_raw(path)
+
+    return read_yaml_to_raw(path)
+
+
 def _read_json(path: Path, klass: type[_T]) -> _T:
     """Read and process content as a JSON file.
 
@@ -85,8 +155,8 @@ def _read_json(path: Path, klass: type[_T]) -> _T:
     -------
     _T
     """
-    with path.open("r", encoding="utf-8") as fp:
-        return klass.model_validate_json(json_data=fp.read())
+    model_dict = read_raw(path, PersistenceMode.json)
+    return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 
 def _read_yaml(path: Path, klass: type[_T]) -> _T:
@@ -103,16 +173,8 @@ def _read_yaml(path: Path, klass: type[_T]) -> _T:
     -------
     _T
     """
-    with path.open("r", encoding="utf-8") as fp:
-        try:
-            model_dict = safe_load(fp)
-        except ScannerError as e:
-            msg = (
-                f"Failed to load yaml from {path}. If are loading a remote YAML, your URL "
-                f"may point to a HTML page instead of the raw YAML content."
-            )
-            raise RuntimeError(msg) from e
-        return klass.model_validate(model_dict)
+    model_dict = read_raw(path, PersistenceMode.yaml)
+    return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 
 def path_representer(

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -335,10 +335,6 @@ def deserialize(
     else:
         model = _read_yaml(path, klass)
 
-    # if model is None:
-    #     msg = f"Unable to deserialize a `{klass.__name__}` at `{path}` as `{mode}` from: \n{path.read_text()}"
-    #     raise ValueError(msg)
-
     msg = f"Deserialized {str(path)!r} into: {model}"
     log.trace(msg)
 

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -1,3 +1,4 @@
+import textwrap
 import typing as t
 import uuid
 from collections.abc import Callable
@@ -9,7 +10,14 @@ from pydantic import BaseModel, Field, ValidationError
 from cstar.applications.plotter_app import PlotterBlueprint
 from cstar.orchestration.launch.slurm import SlurmHandle
 from cstar.orchestration.models import Application, Workplan
-from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+from cstar.orchestration.serialization import (
+    PersistenceMode,
+    deserialize,
+    read_json_to_raw,
+    read_raw,
+    read_yaml_to_raw,
+    serialize,
+)
 from cstar.orchestration.state import sentinel_path
 
 
@@ -308,3 +316,159 @@ def test_serializaton_yaml_schema(plotter_v2_0_0_bp: Path, tmp_path: Path) -> No
     content = target.read_text()
     assert "# yaml-language-server: $schema=" in content
     assert f"{bp.application}_schema.{bp.schema_version}.json" in content
+
+
+@pytest.fixture
+def person_yaml(tmp_path: Path) -> Path:
+    document = textwrap.dedent("""\
+        person:
+          name: unit test
+          age: 42
+          address:
+            street: "101 main st"
+            city: anywhere
+            state: ND
+          pets:
+          - Waffles
+          - Grits
+    """)
+    document_path = tmp_path / "doc.yaml"
+    document_path.write_text(document)
+    return document_path
+
+
+@pytest.fixture
+def person_yml(person_yaml: Path) -> Path:
+    name = person_yaml.with_suffix(".yml")
+    return person_yaml.rename(name)
+
+
+@pytest.fixture
+def person_json(tmp_path: Path) -> Path:
+    document = textwrap.dedent("""\
+        {
+            "person": {
+                "name": "unit test",
+                "address": {
+                    "street": "101 main st",
+                    "city": "anywhere",
+                    "state": "ND"
+                },
+                "age": 42,
+                "pets": [
+                    "Waffles",
+                    "Grits"
+                ]
+            }
+        }
+    """)
+    document_path = tmp_path / "doc.json"
+    document_path.write_text(document)
+    return document_path
+
+
+@pytest.mark.parametrize(
+    "source_fixture",
+    ["person_yaml", "person_yml"],
+)
+def test_read_yaml_to_raw(request: pytest.FixtureRequest, source_fixture: str) -> None:
+    """Verify yaml parsing results in the expected dictionary."""
+    person_doc = request.getfixturevalue(source_fixture)
+    d = read_yaml_to_raw(person_doc)
+
+    person = d.get("person", {})
+    assert person
+    assert person["name"] == "unit test"
+    assert person["age"] == 42
+
+    address = person.get("address", {})
+    assert address
+    assert address["street"] == "101 main st"
+
+    pets = person.get("pets", [])
+    assert "Waffles" in pets
+    assert "Grits" in pets
+
+
+def test_read_json_to_raw(person_json: Path) -> None:
+    """Verify json parsing results in the expected dictionary."""
+    d = read_json_to_raw(person_json)
+
+    person = d.get("person", {})
+    assert person
+    assert person["name"] == "unit test"
+    assert person["age"] == 42
+
+    address = person.get("address", {})
+    assert address
+    assert address["street"] == "101 main st"
+
+    pets = person.get("pets", [])
+    assert "Waffles" in pets
+    assert "Grits" in pets
+
+
+@pytest.mark.parametrize(
+    ("source_fixture", "mode"),
+    [
+        pytest.param("person_yaml", PersistenceMode.yaml, id="mode:correct:yaml"),
+        pytest.param("person_yaml", PersistenceMode.auto, id="mode:auto:yaml"),
+        pytest.param("person_yaml", PersistenceMode.json, id="mode:fallback:yaml"),
+        pytest.param("person_yml", PersistenceMode.yaml, id="mode:correct:yml"),
+        pytest.param("person_yml", PersistenceMode.auto, id="mode:auto:yml"),
+        pytest.param("person_yml", PersistenceMode.json, id="mode:fallback:yml"),
+        pytest.param("person_json", PersistenceMode.json, id="mode:correct:json"),
+        pytest.param("person_json", PersistenceMode.auto, id="mode:auto:json"),
+        pytest.param("person_json", PersistenceMode.yaml, id="mode:fallback:json"),
+    ],
+)
+def test_read_raw(
+    request: pytest.FixtureRequest, source_fixture: str, mode: PersistenceMode
+) -> None:
+    """Verify the automatic read mode selects the right reader and
+    failures are recovered by falling back to the alternate reader.
+    """
+    path = request.getfixturevalue(source_fixture)
+    d = read_raw(path, mode=mode)
+
+    person = d.get("person", {})
+    assert person
+    assert person["name"] == "unit test"
+    assert person["age"] == 42
+
+    address = person.get("address", {})
+    assert address
+    assert address["street"] == "101 main st"
+
+    pets = person.get("pets", [])
+    assert "Waffles" in pets
+    assert "Grits" in pets
+
+
+def test_read_raw_no_auto(
+    person_yaml: Path,
+    person_json: Path,
+) -> None:
+    """Verify that auto-mode does not take precedence over supplied mode value.
+
+    This test renames the file(s) so auto-mode would fail.
+    """
+    renamed0 = person_yaml.rename(person_yaml.with_suffix(".stuff"))
+    d0 = read_raw(renamed0, mode=PersistenceMode.yaml)
+
+    renamed1 = person_json.rename(person_json.with_suffix(".other"))
+    d1 = read_raw(renamed1, mode=PersistenceMode.json)
+
+    for d in [d0, d1]:
+        person = d.get("person", {})
+        assert person
+        assert person["name"] == "unit test"
+        assert person["age"] == 42
+
+        address = person.get("address", {})
+        assert address
+        assert address["street"] == "101 main st"
+
+        pets = person.get("pets", [])
+        assert "Waffles" in pets
+        assert "Grits" in pets


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR exposes methods in the `serialization` module for deserializing file content to the intermediate `dict` representation. This is a prerequisite for a status checking fix.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Add support for deserializing files to a dictionary without immediate model creation

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Prerequisite for #CSD-795
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
