### PR TITLE
Fix dropped lines from ROMS logs

### DIFF
--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -79,6 +79,15 @@ class ExecutionHandler(ABC, LoggingMixin):
         Stream live updates from the task's output file for a specified duration.
     """
 
+    _log_position: int = 0
+    """The current position in the log file.
+
+    Log position is updated after each successful read. It enables resuming reads
+    after relinquishing control to the calling process.
+    """
+    _enabled: bool = True
+    """Flag used to disable processing update requests after the task has terminated."""
+
     @property
     @abstractmethod
     def status(self) -> ExecutionStatus:
@@ -113,7 +122,46 @@ class ExecutionHandler(ABC, LoggingMixin):
         """
         pass
 
-    async def updates(self, seconds: float = 10) -> None:
+    async def on_ready(self) -> None:
+        msg = "This job is still pending. Updates will be available after it starts running."
+        self.log.info(msg)
+
+    async def on_running(self, seconds: float) -> None:
+        """Forward logs from the process until time budget elapses."""
+        try:
+            with open(self.output_file) as f:
+                f.seek(self._log_position)
+                start_time = time.time()
+                while seconds == 0 or (time.time() - start_time < seconds):
+                    line = f.readline()
+                    self._log_position = f.tell()
+
+                    if line:
+                        self.log.info(line.rstrip())
+                        continue
+
+                    if ExecutionStatus.is_terminal(self.status):
+                        break
+
+                    # reached EOF; wait before checking for updates
+                    await asyncio.sleep(0.1)
+        except KeyboardInterrupt:
+            self.log.info("Live status updates stopped by user.")
+
+    async def on_shutdown(self) -> None:
+        """Handle a normal shutdown."""
+        msg = (
+            f"This job has ended ({self.status}). Live updates will no longer be provided."
+            f" See {self.output_file.resolve()} for job output"
+        )
+        self.log.warning(msg)
+
+    async def on_exceptional_shutdown(self) -> None:
+        """Handle a shutdown where no logs were forwarded."""
+        msg = f"This job has ended ({self.status}) and produced no outputs."
+        self.log.warning(msg)
+
+    async def updates(self, seconds: float = 1) -> None:
         """Stream live updates from the task's output file.
 
         This method streams updates from the task's output file for the
@@ -136,85 +184,25 @@ class ExecutionHandler(ABC, LoggingMixin):
         - When streaming indefinitely (`seconds=0`), user confirmation is
           required before proceeding.
         """
-        _status = self.status
-
-        # Track how far the output file has already been forwarded so that repeated
-        # calls (e.g. the worker polling once per second) resume without gaps or
-        # duplication. Initialized lazily so subclasses need not set it.
-        if not hasattr(self, "_log_read_position"):
-            self._log_read_position = 0
-
-        if _status not in [ExecutionStatus.RUNNING, ExecutionStatus.PENDING]:
-            # The job may have reached a terminal state between polls. Forward any
-            # output written since the last poll (the tail is frequently written
-            # right before exit, especially on failures) before returning.
-            if self.output_file.exists():
-                with open(self.output_file) as f:
-                    f.seek(self._log_read_position)
-                    self._forward_available(f)
-
-            error_msg = f"This job is currently not running ({_status}). Live updates cannot be provided."
-            is_complete = _status in {
-                ExecutionStatus.FAILED,
-                ExecutionStatus.COMPLETED,
-            }
-            is_cancelled = (
-                _status == ExecutionStatus.CANCELLED and self.output_file.exists()
-            )
-
-            if is_complete or is_cancelled:
-                error_msg += f" See {self.output_file.resolve()} for job output"
-
-            self.log.warning(error_msg)
+        if not self._enabled:
             return
 
