### PR TITLE
Refactor env var discovery

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -305,7 +305,6 @@ ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
 @lru_cache
 def discover_env_vars() -> dict[str, EnvItem]:
     """Return a mapping from env-var constant to the associated metadata."""
-    unknown_meta: t.Final[EnvVar] = EnvVar(NOT_SET, GROUP_UNK, NOT_SET)
     container: dict[str, EnvItem] = {}
     modules: list[ModuleType] = [
         sys.modules[__name__],
@@ -315,20 +314,15 @@ def discover_env_vars() -> dict[str, EnvItem]:
 
     for module in modules:
         hints = t.get_type_hints(module, include_extras=True)
-        variables = (x for x in dir(module) if x.startswith(CONSTANT_PREFIX))
-
-        for var_name in variables:
+        matches = {k: v for k, v in hints.items() if k.startswith(CONSTANT_PREFIX)}
+        for var_name, hint in matches.items():
             actual = getattr(module, var_name)
-            meta: EnvVar | None = None
-            hint = hints.get(var_name, None)
 
-            if hint and (metadata := getattr(hint, "__metadata__", None)):
-                meta = next((x for x in metadata if x and isinstance(x, EnvVar)), None)
+            if not (meta := getattr(hint, "__metadata__", None)):
+                continue
 
-            if meta:
-                container[actual] = EnvItem.from_env_var(meta, actual)
-            if not meta and actual not in container:
-                container[actual] = EnvItem.from_env_var(unknown_meta, actual)
+            if annotation := next((x for x in meta if isinstance(x, EnvVar)), None):
+                container[actual] = EnvItem.from_env_var(annotation, actual)
 
     return container
 

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -1,7 +1,7 @@
-from collections import defaultdict
 import os
 import sys
 import typing as t
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -327,7 +327,17 @@ def discover_env_vars() -> dict[str, EnvItem]:
 
             if meta:
                 container[actual] = EnvItem.from_env_var(meta, actual)
-            if not meta and not actual in container:
+            if not meta and actual not in container:
                 container[actual] = EnvItem.from_env_var(unknown_meta, actual)
 
     return container
+
+
+def env_var_groups() -> dict[str, list[EnvItem]]:
+    """Return a mapping from group-name to the associated list of env variables."""
+    groups: dict[str, list[EnvItem]] = defaultdict(list)
+
+    for item in discover_env_vars().values():
+        groups[item.group].append(item)
+
+    return groups

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -1,9 +1,10 @@
 import os
 import sys
-import types
 import typing as t
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import lru_cache
+from importlib import import_module
 from pathlib import Path
 
 GROUP_FF: t.Final[str] = "Feature Flags"
@@ -22,6 +23,9 @@ FLAG_OFF: t.Final[str] = "0"
 
 ENV_PREFIX: t.Final[str] = "CSTAR_"
 """The common env var prefix that identifies a C-Star configuration setting."""
+
+if t.TYPE_CHECKING:
+    import types
 
 
 @dataclass(slots=True)
@@ -94,12 +98,12 @@ def indirect_default_factory(env_var: EnvVar) -> str:
     return os.environ.get(var_name, "")
 
 
-def get_env_item(var_name: str, prefix: str = "ENV_") -> EnvItem:
+def get_env_item(var_name: str) -> EnvItem:
     """Retrieve the metadata for an environment variable constant.
 
     Parameters:
     -----------
-    var_name: str
+    var_name : str
         The string value of the environment variable (e.g. "CSTAR_CACHE_HOME")
 
     Returns:
@@ -107,27 +111,11 @@ def get_env_item(var_name: str, prefix: str = "ENV_") -> EnvItem:
     env_item: EnvItem
         The metadata associated with the environment variable
     """
-    constant_mods = [__name__, "cstar.orchestration.utils", "cstar.base.feature"]
-    constant_name = f"{prefix}{var_name}"
+    env_vars = discover_env_vars()
+    if variable := env_vars.get(var_name, None):
+        return variable
 
-    for module_name in constant_mods:
-        hints = t.get_type_hints(sys.modules[module_name], include_extras=True)
-
-        if hint := hints.get(constant_name, None):
-            metadata = getattr(hint, "__metadata__", None)
-            if not metadata:
-                return EnvItem(
-                    description="unknown",
-                    group=GROUP_UNK,
-                    default="unknown",
-                    name=var_name,
-                )
-
-            meta = metadata[0]
-            if isinstance(meta, EnvVar):
-                return EnvItem.from_env_var(meta, var_name)
-
-    msg = f"No environment variable metadata found for: {constant_name}"
+    msg = f"No environment variable metadata found for: {var_name}"
     raise ValueError(msg)
 
 
@@ -309,30 +297,43 @@ ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
 """Delay (in seconds) after a submission to ensure status for a SLURM job can be queried."""
 
 
-def discover_env_vars(
-    modules: list[types.ModuleType],
-    prefix: str = "ENV_",
-) -> list[EnvItem]:
-    """Locate all constants in a module that represent environment variables."""
-    items: list[EnvItem] = []
-    for module in modules:
+@lru_cache
+def discover_env_vars() -> dict[str, EnvItem]:
+    container: dict[str, EnvItem] = {}
+    prefix = "ENV_"
+
+    modules_list = [
+        __name__,
+        "cstar.orchestration.utils",
+        "cstar.base.feature",
+    ]
+    modules: dict[str, types.ModuleType] = {__name__: sys.modules[__name__]}
+
+    for module_name in modules_list[1:]:
+        modules[module_name] = import_module(module_name)
+
+    for module_name, module in modules.items():
         hints = t.get_type_hints(module, include_extras=True)
+        variables = (x for x in dir(module) if x.startswith(prefix))
 
-        for name, hint in hints.items():
-            if name.startswith(prefix):
+        for var_name in variables:
+            # get the actual constant value from the module
+            actual = getattr(module, var_name)
+
+            if hint := hints.get(var_name, None):
                 metadata = getattr(hint, "__metadata__", None)
-                value = getattr(module, name)
-                if metadata and isinstance(metadata[0], EnvVar):
-                    meta = metadata[0]
-                    items.append(EnvItem.from_env_var(meta, value))
-                elif not metadata:
-                    items.append(
-                        EnvItem(
-                            description="unknown",
-                            group=GROUP_UNK,
-                            default="unknown",
-                            name=value,
-                        ),
+                # variable matching naming convention ENV_ is missing annotations
+                if not metadata:
+                    item = EnvItem(
+                        description="unknown",
+                        group=GROUP_UNK,
+                        default="unknown",
+                        name=actual,
                     )
+                    container[actual] = item
+                    continue
 
-    return items
+                meta = metadata[0]
+                if isinstance(meta, EnvVar):
+                    container[actual] = EnvItem.from_env_var(meta, actual)
+    return container

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -7,6 +7,9 @@ from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
 
+if t.TYPE_CHECKING:
+    from types import ModuleType
+
 GROUP_FF: t.Final[str] = "Feature Flags"
 """Group name for feature flag environment variables in documentation."""
 GROUP_FS: t.Final[str] = "File System Configuration"
@@ -23,9 +26,8 @@ FLAG_OFF: t.Final[str] = "0"
 
 ENV_PREFIX: t.Final[str] = "CSTAR_"
 """The common env var prefix that identifies a C-Star configuration setting."""
-
-if t.TYPE_CHECKING:
-    import types
+CONSTANT_PREFIX = "ENV_"
+"""The common prefix used to name an annotated environment variable constant."""
 
 
 @dataclass(slots=True)
@@ -300,40 +302,33 @@ ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
 @lru_cache
 def discover_env_vars() -> dict[str, EnvItem]:
     container: dict[str, EnvItem] = {}
-    prefix = "ENV_"
-
-    modules_list = [
-        __name__,
-        "cstar.orchestration.utils",
-        "cstar.base.feature",
+    modules: list[ModuleType] = [
+        sys.modules[__name__],
+        import_module("cstar.orchestration.utils"),
+        import_module("cstar.base.feature"),
     ]
-    modules: dict[str, types.ModuleType] = {__name__: sys.modules[__name__]}
 
-    for module_name in modules_list[1:]:
-        modules[module_name] = import_module(module_name)
-
-    for module_name, module in modules.items():
+    for module in modules:
         hints = t.get_type_hints(module, include_extras=True)
-        variables = (x for x in dir(module) if x.startswith(prefix))
+        variables = (x for x in dir(module) if x.startswith(CONSTANT_PREFIX))
 
         for var_name in variables:
-            # get the actual constant value from the module
             actual = getattr(module, var_name)
+            meta: EnvVar | None = None
+            hint = hints.get(var_name, None)
 
-            if hint := hints.get(var_name, None):
-                metadata = getattr(hint, "__metadata__", None)
-                # variable matching naming convention ENV_ is missing annotations
-                if not metadata:
-                    item = EnvItem(
-                        description="unknown",
-                        group=GROUP_UNK,
-                        default="unknown",
-                        name=actual,
-                    )
-                    container[actual] = item
-                    continue
+            if hint and (metadata := getattr(hint, "__metadata__", None)):
+                meta = next((x for x in metadata if x and isinstance(x, EnvVar)), None)
 
-                meta = metadata[0]
-                if isinstance(meta, EnvVar):
-                    container[actual] = EnvItem.from_env_var(meta, actual)
+            if meta:
+                container[actual] = EnvItem.from_env_var(meta, actual)
+            else:
+                # EnvVar type annotation not found
+                container[actual] = EnvItem(
+                    description="unknown",
+                    group=GROUP_UNK,
+                    default="unknown",
+                    name=actual,
+                )
+
     return container

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -25,7 +25,7 @@ FLAG_ON: t.Final[str] = "1"
 FLAG_OFF: t.Final[str] = "0"
 """Value indicating a toggle is disabled."""
 
-ENV_PREFIX: t.Final[str] = "CSTAR_"
+ENVVAR_PREFIX: t.Final[str] = "CSTAR_"
 """The common env var prefix that identifies a C-Star configuration setting."""
 CONSTANT_PREFIX: t.Final[str] = "ENV_"
 """The common prefix used to name an annotated environment variable constant."""
@@ -88,7 +88,7 @@ def capture_environment() -> dict[str, str]:
     -------
     dict[str, str]
     """
-    return {k: v for k, v in os.environ.items() if k.startswith(ENV_PREFIX)}
+    return {k: v for k, v in os.environ.items() if k.startswith(ENVVAR_PREFIX)}
 
 
 def indirect_default_factory(env_var: EnvVar) -> str:

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -327,7 +327,7 @@ def discover_env_vars() -> dict[str, EnvItem]:
 
             if meta:
                 container[actual] = EnvItem.from_env_var(meta, actual)
-            else:
+            if not meta and not actual in container:
                 container[actual] = EnvItem.from_env_var(unknown_meta, actual)
 
     return container

--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import os
 import sys
 import typing as t
@@ -26,8 +27,10 @@ FLAG_OFF: t.Final[str] = "0"
 
 ENV_PREFIX: t.Final[str] = "CSTAR_"
 """The common env var prefix that identifies a C-Star configuration setting."""
-CONSTANT_PREFIX = "ENV_"
+CONSTANT_PREFIX: t.Final[str] = "ENV_"
 """The common prefix used to name an annotated environment variable constant."""
+NOT_SET: t.Final[str] = "<not-set>"
+"""Default description and default for variables missing annotations."""
 
 
 @dataclass(slots=True)
@@ -301,6 +304,8 @@ ENV_CSTAR_SLURM_POST_SUBMIT_DELAY: t.Annotated[
 
 @lru_cache
 def discover_env_vars() -> dict[str, EnvItem]:
+    """Return a mapping from env-var constant to the associated metadata."""
+    unknown_meta: t.Final[EnvVar] = EnvVar(NOT_SET, GROUP_UNK, NOT_SET)
     container: dict[str, EnvItem] = {}
     modules: list[ModuleType] = [
         sys.modules[__name__],
@@ -323,12 +328,6 @@ def discover_env_vars() -> dict[str, EnvItem]:
             if meta:
                 container[actual] = EnvItem.from_env_var(meta, actual)
             else:
-                # EnvVar type annotation not found
-                container[actual] = EnvItem(
-                    description="unknown",
-                    group=GROUP_UNK,
-                    default="unknown",
-                    name=actual,
-                )
+                container[actual] = EnvItem.from_env_var(unknown_meta, actual)
 
     return container

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -6,7 +6,7 @@ from enum import StrEnum, auto
 import typer
 from rich import print  # noqa: A004, ignore shadowing of built-in print
 
-from cstar.base.env import discover_env_vars
+from cstar.base.env import NOT_SET, discover_env_vars
 
 if t.TYPE_CHECKING:
     from cstar.base.env import EnvItem
@@ -16,8 +16,6 @@ app = typer.Typer()
 
 H_CONFIG_ALL: t.Final[str] = "C-Star Environment Configuration"
 """Main header displayed before all configuration sections."""
-
-NOT_SET: t.Literal["<not-set>"] = "<not-set>"
 
 
 def _interactive(all_config: dict[str, list["EnvItem"]]) -> None:

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -6,10 +6,7 @@ from enum import StrEnum, auto
 import typer
 from rich import print  # noqa: A004, ignore shadowing of built-in print
 
-from cstar.base import env, feature
-from cstar.base import utils as base_utils
 from cstar.base.env import discover_env_vars
-from cstar.orchestration import utils as orch_utils
 
 if t.TYPE_CHECKING:
     from cstar.base.env import EnvItem
@@ -111,14 +108,14 @@ def show(
     ] = DisplayFormat.INTERACTIVE,
 ) -> None:
     """Display the active environment configuration."""
-    all_items = discover_env_vars([base_utils, env, orch_utils, feature])
+    items = discover_env_vars()
 
     if group != "all":
-        all_items = [item for item in all_items if group.lower() in item.group.lower()]
+        items = {k: v for k, v in items.items() if group.lower() in v.group.lower()}
 
     # Group items by their group name for display
     group_map: dict[str, list[EnvItem]] = defaultdict(list)
-    for item in all_items:
+    for item in items.values():
         group_map[item.group].append(item)
 
     if not group_map:

--- a/cstar/cli/environment/show.py
+++ b/cstar/cli/environment/show.py
@@ -1,12 +1,11 @@
 import textwrap
 import typing as t
-from collections import defaultdict
 from enum import StrEnum, auto
 
 import typer
 from rich import print  # noqa: A004, ignore shadowing of built-in print
 
-from cstar.base.env import NOT_SET, discover_env_vars
+from cstar.base.env import NOT_SET, env_var_groups
 
 if t.TYPE_CHECKING:
     from cstar.base.env import EnvItem
@@ -106,15 +105,10 @@ def show(
     ] = DisplayFormat.INTERACTIVE,
 ) -> None:
     """Display the active environment configuration."""
-    items = discover_env_vars()
+    group_map = env_var_groups()
 
     if group != "all":
-        items = {k: v for k, v in items.items() if group.lower() in v.group.lower()}
-
-    # Group items by their group name for display
-    group_map: dict[str, list[EnvItem]] = defaultdict(list)
-    for item in items.values():
-        group_map[item.group].append(item)
+        group_map = {k: v for k, v in group_map.items() if group in k.lower()}
 
     if not group_map:
         msg = f"[bold red]No environment variables found for group '{group}'[/bold red]"

--- a/cstar/tests/unit_tests/orchestration/cli/test_env.py
+++ b/cstar/tests/unit_tests/orchestration/cli/test_env.py
@@ -1,0 +1,20 @@
+import pytest
+from typer.testing import CliRunner
+
+from cstar.cli.environment.show import app
+
+
+@pytest.mark.usefixtures("mock_env")
+@pytest.mark.asyncio
+async def test_cli_env_show() -> None:
+    """Verify that CLI env show command produces output."""
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [],
+        color=False,
+    )
+    assert "CSTAR_RUNID:" in result.stdout
+    assert "CSTAR_:" not in result.stdout
+    assert not result.stderr

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,14 +79,15 @@ class EnvVarTableDirective(Directive):
 
     def _load_variable_groups(
         self,
-        module: ModuleType,
-        groups: dict[str, list[EnvVarRow]],
-    ) -> None:
+    ) -> dict[str, list[EnvVarRow]]:
         """Reflect through the supplied module to discover all environment variables."""
-        env_vars = discover_env_vars([module])
+        env_vars = discover_env_vars()
+        groups: dict[str, list[EnvVarRow]] = defaultdict(list)
 
-        for var in env_vars:
+        for var in env_vars.values():
             groups[var.group].append(EnvVarRow(var))
+
+        return groups
 
     def _render_table(self, groups: dict[str, list[EnvVarRow]]) -> list[str]:
         """Render restructuredText for all discovered environment variables."""
@@ -116,14 +117,12 @@ class EnvVarTableDirective(Directive):
 
         return input_lines
 
-    def run(self) -> list:
+    def run(self) -> list[EnvVarRow]:
         """Build the content for the environment variable table."""
         all_groups: dict[str, list[EnvVarRow]] = defaultdict(list)
 
         try:
-            for module_name in self.arguments:
-                module = importlib.import_module(module_name)
-                self._load_variable_groups(module, all_groups)
+            all_groups = self._load_variable_groups()
         except ImportError:
             msg = f"Unable to import all modules from: {self.arguments}"
             log.exception(msg)


### PR DESCRIPTION

# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change refactors env variable discovery to:
1. fix a minor naming bug when metadata is missing
2. load variables once and cache for all subsequent calls
3. remove duped code between `get_env_item` and `discover_env`
4. relocate env-var group building to `env` module
5. fix two bugs causing _uncategorized_ variable registration

Prior to this change, the docs generation resulted in a slightly different set of variables when compared to the output of `cstar env show` due to code duplication (3).

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Env var constants missing correct type annotations are ignored.

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix variable name with matching prefix causing erroneous registration
- Fix overwriting existing metadata with secondary import

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Improved discovery speed by caching var metadata

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
