### PR TITLE
Implement step-aware continuance directive

### DIFF
--- a/cstar/applications/roms_marbl/app.py
+++ b/cstar/applications/roms_marbl/app.py
@@ -159,7 +159,10 @@ def main() -> int:
 
     blueprint_uri = str(args.blueprint_uri)
     if args.directives:
-        blueprint_uri = DirectiveConfig.apply_directives(args.directives, blueprint_uri)
+        blueprint_uri = DirectiveConfig.apply_directives(
+            args.directives,
+            blueprint_uri,
+        )
 
     request = RunnerRequest(blueprint_uri, RomsMarblBlueprint)
     runner = RomsMarblRunner(request, service_cfg, job_cfg)

--- a/cstar/applications/roms_marbl/app.py
+++ b/cstar/applications/roms_marbl/app.py
@@ -159,10 +159,7 @@ def main() -> int:
 
     blueprint_uri = str(args.blueprint_uri)
     if args.directives:
-        blueprint_uri = DirectiveConfig.apply_directives(
-            args.directives,
-            blueprint_uri,
-        )
+        blueprint_uri = DirectiveConfig.apply_directives(args.directives, blueprint_uri)
 
     request = RunnerRequest(blueprint_uri, RomsMarblBlueprint)
     runner = RomsMarblRunner(request, service_cfg, job_cfg)

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -15,7 +15,6 @@ from pydantic import (
 
 from cstar.applications.core import Transform
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
-from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.feature import (
     ENV_FF_ORCH_TRX_TIMESPLIT,
     ENV_FF_ORCH_TRX_TIMESPLIT_LONGNAME,
@@ -29,7 +28,6 @@ from cstar.base.utils import (
 )
 from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize, serialize
-from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 from cstar.orchestration.transforms import (
     Directive,
     DirectiveConfig,
@@ -616,7 +614,11 @@ class ContinuanceDirective(Directive, OverrideTransform):
     KEY_STEP: t.Final[str] = "step"
     """Key used to specify a step name as the source for continuance."""
 
-    def __init__(self, config: dict[str, t.Any]) -> None:
+    def __init__(
+        self,
+        config: dict[str, t.Any],
+        workplan: LiveWorkplan | None = None,
+    ) -> None:
         """Initialize the instance.
 
         Parameters
@@ -624,42 +626,12 @@ class ContinuanceDirective(Directive, OverrideTransform):
         config : dict[str, t.Any] | None
             A dictionary containing configuration for the directive.
         """
-        Directive.__init__(self, config)
+        Directive.__init__(self, config, workplan=workplan)
         OverrideTransform.__init__(self, self._create_initial_condition_overrides())
 
     @classmethod
     def key(cls) -> str:
         return "continue-from"
-
-    def _find_step_path(self, name: str) -> Path:
-        """Identify the path to the output directory for another step.
-
-        Parameters
-        ----------
-        name : str
-            The name of the step to locate
-
-        Returns
-        -------
-        Path
-        """
-        run_id = os.getenv(ENV_CSTAR_RUNID, None)
-        run: WorkplanRun | None = None
-
-        if run_id:
-            tracking = TrackingRepository()
-            run = tracking.get_workplan_run_sync(run_id)
-
-        if run is None:
-            msg = "Workplan context information was not supplied."
-            raise RuntimeError(msg)
-
-        wp = deserialize(run.trx_workplan_path, LiveWorkplan)
-        if step := next((s for s in wp.steps if s.name == name), None):
-            return step.fsm.output_dir
-
-        msg = f"Unable to locate metadata for step {name!r} in runtime context."
-        raise RuntimeError(msg)
 
     def _create_initial_condition_overrides(
         self,
@@ -694,7 +666,12 @@ class ContinuanceDirective(Directive, OverrideTransform):
             search_path = Path(target_path)
 
         if name := self._config.get(self.KEY_STEP, None):
-            search_path = self._find_step_path(name)
+            if name in self.workplan:
+                step = self.workplan[name]
+                search_path = step.fsm.output_dir
+            else:
+                msg = f"Unable to locate step {name!r} in workplan"
+                raise KeyError(msg)
 
         if search_path and (
             restart_file := RestartFile.find(search_path, notfound_ok=False)

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -631,6 +631,36 @@ class ContinuanceDirective(Directive, OverrideTransform):
     def key(cls) -> str:
         return "continue-from"
 
+    def _find_step_path(self, name: str) -> Path:
+        """Identify the path to the output directory for another step.
+
+        Parameters
+        ----------
+        name : str
+            The name of the step to locate
+
+        Returns
+        -------
+        Path
+        """
+        run_id = os.getenv(ENV_CSTAR_RUNID, None)
+        run: WorkplanRun | None = None
+
+        if run_id:
+            tracking = TrackingRepository()
+            run = tracking.get_workplan_run_sync(run_id)
+
+        if run is None:
+            msg = "Workplan context information was not supplied."
+            raise RuntimeError(msg)
+
+        wp = deserialize(run.trx_workplan_path, LiveWorkplan)
+        if step := next((s for s in wp.steps if s.name == name), None):
+            return step.fsm.output_dir
+
+        msg = f"Unable to locate metadata for step {name!r} in runtime context."
+        raise RuntimeError(msg)
+
     def _create_initial_condition_overrides(
         self,
     ) -> dict[str, t.Any]:
@@ -664,23 +694,7 @@ class ContinuanceDirective(Directive, OverrideTransform):
             search_path = Path(target_path)
 
         if name := self._config.get(self.KEY_STEP, None):
-            run_id = os.getenv(ENV_CSTAR_RUNID, None)
-            run: WorkplanRun | None = None
-
-            if run_id:
-                tracking = TrackingRepository()
-                run = tracking.get_workplan_run_sync(run_id)
-
-            if run is None:
-                msg = "Workplan context information was not supplied."
-                raise RuntimeError(msg)
-
-            wp = deserialize(run.trx_workplan_path, LiveWorkplan)
-            if step := next((s for s in wp.steps if s.name == name), None):
-                search_path = step.fsm.output_dir
-            else:
-                msg = f"Unable to locate metadata for step {name!r} in runtime context."
-                raise RuntimeError(msg)
+            search_path = self._find_step_path(name)
 
         if search_path and (
             restart_file := RestartFile.find(search_path, notfound_ok=False)

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -604,19 +604,13 @@ class BoundaryFileTrxAdapter:
         }
 
 
-class ContinuanceDirective(Directive, OverrideTransform):
-    """A transform that locates a restart file with an unknown path at the
-    time the task was scheduled.
-    """
-
-    KEY_PATH: t.Final[str] = "path"
-    """Key used to specify a path as the source for continuance."""
-    KEY_STEP: t.Final[str] = "step"
-    """Key used to specify a step name as the source for continuance."""
+class OverrideDirective(Directive, OverrideTransform):
+    _overrides: dict[str, t.Any]
 
     def __init__(
         self,
         config: dict[str, t.Any],
+        *,
         workplan: LiveWorkplan | None = None,
     ) -> None:
         """Initialize the instance.
@@ -627,17 +621,32 @@ class ContinuanceDirective(Directive, OverrideTransform):
             A dictionary containing configuration for the directive.
         """
         Directive.__init__(self, config, workplan=workplan)
-        OverrideTransform.__init__(self, self._create_initial_condition_overrides())
+        OverrideTransform.__init__(self, self._generate_overrides())
+
+    def _generate_overrides(self) -> dict[str, t.Any]:
+        """Generate any system overrides required by the directive."""
+        return {}
+
+
+class ContinuanceDirective(OverrideDirective):
+    """A transform that locates a restart file with an unknown path at the
+    time the task was scheduled.
+    """
+
+    KEY_PATH: t.Final[str] = "path"
+    """Key used to specify a path as the source for continuance."""
+    KEY_STEP: t.Final[str] = "step"
+    """Key used to specify a step name as the source for continuance."""
 
     @classmethod
     def key(cls) -> str:
         return "continue-from"
 
-    def _create_initial_condition_overrides(
-        self,
-    ) -> dict[str, t.Any]:
-        """Create an overrides dictionary that will result in the modified blueprint
-        using a
+    def _generate_overrides(self) -> dict[str, t.Any]:
+        """Create an overrides dictionary that will result in the modified blueprint.
+
+        ContinuanceDirective creates overrides to modify the initial conditions
+        using the output from another step or a fixed directory path.
 
         Returns
         -------
@@ -693,28 +702,18 @@ class ContinuanceDirective(Directive, OverrideTransform):
         return "cfrom"
 
 
-class NestingDirective(Directive, OverrideTransform):
+class NestingDirective(OverrideDirective):
     """A transform that uses a restart file and boundary conditions from a previous parent simulation."""
-
-    def __init__(self, config: dict[str, t.Any]) -> None:
-        """Initialize the instance.
-
-        Parameters
-        ----------
-        config : dict[str, t.Any] | None
-            A dictionary containing configuration for the directive.
-        """
-        Directive.__init__(self, config)
-        OverrideTransform.__init__(
-            self, self._create_initial_condition_and_bc_overrides()
-        )
 
     @classmethod
     def key(cls) -> str:
         return "nest-from"
 
-    def _create_initial_condition_and_bc_overrides(self) -> dict[str, t.Any]:
+    def _generate_overrides(self) -> dict[str, t.Any]:
         """Create an overrides dictionary that will result in the modified blueprint.
+
+        NestingDirective creates overrides that will modify the initial conditions
+        and boundary conditions.
 
         Returns
         -------

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -15,6 +15,7 @@ from pydantic import (
 
 from cstar.applications.core import Transform
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.feature import (
     ENV_FF_ORCH_TRX_TIMESPLIT,
     ENV_FF_ORCH_TRX_TIMESPLIT_LONGNAME,
@@ -26,8 +27,9 @@ from cstar.base.utils import (
     min_padded_index,
     slugify,
 )
-from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 from cstar.orchestration.transforms import (
     Directive,
     DirectiveConfig,
@@ -611,6 +613,8 @@ class ContinuanceDirective(Directive, OverrideTransform):
 
     KEY_PATH: t.Final[str] = "path"
     """Key used to specify a path as the source for continuance."""
+    KEY_STEP: t.Final[str] = "step"
+    """Key used to specify a step name as the source for continuance."""
 
     def __init__(self, config: dict[str, t.Any]) -> None:
         """Initialize the instance.
@@ -644,12 +648,43 @@ class ContinuanceDirective(Directive, OverrideTransform):
         ValueError
             If a restart file cannot be located with the supplied configuration.
         """
-        if "path" not in self._config:
-            msg = "Invalid continuance transform configuration. Only restart paths are supported."
+        found_keys = set(self._config.keys())
+        minimal_keys = {self.KEY_PATH, self.KEY_STEP}
+
+        if found_keys and not found_keys.intersection(minimal_keys):
+            msg = (
+                "Invalid continuance transform configuration; supported configuration: "
+                f"{', '.join(minimal_keys)}, provided configuration: {', '.join(found_keys)}"
+            )
             raise NotImplementedError(msg)
 
-        search_path = Path(self._config["path"])
-        if restart_file := RestartFile.find(search_path, notfound_ok=False):
+        search_path: Path | None = None
+
+        if target_path := self._config.get(self.KEY_PATH, None):
+            search_path = Path(target_path)
+
+        if name := self._config.get(self.KEY_STEP, None):
+            run_id = os.getenv(ENV_CSTAR_RUNID, None)
+            run: WorkplanRun | None = None
+
+            if run_id:
+                tracking = TrackingRepository()
+                run = tracking.get_workplan_run_sync(run_id)
+
+            if run is None:
+                msg = "Workplan context information was not supplied."
+                raise RuntimeError(msg)
+
+            wp = deserialize(run.trx_workplan_path, LiveWorkplan)
+            if step := next((s for s in wp.steps if s.name == name), None):
+                search_path = step.fsm.output_dir
+            else:
+                msg = f"Unable to locate metadata for step {name!r} in runtime context."
+                raise RuntimeError(msg)
+
+        if search_path and (
+            restart_file := RestartFile.find(search_path, notfound_ok=False)
+        ):
             return RestartFileTrxAdapter.adapt(restart_file)
 
         msg = f"No restart file located in search path: {search_path!r}"

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -619,12 +619,19 @@ class OverrideDirective(Directive, OverrideTransform):
         ----------
         config : dict[str, t.Any] | None
             A dictionary containing configuration for the directive.
+        workplan : LiveWorkplan | None
+            The workplan instance containing contextual information for the directive.
         """
         Directive.__init__(self, config, workplan=workplan)
         OverrideTransform.__init__(self, self._generate_overrides())
 
     def _generate_overrides(self) -> dict[str, t.Any]:
-        """Generate any system overrides required by the directive."""
+        """Generate any system overrides required by the directive.
+
+        Returns
+        -------
+        dict[str, t.Any]
+        """
         return {}
 
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -329,6 +329,56 @@ class LiveStep(Step):
 class LiveWorkplan(Workplan):
     steps: Sequence[LiveStep]
 
+    _lookup: Mapping[str, LiveStep] | None = None
+
+    def _get_step_lookup(self) -> Mapping[str, LiveStep]:
+        """Build a mapping from step name to step for the steps
+        contained in the workplan.
+
+        Returns
+        -------
+        Mapping[str, LiveStep]
+        """
+        if self._lookup is None:
+            self._lookup = {s.name: s for s in self.steps}
+        return self._lookup
+
+    def __getitem__(self, step_name: str) -> LiveStep:
+        """Return the step with the given name.
+
+        Parameters
+        ----------
+        step_name : str
+            The name of the step to retrieve.
+
+        Returns
+        -------
+        LiveStep
+
+        Raises
+        ------
+        KeyError
+            If a step with the supplied name cannot be found.
+        """
+        lookup = self._get_step_lookup()
+        return lookup[step_name]
+
+    def __contains__(self, step_name: str) -> bool:
+        """Return `True` then a step with the `Workplan` contains a step with the
+        supplied name.
+
+        Parameters
+        ----------
+        step_name : str
+            The name of the step.
+
+        Returns
+        -------
+        bool
+        """
+        lookup = self._get_step_lookup()
+        return step_name in lookup
+
 
 class Task(BaseModel, t.Generic[_THandle]):
     """A task represents a live-execution of a step."""

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -364,8 +364,7 @@ class LiveWorkplan(Workplan):
         return lookup[step_name]
 
     def __contains__(self, step_name: str) -> bool:
-        """Return `True` then a step with the `Workplan` contains a step with the
-        supplied name.
+        """Return `True` when the `Workplan` contains a step with the supplied name.
 
         Parameters
         ----------

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -326,6 +326,10 @@ class LiveStep(Step):
         return LiveStep(**step_attrs)
 
 
+class LiveWorkplan(Workplan):
+    steps: Sequence[LiveStep]
+
+
 class Task(BaseModel, t.Generic[_THandle]):
     """A task represents a live-execution of a step."""
 

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -305,6 +305,37 @@ class TrackingRepository(LoggingMixin):
 
         return deserialize(run_path, WorkplanRun)
 
+    def get_workplan_run_sync(
+        self, run_id: str, run_date: datetime | None = None
+    ) -> WorkplanRun | None:
+        """Locate a WorkplanRun record.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+        run_date : datetime | None
+            The datetime the run was executed or `None`.
+
+        Returns
+        -------
+        WorkplanRun | None
+            The record when it can be located in history or latest runs, otherwise `None`.
+        """
+        if not run_id:
+            msg = "A valid run-id was not provided; unable to retrieve run"
+            raise ValueError(msg)
+
+        run_path = self._find_run_path(run_id, run_date)
+
+        if not run_path.exists():
+            rd_out = run_date or "latest"
+            msg = f"No run file for `{run_id}` on `{rd_out}` found in {run_path}`"
+            self.log.warning(msg)
+            return None
+
+        return deserialize(run_path, WorkplanRun)
+
     async def put_workplan_run(self, run: WorkplanRun) -> Path:
         """Persist a run record to disk.
 

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import os
 import re
 import typing as t
 from collections import defaultdict
@@ -13,7 +14,8 @@ from pydantic import (
 )
 
 from cstar.applications.core import ApplicationDefinition, Transform, get_application
-from cstar.base.exceptions import CstarExpectationFailed
+from cstar.base.env import ENV_CSTAR_RUNID
+from cstar.base.exceptions import CstarError, CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import deep_merge
 from cstar.execution.file_system import JobFileSystemManager, local_copy
@@ -23,8 +25,9 @@ from cstar.orchestration.models import (
     KeyValueStore,
     Workplan,
 )
-from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize, serialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.runner import BlueprintRunner
@@ -650,8 +653,15 @@ def apply_automatic_overrides(step: LiveStep) -> LiveStep:
 class Directive(Transform[LiveStep], t.Protocol):
     _config: Mapping[str, t.Any]
     """Contract of a transform that can be used as a directive."""
+    _workplan: LiveWorkplan | None = None
+    """The workplan instance containing contextual information for the directive."""
 
-    def __init__(self, config: dict[str, t.Any]) -> None:
+    def __init__(
+        self,
+        config: dict[str, t.Any],
+        *,
+        workplan: LiveWorkplan | None = None,
+    ) -> None:
         """Initialize the instance.
 
         Parameters
@@ -664,6 +674,7 @@ class Directive(Transform[LiveStep], t.Protocol):
             raise ValueError(msg)
 
         self._config = config
+        self._workplan = workplan
 
     @classmethod
     def key(cls) -> str:
@@ -675,6 +686,24 @@ class Directive(Transform[LiveStep], t.Protocol):
         str
         """
         ...
+
+    @property
+    def workplan(self) -> LiveWorkplan:
+        """Return the live workplan.
+
+        Returns
+        -------
+        LiveWorkplan
+
+        Raises
+        ------
+        CStarError
+            If the workplan was not injected into the directives by the runner.
+        """
+        if self._workplan:
+            return self._workplan
+
+        raise CstarError("Directive did not receive workplan")
 
 
 class DirectiveConfig(BaseModel):
@@ -720,14 +749,58 @@ class DirectiveConfig(BaseModel):
                 blueprint=local_bp,
             )
             directive_map = DirectiveConfig.directive_map
+            workplan: LiveWorkplan | None = None
+            if os.getenv(ENV_CSTAR_RUNID, None):
+                workplan = DirectiveConfig.load_workplan()
+
             transforms = {
-                directive_map[key](config=t.cast("dict[str, dict[str, t.Any]]", config))
+                directive_map[key](
+                    config=t.cast("dict[str, dict[str, t.Any]]", config),
+                    workplan=workplan,
+                )
                 for key, config in directives.items()
             }
             for transform in transforms:
                 step = transform(step)[0]
 
         return str(step.blueprint_path)
+
+    @classmethod
+    def load_workplan(
+        cls,
+    ) -> LiveWorkplan:
+        """Identify the path to the output directory for another step.
+
+        Parameters
+        ----------
+        name : str
+            The name of the step to locate
+
+        Returns
+        -------
+        Path
+        """
+        run_id = os.getenv(ENV_CSTAR_RUNID, None)
+        run: WorkplanRun | None = None
+
+        if run_id:
+            repo = TrackingRepository()
+            run = repo.get_workplan_run_sync(run_id)
+        else:
+            msg = f"No run-id could be found in environment variable: {ENV_CSTAR_RUNID}"
+            raise RuntimeError(msg)
+
+        if not run:
+            msg = f"Workplan context could not be provided to directives for run: {run_id}"
+            raise RuntimeError(msg)
+
+        wp_path = run.trx_workplan_path
+
+        if wp := deserialize(run.trx_workplan_path, LiveWorkplan):
+            return wp
+
+        msg = f"Unable to load workplan for run-id {run_id!r} from {wp_path}"
+        raise RuntimeError(msg)
 
     @classmethod
     def register(cls, key: str, directive: type[Directive]) -> None:

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -2,12 +2,12 @@ import functools
 import logging
 import os
 import random
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
 from pathlib import Path
 from subprocess import Popen
-from typing import Any
+from typing import Any, cast
 from unittest import mock
 
 import dotenv
@@ -41,7 +41,9 @@ from cstar.io.stager import Stager
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.models import Step
-from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 from cstar.tests.unit_tests.fake_abc_subclasses import (
     FakeExternalCodeBase,
     FakeInputDataset,
@@ -1905,6 +1907,84 @@ def mocked_simulation_outputs(
         file.write_text(info_msg)
 
     return user_data_dir, step_dir, bp_path
+
+
+@pytest.fixture
+def create_mocked_simulation_outputs(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+    mock_run_id: str,
+) -> Callable[[Path, Path, str], Awaitable[None]]:
+    """This fixture creates a directory structure mocking a completed simulation.
+
+    It includes directoriess matching the expected convention for:
+    - work
+    - logs
+    - output
+    - joined output
+    - etc.
+
+    > See RomsFileSystemManager for the more information.
+
+    It includes mocked files for:
+    - a blueprint (yaml) file
+    - reset files matching glob pattern `*_rst*.nc`
+
+    Returns
+    -------
+    Callable[[Path, Path, str], Awaitable[None]]
+        Function that takes [original wp path, transformed wp path, run_id] and
+        creates the necessary on-disk side-effects for a mocked run.
+    """
+
+    async def _inner(wp_path: Path, trx_wp_path: Path, run_id: str) -> None:
+        info_msg = f"This file was created by the {__name__} fixture\n"
+
+        container_dir = tmp_path / run_id
+        user_data_dir = container_dir / "userdata"
+        user_data_dir.mkdir(parents=True, exist_ok=True)
+
+        wp = deserialize(trx_wp_path, LiveWorkplan)
+
+        # simulate a run occurring
+        repo = TrackingRepository()
+        await repo.put_workplan_run(
+            WorkplanRun(
+                workplan_path=wp_path,
+                trx_workplan_path=trx_wp_path,
+                output_path=container_dir,
+                run_id=run_id,
+            )
+        )
+
+        for step in cast("list[LiveStep]", wp.steps):
+            roms_fsm = RomsFileSystemManager(step.fsm.root_dir)
+            roms_fsm.prepare()
+            step.script_path.write_text("#!/bin/bash\necho 'fake script'")
+
+            log_path = step.fsm.logs_dir / "cstar.out"
+            log_path.write_text(info_msg)
+            log_path.write_text("Simulation completed successfully\n")
+
+            output_dir = step.fsm.output_dir
+
+            # create some mocked "partitioned" restart files
+            reset_files = [
+                output_dir / "output_rst.20120101000000.000.nc",
+                output_dir / "output_rst.20120110000000.001.nc",
+                output_dir / "output_rst.20120120000000.002.nc",
+            ]
+            for file in reset_files:
+                file.write_text(info_msg)
+
+            # create a joined restart file.
+            reset_files = [
+                roms_fsm.joined_output_dir / "output_rst.20120101000000.nc",
+            ]
+            for file in reset_files:
+                file.write_text(info_msg)
+
+    return _inner
 
 
 @pytest.fixture

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import os
 import random
+import uuid
 from collections.abc import Awaitable, Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
@@ -20,6 +21,7 @@ from cstar.base.env import (
     ENV_CSTAR_CONFIG_HOME,
     ENV_CSTAR_DATA_HOME,
     ENV_CSTAR_ORCH_LOCAL_DELAY,
+    ENV_CSTAR_RUNID,
     ENV_CSTAR_STATE_HOME,
 )
 from cstar.base.external_codebase import ExternalCodeBase
@@ -1849,8 +1851,17 @@ def bp_templates_dir(templates_dir: Path) -> Path:
 
 
 @pytest.fixture
+def mock_run_id() -> Generator[str]:
+    """Configure the CSTAR_RUNID environment variable."""
+    run_id = str(uuid.uuid4())
+    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: run_id}):
+        yield run_id
+
+
+@pytest.fixture
 def mocked_simulation_outputs(
     tmp_path: Path,
+    mock_run_id: str,
     bp_templates_dir: Path,
 ) -> tuple[Path, Path, Path]:
     """This fixture creates a directory structure mocking a completed simulation.
@@ -1878,7 +1889,7 @@ def mocked_simulation_outputs(
     """
     info_msg = f"This file was created by the {__name__} fixture\n"
 
-    container_dir = tmp_path / "mock_sim_output_dir"
+    container_dir = tmp_path / mock_run_id
     user_data_dir = container_dir / "userdata"
     user_data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -940,18 +940,6 @@ def test_worker_main_exec_continue_from(
         assert ContinuanceDirective.suffix() in str(self.request.blueprint_uri)
         return self.result
 
-    wp = LiveWorkplan(
-        name="test-workplan",
-        description="a live workplan used to create a `WorkplanRun` to test directives",
-        steps=[
-            LiveStep(
-                name="test-step",
-                application="roms_marbl",
-                blueprint=blueprint_path,
-            )
-        ],
-    )
-
     # don't let it perform any real work; mock out RomsMarblRunner
     with (
         mock.patch.object(sys, "argv", args),
@@ -967,7 +955,19 @@ def test_worker_main_exec_continue_from(
         ),
         mock.patch(
             "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
-            mock.Mock(return_value=wp),
+            mock.Mock(
+                return_value=LiveWorkplan(
+                    name="test-workplan",
+                    description="a live workplan used to create a `WorkplanRun` to test directives",
+                    steps=[
+                        LiveStep(
+                            name="test-step",
+                            application="roms_marbl",
+                            blueprint=blueprint_path,
+                        )
+                    ],
+                )
+            ),
         ),
     ):
         # This should run the simulation and return a success code
@@ -1034,22 +1034,6 @@ def test_worker_main_directive_args_parsed(
     mock_roms_sim_class = mock.Mock()
     mock_roms_sim_class.from_blueprint.return_value = mock_sim_instance
 
-    wp = LiveWorkplan(
-        name="test-workplan",
-        description="a live workplan used to create a `WorkplanRun` to test directives",
-        steps=[
-            LiveStep(
-                name="step-for-testing",
-                application="roms_marbl",
-                blueprint=bp_path,
-                working_dir=Path(),
-                directives={
-                    "continue-from": {"path": step_dir.as_posix()},
-                },
-            )
-        ],
-    )
-
     args = [
         "cstar.applications.roms_marbl",
         ARG_URI_LONG,
@@ -1081,7 +1065,23 @@ def test_worker_main_directive_args_parsed(
         ),
         mock.patch(
             "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
-            mock.Mock(return_value=wp),
+            mock.Mock(
+                return_value=LiveWorkplan(
+                    name="test-workplan",
+                    description="a live workplan used to create a `WorkplanRun` to test directives",
+                    steps=[
+                        LiveStep(
+                            name="step-for-testing",
+                            application="roms_marbl",
+                            blueprint=bp_path,
+                            working_dir=Path(),
+                            directives={
+                                "continue-from": {"path": step_dir.as_posix()},
+                            },
+                        )
+                    ],
+                )
+            ),
         ),
     ):
         _ = main()

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -35,6 +35,7 @@ from cstar.entrypoint.utils import (
 )
 from cstar.execution.file_system import RomsFileSystemManager
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
@@ -939,6 +940,18 @@ def test_worker_main_exec_continue_from(
         assert ContinuanceDirective.suffix() in str(self.request.blueprint_uri)
         return self.result
 
+    wp = LiveWorkplan(
+        name="test-workplan",
+        description="a live workplan used to create a `WorkplanRun` to test directives",
+        steps=[
+            LiveStep(
+                name="test-step",
+                application="roms_marbl",
+                blueprint=blueprint_path,
+            )
+        ],
+    )
+
     # don't let it perform any real work; mock out RomsMarblRunner
     with (
         mock.patch.object(sys, "argv", args),
@@ -951,6 +964,10 @@ def test_worker_main_exec_continue_from(
         mock.patch(
             "cstar.applications.roms_marbl.app.ROMSSimulation",
             mock_roms_sim_class,
+        ),
+        mock.patch(
+            "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
+            mock.Mock(return_value=wp),
         ),
     ):
         # This should run the simulation and return a success code
@@ -996,7 +1013,7 @@ def test_worker_main_cstar_error(
     assert return_code > 0
 
 
-def test_worker_main_preprocessor_args_parsed(
+def test_worker_main_directive_args_parsed(
     mocked_simulation_outputs: tuple[Path, Path, Path],
     continuance_directive_path: Path,
 ) -> None:
@@ -1016,6 +1033,22 @@ def test_worker_main_preprocessor_args_parsed(
     mock_sim_instance.name = "test simulation"
     mock_roms_sim_class = mock.Mock()
     mock_roms_sim_class.from_blueprint.return_value = mock_sim_instance
+
+    wp = LiveWorkplan(
+        name="test-workplan",
+        description="a live workplan used to create a `WorkplanRun` to test directives",
+        steps=[
+            LiveStep(
+                name="step-for-testing",
+                application="roms_marbl",
+                blueprint=bp_path,
+                working_dir=Path(),
+                directives={
+                    "continue-from": {"path": step_dir.as_posix()},
+                },
+            )
+        ],
+    )
 
     args = [
         "cstar.applications.roms_marbl",
@@ -1045,6 +1078,10 @@ def test_worker_main_preprocessor_args_parsed(
         mock.patch(
             "cstar.applications.roms_marbl.app.ROMSSimulation",
             mock_roms_sim_class,
+        ),
+        mock.patch(
+            "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
+            mock.Mock(return_value=wp),
         ),
     ):
         _ = main()

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -182,12 +182,6 @@ def test_blueprint_run_apply_directives(
     mock_sim_instance = mock.Mock()
     mock_sim_instance.name = "test simulation"
 
-    wp = LiveWorkplan(
-        name="test-workplan",
-        description="a live workplan used to create a `WorkplanRun` to test directives",
-        steps=[temp_step],
-    )
-
     async def modify_runner(
         self: BlueprintRunner[RomsMarblBlueprint],
     ) -> RunnerResult[RomsMarblBlueprint]:
@@ -211,7 +205,13 @@ def test_blueprint_run_apply_directives(
         ) as mock_exec_runner,
         mock.patch(
             "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
-            mock.Mock(return_value=wp),
+            mock.Mock(
+                return_value=LiveWorkplan(
+                    name="test-workplan",
+                    description="a live workplan used to create a `WorkplanRun` to test directives",
+                    steps=[temp_step],
+                )
+            ),
         ),
     ):
         runner = CliRunner()

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -19,7 +19,7 @@ from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
 from cstar.execution.handler import ExecutionStatus
 from cstar.orchestration.converter.converter import prepare_directive_file
 from cstar.orchestration.models import Application, Blueprint
-from cstar.orchestration.orchestration import LiveStep
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.roms.simulation import ROMSSimulation
 
 
@@ -182,6 +182,12 @@ def test_blueprint_run_apply_directives(
     mock_sim_instance = mock.Mock()
     mock_sim_instance.name = "test simulation"
 
+    wp = LiveWorkplan(
+        name="test-workplan",
+        description="a live workplan used to create a `WorkplanRun` to test directives",
+        steps=[temp_step],
+    )
+
     async def modify_runner(
         self: BlueprintRunner[RomsMarblBlueprint],
     ) -> RunnerResult[RomsMarblBlueprint]:
@@ -203,6 +209,10 @@ def test_blueprint_run_apply_directives(
             side_effect=modify_runner,
             autospec=True,
         ) as mock_exec_runner,
+        mock.patch(
+            "cstar.orchestration.transforms.DirectiveConfig.load_workplan",
+            mock.Mock(return_value=wp),
+        ),
     ):
         runner = CliRunner()
         _ = runner.invoke(

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -2,7 +2,6 @@ import json
 import os
 import textwrap
 import typing as t
-import uuid
 from collections.abc import AsyncGenerator, Callable, Generator
 from datetime import datetime
 from pathlib import Path
@@ -546,14 +545,6 @@ def plotter_v2_0_0_bp(tmp_path: Path, plotter_v2_0_0_model: dict[str, t.Any]) ->
     bp_path.parent.mkdir(parents=True, exist_ok=True)
     bp_path.write_text(content)
     return bp_path
-
-
-@pytest.fixture
-def mock_run_id() -> Generator[str]:
-    """Configure the CSTAR_RUNID environment variable."""
-    run_id = str(uuid.uuid4())
-    with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: run_id}):
-        yield run_id
 
 
 @pytest.fixture(autouse=True)

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -11,6 +11,7 @@ import pytest
 from pydantic import ValidationError
 
 from cstar.orchestration.models import KeyValueStore, Step, Workplan, WorkplanState
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize, serialize
 
 
@@ -1108,3 +1109,32 @@ def test_workplan_computeenv_set(
         plan.compute_environment = compute_env
 
     assert "compute_environment" in str(error)
+
+
+def test_liveworkplan_step_lookup(
+    gen_fake_steps: Callable[[int], Generator[Step, None, None]],
+) -> None:
+    """Verify __contains__ and __getitem__ work as expected.
+
+    Parameters
+    ----------
+    gen_fake_steps : Callable[[int], Generator[Step, None, None]]
+        A generator function to produce minimally valid test steps
+
+    """
+    steps = list(gen_fake_steps(3))
+    step_names = {s.name for s in steps}
+    wp = Workplan(
+        name="test-plan",
+        description="test-description",
+        steps=steps,
+    )
+
+    live_steps = [LiveStep.from_step(s) for s in steps]
+    live_plan = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
+
+    for s in step_names:
+        # confirm __contains__
+        assert s in live_plan
+        # confirm __getitem__
+        assert live_plan[s].name == s

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -347,7 +347,7 @@ async def test_continuance_directive_context_not_supplied() -> None:
     config = {"step": "any-step-name"}
 
     with pytest.raises(CstarError, match="Directive did not receive workplan"):
-        ContinuanceDirective(config, workplan)
+        ContinuanceDirective(config, workplan=workplan)
 
 
 @pytest.mark.asyncio
@@ -398,7 +398,7 @@ async def test_continuance_directive_step_DNE(
     config = {"step": bad_name}
 
     with pytest.raises(KeyError, match=f"Unable to locate step {bad_name!r}"):
-        ContinuanceDirective(config, live_plan)
+        ContinuanceDirective(config, workplan=live_plan)
 
 
 def test_continuance_directive_incomplete_config_supplied(

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -184,8 +184,8 @@ async def test_continuance_directive_path_resolution(
             assert ContinuanceDirective.key() in directives
 
             config = directives.get(ContinuanceDirective.key(), {})
-            assert "step" in config
-            assert "path" not in config
+            assert ContinuanceDirective.KEY_STEP in config
+            assert ContinuanceDirective.KEY_PATH not in config
 
             modifier = ContinuanceDirective(config)
             altered = modifier(step)[0]
@@ -196,8 +196,9 @@ async def test_continuance_directive_path_resolution(
             config = current_directives.get(ContinuanceDirective.key(), {})
 
             # confirm the path still doesn't exist in the directive
-            assert "step" in config
-            assert "path" not in config
+            assert not altered.blueprint_overrides
+            assert ContinuanceDirective.KEY_STEP in config
+            assert ContinuanceDirective.KEY_PATH not in config
 
             # confirm the initial conditions have been overridden to reference the named step
             bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -2,6 +2,7 @@
 import os
 import typing as t
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
@@ -24,8 +25,8 @@ from cstar.orchestration.models import (
     UserDefinedVariables,
     Workplan,
 )
-from cstar.orchestration.orchestration import LiveStep
-from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
+from cstar.orchestration.serialization import deserialize, serialize
 from cstar.orchestration.transforms import (
     OverrideTransform,
     TemplateFillTransform,
@@ -122,6 +123,87 @@ def step_overiding_wp(
     wp = deserialize(test_wp_path, Workplan)
 
     return wp
+
+
+@pytest.mark.asyncio
+async def test_continuance_directive_path_resolution(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+    wp_templates_dir: Path,
+    create_mocked_simulation_outputs: Callable[
+        [Path, Path, str], Awaitable[None]
+    ],  # tuple[Path, Path, Path]],
+    mock_run_id: str,
+) -> None:
+    """Verify that compose creates a new workplan and blueprint in the expected
+    output directory.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    bp_templates_dir: Path
+        Fixture returning the path to the directory containing blueprint template files
+    wp_templates_dir: Path
+        Fixture returning the path to the directory containing workplan template files
+    mock_run_id
+        A unique run-id that has already been added to os.environ
+    """
+    run_id = mock_run_id
+
+    wp_template_file = "linear.yaml"
+    wp_template_path = wp_templates_dir / wp_template_file
+
+    bp_template_file = "blueprint.yaml"
+    bp_template_path = bp_templates_dir / bp_template_file
+
+    local_bp = tmp_path / bp_template_file
+    local_bp.write_text(bp_template_path.read_text())
+
+    wp = deserialize(wp_template_path, Workplan)
+
+    # Prepare the templated workplan by adding directive configuration
+    live_steps = [LiveStep.from_step(s) for s in wp.steps]
+
+    for i, step in enumerate(live_steps):
+        step.blueprint_path = local_bp
+        step.working_dir = tmp_path / run_id / step.safe_name
+        if i > 0:
+            step.directives[ContinuanceDirective.key()] = {"step": wp.steps[i - 1].name}
+
+    live_plan = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
+    live_wp_path = tmp_path / wp_template_file
+    assert serialize(live_wp_path, live_plan)
+
+    await create_mocked_simulation_outputs(wp_template_path, live_wp_path, run_id)
+
+    for i, step in enumerate(t.cast("list[LiveStep]", live_plan.steps)):
+        if i > 0:
+            prior_step = live_plan.steps[i - 1]
+            directives = t.cast("dict[str, dict[str, str]]", step.directives)
+            assert ContinuanceDirective.key() in directives
+
+            config = directives.get(ContinuanceDirective.key(), {})
+            assert "step" in config
+            assert "path" not in config
+
+            modifier = ContinuanceDirective(config)
+            altered = modifier(step)[0]
+
+            current_directives = t.cast("dict[str, dict[str, str]]", altered.directives)
+            assert ContinuanceDirective.key() in current_directives
+
+            config = current_directives.get(ContinuanceDirective.key(), {})
+
+            # confirm the path still doesn't exist in the directive
+            assert "step" in config
+            assert "path" not in config
+
+            # confirm the initial conditions have been overridden to reference the named step
+            bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)
+            assert Path(bp.initial_conditions.data[0].location).is_relative_to(
+                prior_step.fsm.output_dir
+            )
 
 
 def test_get_transforms() -> None:
@@ -311,6 +393,57 @@ def test_continuance_transform_happy_path(
     transform = ContinuanceDirective(
         {ContinuanceDirective.KEY_PATH: str(continue_from_dir)}
     )
+    step = single_step_workplan.steps[0]
+    step.blueprint_overrides.clear()  # ensure nothing existing
+
+    steps = transform(step)
+
+    transformed = steps[0]
+
+    bp_old = deserialize(step.blueprint_path, RomsMarblBlueprint)
+    bp_new = deserialize(transformed.blueprint_path, RomsMarblBlueprint)
+
+    # confirm the old blueprint has a different initial conditions location
+    assert str(continue_from_dir) not in str(bp_old.initial_conditions.data[0].location)
+    assert str(continue_from_dir) in str(bp_new.initial_conditions.data[0].location)
+
+    # confirm the overrides were removed after being applied
+    assert not transformed.blueprint_overrides
+
+
+@pytest.mark.parametrize("pad_size", range(1, 10))
+def test_continuance_transform_locate_path_for_step(
+    single_step_workplan: Workplan,
+    mocked_simulation_outputs: tuple[Path, Path, Path],
+    pad_size: int,
+) -> None:
+    """Verify that applying a well-formed continuance transform that specifies a step
+    name results in resolution of the correct path.
+
+    Parameters
+    ----------
+    single_step_workplan : Workplan
+        A workplan with a valid blueprint file on disk.
+    mocked_simulation_outputs : Path
+        Paths to mocked simulation outputs; used here to pass a valid path
+        to the continuance transform (containing files meeting glob pattern *_rst.nc)
+    pad_size : int
+        Used to vary the amount of zero padding in the partition segment of the file
+        name. This ensures that the restart file search can locate files regardless
+        of the number of partitions.
+    """
+    _, continue_from_dir, _ = mocked_simulation_outputs
+
+    for seg_id in ["000", "001", "002"]:
+        rf_glob = f"*_rst.*.{seg_id}.nc"
+        reset_file_path = next(continue_from_dir.rglob(rf_glob))
+        name = reset_file_path.name.replace(
+            f"{seg_id}.nc",
+            f"{str(int(seg_id)).zfill(pad_size)}.nc",
+        )
+        reset_file_path = reset_file_path.rename(reset_file_path.with_name(name))
+
+    transform = ContinuanceDirective({"path": str(continue_from_dir)})
     step = single_step_workplan.steps[0]
     step.blueprint_overrides.clear()  # ensure nothing existing
 

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -411,57 +411,6 @@ def test_continuance_transform_happy_path(
     assert not transformed.blueprint_overrides
 
 
-@pytest.mark.parametrize("pad_size", range(1, 10))
-def test_continuance_transform_locate_path_for_step(
-    single_step_workplan: Workplan,
-    mocked_simulation_outputs: tuple[Path, Path, Path],
-    pad_size: int,
-) -> None:
-    """Verify that applying a well-formed continuance transform that specifies a step
-    name results in resolution of the correct path.
-
-    Parameters
-    ----------
-    single_step_workplan : Workplan
-        A workplan with a valid blueprint file on disk.
-    mocked_simulation_outputs : Path
-        Paths to mocked simulation outputs; used here to pass a valid path
-        to the continuance transform (containing files meeting glob pattern *_rst.nc)
-    pad_size : int
-        Used to vary the amount of zero padding in the partition segment of the file
-        name. This ensures that the restart file search can locate files regardless
-        of the number of partitions.
-    """
-    _, continue_from_dir, _ = mocked_simulation_outputs
-
-    for seg_id in ["000", "001", "002"]:
-        rf_glob = f"*_rst.*.{seg_id}.nc"
-        reset_file_path = next(continue_from_dir.rglob(rf_glob))
-        name = reset_file_path.name.replace(
-            f"{seg_id}.nc",
-            f"{str(int(seg_id)).zfill(pad_size)}.nc",
-        )
-        reset_file_path = reset_file_path.rename(reset_file_path.with_name(name))
-
-    transform = ContinuanceDirective({"path": str(continue_from_dir)})
-    step = single_step_workplan.steps[0]
-    step.blueprint_overrides.clear()  # ensure nothing existing
-
-    steps = transform(step)
-
-    transformed = steps[0]
-
-    bp_old = deserialize(step.blueprint_path, RomsMarblBlueprint)
-    bp_new = deserialize(transformed.blueprint_path, RomsMarblBlueprint)
-
-    # confirm the old blueprint has a different initial conditions location
-    assert str(continue_from_dir) not in str(bp_old.initial_conditions.data[0].location)
-    assert str(continue_from_dir) in str(bp_new.initial_conditions.data[0].location)
-
-    # confirm the overrides were removed after being applied
-    assert not transformed.blueprint_overrides
-
-
 def test_workplan_transformer_applies_working_dir_overrides(
     tmp_path: Path,
     step_overiding_wp: Workplan,

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -17,6 +17,7 @@ from cstar.applications.roms_marbl.transforms import (
     RomsMarblTimeSplitter,
 )
 from cstar.base.env import FLAG_OFF
+from cstar.base.exceptions import CstarError
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.orchestration.models import (
     Application,
@@ -123,88 +124,6 @@ def step_overiding_wp(
     wp = deserialize(test_wp_path, Workplan)
 
     return wp
-
-
-@pytest.mark.asyncio
-async def test_continuance_directive_path_resolution(
-    tmp_path: Path,
-    bp_templates_dir: Path,
-    wp_templates_dir: Path,
-    create_mocked_simulation_outputs: Callable[
-        [Path, Path, str], Awaitable[None]
-    ],  # tuple[Path, Path, Path]],
-    mock_run_id: str,
-) -> None:
-    """Verify that compose creates a new workplan and blueprint in the expected
-    output directory.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary directory for test outputs
-    bp_templates_dir: Path
-        Fixture returning the path to the directory containing blueprint template files
-    wp_templates_dir: Path
-        Fixture returning the path to the directory containing workplan template files
-    mock_run_id
-        A unique run-id that has already been added to os.environ
-    """
-    run_id = mock_run_id
-
-    wp_template_file = "linear.yaml"
-    wp_template_path = wp_templates_dir / wp_template_file
-
-    bp_template_file = "blueprint.yaml"
-    bp_template_path = bp_templates_dir / bp_template_file
-
-    local_bp = tmp_path / bp_template_file
-    local_bp.write_text(bp_template_path.read_text())
-
-    wp = deserialize(wp_template_path, Workplan)
-
-    # Prepare the templated workplan by adding directive configuration
-    live_steps = [LiveStep.from_step(s) for s in wp.steps]
-
-    for i, step in enumerate(live_steps):
-        step.blueprint_path = local_bp
-        step.working_dir = tmp_path / run_id / step.safe_name
-        if i > 0:
-            step.directives[ContinuanceDirective.key()] = {"step": wp.steps[i - 1].name}
-
-    live_plan = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
-    live_wp_path = tmp_path / wp_template_file
-    assert serialize(live_wp_path, live_plan)
-
-    await create_mocked_simulation_outputs(wp_template_path, live_wp_path, run_id)
-
-    for i, step in enumerate(t.cast("list[LiveStep]", live_plan.steps)):
-        if i > 0:
-            prior_step = live_plan.steps[i - 1]
-            directives = t.cast("dict[str, dict[str, str]]", step.directives)
-            assert ContinuanceDirective.key() in directives
-
-            config = directives.get(ContinuanceDirective.key(), {})
-            assert ContinuanceDirective.KEY_STEP in config
-            assert ContinuanceDirective.KEY_PATH not in config
-
-            modifier = ContinuanceDirective(config)
-            altered = modifier(step)[0]
-
-            current_directives = t.cast("dict[str, dict[str, str]]", altered.directives)
-            assert ContinuanceDirective.key() in current_directives
-
-            config = current_directives.get(ContinuanceDirective.key(), {})
-
-            # confirm the path still doesn't exist in the directive
-            assert not altered.blueprint_overrides
-            assert ContinuanceDirective.KEY_STEP in config
-            assert ContinuanceDirective.KEY_PATH not in config
-
-            # confirm the initial conditions have been overridden to reference the named step
-            bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)
-            assert Path(bp.initial_conditions.data[0].location).is_relative_to(
-                prior_step.fsm.output_dir
-            )
 
 
 def test_get_transforms() -> None:
@@ -338,7 +257,153 @@ def test_override_transform_system_precedence(
     assert Path(bp_new.working_dir) == sys_od
 
 
-def test_continuance_transform_not_supported(test_working_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_continuance_directive_step_resolution(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+    wp_templates_dir: Path,
+    create_mocked_simulation_outputs: Callable[[Path, Path, str], Awaitable[None]],
+    mock_run_id: str,
+) -> None:
+    """Verify that a continuance directive uses context information to identify
+    the search path when a step name is provided.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    bp_templates_dir: Path
+        Fixture returning the path to the directory containing blueprint template files
+    wp_templates_dir: Path
+        Fixture returning the path to the directory containing workplan template files
+    mock_run_id
+        A unique run-id that has already been added to os.environ
+    """
+    run_id = mock_run_id
+
+    wp_template_file = "linear.yaml"
+    wp_template_path = wp_templates_dir / wp_template_file
+
+    bp_template_file = "blueprint.yaml"
+    bp_template_path = bp_templates_dir / bp_template_file
+
+    local_bp = tmp_path / bp_template_file
+    local_bp.write_text(bp_template_path.read_text())
+
+    wp = deserialize(wp_template_path, Workplan)
+
+    # Prepare the templated workplan by adding directive configuration
+    live_steps = [LiveStep.from_step(s) for s in wp.steps]
+
+    for i, step in enumerate(live_steps):
+        step.blueprint_path = local_bp
+        step.working_dir = tmp_path / run_id / step.safe_name
+        if i > 0:
+            step.directives[ContinuanceDirective.key()] = {"step": wp.steps[i - 1].name}
+
+    live_plan = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
+    live_wp_path = tmp_path / wp_template_file
+    assert serialize(live_wp_path, live_plan)
+
+    await create_mocked_simulation_outputs(wp_template_path, live_wp_path, run_id)
+
+    for i, step in enumerate(t.cast("list[LiveStep]", live_plan.steps)):
+        if i > 0:
+            prior_step = live_plan.steps[i - 1]
+            directives = t.cast("dict[str, dict[str, str]]", step.directives)
+            assert ContinuanceDirective.key() in directives
+
+            config = directives.get(ContinuanceDirective.key(), {})
+            assert ContinuanceDirective.KEY_STEP in config
+            assert ContinuanceDirective.KEY_PATH not in config
+
+            modifier = ContinuanceDirective(config, workplan=live_plan)
+            altered = modifier(step)[0]
+
+            current_directives = t.cast("dict[str, dict[str, str]]", altered.directives)
+            assert ContinuanceDirective.key() in current_directives
+
+            config = current_directives.get(ContinuanceDirective.key(), {})
+
+            # confirm the path still doesn't exist in the directive
+            assert not altered.blueprint_overrides
+            assert ContinuanceDirective.KEY_STEP in config
+            assert ContinuanceDirective.KEY_PATH not in config
+
+            # confirm the initial conditions have been overridden to reference the named step
+            bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)
+            assert Path(bp.initial_conditions.data[0].location).is_relative_to(
+                prior_step.fsm.output_dir
+            )
+
+
+@pytest.mark.asyncio
+async def test_continuance_directive_context_not_supplied() -> None:
+    """Verify that constructing a `ContinuanceDirective` that requires contextual
+    information without supplying the necessary context info results in a failure.
+
+    """
+    workplan: LiveWorkplan | None = None
+    config = {"step": "any-step-name"}
+
+    with pytest.raises(CstarError, match="Directive did not receive workplan"):
+        ContinuanceDirective(config, workplan)
+
+
+@pytest.mark.asyncio
+async def test_continuance_directive_step_DNE(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+    wp_templates_dir: Path,
+    mock_run_id: str,
+) -> None:
+    """Verify that constructing a `ContinuanceDirective` that has an invalid
+    step name as the source results in a failure.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    bp_templates_dir: Path
+        Fixture returning the path to the directory containing blueprint template files
+    wp_templates_dir: Path
+        Fixture returning the path to the directory containing workplan template files
+    mock_run_id
+        A unique run-id that has already been added to os.environ
+    """
+    run_id = mock_run_id
+
+    wp_template_file = "linear.yaml"
+    wp_template_path = wp_templates_dir / wp_template_file
+
+    bp_template_file = "blueprint.yaml"
+    bp_template_path = bp_templates_dir / bp_template_file
+
+    local_bp = tmp_path / bp_template_file
+    local_bp.write_text(bp_template_path.read_text())
+
+    wp = deserialize(wp_template_path, Workplan)
+
+    # Prepare the templated workplan by adding directive configuration
+    live_steps = [LiveStep.from_step(s) for s in wp.steps]
+
+    for i, step in enumerate(live_steps):
+        step.blueprint_path = local_bp
+        step.working_dir = tmp_path / run_id / step.safe_name
+        if i > 0:
+            step.directives[ContinuanceDirective.key()] = {"step": wp.steps[i - 1].name}
+
+    live_plan = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
+    bad_name = str(uuid.uuid4())
+    config = {"step": bad_name}
+
+    with pytest.raises(KeyError, match=f"Unable to locate step {bad_name!r}"):
+        ContinuanceDirective(config, live_plan)
+
+
+def test_continuance_directive_incomplete_config_supplied(
+    test_working_dir: Path,
+) -> None:
     """Verify that unknown configuration results in an exception.
 
     Parameters
@@ -351,7 +416,7 @@ def test_continuance_transform_not_supported(test_working_dir: Path) -> None:
         _ = ContinuanceDirective({"not-path": str(test_working_dir)})
 
 
-def test_continuance_transform_path_dne() -> None:
+def test_continuance_directive_path_dne() -> None:
     """Verify that sending a path to a directory that does not exist results in
     an exception being raised.
     """
@@ -360,12 +425,12 @@ def test_continuance_transform_path_dne() -> None:
 
 
 @pytest.mark.parametrize("pad_size", range(1, 10))
-def test_continuance_transform_happy_path(
+def test_continuance_directive_happy_path(
     single_step_workplan: Workplan,
     mocked_simulation_outputs: tuple[Path, Path, Path],
     pad_size: int,
 ) -> None:
-    """Verify that applying a well-formed continuance transform causes the
+    """Verify that applying a well-formed continuance directive causes the
     blueprint initial conditions to be updated.
 
     Parameters


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change injects the workplan into `Directive` instances to enable them to access contextual information about the running `Workplan`. Additionally, it makes use of the newly available contextual information in the `ContinuanceDirective` to enable referencing another step _by name_.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Add `Directive.workplan` attribute for access to run context information from within the `Directive`

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-836
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

