### PR TITLE
Log safename

### DIFF
--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -61,7 +61,8 @@ def preload_step(context: typer.Context, step_name: str) -> str:
         raise typer.BadParameter(msg, param_hint="run_id")
 
     wp = get_from_ctxmap(context, "workplan", Workplan)
-    step = next((x for x in wp.steps if x.name == step_name), None)
+    step = next((x for x in wp.steps if step_name in {x.name, x.safe_name}), None)
+
     if step is None:
         valid_steps = ", ".join(f"{s.name!r}" for s in wp.steps)
         raise typer.BadParameter(

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
@@ -79,3 +79,29 @@ def test_cli_workplan_log_step_with_logs(
         )
 
         assert f"{step.name} message" in result.stdout
+
+
+def test_cli_workplan_log_step_with_logs_via_slug(
+    executed_workplan_with_sideeffects: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that logs are loaded successfully when a user passes the slugified
+    step name instead of the actual step name.
+
+    Parameters
+    ----------
+    executed_workplan_with_sideeffects : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan_with_sideeffects
+
+    runner = CliRunner()
+
+    for step in wp.steps:
+        result = runner.invoke(
+            app,
+            [fake_run_id, step.safe_name],
+            color=False,
+            catch_exceptions=False,
+        )
+
+        assert f"{step.name} message" in result.stdout


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change enables users to pass a Step's safe-name to `cstar workplan log`. This can be useful if a user has viewed output from a transformed plan.

*before*:

```console
> cstar workplan log xxx300 "WIO Toy Simulation 1"
...
2026-06-25 16:05:34,569 [INFO] - service.py:322 - Shutting down service.
2026-06-25 16:05:34,569 [INFO] - runner.py:95 - Simulation completed successfully.
Blueprint execution completed
>
> x-cmcbride in 🌐 login01 in cstar on  main [$] via 🐍 v3.12.13 via 🅒 cstar 
❯ cstar workplan log xxx300 wio-toy-simulation-1
Usage: cstar workplan log [OPTIONS] RUN_ID STEP_NAME
Try 'cstar workplan log --help' for help.
╭─ Error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value for step_name: Unable to monitor logs for unknown step: 'wio-toy-simulation-1'. Valid values: 'WIO Toy Simulation 1', 'WIO Toy Simulation 2'                                                                                                                                                                                                                                                                                                                                                                                                                             │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

x-cmcbride in 🌐 login01 in cstar on  main [$] via 🐍 v3.12.13 via 🅒 cstar took 6s 
❯ 
```


*after*:

```console
> x-cmcbride in 🌐 login01 in cstar on  log-safename [$] via 🐍 v3.12.13 via 🅒 cstar 
❯ cstar workplan log xxx300 wio-toy-simulation-1
...
2026-06-25 16:05:34,569 [INFO] - service.py:322 - Shutting down service.
2026-06-25 16:05:34,569 [INFO] - runner.py:95 - Simulation completed successfully.
Blueprint execution completed
```

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
