### PR TITLE
Directives clean-up

### DIFF
--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -604,10 +604,13 @@ class BoundaryFileTrxAdapter:
         }
 
 
-class ContinuanceTransform(Directive, OverrideTransform):
+class ContinuanceDirective(Directive, OverrideTransform):
     """A transform that locates a restart file with an unknown path at the
     time the task was scheduled.
     """
+
+    KEY_PATH: t.Final[str] = "path"
+    """Key used to specify a path as the source for continuance."""
 
     def __init__(self, config: dict[str, t.Any]) -> None:
         """Initialize the instance.
@@ -619,6 +622,10 @@ class ContinuanceTransform(Directive, OverrideTransform):
         """
         Directive.__init__(self, config)
         OverrideTransform.__init__(self, self._create_initial_condition_overrides())
+
+    @classmethod
+    def key(cls) -> str:
+        return "continue-from"
 
     def _create_initial_condition_overrides(
         self,
@@ -660,7 +667,7 @@ class ContinuanceTransform(Directive, OverrideTransform):
         return "cfrom"
 
 
-class NestingTransform(Directive, OverrideTransform):
+class NestingDirective(Directive, OverrideTransform):
     """A transform that uses a restart file and boundary conditions from a previous parent simulation."""
 
     def __init__(self, config: dict[str, t.Any]) -> None:
@@ -675,6 +682,10 @@ class NestingTransform(Directive, OverrideTransform):
         OverrideTransform.__init__(
             self, self._create_initial_condition_and_bc_overrides()
         )
+
+    @classmethod
+    def key(cls) -> str:
+        return "nest-from"
 
     def _create_initial_condition_and_bc_overrides(self) -> dict[str, t.Any]:
         """Create an overrides dictionary that will result in the modified blueprint.
@@ -719,5 +730,5 @@ class NestingTransform(Directive, OverrideTransform):
         return "nfrom"
 
 
-DirectiveConfig.register("continue-from", ContinuanceTransform)
-DirectiveConfig.register("nest-from", NestingTransform)
+DirectiveConfig.register(ContinuanceDirective.key(), ContinuanceDirective)
+DirectiveConfig.register(NestingDirective.key(), NestingDirective)

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -666,7 +666,15 @@ class Directive(Transform[LiveStep], t.Protocol):
         self._config = config
 
     @classmethod
-    def key(cls) -> str: ...
+    def key(cls) -> str:
+        """Return a string that will be used to identify the appropriate configuration
+        for the directive in any Mapping.
+
+        Returns
+        -------
+        str
+        """
+        ...
 
 
 class DirectiveConfig(BaseModel):

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -665,6 +665,9 @@ class Directive(Transform[LiveStep], t.Protocol):
 
         self._config = config
 
+    @classmethod
+    def key(cls) -> str: ...
+
 
 class DirectiveConfig(BaseModel):
     directive_map: t.ClassVar[dict[str, type[Directive]]] = {}

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -14,7 +14,7 @@ import pytest
 from cstar.applications.core import RunnerRequest, RunnerResult, RunnerState
 from cstar.applications.roms_marbl.app import RomsMarblRunner, main
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
-from cstar.applications.roms_marbl.transforms import ContinuanceTransform
+from cstar.applications.roms_marbl.transforms import ContinuanceDirective
 from cstar.base.exceptions import BlueprintError, CstarError, CstarExpectationFailed
 from cstar.entrypoint.config import (
     JobConfig,
@@ -936,7 +936,7 @@ def test_worker_main_exec_continue_from(
         attribute is updated.
         """
         self.add_state(ExecutionStatus.COMPLETED)
-        assert ContinuanceTransform.suffix() in str(self.request.blueprint_uri)
+        assert ContinuanceDirective.suffix() in str(self.request.blueprint_uri)
         return self.result
 
     # don't let it perform any real work; mock out RomsMarblRunner
@@ -1055,7 +1055,7 @@ def test_worker_main_preprocessor_args_parsed(
 
     # verify the blueprint uri was modified by preprocessing prior to invocation
     assert modified_uri != str(bp_path)
-    assert ContinuanceTransform.suffix() in modified_uri
+    assert ContinuanceDirective.suffix() in modified_uri
 
     # verify initial conditions now point to the --continue-from location
     blueprint = deserialize(modified_uri, RomsMarblBlueprint)

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
-from cstar.applications.roms_marbl.transforms import ContinuanceTransform
+from cstar.applications.roms_marbl.transforms import ContinuanceDirective
 from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
 from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.converter.converter import (
@@ -260,10 +260,10 @@ def test_convert_step_to_preprocessed_roms_sim_no_reset_files(
     assert not step.blueprint_overrides, "Empty overrides expected"
     assert step.working_dir, "Ensure fixture sets workdir"
 
-    config = {"path": fsm.joined_output_dir}
+    config = {ContinuanceDirective.KEY_PATH: fsm.joined_output_dir}
 
     with pytest.raises(FileNotFoundError, match="No restart files"):
-        _ = ContinuanceTransform(config)
+        _ = ContinuanceDirective(config)
 
 
 def test_continuance_transform(
@@ -289,7 +289,9 @@ def test_continuance_transform(
     assert original_bp.initial_conditions.data, "data list is unexpectedly empty"
     original_ic = original_bp.initial_conditions.data[0].location
 
-    trx = ContinuanceTransform(config={"path": str(fsm.joined_output_dir)})
+    trx = ContinuanceDirective(
+        config={ContinuanceDirective.KEY_PATH: str(fsm.joined_output_dir)}
+    )
 
     transformed_step = next(iter(trx(step)), None)
     assert transformed_step, "Transform didn't return a transformed step"
@@ -302,7 +304,7 @@ def test_continuance_transform(
     assert bp_path_after != bp_path_before, "New step must reference a new blueprint"
 
     # confirm the path includes a suffix specified by the transform
-    assert ContinuanceTransform.suffix() in str(bp_path_after)
+    assert ContinuanceDirective.suffix() in str(bp_path_after)
 
     bp = deserialize(bp_path_after, RomsMarblBlueprint)
     assert bp.initial_conditions.data, "data list is unexpectedly empty"

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -9,7 +9,7 @@ import pytest
 
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
 from cstar.applications.roms_marbl.transforms import (
-    ContinuanceTransform,
+    ContinuanceDirective,
     RestartFile,
     RestartFileTrxAdapter,
     RomsMarblTimeSplitter,
@@ -258,7 +258,7 @@ def test_continuance_transform_not_supported(test_working_dir: Path) -> None:
         and was written to the test directory, tmp_path.
     """
     with pytest.raises(NotImplementedError, match="supported"):
-        _ = ContinuanceTransform({"not-path": str(test_working_dir)})
+        _ = ContinuanceDirective({"not-path": str(test_working_dir)})
 
 
 def test_continuance_transform_path_dne() -> None:
@@ -266,7 +266,7 @@ def test_continuance_transform_path_dne() -> None:
     an exception being raised.
     """
     with pytest.raises(ValueError, match="No directory or file found"):
-        _ = ContinuanceTransform({"path": "./dir-that-dne"})
+        _ = ContinuanceDirective({ContinuanceDirective.KEY_PATH: "./dir-that-dne"})
 
 
 @pytest.mark.parametrize("pad_size", range(1, 10))
@@ -301,7 +301,9 @@ def test_continuance_transform_happy_path(
         )
         reset_file_path = reset_file_path.rename(reset_file_path.with_name(name))
 
-    transform = ContinuanceTransform({"path": str(continue_from_dir)})
+    transform = ContinuanceDirective(
+        {ContinuanceDirective.KEY_PATH: str(continue_from_dir)}
+    )
     step = single_step_workplan.steps[0]
     step.blueprint_overrides.clear()  # ensure nothing existing
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change includes some simple improvements to the `Directive` classes:

- rename from `XxxTransform` to `XxxDirective` to clearly identify directives
- avoid magic strings for configuration keys

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- add a class-level `key` function to return the target configuration key
- rename `ContinuanceTransform` to `ContinuanceDirective`
- rename `NestingTransform` to `NestingDirective`

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

