### PR TITLE
Include workplan paths in the summary

### DIFF
--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -223,6 +223,8 @@ def get_run_summary_display(summary: ExecutiveRunSummary) -> str:
                 {prefix}{run_header}
                 {prefix}{run_underline}
                 {prefix}{INDENT}- {_runft("run_id")}: {colored(summary.run_id, ATTR_COLOR)}
+                {prefix}{INDENT}- {_runft("source_workplan")}: {summary.source_workplan}
+                {prefix}{INDENT}- {_runft("final_workplan")}: {summary.final_workplan}
                 {prefix}{INDENT}- {_runft("state_dir")}: {summary.state_dir}
                 {prefix}
                 {prefix}{section_header_steps}
@@ -469,7 +471,7 @@ def run(
         raise typer.Exit(3) from ex
 
     console.print(
-        f"{summary.workplan_name!r} {'dry-run' if dry_run else 'run'} scheduling has completed"
+        f"{summary.workplan_name!r} {'dry-run' if dry_run else 'run scheduling'} has completed"
     )
 
 

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -446,6 +446,16 @@ class ExecutiveRunSummary(BaseModel):
         title="Workplan name",
     )
     """The run-id associated with the run being summarized."""
+    source_workplan: str = Field(
+        description="The path to the original, unmodified workplan.",
+        title="Original workplan",
+    )
+    """The path to the original, unmodified workplan."""
+    final_workplan: str = Field(
+        description="The path to the transformed, ready-to-run workplan.",
+        title="Runnable workplan",
+    )
+    """The path to the transformed, ready-to-run workplan."""
     steps: list[ExecutiveStepSummary] = Field(
         default_factory=list[ExecutiveStepSummary],
         description="An executive summary for each step in the run.",
@@ -503,6 +513,8 @@ class ExecutiveRunSummary(BaseModel):
         return ExecutiveRunSummary(
             run_id=run.run_id,
             workplan_name=workplan.name,
+            source_workplan=str(run.workplan_path),
+            final_workplan=str(run.trx_workplan_path),
             steps=step_summaries,
             dry_run=is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN),
         )


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change updates the workplan summary displayed to a user when running `cstar workplan run ...` to include the paths to the workplan YAML files.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Workplan run summary includes paths to Workplan YAML files for review.

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->


- [X] Tests passing
