### PR TITLE
Fix incorrect FQN in test mocks after entity rename

### DIFF
--- a/cstar/tests/unit_tests/system/test_hostnameevaluator.py
+++ b/cstar/tests/unit_tests/system/test_hostnameevaluator.py
@@ -148,11 +148,11 @@ def test_partial_platform_fallback(
         patch("platform.system", return_value=system_name),
         patch("platform.machine", return_value=machine_name),
         patch(
-            "cstar.system.manager._EljaSystemContext.is_match",
+            "cstar.system.manager.EljaSystemContext.is_match",
             mock.MagicMock(return_value=False),
         ),
         patch(
-            "cstar.system.manager._AnvilSystemContext.is_match",
+            "cstar.system.manager.AnvilSystemContext.is_match",
             mock.MagicMock(return_value=False),
         ),
     ):

--- a/cstar/tests/unit_tests/system/test_manager.py
+++ b/cstar/tests/unit_tests/system/test_manager.py
@@ -94,7 +94,7 @@ class TestEnvironmentProperty:
         """Verify that environment attributes are correctly initialized."""
         mock_get_sys_ctx = mock.MagicMock(return_value=system_ctx())
 
-        with mock.patch("cstar.system.manager._get_system_context", mock_get_sys_ctx):
+        with mock.patch("cstar.system.manager.get_system_context", mock_get_sys_ctx):
             system = CStarSystemManager()
 
         environment = system.environment


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a trio of regression errors caused by fully-qualified names passed to `mock.patch`. After renaming entities, these strings were not updated.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix regression in test mocks after entities were renamed.

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests passing
