### PR TITLE
Hotfix for env var handling bugs

### DIFF
--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -9,6 +9,7 @@ from cstar.base.env import (
     ENV_CSTAR_CLI_DRY_RUN,
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
+    ENV_CSTAR_RUNID,
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
@@ -224,7 +225,7 @@ def run(
         typer.Option(
             help="The unique identifier for an execution of the workplan.",
             autocompletion=list_runs,
-            callback=preprocess_runid,
+            callback=cb_pipeline(preprocess_runid, set_env(ENV_CSTAR_RUNID)),
         ),
     ] = "",
     user_variables: t.Annotated[

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -270,6 +270,7 @@ def run(
             ARG_DRY_RUN,
             help="Set this flag to generate an execution plan without executing the workplan.",
             envvar=ENV_CSTAR_CLI_DRY_RUN,
+            callback=set_flag(ENV_CSTAR_CLI_DRY_RUN),
         ),
     ] = False,
     log_level: t.Annotated[

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -34,7 +34,6 @@ from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS
 from cstar.system.manager import cstar_sysmgr
 
 log = get_logger(__name__)
-repo = TrackingRepository()
 
 
 @dataclass
@@ -309,6 +308,7 @@ async def build_and_run_dag(
         log.debug(msg)
         return prepared_wp_path
 
+    repo = TrackingRepository()
     await repo.put_workplan_run(
         WorkplanRun(
             workplan_path=wp_path,

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -61,9 +61,6 @@ class WorkplanRun(BaseModel):
 class TrackingRepository(LoggingMixin):
     """The API for persisting tracking data."""
 
-    _root: t.Final[Path]
-    """The root directory where tracking files are stored."""
-
     _LATEST_DIR: t.Final[str] = "latest"
     """The directory containing a mapping to the last run using a given run-id."""
 
@@ -73,9 +70,10 @@ class TrackingRepository(LoggingMixin):
     _MODE: PersistenceMode = PersistenceMode.yaml
     """The serialization mode to use."""
 
-    def __init__(self) -> None:
-        """Initialize the repository."""
-        self._root = StateDirectoryManager.tracking_dir()
+    @property
+    def _root(self) -> Path:
+        """Return the root directory where tracking files are stored."""
+        return StateDirectoryManager.tracking_dir()
 
     @property
     def latest_dir(self) -> Path:

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -91,15 +91,15 @@ async def test_tracking_retrieve(tmp_path: Path) -> None:
         repo = TrackingRepository()
         _ = await repo.put_workplan_run(wp_run)
 
-    # use public API to retrieve using "latest" record (by passing only run_id)
-    latest = await repo.get_workplan_run(run_id=run_id)
-    assert latest
-    assert latest.__dict__ == wp_run.__dict__  # confirm same stored values
+        # use public API to retrieve using "latest" record (by passing only run_id)
+        latest = await repo.get_workplan_run(run_id=run_id)
+        assert latest
+        assert latest.__dict__ == wp_run.__dict__  # confirm same stored values
 
-    # use public API to retrieve using "history" record (by passing run_id & run_date)
-    history = await repo.get_workplan_run(run_id=run_id, run_date=wp_run.start_at)
-    assert history
-    assert history.__dict__ == wp_run.__dict__  # confirm same stored values
+        # use public API to retrieve using "history" record (by passing run_id & run_date)
+        history = await repo.get_workplan_run(run_id=run_id, run_date=wp_run.start_at)
+        assert history
+        assert history.__dict__ == wp_run.__dict__  # confirm same stored values
 
     assert history.output_path == output_path
     assert history.workplan_path == wp_path


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR fixes a trio of defects:
- a bug where a global variable causes configuration to be cached at import time, resulting in writes to an incorrect output directory
- two bugs where CLI arguments were not published to environment variables when expected.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix XDG directory caching bug resulting in writes to default directory
- Fix failure to set `CSTAR_RUNID` and `CSTAR_CLI_DRY_RUN` when supplied in CLI

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing

