### PR TITLE
Update schema gen

### DIFF
--- a/cstar/cli/blueprint/schemas.py
+++ b/cstar/cli/blueprint/schemas.py
@@ -63,7 +63,9 @@ def generate_schema(
     app_name = schema["properties"]["application"]["default"]
     version = schema["properties"]["schema_version"]["default"] or "1.0.0"
     file_name = f"{app_name}_schema.{version}.json"
-    schema_path = output_dir / app_name / file_name
+    schema_dir = output_dir / app_name
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    schema_path = schema_dir / file_name
 
     nbytes = schema_path.write_text(f"{content}\n")
     if not nbytes:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change fixes a bug in the schema generation tool. When an application is new, the tool attempted to write a schema file to a directory that had not yet been created.

The fix ensures `dir.mkdir` is called prior to writing the schema.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix failure to generate schemas for new applications with `cstar blueprint schemas`

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests passing
