### PR TITLE
Remove use of deprecated collection typehints

### DIFF
--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -277,7 +277,7 @@ def check_and_capture_kvps(entries: list[str]) -> Mapping[str, str] | None:
 
     Returns
     -------
-    t.Mapping[str, str]
+    Mapping[str, str]
         The key-value pairs from the list converted into a mapping containing
         all unique key-value pairs
 

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -6,7 +6,7 @@ import re
 import typing as t
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timedelta
 from math import ceil
 from pathlib import Path
@@ -165,7 +165,7 @@ class SlurmStep(BaseModel):
 
         Returns
         -------
-        t.Iterable[SlurmJobDetail]
+        tuple[SlurmStep, ...]
         """
         return tuple(
             cls.from_sacct(line) for line in sacct_stdout.split("\n") if line.strip()
@@ -175,18 +175,18 @@ class SlurmStep(BaseModel):
 class SlurmBatch:
     """Metadata for all steps in a SLURM batch."""
 
-    steps: t.Iterable[SlurmStep]
+    steps: Iterable[SlurmStep]
     """The collection of steps running in a batch."""
 
     _job: SlurmStep | None = None
     """The parent step for the batch."""
 
-    def __init__(self, steps: t.Iterable[SlurmStep]) -> None:
+    def __init__(self, steps: Iterable[SlurmStep]) -> None:
         """Initialize the instance.
 
         Parameters
         ----------
-        steps: t.Iterable[SlurmStep]
+        steps: Iterable[SlurmStep]
             The steps belonging to the batch.
         """
         job_ids = {x.job_id for x in steps}
@@ -224,13 +224,13 @@ class SlurmBatch:
         return self._job.job_id
 
     @classmethod
-    def from_multi_query(cls, steps: t.Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
+    def from_multi_query(cls, steps: Iterable[SlurmStep]) -> dict[str, "SlurmBatch"]:
         """Create a mapping of job-id to Batch for all discovered job-ids
         resulting from a multi-job query.
 
         Parameters
         ----------
-        steps: t.Iterable[SlurmStep]
+        steps: Iterable[SlurmStep]
             The steps belonging to 1-to-many batches.
 
         Returns
@@ -243,12 +243,12 @@ class SlurmBatch:
 
         return {k: SlurmBatch(multi_map[k]) for k in multi_map}
 
-    def __iter__(self) -> t.Iterator["SlurmStep"]:
+    def __iter__(self) -> Iterator["SlurmStep"]:
         """Iterate through the steps associated with the batch.
 
         Returns
         -------
-        t.Iterator[SlurmStep]
+        Iterator[SlurmStep]
         """
         yield from self.steps
 
