### PR TITLE
Add debug-build feature flag

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import typing as t
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,7 +35,7 @@ class EnvVar:
     """A group name used to identify the variable use."""
     default: str = ""
     """The default value for the setting."""
-    default_factory: t.Callable[["EnvVar"], str | None] | None = None
+    default_factory: Callable[["EnvVar"], str | None] | None = None
     """A function used at run-time to generate the default value."""
     indirect_var: str = ""
     """An environment variable name to be used when the primary variable is not set."""

--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -98,6 +98,17 @@ ENV_FF_CLI_BP_MIGRATE_SHOW: t.Annotated[
 """Enable CLI for migrating blueprints to the latest schema."""
 
 
+ENV_FF_DEBUG_BUILD_MODE: t.Annotated[
+    t.Literal["CSTAR_FF_DEBUG_BUILD_MODE"],
+    EnvVar(
+        "Enable building dependent packages in developer/debug mode.",
+        GROUP_FF,
+        default=FLAG_OFF,
+    ),
+] = "CSTAR_FF_DEBUG_BUILD_MODE"
+"""Enable building dependent packages in developer/debug mode."""
+
+
 def is_flag_enabled(flag: str) -> bool:
     """Determine if a boolean environment varible is enabled.
 

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1470,10 +1470,10 @@ class ROMSSimulation(Simulation):
 
         mode_clause = ""
         if is_feature_enabled(ENV_FF_DEBUG_BUILD_MODE):
-            mode_clause = "BUILD_MODE=debug"
+            mode_clause = "BUILD_MODE=debug "
 
         _run_cmd(
-            f"make {mode_clause} COMPILER={cstar_sysmgr.environment.compiler}",
+            f"make {mode_clause}COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=build_dir,
             msg_pre="Compiling UCLA-ROMS configuration...",
             msg_post=f"UCLA-ROMS compiled at {build_dir}",

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -20,6 +20,7 @@ from cstar.base.env import (
     get_env_item,
 )
 from cstar.base.exceptions import CstarExpectationFailed
+from cstar.base.feature import ENV_FF_DEBUG_BUILD_MODE, is_feature_enabled
 from cstar.base.utils import (
     _dict_to_tree,
     _get_sha256_hash,
@@ -1467,8 +1468,12 @@ class ROMSSimulation(Simulation):
 
         self._ensure_makefile(build_dir)
 
+        mode_clause = ""
+        if is_feature_enabled(ENV_FF_DEBUG_BUILD_MODE):
+            mode_clause = "BUILD_MODE=debug"
+
         _run_cmd(
-            f"make COMPILER={cstar_sysmgr.environment.compiler}",
+            f"make {mode_clause} COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=build_dir,
             msg_pre="Compiling UCLA-ROMS configuration...",
             msg_post=f"UCLA-ROMS compiled at {build_dir}",

--- a/cstar/tests/unit_tests/base/test_feature.py
+++ b/cstar/tests/unit_tests/base/test_feature.py
@@ -1,0 +1,28 @@
+import os
+import unittest.mock as mock
+
+import pytest
+
+from cstar.base.env import FLAG_OFF, FLAG_ON, get_env_item
+from cstar.base.feature import ENV_FF_DEBUG_BUILD_MODE
+
+
+def test_feature_debug_build_default() -> None:
+    """Verify the default value for a feature flag."""
+    key = ENV_FF_DEBUG_BUILD_MODE
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        item = get_env_item(key)
+
+        assert item.default == FLAG_OFF
+
+
+@pytest.mark.parametrize("flag_value", [FLAG_ON, FLAG_OFF])
+def test_feature_debug_build_set_externally(flag_value: bool) -> None:
+    """Verify the external value for a feature flag overrides the default."""
+    key = ENV_FF_DEBUG_BUILD_MODE
+
+    with mock.patch.dict(os.environ, {key: flag_value}, clear=True):
+        item = get_env_item(key)
+
+        assert item.value == flag_value


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
Add a feature-flag that enables running simulation engine builds in debug mode. This is useful for debugging simulation-related failures.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Setting `CSTAR_FF_DEBUG_BUILD_MODE=1` results in `ROMS` build in debug mode

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
