### PR TITLE
Hotfix for test regressions

### DIFF
--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import random
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
@@ -1828,27 +1829,32 @@ def prefect_server() -> Generator[str, None, None]:
         yield os.environ["PREFECT_API_URL"]
         return
 
-    prefect_port = "12345"
-    api_url = f"http://127.0.0.1:{prefect_port}/api"
+    process: Popen[str] | None = None
+    for i in range(3):
+        try:
+            prefect_port = random.randint(9000, 20000)
+            process = Popen(
+                [
+                    "prefect",
+                    "server",
+                    "start",
+                    "--port",
+                    str(prefect_port),
+                ],
+                text=True,
+                encoding="utf-8",
+            )
+            if process.returncode:
+                continue
 
-    try:
-        process = Popen(
-            [
-                "prefect",
-                "server",
-                "start",
-                "--port",
-                prefect_port,
-            ],
-            text=True,
-            encoding="utf-8",
-        )
-        yield api_url
-    except Exception as ex:
-        print(f"Failed to start Prefect server: {ex}")
-    finally:
-        if process and process.returncode is None:
-            process.terminate()
+            api_url = f"http://127.0.0.1:{prefect_port}/api"
+            yield api_url
+            break
+        except Exception as ex:
+            print(f"Failed to start Prefect server: {ex}")
+        finally:
+            if process and process.returncode is None:
+                process.terminate()
 
 
 @pytest.fixture(autouse=True)

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 
-import pytest
 from typer.testing import CliRunner
 
 from cstar.cli.workplan.log import app
 from cstar.orchestration.models import Workplan
 
 
-@pytest.mark.asyncio
-async def test_cli_workplan_log_step_dne(
+def test_cli_workplan_log_step_dne(
     executed_workplan: tuple[Path, Workplan, str],
 ) -> None:
     """Verify that an invalid step name results in an error message.
@@ -29,11 +27,11 @@ async def test_cli_workplan_log_step_dne(
         color=False,
     )
 
-    assert f"No log file found for step {invalid_step_name!r}" in result.stdout
+    assert invalid_step_name in result.stderr
+    assert "Unable to monitor logs for unknown step" in result.stderr
 
 
-@pytest.mark.asyncio
-async def test_cli_workplan_log_step_no_logs(
+def test_cli_workplan_log_step_no_logs(
     executed_workplan: tuple[Path, Workplan, str],
 ) -> None:
     """Verify that a step where no logs have been created results in an error message.
@@ -58,8 +56,7 @@ async def test_cli_workplan_log_step_no_logs(
     assert f"No log file found for step {step_name!r}" in result.stdout
 
 
-@pytest.mark.asyncio
-async def test_cli_workplan_log_step_with_logs(
+def test_cli_workplan_log_step_with_logs(
     executed_workplan_with_sideeffects: tuple[Path, Workplan, str],
 ) -> None:
     """Verify that logs are loaded successfully.


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change contains two fixes for the test suite:
1. Use a random port for prefect and retry on collisions
2. Convert failing CliRunner tests to synchronous to allow calls to `asyncio.run` from CLI code under test

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Avoid use of fixed port number causing tests to sporadically fail if port `12345` is taken
- Fix `cannot call asyncio.run on running event loop` failure from CLI tests

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests passing
