### PR TITLE
Rename system contexts

### DIFF
--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -155,7 +155,7 @@ class HostNameEvaluator:
         return (self.lmod_settings.SYSHOST or self.lmod_settings.SYSTEM_NAME).casefold()
 
 
-class _SystemContext(Protocol):
+class SystemContext(Protocol):
     """The contextual dependencies for the system/platform."""
 
     name: ClassVar[str]
@@ -184,17 +184,17 @@ class _SystemContext(Protocol):
         return False
 
 
-_registry: dict[str, type[_SystemContext]] = {}
+CTX_REGISTRY: dict[str, type[SystemContext]] = {}
 
 
 def register_sys_context(
-    wrapped_cls: type[_SystemContext],
-) -> type[_SystemContext]:
+    wrapped_cls: type[SystemContext],
+) -> type[SystemContext]:
     """Register the decorated type as an available _SystemContext."""
-    _registry[wrapped_cls.name] = wrapped_cls
+    CTX_REGISTRY[wrapped_cls.name] = wrapped_cls
 
     @functools.wraps(wrapped_cls)
-    def _inner() -> type[_SystemContext]:
+    def _inner() -> type[SystemContext]:
         """Return the original type after it is registered.
 
         Returns
@@ -207,7 +207,7 @@ def register_sys_context(
     return _inner()
 
 
-def _get_system_context() -> _SystemContext:
+def get_system_context() -> SystemContext:
     """Retrieve a system context from the context registry.
 
     Returns
@@ -222,25 +222,25 @@ def _get_system_context() -> _SystemContext:
     """
     namer = HostNameEvaluator()
 
-    if klass := _registry.get(namer.name):
+    if klass := CTX_REGISTRY.get(namer.name):
         return klass()
 
     raise CstarError(f"Unknown system requested: {namer.name}")
 
 
-def get_registered_sys_contexts() -> Sequence[type[_SystemContext]]:
+def get_registered_sys_contexts() -> Sequence[type[SystemContext]]:
     """Return a sequence containing all registered context types.
 
     Returns
     -------
     Sequence[type[_SystemContext]]
     """
-    return list(_registry.values())
+    return list(CTX_REGISTRY.values())
 
 
 @register_sys_context
 @dataclass(frozen=True)
-class _PerlmutterSystemContext(_SystemContext):
+class PerlmutterSystemContext(SystemContext):
     """The contextual dependencies for the Perlmutter system."""
 
     name: ClassVar[str] = "perlmutter"
@@ -270,7 +270,7 @@ class _PerlmutterSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _AnvilSystemContext(_SystemContext):
+class AnvilSystemContext(SystemContext):
     """The contextual dependencies for the Anvil system."""
 
     name: ClassVar[str] = "anvil"
@@ -326,7 +326,7 @@ class _AnvilSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _DerechoSystemContext(_SystemContext):
+class DerechoSystemContext(SystemContext):
     """The contextual dependencies for the Derecho system."""
 
     name: ClassVar[str] = "derecho"
@@ -357,7 +357,7 @@ class _DerechoSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _EljaSystemContext(_SystemContext):
+class EljaSystemContext(SystemContext):
     """The contextual dependencies for the Elja system."""
 
     name: ClassVar[str] = "elja"
@@ -424,7 +424,7 @@ class _EljaSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _ExpanseSystemContext(_SystemContext):
+class ExpanseSystemContext(SystemContext):
     """The contextual dependencies for the Expanse system."""
 
     name: ClassVar[str] = "expanse"
@@ -450,7 +450,7 @@ class _ExpanseSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _LinuxSystemContext(_SystemContext):
+class LinuxSystemContext(SystemContext):
     """The contextual dependencies for the Linux system on the x86_64 platform."""
 
     name: ClassVar[str] = "linux_x86_64"
@@ -468,7 +468,7 @@ class _LinuxSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _MacOSSystemContext(_SystemContext):
+class MacOSSystemContext(SystemContext):
     name: ClassVar[str] = "darwin_arm64"
     """The unique name identifying the MacOS system on an ARM64 platform."""
     compiler: ClassVar[str] = "gnu"
@@ -484,7 +484,7 @@ class _MacOSSystemContext(_SystemContext):
 
 @register_sys_context
 @dataclass(frozen=True)
-class _LinuxARM64SystemContext(_SystemContext):
+class LinuxARM64SystemContext(SystemContext):
     name: ClassVar[str] = "linux_aarch64"
     """The unique name identifying the Linux system on an ARM64 platform."""
     compiler: ClassVar[str] = "gnu"
@@ -501,7 +501,7 @@ class _LinuxARM64SystemContext(_SystemContext):
 class CStarSystemManager:
     """Manage system-specific configuration and resources."""
 
-    _context: Final[_SystemContext]
+    _context: Final[SystemContext]
     """A context object configured for the current system."""
     _environment: Final[CStarEnvironment]
     """An environment manager configured for the current system."""
@@ -514,7 +514,7 @@ class CStarSystemManager:
         Initialize the system manager by determining the system name and initializing
         the environment and scheduler based on that name.
         """