-        if _status == ExecutionStatus.PENDING:
-            start_time = time.time()
-            msg = "This job is still pending. Updates will be available after it starts running."
-            while seconds == 0 or (time.time() - start_time < seconds):
-                self.log.info(msg)
-                await asyncio.sleep(STATUS_RECHECK_SECONDS)
-                _status = self.status
-                if _status != ExecutionStatus.PENDING:
-                    msg = f"Job status is now {_status}"
-                    self.log.info(msg)
-                    break
-            return
-
-        if not self.output_file.exists():
-            await asyncio.sleep(1)
-            msg = f"Log `{self.output_file}` does not exist yet. Skipping update check."
-            self.log.info(msg)
-            return
-
-        try:
-            with open(self.output_file) as f:
-                f.seek(self._log_read_position)
-                start_time = time.time()
-                while seconds == 0 or (time.time() - start_time < seconds):
-                    line = f.readline()
-                    if line:
-                        self.log.info(line.rstrip())
-                        continue
-
-                    # Caught up to the current end of the file.
-                    self._log_read_position = f.tell()
-
-                    if self.status != ExecutionStatus.RUNNING:
-                        # The job has finished. Allow a brief moment for the final
-                        # flush, then forward any remaining output so the tail of
-                        # the ROMS log is never lost on exit.
-                        await asyncio.sleep(0.1)
-                        self._forward_available(f)
-                        return
-
-                    await asyncio.sleep(0.1)  # 100ms delay between updates
-
-                # Time budget expired while still running; remember our position
-                # so the next call resumes without gaps.
-                self._log_read_position = f.tell()
-        except KeyboardInterrupt:
-            self.log.info("Live status updates stopped by user.")
+        match (ExecutionStatus.is_terminal(self.status), self.output_file.exists()):
+            case [False, False]:
+                # ready state - process is running but hasn't produced output, yet.
+                await self.on_ready()
+            case [False, True]:
+                # running state - process is running with logs to forward
+                await self.on_running(seconds)
+            case [True, True]:
+                # shutdown state - process has completed with logs to finalize
+                await self.on_running(seconds=1)
+                await self.on_shutdown()
+                self._enabled = False
+            case [True, False]:
+                # exception state - the process has terminated, but no logs were produced.
+                await self.on_exceptional_shutdown()
+                self._enabled = False
 
     def _forward_available(self, file_handle: TextIO) -> None:
         """Forward all currently-available lines from ``file_handle`` to the log.
@@ -234,4 +222,4 @@ class ExecutionHandler(ABC, LoggingMixin):
             if not line:
                 break
             self.log.info(line.rstrip())
-        self._log_read_position = file_handle.tell()
+        self._log_position = file_handle.tell()

--- a/cstar/execution/handler.py
+++ b/cstar/execution/handler.py
@@ -3,6 +3,7 @@ import time
 from abc import ABC, abstractmethod
 from enum import Enum, auto
 from pathlib import Path
+from typing import TextIO
 
 from cstar.base.log import LoggingMixin
 
@@ -136,7 +137,22 @@ class ExecutionHandler(ABC, LoggingMixin):
           required before proceeding.
         """
         _status = self.status
+
+        # Track how far the output file has already been forwarded so that repeated
+        # calls (e.g. the worker polling once per second) resume without gaps or
+        # duplication. Initialized lazily so subclasses need not set it.
+        if not hasattr(self, "_log_read_position"):
+            self._log_read_position = 0
+
         if _status not in [ExecutionStatus.RUNNING, ExecutionStatus.PENDING]:
+            # The job may have reached a terminal state between polls. Forward any
+            # output written since the last poll (the tail is frequently written
+            # right before exit, especially on failures) before returning.
+            if self.output_file.exists():
+                with open(self.output_file) as f:
+                    f.seek(self._log_read_position)
+                    self._forward_available(f)
+
             error_msg = f"This job is currently not running ({_status}). Live updates cannot be provided."
             is_complete = _status in {
                 ExecutionStatus.FAILED,
@@ -167,22 +183,55 @@ class ExecutionHandler(ABC, LoggingMixin):
 
         if not self.output_file.exists():
             await asyncio.sleep(1)
-            msg = f"Log `{self.output_file}` does not exist. Skipping update check."
+            msg = f"Log `{self.output_file}` does not exist yet. Skipping update check."
             self.log.info(msg)
             return
 
         try:
             with open(self.output_file) as f:
-                f.seek(0, 2)  # Move to the end of the file
+                f.seek(self._log_read_position)
                 start_time = time.time()
                 while seconds == 0 or (time.time() - start_time < seconds):
                     line = f.readline()
+                    if line:
+                        self.log.info(line.rstrip())
+                        continue
+
+                    # Caught up to the current end of the file.
+                    self._log_read_position = f.tell()
 
                     if self.status != ExecutionStatus.RUNNING:
+                        # The job has finished. Allow a brief moment for the final
+                        # flush, then forward any remaining output so the tail of
+                        # the ROMS log is never lost on exit.
+                        await asyncio.sleep(0.1)
+                        self._forward_available(f)
                         return
-                    elif line:
-                        self.log.info(line.rstrip())
-                    else:
-                        await asyncio.sleep(0.1)  # 100ms delay between updates
+
+                    await asyncio.sleep(0.1)  # 100ms delay between updates
+
+                # Time budget expired while still running; remember our position
+                # so the next call resumes without gaps.
+                self._log_read_position = f.tell()
         except KeyboardInterrupt:
             self.log.info("Live status updates stopped by user.")
+
+    def _forward_available(self, file_handle: TextIO) -> None:
+        """Forward all currently-available lines from ``file_handle`` to the log.
+
+        Reads from the handle's current position to end-of-file, logging each line,
+        and records the new read position so subsequent calls resume without gaps or
+        duplication.
+
+        Parameters
+        ----------
+        file_handle : TextIO
+            An open text handle for the task's output file, positioned at the point
+            from which to begin reading.
+        """
+        while True:
+            line = file_handle.readline()
+            if not line:
+                break
+            self.log.info(line.rstrip())
+        self._log_read_position = file_handle.tell()

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -38,9 +38,29 @@ class TestExecutionHandlerUpdates:
         Confirms that `updates()` runs indefinitely when `seconds=0` and allows termination via user interruption.
     """
 
+    @pytest.mark.parametrize(
+        ("create_file", "exp_msg", "is_path_exp"),
+        [
+            (
+                False,
+                "produced no outputs",
+                False,
+            ),
+            (
+                True,
+                "Live updates will no longer be provided.",
+                False,
+            ),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_updates_non_running_job(
-        self, tmp_path, caplog: pytest.LogCaptureFixture
+        self,
+        create_file: bool,
+        exp_msg: str,
+        is_path_exp: bool,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
     ):
         """Validates that `updates()` provides appropriate feedback when the job is not
         running.
@@ -65,18 +85,19 @@ class TestExecutionHandlerUpdates:
           is `COMPLETED` or similar.
         """
         caplog.set_level(logging.WARNING)
-        handler = MockExecutionHandler(
-            ExecutionStatus.COMPLETED, tmp_path / "mock_output.log"
-        )
+        target_path = tmp_path / "mock_output.log"
+        if create_file:
+            target_path.touch()
 
-        await handler.updates(seconds=10)
+        handler = MockExecutionHandler(ExecutionStatus.COMPLETED, target_path)
+
+        await handler.updates(seconds=1)
 
         captured = caplog.text
-        assert (
-            "This job is currently not running (completed). Live updates cannot be provided."
-            in captured
-        )
-        assert f"See {handler.output_file.resolve()} for job output" in captured
+
+        assert exp_msg in captured
+        if is_path_exp:
+            assert str(handler.output_file.resolve()) in captured
 
     @pytest.mark.asyncio
     async def test_updates_running_job_with_tmp_file(
@@ -247,7 +268,7 @@ class TestExecutionHandlerUpdates:
         updater_thread = threading.Thread(target=finish_job, daemon=True)
         updater_thread.start()
 
-        await handler.updates(seconds=0)
+        await handler.updates(seconds=1)
 
         captured = caplog.text
         for line in all_lines:
@@ -276,7 +297,7 @@ class TestExecutionHandlerUpdates:
         handler = MockExecutionHandler(ExecutionStatus.FAILED, output_file)
         caplog.set_level(logging.INFO, logger=handler.log.name)
 
-        await handler.updates(seconds=5)
+        await handler.updates(seconds=1)
 
         captured = caplog.text
         # the remaining output (including the tail) is forwarded to the main log

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -207,67 +207,105 @@ class TestExecutionHandlerUpdates:
                 assert "Live status updates stopped by user." in caplog.text
 
     @pytest.mark.asyncio
-    async def test_updates_stops_when_status_changes(
+    async def test_updates_forwards_tail_when_status_becomes_terminal(
         self, tmp_path, caplog: pytest.LogCaptureFixture
     ):
-        """Verifies that `updates()` stops execution when `status` changes to non-
-        RUNNING.
+        """Regression: when the job reaches a terminal state mid-stream, `updates()`
+        must forward the remaining output (the tail) before stopping, and must return
+        rather than loop forever.
 
-        This test ensures:
-        - The conditional block exits `updates` when `status` is not `RUNNING`.
-        - Only lines added while the job is `RUNNING` are streamed.
+        Previously the loop checked the status *before* logging the line it had just
+        read and returned immediately on a terminal status, dropping the final lines
+        of the ROMS log on exit.
 
         Fixtures
         --------
         caplog (pytest.LogCaptureFixture)
             Builtin fixture to capture log outputs
         """
-        # Create a temporary output file
         output_file = tmp_path / "output.log"
-        initial_content = ["First line\n"]
-        running_updates = ["Second line\n", "Third line\n"]
-        completed_updates = ["Fourth line\n", "Fifth line\n"]
-        # Write initial content to the file
+        # The process writes all of its output (including the final tail), then dies.
+        all_lines = [
+            "First line\n",
+            "Second line\n",
+            "Third line\n",
+            "Final crash message\n",
+        ]
         with output_file.open("w") as f:
-            f.writelines(initial_content)
+            f.writelines(all_lines)
 
-        # Initialize the handler with status `RUNNING`
         handler = MockExecutionHandler(ExecutionStatus.RUNNING, output_file)
         caplog.set_level(logging.INFO, logger=handler.log.name)
 
-        # Function to simulate appending live updates and changing status
-        def append_updates_and_change_status():
-            with output_file.open("a") as f:
-                for line in running_updates:
-                    time.sleep(0.1)  # Ensure updates() is actively reading
-                    f.write(line)
-                    f.flush()
+        # Flip to a terminal status shortly after `updates()` starts so the loop
+        # observes the transition. With seconds=0 the call would loop forever if the
+        # terminal transition were ignored, so returning on its own is part of the test.
+        def finish_job():
+            time.sleep(0.2)
+            handler._status = ExecutionStatus.FAILED
 
-                # Change the status to `COMPLETED` after writing running updates
-                time.sleep(0.2)
-                handler._status = ExecutionStatus.COMPLETED
-                for line in completed_updates:
-                    time.sleep(0.1)
-                    f.write(line)
-                    f.flush()
-
-        # Start the background thread to append updates and change status
-        updater_thread = threading.Thread(
-            target=append_updates_and_change_status, daemon=True
-        )
+        updater_thread = threading.Thread(target=finish_job, daemon=True)
         updater_thread.start()
 
         await handler.updates(seconds=0)
 
-        # Verify that only lines from `running_updates` were printed
-        printed_calls = caplog.text
+        captured = caplog.text
+        for line in all_lines:
+            assert line.rstrip() in captured
 
-        for line in running_updates:
-            assert line in printed_calls
-
-        # Verify that lines from `completed_updates` were not printed
-        for line in completed_updates:
-            assert line not in printed_calls
-
-        # Ensure the thread finishes before the test ends
         updater_thread.join()
+
+    @pytest.mark.asyncio
+    async def test_updates_forwards_output_when_already_terminal(
+        self, tmp_path, caplog: pytest.LogCaptureFixture
+    ):
+        """Regression: if the job finished between polls (already terminal when
+        `updates()` is called), output not yet forwarded must still be logged rather
+        than replaced by only a 'see the file' message.
+
+        Fixtures
+        --------
+        caplog (pytest.LogCaptureFixture)
+            Builtin fixture to capture log outputs
+        """
+        output_file = tmp_path / "output.log"
+        lines = ["line A\n", "line B\n", "final line\n"]
+        with output_file.open("w") as f:
+            f.writelines(lines)
+
+        handler = MockExecutionHandler(ExecutionStatus.FAILED, output_file)
+        caplog.set_level(logging.INFO, logger=handler.log.name)
+
+        await handler.updates(seconds=5)
+
+        captured = caplog.text
+        # the remaining output (including the tail) is forwarded to the main log
+        for line in lines:
+            assert line.rstrip() in captured
+        # and the user is still pointed at the full output file
+        assert f"See {output_file.resolve()} for job output" in captured
+
+    @pytest.mark.asyncio
+    async def test_updates_does_not_duplicate_across_calls(
+        self, tmp_path, caplog: pytest.LogCaptureFixture
+    ):
+        """Verify that the tracked read position prevents the same lines from being
+        forwarded twice across successive `updates()` calls.
+        """
+        output_file = tmp_path / "output.log"
+        with output_file.open("w") as f:
+            f.writelines(["alpha\n", "beta\n"])
+
+        handler = MockExecutionHandler(ExecutionStatus.RUNNING, output_file)
+        caplog.set_level(logging.INFO, logger=handler.log.name)
+
+        # First poll forwards the two existing lines.
+        await handler.updates(seconds=0.2)
+        # Append one new line, then poll again.
+        with output_file.open("a") as f:
+            f.write("gamma\n")
+        await handler.updates(seconds=0.2)
+
+        assert caplog.text.count("alpha") == 1
+        assert caplog.text.count("beta") == 1
+        assert caplog.text.count("gamma") == 1


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Somewhat following the exit-code problem, if ROMS crashes fast, we often do not capture the tail of the ROMS log in the C-Star log, meaning the user needs to go open a different log to see what happened. I was going to start mucking with the order of operations of some of the returns, but asked Claude to take a look. It came up with three related issues and proposed the fixes in this PR.

```
The bug (three compounding tail-loss paths)

  In ExecutionHandler.updates():
  1. In-loop: the loop checked self.status != RUNNING and returned before logging the line it had just read — so on the terminal-transition iteration it dropped that line and stopped reading any remaining buffered lines.
  2. Between polls: the worker calls updates(seconds=1.0) repeatedly, and each call did f.seek(0, 2) (jump to EOF), so anything written between polls was skipped entirely.
  3. Already-terminal call: if the job finished between polls, the next call hit the top-of-method branch and only logged "see the output file" — never forwarding the actual tail.

The fix (cstar/execution/handler.py)

  - Log-then-check-then-drain: the streaming loop now logs every available line first, and only when caught up to EOF does it check status; on a terminal status it waits briefly for the final flush, drains the remainder to EOF,
  then returns.
  - Tracked read position (self._log_read_position, lazily initialized): each call resumes exactly where the last left off instead of seeking to EOF — so nothing between polls is skipped and nothing is double-logged. Starts at
  the beginning of the file for full capture (safe since the worker is the sole caller).
  - Terminal-at-top now forwards the tail: before the "see the file" warning, it drains any not-yet-forwarded output to the log.
  - Added a _forward_available(file_handle) helper for the drain-to-EOF logic.
  - Cleanup: removed a duplicated PENDING block that used a blocking time.sleep inside this async method.
```


## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- C-Star log stream should now more fully capture ROMS log stream

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
