### PR TITLE
Remove unnecessary command mapping feature

### DIFF
--- a/cstar/orchestration/converter/converter.py
+++ b/cstar/orchestration/converter/converter.py
@@ -1,19 +1,14 @@
-import os
 import random
 import textwrap
 import typing as t
-from collections import defaultdict
 from pathlib import Path
 
 import yaml
 
 from cstar.base.env import ENV_CSTAR_CLOBBER_WORKING_DIR
-from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
 from cstar.entrypoint.utils import ARG_CLOBBER, ARG_DIRECTIVES_URI_LONG
-from cstar.orchestration.models import Application
-from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
@@ -124,48 +119,3 @@ def convert_step_to_placeholder(step: "LiveStep") -> str:
     script_path.write_text(script)
 
     return f"sh {script_path}"
-
-
-app_to_cmd_map: dict[str, StepToCommandConversionFn] = defaultdict(
-    lambda: convert_step_to_blueprint_run_command,
-    {
-        Application.SLEEP.value: convert_step_to_placeholder,
-        Application.ROMS_MARBL.value: convert_step_to_blueprint_run_command,
-    },
-)
-"""Map application types to a function that converts a step to a CLI command."""
-
-
-def register_command_mapping(
-    application: Application | str,
-    mapping_func: StepToCommandConversionFn,
-) -> None:
-    if isinstance(application, Application):
-        application = application.value
-    app_to_cmd_map[application] = mapping_func
-
-
-def get_command_mapping(
-    application: str,
-) -> StepToCommandConversionFn:
-    if isinstance(application, Application):
-        application = application.value
-
-    step_converter = app_to_cmd_map[application]
-    if step_converter is None:
-        msg = f"No command converter found for application: {application!r}"
-        raise CstarExpectationFailed(msg)
-
-    if converter_override := os.getenv(ENV_CSTAR_CMD_CONVERTER_OVERRIDE, ""):
-        if converter_override not in app_to_cmd_map:
-            msg = f"Override in env var `{ENV_CSTAR_CMD_CONVERTER_OVERRIDE}` has invalid value: {converter_override}"
-            raise ValueError(msg)
-
-        converter = app_to_cmd_map[converter_override]
-        msg = f"Overriding step converter `{step_converter}` with `{converter}` for `{application}` commands."
-        step_converter = converter
-    else:
-        msg = f"Using `{step_converter}` for `{application}` commands."
-
-    log.trace(msg)
-    return step_converter

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -19,7 +19,9 @@ from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
 )
