### PR TITLE
Fix Elja system context recognition on compute nodes

### DIFF
--- a/cstar/entrypoint/config.py
+++ b/cstar/entrypoint/config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import parse_log_level_name
-from cstar.system.environment import EnvSettingsBase, SlurmSettingsBase
+from cstar.system.environment import SlurmSettingsBase
 from cstar.system.manager import cstar_sysmgr
 
 JOBFILE_DATE_FORMAT: t.Final[str] = "%Y%m%d_%H%M%S"
@@ -102,16 +102,12 @@ def get_job_config() -> JobConfig:
     -------
     JobConfig
     """
-    account_id: str = ""
-    walltime: str = ""
-    priority: str = ""
+    account_id, walltime, priority = "", "", ""
 
-    if cstar_sysmgr.environment.settings_klass:
-        system_env: EnvSettingsBase | None = None
-
+    if klass := cstar_sysmgr.environment.settings_klass:
         try:
-            system_env = cstar_sysmgr.environment.settings_klass()
-            if system_env and isinstance(system_env, SlurmSettingsBase):
+            system_env = klass()
+            if isinstance(system_env, SlurmSettingsBase):
                 account_id = system_env.SLURM_ACCOUNT
                 walltime = system_env.SLURM_MAX_WALLTIME
                 priority = system_env.SLURM_QUEUE

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1322,6 +1322,7 @@ class ROMSSimulation(Simulation):
                 or (inp.start_date <= self.end_date)
                 and (self.end_date >= self.start_date)
             ):
+                self.log.debug(f"Fetching {inp.source.location}")
                 inp.get(local_dir=input_datasets_dir)
 
     @property

--- a/cstar/system/environment.py
+++ b/cstar/system/environment.py
@@ -412,8 +412,8 @@ class CStarEnvironment:
         with open(self.lmod_path) as fp:
             lmod_list = fp.readlines()
 
-        modules = " ".join(x.strip() for x in lmod_list)
-        self._call_lmod(f"load {modules}")
+        for module in (x.strip() for x in lmod_list):
+            self._call_lmod(f"load {module}")
 
     @staticmethod
     def set_env_var(key: str, value: str) -> None:

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -129,17 +129,17 @@ class HostNameEvaluator:
             If the name cannot be determined.
         """
         if lmod_hostname := self.lmod_hostname:
-            log.trace("Using lmod hostname as system name")
+            log.debug("Using lmod hostname as system name")
             return lmod_hostname
 
         for ctx_klass in get_registered_sys_contexts():
             if ctx_klass.is_match():
                 name = ctx_klass.name
-                log.trace(f"Using {name!r} as system name due to context match")
+                log.debug(f"Using {name!r} as system name due to context match")
                 return name
 
         if self.platform_hostname:
-            log.trace("Using platform hostname as system name")
+            log.debug("Using platform hostname as system name")
             return self.platform_hostname
 
         raise OSError(

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -129,17 +129,17 @@ class HostNameEvaluator:
             If the name cannot be determined.
         """
         if lmod_hostname := self.lmod_hostname:
-            log.debug("Using lmod hostname as system name")
+            log.trace("Using lmod hostname as system name")
             return lmod_hostname
 
         for ctx_klass in get_registered_sys_contexts():
             if ctx_klass.is_match():
                 name = ctx_klass.name
-                log.debug(f"Using {name!r} as system name due to context match")
+                log.trace(f"Using {name!r} as system name due to context match")
                 return name
 
         if self.platform_hostname:
-            log.debug("Using platform hostname as system name")
+            log.trace("Using platform hostname as system name")
             return self.platform_hostname
 
         raise OSError(

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -53,6 +53,8 @@ class EljaEnvSettings(SlurmSettingsBase):
 
     HOST_IDENTIFIER: ClassVar[str] = "elja-irhpc"
     """Fixed value in HOSTNAME env var on Elja that uniquely identifies the system."""
+    CLUSTER_IDENTIFIER: ClassVar[str] = "elja"
+    """Fixed value in SLURM_CLUSTER_NAME on compute nodes that identifies the system."""
 
     HOSTNAME: str = Field(default="", alias="HOSTNAME")
     """The hostname of the machine.
@@ -419,7 +421,10 @@ class EljaSystemContext(SystemContext):
         """Return `True` if the current system is identified as *Elja* by matching
         value `elja-irhpc` in `HOSTNAME` env var.
         """
-        return os.getenv("HOSTNAME", "") == EljaEnvSettings.HOST_IDENTIFIER
+        if host_match := os.getenv("HOSTNAME", "") == EljaEnvSettings.HOST_IDENTIFIER:
+            return host_match
+
+        return os.getenv("SLURM_CLUSTER_NAME", "") == EljaEnvSettings.CLUSTER_IDENTIFIER
 
 
 @register_sys_context


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change fixes an issue identifying the correct system context on compute nodes in Elja.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Use alternative method for identifying cluster on Elja compute nodes

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- Revert prior change resulting in less control of lmod module loading

## Security Fixes
<!-- List any changes resulting in a change of security posture -->
- N/A

## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->

- [X] Tests passing
