### PR TITLE
Enable strict model validation

### DIFF
--- a/cstar/additional_files/templates/bp/hello_world/blueprint.1.0.0.yaml
+++ b/cstar/additional_files/templates/bp/hello_world/blueprint.1.0.0.yaml
@@ -3,4 +3,4 @@ description: This blueprint says hello to a very nice guy
 application: hello_world
 state: draft
 target: '@ankona'
-version: '1.0.0'
+schema_version: '1.0.0'

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -3,12 +3,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from itertools import chain
+from pathlib import Path
 
 from cstar.base.adapter import SchemaAdapter
 from cstar.base.log import get_logger
 from cstar.entrypoint.config import JOBFILE_DATE_FORMAT
 from cstar.execution.file_system import local_copy
 from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import SerializableModel, deserialize
 
 if t.TYPE_CHECKING:
@@ -321,6 +323,22 @@ _registry: dict[str, type[_TAnyApp]] = {}
 _AppDef = t.TypeVar("_AppDef", bound=_TAnyApp)
 
 
+def get_application_name(path: Path) -> str:
+    """Retrieve the application name from a blueprint file.
+
+    Parameters
+    ----------
+    path : Path
+        The path to a file containing a blueprint.
+
+    Returns
+    -------
+    str
+    """
+    base_bp = deserialize(path, BlueprintCore)
+    return base_bp.application
+
+
 def register_application(
     klass: type[_AppDef],
 ) -> type[_AppDef]:
@@ -349,3 +367,19 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
 
     msg = f"No application for {name!r}"
     raise ValueError(msg)
+
+
+def get_app_for_blueprint(path: Path) -> ApplicationDefinition[t.Any, t.Any]:
+    """Retrieve the appropriate application for a blueprint.
+
+    Parameters
+    ----------
+    path : Path
+        The path to a file containing a blueprint.
+
+    Returns
+    -------
+    ApplicationDefinition[t.Any, t.Any]
+    """
+    name = get_application_name(path)
+    return get_application(name)

--- a/cstar/applications/roms_marbl/models.py
+++ b/cstar/applications/roms_marbl/models.py
@@ -41,7 +41,7 @@ class ForcingConfiguration(ConfiguredBaseModel):
     """Wind or other forcing corrections."""
 
 
-class CodeRepository(DocLocMixin, ConfiguredBaseModel):
+class CodeRepository(DocLocMixin):
     """Reference to a remote code repository with optional path filtering
     and point-in-time specification.
     """
@@ -96,7 +96,7 @@ class ROMSCompositeCodeRepository(ConfiguredBaseModel):
     """Codebase used to add MARBL to the simulation."""
 
 
-class ParameterSet(DocLocMixin, ConfiguredBaseModel):
+class ParameterSet(DocLocMixin):
     """A base class for parameter sets exposed on a blueprint."""
 
     hash: str | None = Field(default=None, init=False, validate_default=False)
@@ -195,7 +195,7 @@ class ModelParameterSet(ParameterSet):
     """The time step the model integrates over."""
 
 
-class RomsMarblBlueprint(Blueprint, ConfiguredBaseModel):
+class RomsMarblBlueprint(Blueprint):
     """Blueprint schema for running a ROMS-MARBL simulation."""
 
     schema_version: str = Field("2.0.0", frozen=True)

--- a/cstar/applications/roms_marbl/models.py
+++ b/cstar/applications/roms_marbl/models.py
@@ -198,7 +198,7 @@ class ModelParameterSet(ParameterSet):
 class RomsMarblBlueprint(Blueprint):
     """Blueprint schema for running a ROMS-MARBL simulation."""
 
-    schema_version: str = Field("2.0.0", frozen=True)
+    schema_version: str = "2.0.0"
     """The blueprint schema version."""
 
     application: str = APP_NAME

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -27,7 +27,7 @@ from cstar.base.utils import (
     slugify,
 )
 from cstar.orchestration.orchestration import LiveStep
-from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.serialization import serialize
 from cstar.orchestration.transforms import (
     Directive,
     DirectiveConfig,
@@ -92,7 +92,7 @@ class RomsMarblTimeSplitter(Transform[LiveStep]):
         if not is_feature_enabled(ENV_FF_ORCH_TRX_TIMESPLIT):
             return [step]
 
-        blueprint = deserialize(step.blueprint_path, RomsMarblBlueprint)
+        blueprint = t.cast("RomsMarblBlueprint", step.blueprint)
         start_date = blueprint.runtime_params.start_date
         end_date = blueprint.runtime_params.end_date
 

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -149,8 +149,9 @@ class RomsMarblTimeSplitter(Transform[LiveStep]):
                 "blueprint_overrides": overrides,
                 "depends_on": depends_on,
                 "name": child_step_name,
+                "parent": step,
             }
-            child_step = LiveStep.from_step(step, parent=step, update=updates)
+            child_step = LiveStep.from_step(step, update=updates)
             results.append(child_step)
 
             if i == len(time_slices) - 1:

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -117,6 +117,7 @@ class RomsMarblTimeSplitter(Transform[LiveStep]):
                     exclude_unset=True,
                     exclude_defaults=True,
                     exclude_computed_fields=True,
+                    exclude={"$schema"},
                 ),
             )
 

--- a/cstar/cli/blueprint/check.py
+++ b/cstar/cli/blueprint/check.py
@@ -3,7 +3,7 @@ import typing as t
 import typer
 
 from cstar.applications.core import get_application
-from cstar.orchestration.models import Blueprint
+from cstar.orchestration.models import Blueprint, BlueprintCore
 from cstar.orchestration.serialization import validate_serialized_entity
 
 app = typer.Typer()
@@ -23,7 +23,7 @@ def check(
     bool
         `True` if valid
     """
-    result = validate_serialized_entity(path, Blueprint)
+    result = validate_serialized_entity(path, BlueprintCore)
     if result.item is None:
         raise typer.BadParameter(result.error_msg)
 

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -6,9 +6,8 @@ import typer
 from pydantic import ValidationError
 
 from cstar.applications.core import (
-    ApplicationDefinition,
     RunnerRequest,
-    get_application,
+    get_app_for_blueprint,
 )
 from cstar.base.env import (
     ENV_CSTAR_CLI_VERBOSE,
@@ -40,13 +39,12 @@ from cstar.entrypoint.utils import (
     ARG_VERBOSE_HELP,
 )
 from cstar.execution.file_system import local_copy
-from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import deserialize, validate_serialized_entity
 from cstar.orchestration.transforms import DirectiveConfig
 from cstar.system.migration import CStarMigrationNotRegisteredError
 
 if t.TYPE_CHECKING:
-    from cstar.entrypoint.runner import BlueprintRunner
+    ...
 
 
 CMD_NAME: t.Final[str] = "run"
@@ -93,10 +91,6 @@ def path_callback(
                     bp_path = Path(persist_result.target)
                 except CStarMigrationNotRegisteredError:
                     log.info("Skipping schema migration; no registered adapters")
-
-            base_bp = deserialize(bp_path, Blueprint)
-            app = get_application(base_bp.application)
-            ctx.obj = app.blueprint(**base_bp.model_dump())
             return str(bp_path)
 
     except FileNotFoundError as ex:
@@ -193,16 +187,17 @@ def run(
     ] = False,
 ) -> None:
     """Execute a blueprint in a local worker service."""
-    bp = t.cast("Blueprint", ctx.obj)
-    name = f"{bp.application}_runner"
+    bp_path = Path(uri)
+    app_config = get_app_for_blueprint(bp_path)
 
+    name = f"{app_config.name}_runner"
     job_cfg = get_job_config()
     service_cfg = get_service_config(get_env_item(ENV_CSTAR_LOG_LEVEL).value, name=name)
 
-    msg = f"Executing {bp.application!r} blueprint in a {type(bp)} service"
+    msg = f"Executing {app_config.name!r} blueprint in a {type(app_config.runner).__name__} service"
     log.debug(msg)
 
-    result = validate_serialized_entity(uri, type(bp))
+    result = validate_serialized_entity(bp_path, app_config.blueprint)
     if not result.is_valid:
         print(result.error_msg)
         return
@@ -210,11 +205,8 @@ def run(
     if directive_uri:
         uri = DirectiveConfig.apply_directives(directive_uri, uri)
 
-    request = RunnerRequest(uri, type(bp))
+    request = RunnerRequest(uri, app_config.blueprint)
 
-    app_config: ApplicationDefinition[Blueprint, BlueprintRunner[Blueprint]] = (
-        get_application(bp.application)
-    )
     runner = app_config.runner(request, service_cfg, job_cfg)
     asyncio.run(runner.execute())
 

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -18,7 +18,7 @@ from cstar.base.env import (
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, reset_log_level
 from cstar.execution.file_system import DirectoryManager, is_remote_resource
-from cstar.orchestration.models import Blueprint
+from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import (
     PersistenceMode,
     serialize,
@@ -342,7 +342,7 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
     CStarMigrationNotRegisteredError
         If there are no registered migrations for the requested schema.
     """
-    validation_result = validate_serialized_entity(request.source, Blueprint)
+    validation_result = validate_serialized_entity(request.source, BlueprintCore)
     if validation_result.item is None:
         raise typer.BadParameter(validation_result.error_msg)
 

--- a/cstar/cli/workplan/generate.py
+++ b/cstar/cli/workplan/generate.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from cstar.applications.core import ApplicationDefinition, get_application
+from cstar.applications.core import get_app_for_blueprint
 from cstar.base.utils import slugify
 from cstar.orchestration.models import (
     Blueprint,
@@ -19,8 +19,6 @@ from cstar.orchestration.models import (
 from cstar.orchestration.serialization import deserialize, serialize
 
 if t.TYPE_CHECKING:
-    from cstar.entrypoint.runner import BlueprintRunner
-
     BPResult: t.TypeAlias = tuple[Path, Blueprint]
 
 
@@ -56,13 +54,8 @@ def _locate_blueprints(
 
     try:
         for file in files:
-            base_bp = deserialize(file, Blueprint)
-
-            app: ApplicationDefinition[Blueprint, BlueprintRunner[Blueprint]] = (
-                get_application(base_bp.application)
-            )
-            bp_type = app.blueprint
-            bp = bp_type(**base_bp.model_dump())
+            app = get_app_for_blueprint(file)
+            bp = deserialize(file, app.blueprint)
 
             valid_blueprints.append((file, bp))
     except ValueError as ex:

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -486,7 +486,10 @@ def local_copy(uri: str) -> Generator[Path, None, None]:
             bp_path = write_local_copy(uri, Path(tmp_dir))
             yield bp_path
     else:
-        yield Path(uri).expanduser().resolve()
+        bp_path = Path(uri).expanduser().resolve()
+        if not bp_path.exists():
+            raise FileNotFoundError(f"File not found at path: {bp_path}")
+        yield bp_path
 
 
 @asynccontextmanager

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -239,6 +239,9 @@ class WorkplanState(StrEnum):
 class Step(PolymorphicBaseModel):
     """An individual unit of execution within a workplan."""
 
+    resolver: t.ClassVar[dict[str, type["Step"]]] = {}
+    """Subclass registry for type resolution during deserialization."""
+
     name: RequiredString
     """The user-friendly name of the step."""
 
@@ -294,6 +297,18 @@ class Step(PolymorphicBaseModel):
         str
         """
         return slugify(self.name)
+
+    @classmethod
+    def discriminator(cls) -> str:
+        """Return the sub-type discriminator."""
+        raise NotImplementedError("Subclasses must implement")
+
+    def __init_subclass__(cls, **kwargs: t.Any):
+        """Register `Step` subclasses with a unique _kind_ value that will be used
+        for discrimination during deserialization.
+        """
+        super().__init_subclass__(**kwargs)
+        cls.resolver[cls.discriminator()] = cls
 
 
 class Workplan(PolymorphicBaseModel):
@@ -413,10 +428,25 @@ class Workplan(PolymorphicBaseModel):
 
         return value
 
-    @model_validator(mode="after")
-    def _model_validator(self) -> "Workplan":
+    @model_validator(mode="before")
+    @classmethod
+    def _model_validator(cls, data: t.Any) -> t.Any:
         """Validate attribute relationships."""
-        return self
+        if (
+            isinstance(data, dict)
+            and isinstance(data.get("steps"), list)
+            and len(data.get("steps", [])) > 0
+            and isinstance(data.get("steps", [None])[0], dict)
+        ):
+            step_data = t.cast("list[dict[str, t.Any]]", data["steps"])
+            if "kind" not in step_data[0]:
+                return data
+
+            data["steps"] = [
+                Step.resolver.get(s.get("kind", ""), Step).model_validate(s)
+                for s in step_data
+            ]
+        return data
 
 
 class UserDefinedVariables(ConfiguredBaseModel):

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -60,8 +60,11 @@ class ConfiguredBaseModel(BaseModel):
     for subclasses.
     """
 
-    model_config = ConfigDict(extra="allow", from_attributes=True)
-    """Pydantic ConfigDict with options we want changed."""
+    model_config: t.ClassVar[ConfigDict] = ConfigDict(
+        extra="allow",
+        from_attributes=True,
+    )
+    """Configures the behavior of the pydantic model."""
 
 
 class Resource(ConfiguredBaseModel):
@@ -400,7 +403,7 @@ class Workplan(BaseModel):
         return self
 
 
-class UserDefinedVariables(BaseModel):
+class UserDefinedVariables(ConfiguredBaseModel):
     """A collection of key-value pairs that provides validation of the static
     keys specified at design time and dynamically configured keys at runtime.
 

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -16,7 +16,6 @@ from pydantic import (
     PlainSerializer,
     PrivateAttr,
     SerializationInfo,
-    SerializeAsAny,
     StringConstraints,
     ValidationInfo,
     WithJsonSchema,
@@ -63,6 +62,23 @@ class ConfiguredBaseModel(BaseModel):
     model_config: t.ClassVar[ConfigDict] = ConfigDict(
         extra="allow",
         from_attributes=True,
+        str_strip_whitespace=True,
+        use_attribute_docstrings=True,
+    )
+    """Configures the behavior of the pydantic model."""
+
+
+class PolymorphicBaseModel(BaseModel):
+    """Base-model configuring common instantiation and validation behavior
+    for serialization of covariant references.
+    """
+
+    model_config: t.ClassVar[ConfigDict] = ConfigDict(
+        extra="allow",
+        from_attributes=True,
+        str_strip_whitespace=True,
+        use_attribute_docstrings=True,
+        polymorphic_serialization=True,
     )
     """Configures the behavior of the pydantic model."""
 
@@ -220,7 +236,7 @@ class WorkplanState(StrEnum):
     """A workflow that has been validated."""
 
 
-class Step(BaseModel):
+class Step(PolymorphicBaseModel):
     """An individual unit of execution within a workplan."""
 
     name: RequiredString
@@ -280,7 +296,7 @@ class Step(BaseModel):
         return slugify(self.name)
 
 
-class Workplan(BaseModel):
+class Workplan(PolymorphicBaseModel):
     """A collection of executable steps and the associated configuration to run them."""
 
     name: RequiredString
@@ -289,7 +305,7 @@ class Workplan(BaseModel):
     description: RequiredString
     """A user-friendly description of the workplan."""
 
-    steps: Sequence[SerializeAsAny[Step]] = Field(
+    steps: Sequence[Step] = Field(
         min_length=1,
         frozen=True,
     )

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -68,16 +68,12 @@ class ConfiguredBaseModel(BaseModel):
     """Configures the behavior of the pydantic model."""
 
 
-class PolymorphicBaseModel(BaseModel):
+class PolymorphicBaseModel(ConfiguredBaseModel):
     """Base-model configuring common instantiation and validation behavior
     for serialization of covariant references.
     """
 
     model_config: t.ClassVar[ConfigDict] = ConfigDict(
-        extra="forbid",
-        from_attributes=True,
-        str_strip_whitespace=True,
-        use_attribute_docstrings=True,
         polymorphic_serialization=True,
     )
     """Configures the behavior of the pydantic model."""
@@ -183,7 +179,7 @@ class BlueprintCore(ConfiguredBaseModel):
     """The schema version for the document."""
 
     model_config: t.ClassVar[ConfigDict] = ConfigDict(
-        extra="allow", from_attributes=True
+        extra="allow",
     )
     """Configuration allowing extra field data."""
 

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -60,7 +60,7 @@ class ConfiguredBaseModel(BaseModel):
     """
 
     model_config: t.ClassVar[ConfigDict] = ConfigDict(
-        extra="allow",
+        extra="forbid",
         from_attributes=True,
         str_strip_whitespace=True,
         use_attribute_docstrings=True,
@@ -74,7 +74,7 @@ class PolymorphicBaseModel(BaseModel):
     """
 
     model_config: t.ClassVar[ConfigDict] = ConfigDict(
-        extra="allow",
+        extra="forbid",
         from_attributes=True,
         str_strip_whitespace=True,
         use_attribute_docstrings=True,
@@ -170,6 +170,24 @@ class Application(StrEnum):
     """Application performing an upscaled simulation run."""
 
 
+class BlueprintCore(ConfiguredBaseModel):
+    """Model used for metadata-only loading of blueprints"""
+
+    name: RequiredString
+    """A unique, user-friendly name for this blueprint."""
+
+    application: RequiredString
+    """The process type to be executed by the blueprint."""
+
+    schema_version: str = "1.0.0"
+    """The schema version for the document."""
+
+    model_config: t.ClassVar[ConfigDict] = ConfigDict(
+        extra="allow", from_attributes=True
+    )
+    """Configuration allowing extra field data."""
+
+
 class Blueprint(ConfiguredBaseModel, ABC):
     """Common elements of all blueprints."""
 
@@ -179,13 +197,13 @@ class Blueprint(ConfiguredBaseModel, ABC):
     description: RequiredString
     """A user-friendly description of the scenario to be executed by the blueprint."""
 
-    application: str
+    application: RequiredString
     """The process type to be executed by the blueprint."""
 
     state: BlueprintState = BlueprintState.NotSet
     """The current validation status of the blueprint."""
 
-    schema_version: str = Field("1.0.0", frozen=True)
+    schema_version: str = "1.0.0"
     """The schema version for the document."""
 
     working_dir: TargetDirectoryPath = Path()
@@ -215,13 +233,15 @@ class Blueprint(ConfiguredBaseModel, ABC):
         info: "SerializationInfo",
     ) -> dict[str, t.Any]:
         data = handler(self)
-        return {
-            "$schema": generate_schema_ref(
-                self.application,
-                self.schema_version,
-            ),
-            **data,
-        }
+        if not info.exclude or "$schema" not in info.exclude:
+            return {
+                "$schema": generate_schema_ref(
+                    self.application,
+                    self.schema_version,
+                ),
+                **data,
+            }
+        return data
 
 
 class WorkplanState(StrEnum):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -5,7 +5,14 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from enum import IntEnum, StrEnum, auto
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    model_validator,
+)
 
 from cstar.applications.core import ApplicationDefinition, get_application
 from cstar.base.env import (
@@ -225,27 +232,27 @@ _THandle = t.TypeVar("_THandle", bound=ProcessHandle)
 class LiveStep(Step):
     """A Step enriched with runtime metadata."""
 
-    parent: t.Self | None = Field(default=None, exclude=True)
+    parent: t.Self | None = Field(default=None, exclude=True, frozen=True)
     """The step for which this step is a sub-task."""
-    working_dir: Path | None = Field(default=None)
+    working_dir: Path | None = Field(default=None, frozen=True)
     """The root directory where this step can write outputs."""
-    _fsm: JobFileSystemManager | None = None
+    _fsm: JobFileSystemManager = PrivateAttr()
     """Manages the structure of outputs from the step."""
 
-    @property
-    def get_working_dir(self) -> Path:
-        if self.working_dir is None:
-            if self.parent:
-                root_fsm = self.parent.fsm
-            else:
-                root_dir = DirectoryManager.data_home()
-                if run_id := os.environ.get(ENV_CSTAR_RUNID, ""):
-                    root_dir = root_dir.joinpath(run_id)
-                root_fsm = JobFileSystemManager(root_dir)
 
-            self.working_dir = root_fsm.tasks_dir / self.safe_name
+    @staticmethod
+    def get_root_fsm() -> JobFileSystemManager:
+        """Return the default, run-aware job file-system manager.
 
-        return self.working_dir
+        Returns
+        -------
+        JobFileSystemManager
+        """
+        root_dir = DirectoryManager.data_home()
+        run_dir = root_dir
+        if run_id := os.environ.get(ENV_CSTAR_RUNID, ""):
+            run_dir = root_dir / run_id
+        return JobFileSystemManager(run_dir)
 
     @property
     def fsm(self) -> JobFileSystemManager:
@@ -255,9 +262,9 @@ class LiveStep(Step):
         -------
         JobFileSystemManager
         """
-        if self._fsm is None:
-            self._fsm = JobFileSystemManager(self.get_working_dir)
-        return self._fsm
+        if not self.working_dir:
+            raise RuntimeError
+        return JobFileSystemManager(self.working_dir)
 
     @property
     def blueprint(self) -> Blueprint:
@@ -293,7 +300,6 @@ class LiveStep(Step):
     def from_step(
         cls,
         step: Step,
-        parent: "LiveStep | Step | None" = None,
         update: Mapping[str, t.Any] | None = None,
     ) -> "LiveStep":
         """Convert a step from orchestration planning into a LiveStep.
@@ -307,25 +313,60 @@ class LiveStep(Step):
         update : Mapping[str, t.Any]
             A mapping of updates to apply to the step
         """
-        step_attrs = step.model_dump(by_alias=True)
+        attributes = step.model_dump(by_alias=True)
+        update = update or {}
 
-        if update:
-            step_attrs.update(update)
+        if "name" in update:
+            attributes.pop("working_dir", None)
 
-        effective_parent: LiveStep | None = (
-            parent
-            if isinstance(parent, LiveStep)
-            else (LiveStep.from_step(parent) if parent else None)
+        attributes.update(update)
+        return LiveStep(**attributes)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _model_validator_pre(cls, data: t.Any) -> "t.Any":
+        """Ensure the working directory and fsm are computed.
+
+        Returns
+        -------
+        LiveStep
+        """
+        name = str(data.get("name", ""))
+        wd = t.cast("Path | str | None", data.get("working_dir", None))
+        parent = t.cast("Step | None", data.get("parent", None))
+
+        if parent and not isinstance(parent, LiveStep):
+            parent = LiveStep(**parent.model_dump(by_alias=True))
+
+        if parent:
+            fsm = parent.fsm.get_subtask_manager(name)
+            wd = fsm.root_dir
+            data["parent"] = parent
+
+        data["blueprint"] = data.get("blueprint")
+
+        if wd:
+            data["working_dir"] = wd
+            fsm = JobFileSystemManager(Path(wd))
+        else:
+            fsm = LiveStep.get_root_fsm().get_subtask_manager(name)
+            data["working_dir"] = fsm.root_dir
+
+        return data
+
+    @model_validator(mode="after")
+    def _model_validator_post(self) -> "LiveStep":
+        """Ensure string paths are converted to Path.
+
+        Returns
+        -------
+        LiveStep
+        """
+        object.__setattr__(
+            self, "working_dir", Path(self.working_dir) if self.working_dir else None
         )
-        # when no parent is given, inherit the parent from the source step (if it has one)
-        if effective_parent is None and isinstance(step, LiveStep):
-            effective_parent = step.parent
-
-        if effective_parent is not None:
-            step_attrs.pop("working_dir", None)
-            step_attrs["parent"] = effective_parent
-
-        return LiveStep(**step_attrs)
+        object.__setattr__(self, "blueprint_path", Path(self.blueprint_path))
+        return self
 
 
 class Task(BaseModel, t.Generic[_THandle]):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -239,7 +239,6 @@ class LiveStep(Step):
     _fsm: JobFileSystemManager = PrivateAttr()
     """Manages the structure of outputs from the step."""
 
-
     @staticmethod
     def get_root_fsm() -> JobFileSystemManager:
         """Return the default, run-aware job file-system manager.

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -28,7 +28,7 @@ from cstar.execution.file_system import (
 from cstar.orchestration.converter.converter import (
     convert_step_to_blueprint_run_command,
 )
-from cstar.orchestration.models import Blueprint, Step, Workplan
+from cstar.orchestration.models import Blueprint, BlueprintCore, Step, Workplan
 from cstar.orchestration.serialization import (
     deserialize,
     intenum_representer,
@@ -267,7 +267,7 @@ class LiveStep(Step):
     @property
     def blueprint(self) -> Blueprint:
         """Load and return the blueprint associated with this step."""
-        base_bp = deserialize(self.blueprint_path, Blueprint)
+        base_bp = deserialize(self.blueprint_path, BlueprintCore)
         app: ApplicationDefinition[Blueprint, BlueprintRunner[Blueprint]] = (
             get_application(base_bp.application)
         )

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -9,7 +9,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    PrivateAttr,
     ValidationError,
     model_validator,
 )
@@ -236,8 +235,6 @@ class LiveStep(Step):
     """The step for which this step is a sub-task."""
     working_dir: Path | None = Field(default=None, frozen=True)
     """The root directory where this step can write outputs."""
-    _fsm: JobFileSystemManager = PrivateAttr()
-    """Manages the structure of outputs from the step."""
     kind: str = Field(default="", frozen=True, init=False)
     """The instance discriminator."""
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -238,6 +238,8 @@ class LiveStep(Step):
     """The root directory where this step can write outputs."""
     _fsm: JobFileSystemManager = PrivateAttr()
     """Manages the structure of outputs from the step."""
+    kind: str = Field(default="", frozen=True, init=False)
+    """The instance discriminator."""
 
     @staticmethod
     def get_root_fsm() -> JobFileSystemManager:
@@ -333,6 +335,7 @@ class LiveStep(Step):
         name = str(data.get("name", ""))
         wd = t.cast("Path | str | None", data.get("working_dir", None))
         parent = t.cast("Step | None", data.get("parent", None))
+        data["kind"] = "live"
 
         if parent and not isinstance(parent, LiveStep):
             parent = LiveStep(**parent.model_dump(by_alias=True))
@@ -366,6 +369,12 @@ class LiveStep(Step):
         )
         object.__setattr__(self, "blueprint_path", Path(self.blueprint_path))
         return self
+
+    @t.override
+    @classmethod
+    def discriminator(cls) -> str:
+        """Return the sub-type discriminator."""
+        return "live"
 
 
 class Task(BaseModel, t.Generic[_THandle]):

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -342,8 +342,6 @@ class LiveStep(Step):
             wd = fsm.root_dir
             data["parent"] = parent
 
-        data["blueprint"] = data.get("blueprint")
-
         if wd:
             data["working_dir"] = wd
             fsm = JobFileSystemManager(Path(wd))

--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -163,6 +163,8 @@ def _read_json(path: Path, klass: type[_T]) -> _T:
     _T
     """
     model_dict = read_json_to_raw(path)
+    if model_dict:
+        model_dict.pop("$schema", None)
     return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 
@@ -181,6 +183,8 @@ def _read_yaml(path: Path, klass: type[_T]) -> _T:
     _T
     """
     model_dict = read_yaml_to_raw(path)
+    if model_dict:
+        model_dict.pop("$schema", None)
     return klass.model_validate(model_dict)  # type: ignore  # noqa: PGH003
 
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -562,7 +562,9 @@ class OverrideTransform(Transform[LiveStep]):
         """
         overrides = overrides.copy() if overrides else {}
 
-        model = bp.model_dump(exclude_defaults=True, exclude_unset=True)
+        model = bp.model_dump(
+            exclude={"$schema"},
+        )
 
         # system-level overrides take precedence over step-level overrides
         changeset = deep_merge(overrides, self._system_overrides)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -603,9 +603,10 @@ class OverrideTransform(Transform[LiveStep]):
         live_step = LiveStep.from_step(step, update=update)
 
         bp_renamed = bp_path.with_stem(f"{bp_path.stem}.{self.suffix()}").name
-        live_step.blueprint_path = live_step.fsm.run_dir / bp_renamed
+        bp_path = live_step.fsm.run_dir / bp_renamed
+        serialize(bp_path, updated_bp)
 
-        serialize(live_step.blueprint_path, updated_bp)
+        live_step.blueprint_path = bp_path
         return (live_step,)
 
     @staticmethod

--- a/cstar/roms/namelist.py
+++ b/cstar/roms/namelist.py
@@ -25,7 +25,7 @@ that this model reads back.)
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import f90nml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -83,7 +83,7 @@ class _NmlGroup(BaseModel):
     # validate_assignment => edits in the read->edit->write flow are re-checked.
     # use_attribute_docstrings => the per-field docstrings below become the field
     # descriptions in the generated JSON schema.
-    model_config = ConfigDict(
+    model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid", validate_assignment=True, use_attribute_docstrings=True
     )
 
@@ -622,7 +622,7 @@ class RomsNamelist(BaseModel):
     Group order matches ``write_roms_namelist`` / the reference namelist.
     """
 
-    model_config = ConfigDict(
+    model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid", validate_assignment=True, use_attribute_docstrings=True
     )
 

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -3,13 +3,13 @@ import typing as t
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from copy import deepcopy
+from pathlib import Path
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
     FilePath,
-    NewPath,
 )
 
 from cstar.base.adapter import SchemaAdapter
@@ -50,7 +50,7 @@ class MigrationRequest(BaseModel):
         description="Path to a file containing a serialized blueprint",
         alias="path",
     )
-    target: NewPath | None = Field(
+    target: Path | None = Field(
         default=None,
         description="Path where the migrated blueprint will be serialized",
         frozen=True,
@@ -252,6 +252,7 @@ class BlueprintMigration(Migration):
 
         for klass in plan.adapters:
             if model := klass(model).adapt():
+                model[KEY_SV] = klass.target()
                 continue
 
             msg = f"Schema migration from {plan.source!r} to {plan.target!r} failed."

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -252,7 +252,6 @@ class BlueprintMigration(Migration):
 
         for klass in plan.adapters:
             if model := klass(model).adapt():
-                model[KEY_SV] = klass.target()
                 continue
 
             msg = f"Schema migration from {plan.source!r} to {plan.target!r} failed."

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -131,43 +131,43 @@ def test_live_step(tmp_path: Path) -> None:
     step_2 = Step(name="B", application="roms_marbl", blueprint=bp.as_posix())
     step_3 = Step(name="C", application="roms_marbl", blueprint=bp.as_posix())
 
-    ls_1 = LiveStep.from_step(step_1)
-    ls_2 = LiveStep.from_step(step_2, step_1)  # use plan "Step" as parent
-    ls_3 = LiveStep.from_step(step_3, ls_2)  # use "LiveStep" as parent
-    ls_4 = LiveStep.from_step(ls_3)  # step from another live step
-
-    ls_5_name = "child of ls 2"
-    ls_5 = LiveStep.from_step(ls_1, update={"name": ls_5_name})  # override attributes
-
     with mock.patch.dict(
         os.environ,
         {ENV_CSTAR_DATA_HOME: data_home.as_posix()},
         clear=True,
     ):
-        actual = ls_1.get_working_dir
+        # use plan "Step" as parent (expect step_1 parent dir to step_2)
+        ls_1 = LiveStep.from_step(step_1)
+        # use "LiveStep" as parent
+        ls_2 = LiveStep.from_step(step_2, update={"parent": step_1})
+        # step from another live step (one with parent, one as base task)
+        ls_3 = LiveStep.from_step(step_3, update={"parent": ls_2})
+        ls_4 = LiveStep.from_step(ls_3)
+
+        # updating name should change the dir name
+        ls_5_name = "child of ls 2"
+        ls_5 = LiveStep.from_step(
+            ls_1, update={"name": ls_5_name}
+        )  # override attributes
+
+        actual = ls_1.working_dir
         expected = data_home / JobFileSystemManager._TASKS_NAME / ls_1.safe_name  # noqa: SLF001
         assert actual == expected
 
-        actual = ls_2.get_working_dir
-        expected = (
-            ls_1.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_2.safe_name
-        )  # noqa: SLF001
+        actual = ls_2.working_dir
+        expected = ls_1.working_dir / JobFileSystemManager._TASKS_NAME / ls_2.safe_name  # type: ignore # noqa: SLF001
         assert actual == expected
 
-        actual = ls_3.get_working_dir
-        expected = (
-            ls_2.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_3.safe_name
-        )  # noqa: SLF001
+        actual = ls_3.working_dir
+        expected = ls_2.working_dir / JobFileSystemManager._TASKS_NAME / ls_3.safe_name  # type: ignore # noqa: SLF001
         assert actual == expected
 
-        actual = ls_4.get_working_dir
+        actual = ls_4.working_dir
         # confirm the parent carries over and ls4 is a child of ls2
-        expected = (
-            ls_2.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_4.safe_name
-        )  # noqa: SLF001
+        expected = ls_2.working_dir / JobFileSystemManager._TASKS_NAME / ls_4.safe_name  # type: ignore # noqa: SLF001
         assert actual == expected
 
-        actual = ls_5.get_working_dir
+        actual = ls_5.working_dir
         expected = data_home / JobFileSystemManager._TASKS_NAME / ls_5.safe_name  # noqa: SLF001
         assert actual == expected
         assert ls_5.name == ls_5_name  # confirm the update was honored

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -112,7 +112,7 @@ def test_blueprint_run_remote_blueprint() -> None:
         "https://www.google.com/directive-dne.json",
     ],
 )
-def test_blueprint_run_apply_directive_dne(tmp_path: Path, directive_path: str) -> None:
+def test_blueprint_run_apply_directive_dne(directive_path: str) -> None:
     """Verify that an exception is raised if a path to a non-existent directive file is passed."""
     bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
 
@@ -138,9 +138,12 @@ def test_blueprint_run_apply_directive_dne(tmp_path: Path, directive_path: str) 
     mock_exec.assert_not_called()
 
 
-def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
+def test_blueprint_run_apply_directive_empty(
+    tmp_path: Path,
+    package_path: Path,
+) -> None:
     """Verify that an exception is raised if an empty directive file is passed."""
-    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    bp_path = str(package_path / "docs/tutorials/wales_toy_blueprint.yaml")
     directive_file_path = tmp_path / "directive-dne.json"
     directive_file_path.touch()
 
@@ -160,12 +163,14 @@ def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
 
 
 def test_blueprint_run_apply_directives(
-    tmp_path: Path, mocked_simulation_outputs: tuple[Path, Path, Path]
+    tmp_path: Path,
+    mocked_simulation_outputs: tuple[Path, Path, Path],
+    package_path: Path,
 ) -> None:
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is executed.
     """
-    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    bp_path = str(package_path / "docs/tutorials/wales_toy_blueprint.yaml")
     _, step_dir, _ = mocked_simulation_outputs
 
     temp_step = LiveStep(

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -477,7 +477,7 @@ def hello_world_bp_content(hello_world_default_target: str) -> str:
         application: hello_world
         state: draft
         target: '{hello_world_default_target}'
-        version: '1.0.0'
+        schema_version: '1.0.0'
         """)
 
 

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -894,7 +894,7 @@ def test_workplan_yaml_deserialize(
     yaml_path = tmp_path / "test.yaml"
     _ = serialize(yaml_path, plan)
 
-    plan2 = t.cast("Workplan", deserialize(yaml_path, Workplan))
+    plan2 = deserialize(yaml_path, Workplan)
     # todo: fix so this str conversion isn't required.
     for step in plan.steps:
         step.blueprint_path = str(step.blueprint_path)

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -282,9 +282,10 @@ def test_serialization_workplan_steps_with_directives(
     step = wp.steps[-1]
 
     # confirm the directive has been loaded
-    assert step.directives
-    assert "continue-from" in step.directives
-    assert "path" in step.directives["continue-from"]
+    directives = t.cast("dict[str, dict[str, str]]", step.directives)
+    assert directives
+    assert "continue-from" in directives
+    assert "path" in directives["continue-from"]
 
     # confirm the directives can be written
     serialize_to = tmp_path / "reserialized.yaml"

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ValidationError
 from cstar.applications.plotter_app import PlotterBlueprint
 from cstar.orchestration.launch.slurm import SlurmHandle
 from cstar.orchestration.models import Application, Workplan
+from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.serialization import (
     PersistenceMode,
     deserialize,
@@ -154,6 +155,44 @@ def test_serialization_workplan_happy_path(
     assert workplan.steps[0].workflow_overrides["segment_length"] in {16, 16.0}
     assert workplan.steps[0].compute_overrides["walltime"] == "00:10:00"
     assert workplan.steps[0].compute_overrides["num_nodes"] == 4
+
+
+def test_serialization_polymorphic_workplan(
+    tmp_path: Path,
+    wp_templates_dir: Path,
+    bp_templates_dir: Path,
+    default_blueprint_path: str,
+) -> None:
+    """Verify that a workplan serialized with steps of a subclass of `Step` results
+    in deserialization to the correct subclass/type.
+    """
+    template_file = "workplan.yaml"
+    template_path = wp_templates_dir / template_file
+
+    bp_path = tmp_path / "blueprint.yaml"
+    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
+    bp_path.write_text(bp_tpl_path.read_text())
+
+    wp_content = template_path.read_text()
+    wp_content = wp_content.replace(default_blueprint_path, bp_path.as_posix())
+
+    wp_path = tmp_path / template_file
+    wp_path.write_text(wp_content)
+
+    wp = deserialize(wp_path, Workplan)
+
+    # convert steps to live-steps and store on a workplan
+    all_steps = [LiveStep.from_step(s) for s in wp.steps]
+
+    poly_path = tmp_path / "live_workplan.yaml"
+    poly_wp = Workplan(**wp.model_dump(exclude={"steps"}), steps=all_steps)
+
+    assert serialize(poly_path, poly_wp)
+
+    # confirm that the subclass LiveStep was serialized
+    wp_content = poly_path.read_text()
+    print(wp_content)
+    assert "working_dir" in wp_content
 
 
 def test_serialization_workplan_compute_env(

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -194,6 +194,12 @@ def test_serialization_polymorphic_workplan(
     print(wp_content)
     assert "working_dir" in wp_content
 
+    # now, deserialize and confirm the workplan contains LiveStep
+    result = deserialize(poly_path, Workplan)
+
+    for step in result.steps:
+        assert isinstance(step, LiveStep)
+
 
 def test_serialization_workplan_compute_env(
     tmp_path: Path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "networkx>=3.6.1",
     "prefect>=3.6.1",
     "psutil>=7.2.2",
-    "pydantic>=2.12",
+    "pydantic>=2.13",
     "python-dateutil>=2.8.2",
     "pytimeparse>=1.1.8",
     "python-dotenv",


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change re-enables strict model validation and mitigates any issues that cropped up while it was disabled. 

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Enable strict validation in user-facing models
- Create `BlueprintCore` model for bootstrapping the model loading process

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix incorrectly named schema version keys in sample and test blueprints
- Fix model fields not serializing
- Fix symlink failures when persisting latest run

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Avoid extraneous reloading of blueprints from disk
- Remove unused method(s)
- Ensure migration adapters receive appropriate schema version
- Avoid unnecessary uses of remote blueprints in tests
- Reduced boilerplate for loading blueprints from disk

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-938
- [ ] Tests added
- [ ] Tests passing
- [ ] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation
