### PR TITLE
Ensure disk writes are flushed

### DIFF
--- a/cstar/orchestration/serialization.py
+++ b/cstar/orchestration/serialization.py
@@ -383,6 +383,7 @@ def serialize(
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open(mode="w") as fp:
         nbytes = fp.write(content)
+        fp.flush()
 
     return nbytes
 

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -239,7 +239,7 @@ class TrackingRepository(LoggingMixin):
             self.log.warning(msg)
             return None
 
-        return await asyncio.to_thread(deserialize, run_path, WorkplanRun)
+        return deserialize(run_path, WorkplanRun)
 
     async def put_workplan_run(self, run: WorkplanRun) -> Path:
         """Persist a run record to disk.
@@ -259,15 +259,14 @@ class TrackingRepository(LoggingMixin):
         run_path = self._history_path(run.run_id, run.start_at)
         latest_path = self._latest_path(run.run_id)
 
-        if not await asyncio.to_thread(serialize, run_path, run):
+        if not serialize(run_path, run):
             self.log.warning("Run could not be persisted")
 
         if not latest_path.parent.exists():
             latest_path.parent.mkdir(parents=True)
 
-        if latest_path.resolve() != run_path:
-            await asyncio.to_thread(latest_path.unlink, missing_ok=True)
-            await asyncio.to_thread(latest_path.symlink_to, run_path)
+        latest_path.unlink(missing_ok=True)
+        latest_path.symlink_to(run_path)
 
         msg = f"Run persisted to: {run_path}"
         self.log.debug(msg)


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change avoids using separate threads for disk writes related to orchestrator state to mitigate intermittent failures for parameterized tests `test_dag_runner_get_status_detail_map`

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