-        self._context = _get_system_context()
+        self._context = get_system_context()
         self._environment = CStarEnvironment(
             system_name=self._context.name,
             mpi_exec_prefix=self._context.mpi_prefix,

--- a/cstar/tests/unit_tests/system/test_context_registry.py
+++ b/cstar/tests/unit_tests/system/test_context_registry.py
@@ -5,17 +5,17 @@ import pytest
 
 from cstar.base.exceptions import CstarError
 from cstar.system.manager import (
-    _AnvilSystemContext,
-    _DerechoSystemContext,
-    _EljaSystemContext,
-    _ExpanseSystemContext,
-    _get_system_context,
-    _LinuxARM64SystemContext,
-    _LinuxSystemContext,
-    _MacOSSystemContext,
-    _PerlmutterSystemContext,
-    _registry,
-    _SystemContext,
+    CTX_REGISTRY,
+    AnvilSystemContext,
+    DerechoSystemContext,
+    EljaSystemContext,
+    ExpanseSystemContext,
+    LinuxARM64SystemContext,
+    LinuxSystemContext,
+    MacOSSystemContext,
+    PerlmutterSystemContext,
+    SystemContext,
+    get_system_context,
     register_sys_context,
 )
 from cstar.system.scheduler import Scheduler
@@ -27,17 +27,17 @@ DEFAULT_MOCK_HOST_NAME = "mock_system"
 def test_unique_context_names() -> None:
     """Verify that known contexts have a unique key."""
     context_types = (
-        _PerlmutterSystemContext,
-        _MacOSSystemContext,
-        _DerechoSystemContext,
-        _ExpanseSystemContext,
-        _LinuxARM64SystemContext,
-        _LinuxSystemContext,
-        _AnvilSystemContext,
-        _EljaSystemContext,
+        PerlmutterSystemContext,
+        MacOSSystemContext,
+        DerechoSystemContext,
+        ExpanseSystemContext,
+        LinuxARM64SystemContext,
+        LinuxSystemContext,
+        AnvilSystemContext,
+        EljaSystemContext,
     )
 
-    registered_names = set(_registry.keys())
+    registered_names = set(CTX_REGISTRY.keys())
 
     assert len({ctx.name for ctx in context_types}) == len(registered_names)
 
@@ -45,23 +45,23 @@ def test_unique_context_names() -> None:
 @pytest.mark.parametrize(
     "wrapped_class",
     [
-        _PerlmutterSystemContext,
-        _MacOSSystemContext,
-        _DerechoSystemContext,
-        _EljaSystemContext,
-        _ExpanseSystemContext,
-        _LinuxSystemContext,
-        _LinuxARM64SystemContext,
+        PerlmutterSystemContext,
+        MacOSSystemContext,
+        DerechoSystemContext,
+        EljaSystemContext,
+        ExpanseSystemContext,
+        LinuxSystemContext,
+        LinuxARM64SystemContext,
     ],
 )
-def test_context_registry(wrapped_class: type[_SystemContext]) -> None:
+def test_context_registry(wrapped_class: type[SystemContext]) -> None:
     """Verify that all known system contexts are registered."""
     with patch(
         "cstar.system.manager.HostNameEvaluator.name",
         new_callable=PropertyMock,
         return_value=wrapped_class.name,
     ):
-        ctx = _get_system_context()
+        ctx = get_system_context()
 
     # confirm all properties of the factory produced context match
     assert ctx.name == wrapped_class.name
@@ -73,15 +73,15 @@ def test_context_registry(wrapped_class: type[_SystemContext]) -> None:
 @pytest.mark.parametrize(
     ("expected_name", "wrapped_class"),
     [
-        ("perlmutter", _PerlmutterSystemContext),
-        ("darwin_arm64", _MacOSSystemContext),
-        ("derecho", _DerechoSystemContext),
-        ("elja", _EljaSystemContext),
-        ("expanse", _ExpanseSystemContext),
-        ("linux_x86_64", _LinuxSystemContext),
+        ("perlmutter", PerlmutterSystemContext),
+        ("darwin_arm64", MacOSSystemContext),
+        ("derecho", DerechoSystemContext),
+        ("elja", EljaSystemContext),
+        ("expanse", ExpanseSystemContext),
+        ("linux_x86_64", LinuxSystemContext),
     ],
 )
-def test_registry_keys(expected_name: str, wrapped_class: type[_SystemContext]) -> None:
+def test_registry_keys(expected_name: str, wrapped_class: type[SystemContext]) -> None:
     """Verify that the system contexts have the names expected from using
     HostNameEvaluator for all known systems.
     """
@@ -92,7 +92,7 @@ def test_new_registration() -> None:
     """Verify that registrations of new context types are immediately available."""
 
     @register_sys_context
-    class MockSystemContext(_SystemContext):
+    class MockSystemContext(SystemContext):
         """Mock system context to test the context registry."""
 
         name: ClassVar[str] = "mock-system-name"
@@ -109,7 +109,7 @@ def test_new_registration() -> None:
         new_callable=PropertyMock,
         return_value=MockSystemContext.name,
     ):
-        ctx = _get_system_context()
+        ctx = get_system_context()
 
     assert ctx
     assert ctx.name == MockSystemContext.name
@@ -125,4 +125,4 @@ def test_unknown_context_name() -> None:
             return_value="invalid-name",
         ),
     ):
-        _ = _get_system_context()
+        _ = get_system_context()

--- a/cstar/tests/unit_tests/system/test_context_schedulers.py
+++ b/cstar/tests/unit_tests/system/test_context_schedulers.py
@@ -1,13 +1,13 @@
 import pytest
 
 from cstar.system.manager import (
-    _AnvilSystemContext,
-    _DerechoSystemContext,
-    _ExpanseSystemContext,
-    _LinuxSystemContext,
-    _MacOSSystemContext,
-    _PerlmutterSystemContext,
-    _SystemContext,
+    AnvilSystemContext,
+    DerechoSystemContext,
+    ExpanseSystemContext,
+    LinuxSystemContext,
+    MacOSSystemContext,
+    PerlmutterSystemContext,
+    SystemContext,
 )
 from cstar.system.scheduler import PBSScheduler, Scheduler, SlurmScheduler
 
@@ -18,16 +18,16 @@ DEFAULT_MOCK_HOST_NAME = "mock_system"
 @pytest.mark.parametrize(
     ("wrapped_class", "exp_sched_type", "exp_queue_names"),
     [
-        (_AnvilSystemContext, SlurmScheduler, {"wholenode", "shared", "debug"}),
-        (_PerlmutterSystemContext, SlurmScheduler, {"regular", "shared", "debug"}),
-        (_MacOSSystemContext, None, None),
-        (_DerechoSystemContext, PBSScheduler, {"main", "preempt", "develop"}),
-        (_ExpanseSystemContext, SlurmScheduler, {"compute", "debug"}),
-        (_LinuxSystemContext, None, None),
+        (AnvilSystemContext, SlurmScheduler, {"wholenode", "shared", "debug"}),
+        (PerlmutterSystemContext, SlurmScheduler, {"regular", "shared", "debug"}),
+        (MacOSSystemContext, None, None),
+        (DerechoSystemContext, PBSScheduler, {"main", "preempt", "develop"}),
+        (ExpanseSystemContext, SlurmScheduler, {"compute", "debug"}),
+        (LinuxSystemContext, None, None),
     ],
 )
 def test_context_registry(
-    wrapped_class: type[_SystemContext],
+    wrapped_class: type[SystemContext],
     exp_sched_type: type[Scheduler],
     exp_queue_names: set[str] | None,
 ) -> None:
@@ -40,7 +40,7 @@ def test_context_registry(
         assert type(scheduler) is exp_sched_type
         queues = getattr(scheduler, "queues")  # noqa: B009
         assert {q.name for q in queues} == exp_queue_names
-        if exp_sched_type == _PerlmutterSystemContext:
+        if exp_sched_type == PerlmutterSystemContext:
             assert scheduler.global_max_cpus_per_node == 128
     else:
         assert scheduler is None

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -8,12 +8,12 @@ import pytest
 from cstar.system.environment import CStarEnvironment, LmodEnvSettings
 from cstar.system.manager import (
     CStarSystemManager,
-    _DerechoSystemContext,
-    _ExpanseSystemContext,
-    _LinuxSystemContext,
-    _MacOSSystemContext,
-    _PerlmutterSystemContext,
-    _SystemContext,
+    DerechoSystemContext,
+    ExpanseSystemContext,
+    LinuxSystemContext,
+    MacOSSystemContext,
+    PerlmutterSystemContext,
+    SystemContext,
 )
 
 
@@ -50,35 +50,35 @@ class TestEnvironmentProperty:
         ("system_ctx", "expected_attributes"),
         [
             (
-                _ExpanseSystemContext,
+                ExpanseSystemContext,
                 {
                     "mpi_exec_prefix": "srun --mpi=pmi2",
                     "compiler": "intel",
                 },
             ),
             (
-                _PerlmutterSystemContext,
+                PerlmutterSystemContext,
                 {
                     "mpi_exec_prefix": "srun",
                     "compiler": "gnu",
                 },
             ),
             (
-                _DerechoSystemContext,
+                DerechoSystemContext,
                 {
                     "mpi_exec_prefix": "mpirun",
                     "compiler": "intel",
                 },
             ),
             (
-                _MacOSSystemContext,
+                MacOSSystemContext,
                 {
                     "mpi_exec_prefix": "mpirun",
                     "compiler": "gnu",
                 },
             ),
             (
-                _LinuxSystemContext,
+                LinuxSystemContext,
                 {
                     "mpi_exec_prefix": "mpirun",
                     "compiler": "gnu",
@@ -88,7 +88,7 @@ class TestEnvironmentProperty:
     )
     def test_environment_initialization(
         self,
-        system_ctx: type[_SystemContext],
+        system_ctx: type[SystemContext],
         expected_attributes: dict[str, str],
     ) -> None:
         """Verify that environment attributes are correctly initialized."""


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This pull request mitigates warnings related to "private" classes and methods consumed from `cstar.system.manager` by renaming the entities to meet the naming standard.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- All system contexts have been renamed

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Tests passing
- [X] Full type hint coverage
