### PR TITLE
Fix safe-name collisions in workplan steps

### DIFF
--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -352,12 +352,22 @@ class Workplan(BaseModel):
         value : list[Step]
             The steps in the workplan.
         """
-        name_counter = Counter(step.name for step in value)
-        most_common = name_counter.most_common(1)
-        step_name, step_count = most_common[0] if most_common else ("", 0)
+        # use a map to avoid generating safe names repeatedly
+        n2s = {s.name: s.safe_name for s in value}
 
-        if step_count > 1:
-            msg = f"Step names must be unique. Found {step_count} steps with name {step_name}"
+        # identify all steps that resolve to a given safe name
+        safe_name_map = {
+            n2s[s.name]: [x.name for x in value if n2s[x.name] == n2s[s.name]]
+            for s in value
+        }
+
+        if collisions := {k: v for k, v in safe_name_map.items() if len(v) > 1}:
+            line_errors: list[str] = []
+            for v in collisions.values():
+                names = ", ".join(f"{x!r}" for x in v)
+                line_errors.append(f"Name collision among: {names}.")
+
+            msg = f"Step names must be unique. {' '.join(line_errors)}"
             raise ValueError(msg)
 
         return value

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -721,6 +721,46 @@ def test_workplan_steps_validation(invalid_value: list[str | None] | None) -> No
 
 
 @pytest.mark.parametrize(
+    "step_names",
+    [
+        pytest.param(["S1", "S1"], id="duped name"),
+        pytest.param(["S1", "s1"], id="case sensitivity"),
+        pytest.param(["S1", " S1"], id="whitespaced name (pre)"),
+        pytest.param(["S1", "S1 "], id="whitespaced name (post)"),
+        pytest.param(["S1", "S2", "S1 "], id="non-consecutive"),
+        pytest.param(["S1", "S1 ", " s1 "], id="many copies"),
+        pytest.param(["S1", "S2", "s1 ", " s2"], id="multiple collisions"),
+    ],
+)
+def test_workplan_steps_uniqueness_validation(
+    step_names: list[str],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
+) -> None:
+    """Verify step names are unique.
+
+    Parameters
+    ----------
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
+        A generator function to produce minimally valid test steps
+    """
+    name = f"test-plan-{uuid.uuid4()}"
+    description = f"test-desc-{uuid.uuid4()}"
+
+    steps = list(gen_fake_steps(len(step_names)))
+    for i in range(len(step_names)):
+        steps[i].name = step_names[i]
+
+    with pytest.raises(ValidationError) as error:
+        _ = Workplan(
+            name=name,
+            description=description,
+            steps=steps,
+        )
+
+    assert "Step names must be unique" in str(error)
+
+
+@pytest.mark.parametrize(
     "compute_env",
     [
         {},


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a bug in `Workplan` model validation. Given non-unique names like `"foo"`, `" foo "`, and `"FOO"`, a name collision could occur. 

Testing for these collisions before the fix:

<img width="352" height="184" alt="image" src="https://github.com/user-attachments/assets/23b590a5-07c5-42b2-b42c-37e47273b16a" />

Testing after the fix:

<img width="352" height="184" alt="image" src="https://github.com/user-attachments/assets/1df33482-d01a-4fb3-82ee-e77162ffd5b0" />


## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug in `Workplan._check_steps` that allows multiple steps to resolve to the same safe name.

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
