### PR TITLE
Handle SLURM out-of-memory status

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -40,6 +40,7 @@ sacct_status_map = defaultdict(
         "CANCELLED": ExecutionStatus.CANCELLED,
         "FAILED": ExecutionStatus.FAILED,
         "TIMEOUT": ExecutionStatus.TIMEOUT,
+        "OUT_OF_MEMORY": ExecutionStatus.FAILED,
     },
 )
 """Map sacct states to ExecutionStatus enum."""

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -892,6 +892,7 @@ async def test_get_slurm_batches() -> None:
         (ExecutionStatus.CANCELLED, "CANCELLED"),
         (ExecutionStatus.FAILED, "FAILED"),
         (ExecutionStatus.TIMEOUT, "TIMEOUT"),
+        (ExecutionStatus.FAILED, "OUT_OF_MEMORY"),
     ],
 )
 def test_get_slurm_batch_sync(exp_status: ExecutionStatus, raw_status: str) -> None:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a failure in C-Star when a `SLURM` *out-of-memory* status is encountered.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix unmapped `OUT_OF_MEMORY` status returned by SLURM resulting in run failure.

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-1016
- [X] Tests added
- [X] Tests passing
- [X] Full type hint coverage
