### PR TITLE
Fix runid-not-set bug

### DIFF
--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import os
 import subprocess
 import textwrap
 import typing as t
@@ -10,7 +11,7 @@ from psutil import NoSuchProcess
 from psutil import Process as PsProcess
 from pydantic import PrivateAttr
 
-from cstar.base.env import ENV_CSTAR_ORCH_LOCAL_DELAY, get_env_item
+from cstar.base.env import ENV_CSTAR_ORCH_LOCAL_DELAY, ENV_CSTAR_RUNID, get_env_item
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import get_logger
 from cstar.orchestration.orchestration import (
@@ -213,6 +214,7 @@ class LocalLauncher(Launcher[LocalHandle]):
                 handle = LocalHandle(
                     pid=str(pid),
                     name=step.name,
+                    run_id=str(os.getenv(ENV_CSTAR_RUNID, "")),
                     start_at=create_time,
                     status=Status.Submitted,
                 )

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -200,7 +200,11 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             await asyncio.sleep(SlurmLauncher.POST_SUBMIT_DELAY)
 
             log.debug("Submission of `%s` created Job ID `%s`", step.name, job.id)
-            return SlurmHandle(pid=str(job.id), name=step.name)
+            return SlurmHandle(
+                pid=str(job.id),
+                name=step.name,
+                run_id=str(os.getenv(ENV_CSTAR_RUNID, "")),
+            )
 
         msg = f"Unable to retrieve job ID for step `{step.name}`. Job `{job}` failed"
         raise RuntimeError(msg)

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -202,7 +202,7 @@ class ProcessHandle(BaseModel):
     """The process identifier."""
     name: str
     """The name of the process."""
-    run_id: str = Field(default_factory=lambda: str(os.getenv(ENV_CSTAR_RUNID, "")))
+    run_id: str
     """The run-id the process was run under."""
     launcher_name: str = ""
     """The launcher used to launch the process."""

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -653,6 +653,7 @@ async def executed_workplan_with_sideeffects(
         handle = LocalHandle(
             pid=f"100{i}",
             name=step.name,
+            run_id=fake_run_id,
             start_at=datetime.now(),
         )
 

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -99,6 +99,7 @@ async def layered_workplan(
             handle = LocalHandle(
                 pid=f"100{idx}",
                 name=step.name,
+                run_id=fake_run_id,
                 start_at=datetime.now(),
             )
             handles[step.name] = handle

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -265,8 +265,8 @@ def test_serialization_workplan_steps_with_directives(
 )
 def test_serialization_handle(mode: PersistenceMode) -> None:
     """Verify that a task can be properly serialized to disk and reloaded."""
-    pid, job_name = "test-pid", "abc123"
-    handle = SlurmHandle(pid=pid, name=job_name, run_id="test-run-id")
+    pid, job_name, run_id = "test-pid", "abc123", "fake-run-id"
+    handle = SlurmHandle(pid=pid, name=job_name, run_id=run_id)
 
     persist_as = StateRepository.sentinel_path(handle, mode=mode)
 
@@ -290,6 +290,7 @@ def test_serialization_handle(mode: PersistenceMode) -> None:
 
     assert dhandle.name == handle.name
     assert dhandle.pid == handle.pid
+    assert dhandle.run_id == run_id
 
 
 def test_serializaton_json_schema(plotter_v2_0_0_bp: Path, tmp_path: Path) -> None:

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -266,7 +266,7 @@ def test_serialization_workplan_steps_with_directives(
 def test_serialization_handle(mode: PersistenceMode) -> None:
     """Verify that a task can be properly serialized to disk and reloaded."""
     pid, job_name = "test-pid", "abc123"
-    handle = SlurmHandle(pid=pid, name=job_name)
+    handle = SlurmHandle(pid=pid, name=job_name, run_id="test-run-id")
 
     persist_as = StateRepository.sentinel_path(handle, mode=mode)
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes a regression issue where the default value of `ProcessHandle.run_id` is not set.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix `SlurmHandle has no attribute run_id` bug 

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests passing
- [X] Full type hint coverage