@@ -327,7 +327,7 @@ async def get_slurm_batches(
 
     Parameters
     ----------
-    job_ids: t.Iterable[str | int]
+    job_ids: Iterable[str | int]
         A collection containing batch job ID's
 
     Returns

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -325,7 +325,7 @@ async def prepare_workplan(
         The directory where workplan outputs will be written.
     run_id : str
         The unique ID for the current run.
-    user_variables : t.Mapping | None
+    user_variables : Mapping | None
         User-defined variables specified at runtime
 
     Returns

--- a/cstar/tests/integration_tests/test_cstar_test_blueprints.py
+++ b/cstar/tests/integration_tests/test_cstar_test_blueprints.py
@@ -1,5 +1,6 @@
 import logging
 import typing as t
+from collections.abc import Callable
 from pathlib import Path
 from unittest import mock
 
@@ -20,11 +21,11 @@ class TestCStar:
     async def test_cstar(
         self,
         tmp_path: Path,
-        modify_template_blueprint: t.Callable[
+        modify_template_blueprint: Callable[
             [Path | str, dict[str, str], Path | str], str
         ],
         mock_lmod_path: Path,
-        fetch_remote_test_case_data: t.Callable[[], None],
+        fetch_remote_test_case_data: Callable[[], None],
         test_config_key: str,
         log: logging.Logger,
         integration_test_configuration: dict[str, dict[str, str | dict[str, str]]],

--- a/cstar/tests/unit_tests/base/test_log.py
+++ b/cstar/tests/unit_tests/base/test_log.py
@@ -1,9 +1,8 @@
 import logging
-import logging.handlers
 import pathlib
 import re
-import typing as t
 import uuid
+from collections.abc import Callable
 from time import strftime
 from unittest import mock
 
@@ -26,12 +25,12 @@ def all_levels() -> list[int]:
 @pytest.fixture
 def levels_fn(
     all_levels: list[int],
-) -> t.Callable[[int], tuple[list[int], list[int]]]:
+) -> Callable[[int], tuple[list[int], list[int]]]:
     """Return a function that returns a tuple of lists containing all log levels below
     and above the specified log level.
 
     Returns:
-        t.Callable[list[int], list[int]]: the function
+        Callable[list[int], list[int]]: the function
     """
 
     def _inner(level: int) -> tuple[list[int], list[int]]:
@@ -45,7 +44,8 @@ def levels_fn(
         Returns:
             tuple[list[int], list[int]]: the lists of log levels
         """
-        lt, gte = [], []
+        lt: list[int] = []
+        gte: list[int] = []
 
         for level_ in all_levels:
             if level_ < level:
@@ -71,7 +71,7 @@ def levels_fn(
 def test_loglevel_fh(
     request: pytest.FixtureRequest,
     level: int,
-    levels_fn: t.Callable[[int], tuple[list[int], list[int]]],
+    levels_fn: Callable[[int], tuple[list[int], list[int]]],
     all_levels: list[int],
     tmp_path: pathlib.Path,
 ) -> None:

--- a/cstar/tests/unit_tests/io/test_cached_stager.py
+++ b/cstar/tests/unit_tests/io/test_cached_stager.py
@@ -1,4 +1,5 @@
 import typing as t
+from collections.abc import Callable, Generator
 from pathlib import Path
 from unittest import mock
 
@@ -11,7 +12,7 @@ if t.TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_home_dir(tmp_path: Path) -> t.Generator[t.Callable[[], Path], None, None]:
+def mock_home_dir(tmp_path: Path) -> Generator[Callable[[], Path], None, None]:
     """Fixture that replaces the default home directory with a temporary
     home directory.
     """

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_shared.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_shared.py
@@ -105,7 +105,7 @@ def test_capture_kvps_happy_path(
     ----------
     entries : list[str]
         The list of items to parse
-    expected : t.Mapping[str, str]
+    expected : Mapping[str, str]
         The expected output
     """
     actual = check_and_capture_kvps(entries)
@@ -145,7 +145,7 @@ def test_capture_kvps_duplicate(
     ----------
     entries : list[str]
         The list of items to parse
-    expected : t.Mapping[str, str]
+    expected : Mapping[str, str]
         The expected output
     """
     with pytest.raises(typer.BadParameter, match="multiple"):

--- a/cstar/tests/unit_tests/orchestration/test_planner.py
+++ b/cstar/tests/unit_tests/orchestration/test_planner.py
@@ -1,6 +1,7 @@
 # ruff: noqa: S101
 
 import typing as t
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,7 @@ from cstar.orchestration.serialization import deserialize
 @pytest.fixture
 def the_workplan(
     tmp_path: Path,
-    fill_workplan_template: t.Callable[[dict[str, t.Any]], str],
+    fill_workplan_template: Callable[[dict[str, t.Any]], str],
     complete_workplan_template_input: dict[str, t.Any],
 ) -> Workplan:
     """Create a valid workplan.
@@ -86,8 +87,8 @@ def get_monitored_graph_plan_size(plan: Workplan) -> int:
 def test_planner_with_tasks(
     planner_type: type[Planner],
     num_steps: int,
-    node_fn: t.Callable[[Workplan], int],
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    node_fn: Callable[[Workplan], int],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
     # the_workplan: Workplan,
 ) -> None:
     """Verify that the planner produces a plan with the expected number of steps.
@@ -100,7 +101,7 @@ def test_planner_with_tasks(
         The number of steps to add to the workplan
     node_fn : Callable[[Workplan], int]
         A function that takes a workplan as input and returns the size of the plan
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """
@@ -144,22 +145,19 @@ def test_planner_with_tasks(
     ],
 )
 def test_planner_bfs_breaker(
-    tmp_path: Path,
     num_steps: int,
     deps: list[tuple[int, int]],
-    gen_fake_steps: t.Callable[[int], t.Generator[Step, None, None]],
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
 ) -> None:
     """Verify that a dependency that breaks BFS ordering is honored.
 
     Parameters
     ----------
-    tmp_path : Path
-        A temporary path to store test outputs
     num_steps : int
         The number of steps to add to the workplan
     deps : list[tuple[int, int]]
         Tuples containing indices of tasks to create dependencies between
-    gen_fake_steps : t.Callable[[int], t.Generator[Step, None, None]]
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
         A generator function to produce minimally valid test steps
 
     """

--- a/cstar/tests/unit_tests/orchestration/test_userdefinedvariables.py
+++ b/cstar/tests/unit_tests/orchestration/test_userdefinedvariables.py
@@ -1,4 +1,4 @@
-import typing as t
+from collections.abc import Mapping
 
 import pytest
 
@@ -15,7 +15,7 @@ from cstar.orchestration.models import UserDefinedVariables
 )
 def test_userdefinedvariables_valid_inputs(
     keys: set[str],
-    mapping: t.Mapping[str, str],
+    mapping: Mapping[str, str],
 ) -> None:
     """Verify that a valid input does not result in an error.
 
@@ -23,7 +23,7 @@ def test_userdefinedvariables_valid_inputs(
     ----------
     keys : set[str]
         A valid set of "declared keys"
-    mapping : t.Mapping[str, str]
+    mapping : Mapping[str, str]
         A valid mapping of key-value pairs
     """
     replacements = UserDefinedVariables(
@@ -67,7 +67,7 @@ def test_userdefinedvariables_valid_inputs(
 )
 def test_userdefinedvariables_coverage_fail(
     keys: set[str],
-    mapping: t.Mapping[str, str],
+    mapping: Mapping[str, str],
     matches: set[str],
 ) -> None:
     """Verify that mappings that do not cover all declared keys result in an error
@@ -77,7 +77,7 @@ def test_userdefinedvariables_coverage_fail(
     ----------
     keys : set[str]
         A valid set of "declared keys"
-    mapping : t.Mapping[str, str]
+    mapping : Mapping[str, str]
         A valid mapping of key-value pairs
     matches : set[str]
         Strings that must be found in the error output
@@ -170,7 +170,7 @@ def test_userdefinedvariables_no_declarations() -> None:
 )
 def test_userdefinedvariables_declaration_fail(
     keys: set[str],
-    mapping: t.Mapping[str, str],
+    mapping: Mapping[str, str],
     matches: set[str],
 ) -> None:
     """Verify that mappings including undeclared keys result in an error
@@ -180,7 +180,7 @@ def test_userdefinedvariables_declaration_fail(
     ----------
     keys : set[str]
         A valid set of "declared keys"
-    mapping : t.Mapping[str, str]
+    mapping : Mapping[str, str]
         A valid mapping of key-value pairs
     matches : set[str]
         Strings that must be found in the error output


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change is a minor QoL improvement that removes the remaining use of deprecated types from the `typing` module (Callable, Generator, Iterator).

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce warnings produced by linter

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Full type hint coverage
