### PR TITLE
Fix log tight coupling

### DIFF
--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -390,3 +390,46 @@ def print_validation_errors(ex: ValidationError) -> None:
             f"{error['msg']}",
         )
         print(msg)
+
+
+_TValue = t.TypeVar("_TValue")
+
+
+def get_from_ctxmap(context: typer.Context, key: str, klass: type[_TValue]) -> _TValue:
+    """Retrieve a strongly-typed value from the typer context from the supplied key."""
+    context_map: dict[str, t.Any] | None = context.obj
+
+    if not context_map:
+        print("Unable to retrieve value from empty context map")
+        raise typer.Exit(100)
+
+    if key not in context_map:
+        items = ", ".join(context_map.keys())
+        print(f"Unable to retrieve key {key!r} from context. Available data: {items}")
+
+    value: _TValue | None = context.obj[key]
+    if value is None:
+        print(f"Context map contains null value for key: {key}")
+        raise typer.Exit(101)
+
+    if not isinstance(value, klass):
+        print(
+            "Context map contains value with type mismatch. "
+            f"Expected {klass.__name__!r} but received {value.__class__.__name__!r}."
+        )
+        raise typer.Exit(102)
+
+    return value
+
+
+def set_ctxmap(context: typer.Context, key: str, value: object) -> None:
+    """Prepare a mapping in the typer context and store the supplied value at the chosen key."""
+    if context.obj is None:
+        context.obj = {}
+
+    context_map: dict[str, t.Any] = context.obj
+
+    if key in context_map and context_map[key] is not None:
+        print(f"Value in context map using key {key!r} will be overwritten")
+
+    context_map[key] = value

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -104,7 +104,7 @@ def workplan_log(
     ] = False,
 ) -> None:
     """Print the log for a workplan step."""
-    step = get_from_ctxmap(context, "step", LiveStep)
+    step = get_from_ctxmap(context, "live_step", LiveStep)
     log_path = step.log_path
 
     if not monitor and not log_path.exists():

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -5,10 +5,9 @@ import typer
 
 from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import cb_pipeline, set_env
+from cstar.cli.common import cb_pipeline, get_from_ctxmap, set_env
 from cstar.cli.workplan.shared import (
     autocomplete_step_list,
-    get_from_ctxmap,
     list_runs,
     preload_run,
     set_ctxmap,

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -1,12 +1,17 @@
+import asyncio
 import time
 import typing as t
 
 import typer
 
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.base.utils import slugify
+from cstar.cli.common import set_env
 from cstar.cli.workplan.shared import autocomplete_step_list, list_runs
-from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
 app = typer.Typer()
@@ -31,6 +36,7 @@ def workplan_log(
         typer.Argument(
             help="The unique identifier of a specific workplan execution.",
             autocompletion=list_runs,
+            callback=set_env(ENV_CSTAR_RUNID),
         ),
     ],
     step_name: t.Annotated[
@@ -50,9 +56,24 @@ def workplan_log(
     ] = False,
 ) -> None:
     """Print the log for a workplan step."""
-    root_fsm = JobFileSystemManager(DirectoryManager.data_home() / run_id)
-    step_fsm = root_fsm.get_subtask_manager(step_name)
-    log_path = step_fsm.logs_dir / f"{slugify(step_name)}.out"
+    repo = TrackingRepository()
+    wp_run = asyncio.run(repo.get_workplan_run(run_id))
+    if not wp_run:
+        raise typer.BadParameter(
+            f"Unable to monitor logs for unknown run-id: {run_id}",
+            param_hint="run_id",
+        )
+
+    wp = deserialize(wp_run.trx_workplan_path, Workplan)
+    step = next((x for x in wp.steps if x.name == step_name), None)
+    if step is None:
+        valid_steps = ", ".join(f"{s.name!r}" for s in wp.steps)
+        raise typer.BadParameter(
+            f"Unable to monitor logs for unknown step: {step_name!r}. Valid values: {valid_steps}",
+            param_hint="step_name",
+        )
+
+    log_path = LiveStep.from_step(step).log_path
 
     if not monitor and not log_path.exists():
         print(f"No log file found for step {step_name!r} in run {run_id!r}.")

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 import typing as t
 
@@ -6,12 +5,16 @@ import typer
 
 from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import set_env
-from cstar.cli.workplan.shared import autocomplete_step_list, list_runs
+from cstar.cli.common import cb_pipeline, set_env
+from cstar.cli.workplan.shared import (
+    autocomplete_step_list,
+    get_from_ctxmap,
+    list_runs,
+    preload_run,
+    set_ctxmap,
+)
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.orchestration import LiveStep
-from cstar.orchestration.serialization import deserialize
-from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
 app = typer.Typer()
@@ -29,14 +32,57 @@ The `run_id` may be from an in-progress or completed run.
 ARG_MONITOR: t.Final[str] = "--monitor"
 
 
+def preload_step(context: typer.Context, step_name: str) -> str:
+    """Given a step-name,  is a valid name from the target workplan.
+
+    NOTE: Requires the workplan to be loaded into context dict as "workplan", e.g.
+    `wp = context.obj["workplan"]`
+
+    Parameters
+    ----------
+    context : typer.Context
+        The typer context.
+    step_name : str
+        The user-suppplied step-name.
+
+    Returns
+    -------
+    str
+
+    Raises
+    ------
+    typer.BadParamter
+        - Raised when the step-name cannot be found in the target workplan.
+    """
+    run_id = str(context.params.get("run_id", ""))
+    if not run_id:
+        msg = "A run-id is required to retrieve steps"
+        raise typer.BadParameter(msg, param_hint="run_id")
+
+    wp = get_from_ctxmap(context, "workplan", Workplan)
+    step = next((x for x in wp.steps if x.name == step_name), None)
+    if step is None:
+        valid_steps = ", ".join(f"{s.name!r}" for s in wp.steps)
+        raise typer.BadParameter(
+            f"Unable to monitor logs for unknown step: {step_name!r}. Valid values: {valid_steps}",
+            param_hint="step_name",
+        )
+
+    set_ctxmap(context, "step", step)
+    set_ctxmap(context, "live_step", LiveStep.from_step(step))
+
+    return step_name
+
+
 @app.command(name="log", help=HELP_LONG, short_help=HELP_SHORT)
 def workplan_log(
+    context: typer.Context,
     run_id: t.Annotated[
         str,
         typer.Argument(
             help="The unique identifier of a specific workplan execution.",
             autocompletion=list_runs,
-            callback=set_env(ENV_CSTAR_RUNID),
+            callback=cb_pipeline(set_env(ENV_CSTAR_RUNID), preload_run),
         ),
     ],
     step_name: t.Annotated[
@@ -44,6 +90,7 @@ def workplan_log(
         typer.Argument(
             help="The name of the step whose log should be printed.",
             autocompletion=autocomplete_step_list,
+            callback=preload_step,
         ),
     ],
     monitor: t.Annotated[
@@ -56,24 +103,8 @@ def workplan_log(
     ] = False,
 ) -> None:
     """Print the log for a workplan step."""
-    repo = TrackingRepository()
-    wp_run = asyncio.run(repo.get_workplan_run(run_id))
-    if not wp_run:
-        raise typer.BadParameter(
-            f"Unable to monitor logs for unknown run-id: {run_id}",
-            param_hint="run_id",
-        )
-
-    wp = deserialize(wp_run.trx_workplan_path, Workplan)
-    step = next((x for x in wp.steps if x.name == step_name), None)
-    if step is None:
-        valid_steps = ", ".join(f"{s.name!r}" for s in wp.steps)
-        raise typer.BadParameter(
-            f"Unable to monitor logs for unknown step: {step_name!r}. Valid values: {valid_steps}",
-            param_hint="step_name",
-        )
-
-    log_path = LiveStep.from_step(step).log_path
+    step = get_from_ctxmap(context, "step", LiveStep)
+    log_path = step.log_path
 
     if not monitor and not log_path.exists():
         print(f"No log file found for step {step_name!r} in run {run_id!r}.")

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -32,10 +32,12 @@ ARG_MONITOR: t.Final[str] = "--monitor"
 
 
 def preload_step(context: typer.Context, step_name: str) -> str:
-    """Given a step-name,  is a valid name from the target workplan.
+    """Given a step-name, ensure is a valid name in a preloaded workplan
 
     NOTE: Requires the workplan to be loaded into context dict as "workplan", e.g.
-    `wp = context.obj["workplan"]`
+    `wp = cstar.cli.common.get_from_ctxmap(context, "workplan", Workplan)`
+
+    See also: `cstar.cli.common.set_ctxmap`
 
     Parameters
     ----------
@@ -50,7 +52,7 @@ def preload_step(context: typer.Context, step_name: str) -> str:
 
     Raises
     ------
-    typer.BadParamter
+    typer.BadParameter
         - Raised when the step-name cannot be found in the target workplan.
     """
     run_id = str(context.params.get("run_id", ""))

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -13,12 +13,13 @@ from cstar.applications.core import (
     get_application,
 )
 from cstar.base.log import get_logger
+from cstar.cli.common import set_ctxmap
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
 from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
 from cstar.orchestration.dag_runner import DagDetailRecord
 from cstar.orchestration.models import Blueprint, Workplan
-from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.serialization import deserialize, try_deserialize
 from cstar.orchestration.tracking import TrackingRepository
 
 console = Console()
@@ -333,3 +334,48 @@ def create_xrunner(
     )
     klass = app.runner
     return klass(request, service_cfg, job_cfg)
+
+
+def preload_run(context: typer.Context, run_id: str) -> str:
+    """Verify a run-id is valid then load the `WorkplanRun` record and transformed `Workplan`.
+
+    Parameters
+    ----------
+    context : typer.Context
+        The typer context.
+    run_id : str
+        The user-suppplied run-id.
+
+    Returns
+    -------
+    str
+
+    Raises
+    ------
+    typer.BadParamter
+        - Raised when the run-id is invalid and a `WorkplanRun` cannot be loaded
+    """
+    if not run_id.strip():
+        msg = "An invalid run-id was supplied"
+        raise typer.BadParameter(msg, param_hint="run_id")
+
+    repo = TrackingRepository()
+    wp_run = asyncio.run(repo.get_workplan_run(run_id))
+    if not wp_run:
+        raise typer.BadParameter(
+            f"Unable to monitor logs for unknown run-id: {run_id}",
+            param_hint="run_id",
+        )
+    set_ctxmap(context, "run", wp_run)
+
+    wp_path = wp_run.trx_workplan_path
+    wp = try_deserialize(wp_path, Workplan)
+    if not wp:
+        msg = f"Unable to deserialize workplan for run {run_id!r} from {str(wp_path)!r}"
+        raise typer.BadParameter(
+            msg,
+            param_hint="run_id",
+        )
+    set_ctxmap(context, "workplan", wp)
+
+    return run_id

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -352,7 +352,7 @@ def preload_run(context: typer.Context, run_id: str) -> str:
 
     Raises
     ------
-    typer.BadParamter
+    typer.BadParameter
         - Raised when the run-id is invalid and a `WorkplanRun` cannot be loaded
     """
     if not run_id.strip():


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This pull request re-implements the `cstar workplan log` command via use of the `TrackingRepository`. 

Updated process:
- Retrieve a `WorkplanRun` record to locate the `Workplan`
- Validate step name against `Workplan.steps` for improved user feedback
- Use `Step.log_path` to avoid duplicating internal path resolution and file naming

Typer callbacks are now used to extract _loading_ behaviors from the handler (yay, SRP).

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- UX improved by printing 'available step names' hint for user when handling incorrect step name in input
- `workplan log` CLI handler no longer reproduces internal path resolution

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- Added shared functions for storing data in the typer context

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [X] Tests passing
- [X] Full type hint coverage