-from cstar.orchestration.converter.converter import get_command_mapping
+from cstar.orchestration.converter.converter import (
+    convert_step_to_blueprint_run_command,
+)
 from cstar.orchestration.models import Blueprint, Step, Workplan
 from cstar.orchestration.serialization import (
     deserialize,
@@ -275,8 +277,7 @@ class LiveStep(Step):
         -------
         str
         """
-        step_converter = get_command_mapping(self.application)
-        return step_converter(self)
+        return convert_step_to_blueprint_run_command(self)
 
     @property
     def script_path(self) -> Path:

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -27,17 +27,6 @@ ENV_CSTAR_ORCH_TRX_FREQ: t.Annotated[
 ] = "CSTAR_ORCH_TRX_FREQ"
 """Environment variable containing the time span for time-splitting transforms."""
 
-ENV_CSTAR_CMD_CONVERTER_OVERRIDE: t.Annotated[
-    t.Literal["CSTAR_CMD_CONVERTER_OVERRIDE"],
-    EnvVar(
-        "Overridden mapping key to apply when converting applications into CLI commands.",
-        _GROUP_DEV,
-        "",
-    ),
-] = "CSTAR_CMD_CONVERTER_OVERRIDE"
-"""Environment variable containing an overridden mapping key to apply when
-converting applications into CLI commands."""
-
 ENV_CSTAR_SLURM_ACCOUNT: t.Annotated[
     t.Literal["CSTAR_SLURM_ACCOUNT"],
     EnvVar(

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -12,13 +12,13 @@ from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.cli.workplan.compose import WorkplanTemplate, compose
 from cstar.execution.file_system import DirectoryManager
+from cstar.orchestration.converter.converter import convert_step_to_placeholder
 from cstar.orchestration.dag_runner import build_and_run_dag, prepare_workplan
 from cstar.orchestration.models import Application, Workplan
 from cstar.orchestration.orchestration import check_environment, configure_environment
 from cstar.orchestration.serialization import deserialize, serialize
 from cstar.orchestration.transforms import WorkplanTransformer
 from cstar.orchestration.utils import (
-    ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
     ENV_CSTAR_ORCH_TRX_FREQ,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -348,7 +348,6 @@ async def test_run_composed_dag(
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:5:00",
         ENV_FF_ORCH_TRX_TIMESPLIT: FLAG_ON,
         ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
-        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
     }
 
     mock_run_cmd = mock.Mock(return_code=0, stderr="", stdout="mock-run-output")
@@ -356,6 +355,10 @@ async def test_run_composed_dag(
     with (
         mock.patch.dict(os.environ, mock_env, clear=True),
         mock.patch("cstar.base.utils._run_cmd", mock_run_cmd),
+        mock.patch(
+            "cstar.orchestration.converter.converter.convert_step_to_blueprint_run_command",
+            convert_step_to_placeholder,
+        ),
     ):
         generated_wp_path = compose(
             wp_template_path.as_posix(),

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -1,7 +1,5 @@
-import os
 import shutil
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -10,9 +8,7 @@ from cstar.applications.roms_marbl.transforms import ContinuanceTransform
 from cstar.entrypoint.utils import ARG_DIRECTIVES_URI_LONG
 from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.converter.converter import (
-    app_to_cmd_map,
-    get_command_mapping,
-    register_command_mapping,
+    convert_step_to_blueprint_run_command,
 )
 from cstar.orchestration.models import (
     Application,
@@ -20,7 +16,6 @@ from cstar.orchestration.models import (
 )
 from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.serialization import deserialize
-from cstar.orchestration.utils import ENV_CSTAR_CMD_CONVERTER_OVERRIDE
 
 
 def custom_map_function(step: Step) -> str:
@@ -59,157 +54,8 @@ def test_converter_defaults(
         working_dir=tmp_path / "unit-test-work-dir",
     )
 
-    mapped_fn = get_command_mapping(target_application)
-
     # confirm a mapping function was returned
-    assert mapped_fn(step)
-
-
-@pytest.mark.parametrize(
-    ("target_application"),
-    [Application.ROMS_MARBL, Application.SLEEP],
-)
-def test_converter_registration(
-    tmp_path: Path,
-    target_application: Application,
-) -> None:
-    """Verify that the registration of a converter is not required for the default apps.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary path fixture for writing per-test outputs
-    target_application: Application
-        The application type to locate a mapping for
-    """
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_path.touch()
-
-    step = LiveStep(
-        name="test step",
-        application=target_application,
-        blueprint=bp_path,
-        working_dir=tmp_path / "unit-test-work-dir",
-    )
-
-    # ensure registration doesn't persist after test completes.
-    with mock.patch.dict(app_to_cmd_map, {}):
-        original_fn = get_command_mapping(target_application)
-
-        register_command_mapping(target_application, custom_map_function)
-
-        mapped_fn = get_command_mapping(target_application)
-
-    # confirm the function is a mapping function
-    assert mapped_fn(step)
-
-    # confirm the newly registered function was returned
-    assert mapped_fn != original_fn
-    assert mapped_fn == custom_map_function
-
-
-@pytest.mark.parametrize(
-    ("target_application"),
-    [Application.ROMS_MARBL, Application.SLEEP],
-)
-def test_converter_override_invalid(
-    tmp_path: Path,
-    target_application: Application,
-) -> None:
-    """Verify that an invalid converter override results in an error.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary path fixture for writing per-test outputs
-    target_application: Application
-        The application type to locate a mapping for
-    """
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_path.touch()
-
-    with (
-        mock.patch.dict(os.environ, {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "DNE-key"}),
-        pytest.raises(ValueError) as error,
-    ):
-        _ = get_command_mapping(target_application)
-
-    assert ENV_CSTAR_CMD_CONVERTER_OVERRIDE in str(error)
-
-
-@pytest.mark.parametrize(
-    ("target_application", "overridden_target"),
-    [
-        (Application.ROMS_MARBL, Application.SLEEP),
-        (Application.SLEEP, Application.ROMS_MARBL),
-    ],
-)
-def test_converter_override_capability(
-    tmp_path: Path,
-    target_application: str,
-    overridden_target: str,
-) -> None:
-    """Verify that the the override specified in an environment variable takes precedence
-    over defaults.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary path fixture for writing per-test outputs
-    target_application: Application
-        The application type to locate a mapping for
-    overridden_target: Application
-        The key to use to locate the override
-    """
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_path.touch()
-
-    original_fn = get_command_mapping(target_application)
-
-    with mock.patch.dict(
-        os.environ,
-        {ENV_CSTAR_CMD_CONVERTER_OVERRIDE: overridden_target},
-    ):
-        overridden_fn = get_command_mapping(target_application)
-
-    assert original_fn != overridden_fn
-
-
-@pytest.mark.asyncio
-async def test_converter_hello_world(
-    tmp_path: Path,
-    hello_world_bp_path: Path,
-) -> None:
-    """Verify that the command converter produces a working CLI
-    command.
-
-    Parameters
-    ----------
-    tmp_path : Path
-        Temporary output location for writing the test blueprint.
-    hello_world_bp_path : Path
-        Path to the hello world blueprint.
-    """
-    working_dir = tmp_path / "work"
-
-    step = LiveStep(
-        name=f"{__name__}",
-        application=Application.HELLO_WORLD,
-        blueprint=hello_world_bp_path.as_posix(),
-        working_dir=working_dir,
-    )
-
-    # find the registered command converter for this application and launcher type
-    cmd_converter = get_command_mapping(Application.HELLO_WORLD)
-    assert cmd_converter is not None, "Command converter not found"
-
-    # use the converter function to generate the command
-    command = cmd_converter(step)
-
-    # confirm the retrieved converter produces the output expected
-    # from the function: convert_step_to_blueprint_run_command
-    assert "cstar blueprint run" in command
-    assert str(hello_world_bp_path) in command
+    assert convert_step_to_blueprint_run_command(step)
 
 
 def test_convert_step_with_directives(
@@ -226,8 +72,7 @@ def test_convert_step_with_directives(
     step = preprocessable_roms_livestep
     bp_path = str(step.blueprint_path)
 
-    cmd_converter = get_command_mapping(Application.ROMS_MARBL)
-    result = cmd_converter(step)
+    result = convert_step_to_blueprint_run_command(step)
 
     # confirm the parameter is sent
     assert ARG_DIRECTIVES_URI_LONG in result

--- a/cstar/tests/unit_tests/orchestration/test_helloworldrunner.py
+++ b/cstar/tests/unit_tests/orchestration/test_helloworldrunner.py
@@ -18,10 +18,10 @@ from cstar.cli.blueprint.run import app as app_run_blueprint
 from cstar.cli.workplan.run import app as app_run_workplan
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.converter.converter import convert_step_to_placeholder
 from cstar.orchestration.models import Workplan, WorkplanState
 from cstar.orchestration.serialization import deserialize, serialize
 from cstar.orchestration.utils import (
-    ENV_CSTAR_CMD_CONVERTER_OVERRIDE,
     ENV_CSTAR_ORCH_DELAYS,
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -277,7 +277,6 @@ def test_hello_world_workplan_dry_run(
         ENV_CSTAR_ORCH_DELAYS: "0.01",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
         ENV_CSTAR_SLURM_QUEUE: "debug",
-        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
     }
 
     run_id = str(uuid.uuid4())
@@ -286,6 +285,10 @@ def test_hello_world_workplan_dry_run(
         mock.patch(
             "cstar.system.manager.CStarSystemManager.scheduler",
             mock.PropertyMock(return_value=None),
+        ),
+        mock.patch(
+            "cstar.orchestration.converter.converter.convert_step_to_blueprint_run_command",
+            convert_step_to_placeholder,
         ),
     ):
         args = [hw_single_step_wp_path.as_posix(), "--run-id", run_id]
@@ -333,7 +336,6 @@ def test_heterogeneous_workplan(
         ENV_CSTAR_ORCH_DELAYS: "0.01",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
         ENV_CSTAR_SLURM_QUEUE: "debug",
-        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
     }
     run_id = str(uuid.uuid4())
     with (
@@ -341,6 +343,10 @@ def test_heterogeneous_workplan(
         mock.patch(
             "cstar.system.manager.CStarSystemManager.scheduler",
             mock.PropertyMock(return_value=None),
+        ),
+        mock.patch(
+            "cstar.orchestration.converter.converter.convert_step_to_blueprint_run_command",
+            convert_step_to_placeholder,
         ),
     ):
         args = [heterogeneous_workplan_path.as_posix(), "--run-id", run_id]
@@ -377,13 +383,16 @@ def test_hw_runner_bp_only(
         ENV_CSTAR_ORCH_DELAYS: "0.01",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:02:00",
         ENV_CSTAR_SLURM_QUEUE: "debug",
-        ENV_CSTAR_CMD_CONVERTER_OVERRIDE: "sleep",
     }
     with (
         mock.patch.dict(os.environ, custom_env),
         mock.patch(
             "cstar.system.manager.CStarSystemManager.scheduler",
             mock.PropertyMock(return_value=None),
+        ),
+        mock.patch(
+            "cstar.orchestration.converter.converter.convert_step_to_blueprint_run_command",
+            convert_step_to_placeholder,
         ),
     ):
         args = [str(hello_world_bp_path)]


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change removes a rarely-used, developer-only feature. It can be replicated, code-free with `unittest.mock` (see modified test code).

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Registration of _step-to-command_ mapping functions is removed.

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

