### PR TITLE
Fix exit code when ROMS crashes

### DIFF
--- a/cstar/applications/roms_marbl/app.py
+++ b/cstar/applications/roms_marbl/app.py
@@ -103,7 +103,11 @@ class RomsMarblRunner(BlueprintRunner[RomsMarblBlueprint]):
 
         try:
             await self._handler.updates(seconds=1.0)
-            self.add_state(self._handler.status)
+            status = self._handler.status
+            if status == ExecutionStatus.FAILED:
+                self.add_state(status, ["ROMS execution reported a failed status"])
+            else:
+                self.add_state(status)
         except Exception as ex:
             msg = "An error occurred while running the simulation"
             self.log.exception(msg)
@@ -162,8 +166,9 @@ def main() -> int:
 
     try:
         asyncio.run(runner.execute())
-        if runner.result.errors:
-            print(f"Errors occurred: {', '.join(runner.result.errors)}")
+        if runner.state.status == ExecutionStatus.FAILED or runner.result.errors:
+            if runner.result.errors:
+                print(f"Errors occurred: {', '.join(runner.result.errors)}")
             return 1
     except CstarError as ex:
         print(f"An error occurred during the simulation: {ex}")

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -1137,3 +1137,71 @@ async def test_bluerintrunner_can_shutdown(
     with mock.patch.object(sim_runner, "_result", result):
         # and confirm it does not say it can exit
         assert sim_runner.can_shutdown
+
+
+@pytest.mark.parametrize(
+    ("handler_status", "expect_errors"),
+    [
+        (ExecutionStatus.FAILED, True),
+        (ExecutionStatus.COMPLETED, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_records_error_on_failed_handler_status(
+    sim_runner: RomsMarblRunner,
+    handler_status: ExecutionStatus,
+    expect_errors: bool,
+) -> None:
+    """Regression: when the execution handler reports a FAILED status (e.g. ROMS
+    crashed under Slurm but the job ran to completion), `run()` must record the FAILED
+    state *with* an error message rather than silently, so the failure surfaces in
+    `result.errors`. A non-failed status must not gain spurious errors.
+    """
+    mock_handler = mock.Mock(spec=ExecutionHandler)
+    type(mock_handler).status = mock.PropertyMock(return_value=handler_status)
+    mock_handler.updates = mock.AsyncMock()
+
+    with mock.patch.object(sim_runner, "_handler", mock_handler):
+        result = await sim_runner.run()
+
+    assert result.state.status == handler_status
+    assert bool(result.errors) == expect_errors
+
+
+def test_worker_main_returns_nonzero_on_failed_status(
+    blueprint_path: Path,
+) -> None:
+    """Regression: `main()` returns a non-zero exit code when the runner ends in a
+    FAILED state, even if `result.errors` is empty (e.g. a ROMS/Slurm job that runs to
+    completion but reports failure). Previously the exit code keyed only off
+    `result.errors`, so a FAILED-but-error-less run incorrectly exited 0.
+    """
+
+    async def fail_runner(
+        self: BlueprintRunner[RomsMarblBlueprint],
+    ) -> RunnerResult[RomsMarblBlueprint]:
+        # terminal FAILED state with NO errors recorded
+        self.add_state(ExecutionStatus.FAILED)
+        return self.result
+
+    args = [
+        "cstar.applications.roms_marbl",
+        ARG_URI_LONG,
+        str(blueprint_path),
+        ARG_LOGLEVEL_LONG,
+        "DEBUG",
+    ]
+
+    with (
+        mock.patch.object(
+            RomsMarblRunner,
+            "execute",
+            side_effect=fail_runner,
+            autospec=True,
+        ) as mock_execute,
+        mock.patch.object(sys, "argv", args),
+    ):
+        return_code = main()
+
+    assert return_code == 1
+    assert mock_execute.call_count == 1


### PR DESCRIPTION
# Summary
I have still been having problems where a crash in ROMS would not register a non-zero exit and Slurm would move on to the next dependency. Asked Claude what we were still missing -- turns out we we relying on a non-empty `errors` list but not actually adding an error to the list, even though we were setting the `status` correctly. This PR double-fixes it, most importantly by adding an error to the list, but additionally by still exiting non-zero if the status is Failed, regardless of the error list.

Also adds regression tests for the bug.


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- ROMS-MARBL app will now exit non-zero if ROMS crashes


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
