### PR TITLE
Fix status checks using a hardcoded handle type

### DIFF
--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -12,9 +12,10 @@ from cstar.base.env import capture_environment
 from cstar.base.log import get_logger
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
-from cstar.orchestration.launch.slurm import SlurmHandle, SlurmLauncher
+from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import UserDefinedVariables, Workplan
 from cstar.orchestration.orchestration import (
+    Launcher,
     Orchestrator,
     Planner,
     RunMode,
@@ -56,7 +57,7 @@ class DagStatus:
         return (k for k, v in self.details.items() if Status.is_terminal(v))
 
 
-def get_launcher() -> SlurmLauncher | LocalLauncher:
+def get_launcher() -> Launcher[t.Any]:
     """Get the appropriate launcher for the current environment."""
     launcher = SlurmLauncher() if cstar_sysmgr.scheduler else LocalLauncher()
     launcher.check_preconditions()
@@ -83,7 +84,8 @@ def incremental_delays() -> Generator[float, None, None]:
 
 
 async def load_run_state(
-    run_id: str, launcher: SlurmLauncher | LocalLauncher
+    run_id: str,
+    launcher: Launcher[t.Any],
 ) -> DagStatus:
     """Load the run state.
 
@@ -97,7 +99,7 @@ async def load_run_state(
     DagStatus
     """
     configure_environment(run_id=run_id)
-    sentinels = await load_sentinels(SlurmHandle)
+    sentinels = await load_sentinels(launcher.handle_klass())
 
     open_set: dict[str, Status] = {}
     closed_set: dict[str, Status] = {}
@@ -175,7 +177,7 @@ async def process_plan(orchestrator: Orchestrator, mode: RunMode) -> DagStatus:
         sleep_duration = next(delay_iter)
         await asyncio.sleep(sleep_duration)
 
-    msg = f"Workplan {mode!r} is complete."
+    msg = f"Workplan {str(mode)!r} is complete."
     log.info(msg)
 
     if open_set is None:

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -78,6 +78,10 @@ class LocalHandle(ProcessHandle):
     def safe_name(self) -> str:
         return slugify(self.name)
 
+    @property
+    def is_expired(self) -> bool:
+        return not hasattr(self, "_process")
+
 
 class LocalLauncher(Launcher[LocalHandle]):
     """A launcher that executes steps in a local process."""
@@ -165,6 +169,11 @@ class LocalLauncher(Launcher[LocalHandle]):
         str
             The current status of the step.
         """
+        if handle.is_expired:
+            if not Status.is_terminal(handle.status):
+                return "RUNNING"
+            return "COMPLETED"
+
         rc = handle.process.exitcode
 
         if rc is None:
@@ -299,7 +308,7 @@ class LocalLauncher(Launcher[LocalHandle]):
         """
         process = item.handle.process
 
-        if process is not None:
+        if not item.handle.is_expired:  # wonky is-null check...
             if process.exitcode is not None:
                 msg = f"Unable to cancel a completed task `{process.pid}"
                 log.debug(msg)
@@ -308,3 +317,7 @@ class LocalLauncher(Launcher[LocalHandle]):
                 item.status = Status.Cancelled
 
         return item
+
+    @classmethod
+    def handle_klass(cls) -> type[LocalHandle]:
+        return LocalHandle

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -429,3 +429,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             log.exception("Unable to cancel the task `%s`", handle.pid)
 
         return item
+
+    @classmethod
+    def handle_klass(cls) -> type[SlurmHandle]:
+        return SlurmHandle

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -598,6 +598,11 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
         """
         ...
 
+    @classmethod
+    def handle_klass(cls) -> type[_THandle]:
+        """Return the type used by the launcher instance for managing tasks."""
+        ...
+
 
 class Orchestrator(LoggingMixin):
     """Manage the execution of a `Workplan`."""

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -191,7 +191,12 @@ class TrackingRepository(LoggingMixin):
                 self.log.trace(msg)
                 return path
 
-        return self._latest_path(run_id)
+        path = self._latest_path(run_id)
+        if path.exists():
+            msg = f"Located latest run of {run_id!r} at: {path}"
+            self.log.trace(msg)
+
+        return path
 
     async def get_workplan_run(
         self, run_id: str, run_date: datetime | None = None


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR fixes a CLI defect where `cstar workplan status` fails on any run executed with the local launcher.

> [!WARNING]
> This avoids instant failures when using `LocalLauncher` but does not reach 
> feature-parity with `SlurmLauncher` due _PID-reuse_. It is a temporary workaround.
> 
> It reports any known statuses and marks any unknowns as `Status.Failed` 

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix failure caused by `cstar workplan status` using `SlurmHandle` with `LocalLauncher`

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Prerequisite to #CSD-795
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
