### PR TITLE
Add `cstar admin clean` command

### DIFF
--- a/cstar/cli/admin/__init__.py
+++ b/cstar/cli/admin/__init__.py
@@ -1,0 +1,15 @@
+import typer
+
+from cstar.base.feature import (
+    ENV_FF_DEVELOPER_MODE,
+    is_feature_enabled,
+)
+from cstar.cli.admin.clean import app as app_clean
+
+app = typer.Typer(
+    name="admin",
+    help="Perform administrative tasks related to your C-Star installation and runs.",
+)
+
+if is_feature_enabled(ENV_FF_DEVELOPER_MODE):
+    app.add_typer(app_clean)

--- a/cstar/cli/admin/__init__.py
+++ b/cstar/cli/admin/__init__.py
@@ -4,7 +4,6 @@ from cstar.base.feature import (
     ENV_FF_DEVELOPER_MODE,
     is_feature_enabled,
 )
-from cstar.cli.admin.clean import app as app_clean
 
 app = typer.Typer(
     name="admin",
@@ -12,4 +11,6 @@ app = typer.Typer(
 )
 
 if is_feature_enabled(ENV_FF_DEVELOPER_MODE):
+    from cstar.cli.admin.clean import app as app_clean
+
     app.add_typer(app_clean)

--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -1,23 +1,31 @@
+import abc
 import asyncio
-import itertools
 import shutil
 import typing as t
+from abc import ABC
 from collections.abc import Sequence
+from enum import IntEnum, auto
 from pathlib import Path
 
 import typer
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, PrivateAttr
 from rich.console import Console
 from rich.prompt import Prompt
 
-from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN
+from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_RUNID
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
-from cstar.cli.common import cb_pipeline, get_from_ctxmap, set_ctxmap, set_flag
-from cstar.cli.workplan.shared import colored, list_runs, preload_run
+from cstar.cli.common import (
+    cb_pipeline,
+    set_env,
+    set_flag,
+)
+from cstar.cli.workplan.shared import colored, list_runs
 from cstar.entrypoint.utils import ARG_DRY_RUN
-from cstar.execution.file_system import DirectoryManager
-from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
+from cstar.execution.file_system import DirectoryManager, StateDirectoryManager
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.tracking import TrackingRepository
 
 log = get_logger(__name__)
 app = typer.Typer()
@@ -37,19 +45,169 @@ run_help: t.Final[str] = "Clean up stored assets for a specific run"
 ARG_YES: t.Final[str] = "--yes"
 
 
-class CleanupAction(BaseModel):
+class CleanupStatus(IntEnum):
+    """Describes the status of a cleanup action."""
+
+    READY = auto()
+    """The cleanup action has not been evaluated."""
+    DONE = auto()
+    """The cleanup was successfully completed."""
+    SKIPPED = auto()
+    """The cleanup action was determined to be unnecessary."""
+    INCOMPLETE = auto()
+    """The cleanup action was not completed successfully."""
+
+
+class CleanupResult(BaseModel):
+    """Describes the result of executing a cleanup action."""
+
+    name: str
+    """The name of the action producing the result."""
+
+    ledger: dict[str, tuple[CleanupStatus, str]] = Field(
+        default_factory=dict, init=False
+    )
+    """Mapping from action identifier to a tuple containing the status and,
+    if necessary, an error description.
+    """
+
+    def record(self, key: str, status: CleanupStatus, error: str | None = None) -> None:
+        """Record a cleanup task into the ledger."""
+        self.ledger[key] = status, error or ""
+
+    @property
+    def status(self) -> CleanupStatus:
+        if not self.ledger:
+            return CleanupStatus.READY
+
+        statuses = {x[0] for x in self.ledger.values()}
+        if {CleanupStatus.INCOMPLETE, CleanupStatus.READY}.intersection(statuses):
+            return CleanupStatus.INCOMPLETE
+
+        return CleanupStatus.DONE
+
+    def display(self) -> str:
+        details: list[str] = []
+
+        for k, (status, error) in self.ledger.items():
+            view = f"{status.name}: {k}"
+            if error:
+                view = f"{status.name}: {k}\n{error}"
+            details.append(view)
+
+        csv = "\n".join(f"* {item}" for item in details)
+        return f"{self.name}\n{csv}"
+
+
+class CleanupAction(BaseModel, ABC):
     """A resource managed by C-Star that can be cleaned up."""
 
     name: str
     """The user-friendly name of the resource."""
     description: str | None = None
     """An extended description of the resource to display to a user."""
-    asset_paths: list[Path]
+    _results: CleanupResult | None = PrivateAttr(default=None)
+    """The results of executing the action."""
+
+    @abc.abstractmethod
+    def execute(self) -> CleanupResult:
+        """Perform the cleanup behavior for an associated resource.
+
+        Returns
+        -------
+        `True` if cleanup was completed (or unnecessary), `False` otherwise.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def mitigated(self) -> bool:
+        """Return `True` when all underlying assets are not found."""
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def state(self) -> CleanupResult:
+        """Return the results of executing the action.
+
+        When the action has not been executed, all tasks are considered READY.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def display(self) -> str: ...
+
+
+class FileSystemCleanupAction(CleanupAction):
+    """A file-system resource managed by C-Star that can be cleaned up."""
+
+    asset_paths: list[Path] = Field(default_factory=list[Path], min_length=1)
     """The paths containing the resources to be cleaned up."""
+
+    def execute(self) -> CleanupResult:
+        """Perform the cleanup behavior for an associated resource.
+
+        Returns
+        -------
+        `True` if cleanup was completed (or unnecessary), `False` otherwise.
+        """
+        dry_run = is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN)
+        results = CleanupResult(name=self.name)
+        self._results = results
+
+        asset_iter = iter(self.asset_paths)
+        while asset := next(asset_iter, None):
+            asset_key = str(asset)
+            state = asset_key, CleanupStatus.READY, ""
+            if not asset.exists():
+                results.record(asset_key, CleanupStatus.SKIPPED, "")
+                continue
+
+            asset_type = "file" if asset.is_file() else "directory"
+
+            try:
+                if not dry_run:
+                    if asset_type == "directory":
+                        shutil.rmtree(asset)
+                    elif asset_type == "file":
+                        asset.unlink()
+                    state = asset_key, CleanupStatus.DONE, ""
+            except Exception:
+                msg = f"An error occurred cleaning up {asset_type}: {asset}"
+                state = asset_key, CleanupStatus.INCOMPLETE, msg
+                log.exception(msg)
+            finally:
+                results.record(*state)
+
+        self._results = results
+        return results
 
     def mitigated(self) -> bool:
         """Return `True` when all underlying assets are not found."""
         return all(not p.exists() for p in self.asset_paths)
+
+    @property
+    def state(self) -> CleanupResult:
+        if self._results is None:
+            result = CleanupResult(name=self.name)
+            for asset in self.asset_paths:
+                result.record(str(asset), CleanupStatus.READY, None)
+            return result
+        return self._results
+
+    def display(self) -> str:
+        if self.description:
+            header = f"{self.name} ({self.description})"
+        else:
+            header = f"{self.name}"
+
+        if len(self.asset_paths) > 1:
+            tasks = "\n".join(f"* {p}" for p in self.asset_paths)
+            return f"{header}\n{tasks}"
+
+        if self.asset_paths:
+            return f"{header}\n{self.asset_paths[0]}"
+
+        return header
 
 
 def get_prefect_storage_path() -> Path:
@@ -65,7 +223,7 @@ def get_prefect_storage_path() -> Path:
 def get_default_cleanup_actions() -> list[CleanupAction]:
     """Return a list of all available clean-up actions.
 
-    Performing cleanup on these folders is _the nuclear option_ and will
+    Performing cleanup on these folders is the **nuclear option** and will
     wipe out all stored state.
 
     Returns
@@ -75,12 +233,12 @@ def get_default_cleanup_actions() -> list[CleanupAction]:
     return list(
         sorted(
             [
-                CleanupAction(
+                FileSystemCleanupAction(
                     name="C-Star package cache",
                     description="Cached copies of previously retrieved github repositories",
                     asset_paths=[DirectoryManager.cache_home()],
                 ),
-                CleanupAction(
+                FileSystemCleanupAction(
                     name="C-Star state files",
                     description="Internal C-Star state information related to run history.",
                     asset_paths=[
@@ -88,12 +246,12 @@ def get_default_cleanup_actions() -> list[CleanupAction]:
                         get_prefect_storage_path(),
                     ],
                 ),
-                CleanupAction(
+                FileSystemCleanupAction(
                     name="C-Star Data",
                     description="All datasets and assets created during a run.",
                     asset_paths=[DirectoryManager.data_home()],
                 ),
-                CleanupAction(
+                FileSystemCleanupAction(
                     name="C-Star configuration",
                     description="Local user-specific C-Star configuration files",
                     asset_paths=[DirectoryManager.config_home()],
@@ -102,30 +260,6 @@ def get_default_cleanup_actions() -> list[CleanupAction]:
             key=lambda x: x.name,
         )
     )
-
-
-def remove_asset(action: CleanupAction) -> list[Path]:
-    """Clean up the files and directories for the action.
-
-    Returns
-    -------
-    list[Path]
-        A list of all paths that were removed.
-    """
-    removed: list[Path] = []
-
-    try:
-        for path in action.asset_paths:
-            if path.exists() and path.is_dir():
-                shutil.rmtree(path, ignore_errors=True)
-            elif path.exists() and path.is_file():
-                path.unlink()
-
-            removed.append(path)
-    except Exception:
-        log.exception(f"Unable to remove assets for {action.name!r}")
-
-    return removed
 
 
 async def perform_actions(actions: Sequence[CleanupAction]) -> int:
@@ -141,33 +275,34 @@ async def perform_actions(actions: Sequence[CleanupAction]) -> int:
     int
         The total number of actions taken
     """
-    COLOR_WHITE: t.Final[str] = "white"
-    COLOR_RED: t.Final[str] = "red"
+    COLOR_READY: t.Final[str] = "white"
+    COLOR_EXECUTED: t.Final[str] = "red"
     dry_run = is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN)
-    msg, color = "Removed", COLOR_RED
+    msg, color = "Will remove", COLOR_READY
 
-    if dry_run:
-        msg = "Will remove"
-        color = COLOR_WHITE
-        removal_results = [a.asset_paths for a in actions]
+    if not dry_run:
+        log.debug(f"Performing {len(actions)} cleanup actions")
+        msg, color = "Removed", COLOR_EXECUTED
+        pending = {asyncio.Task(asyncio.to_thread(a.execute)) for a in actions}
+
+        while pending:
+            done, pending = await asyncio.wait(pending, timeout=0.1)
+
+            displays = (task.result().display().split("\n") for task in done)
+
+            for group in displays:
+                group[0] = f"{colored(msg, color)}: {group[0]}"
+                for item in group:
+                    console.print(item)
     else:
-        removal_coros = [
-            asyncio.to_thread(remove_asset, a) for a in actions if a.asset_paths
-        ]
-        removal_results = await asyncio.gather(*removal_coros)
+        displays = (a.display().split("\n") for a in actions)
 
-    for i, dirs in enumerate(removal_results):
-        descriptor = colored(msg, color)
+        for group in displays:
+            group[0] = f"{colored(msg, color)}: {group[0]}"
+            for item in group:
+                console.print(item)
 
-        if len(dirs) == 1:
-            path_csv = ", ".join(str(d) for d in dirs)
-            console.print(f"{descriptor} {actions[i].name!r}: {path_csv}")
-        else:
-            console.print(f"{descriptor} {actions[i].name!r}:")
-            for d in dirs:
-                console.print(f"* {d}")
-
-    return len(list(itertools.chain.from_iterable(removal_results)))
+    return sum(len(a.state.ledger) for a in actions)
 
 
 def actions_filter_prompt(
@@ -187,10 +322,15 @@ def actions_filter_prompt(
     -------
     list[CleanupAction]
     """
+    if not available:
+        console.print("No cleanup actions to perform")
+        raise typer.Exit(99)
+
     CHOICE_YES: t.Final[str] = "y"
     CHOICE_NO: t.Final[str] = "n"
+    CHOICE_DETAILS: t.Final[str] = "d"
 
-    choices: t.Final[list[str]] = [CHOICE_YES, CHOICE_NO]
+    choices: t.Final[list[str]] = [CHOICE_YES, CHOICE_NO, CHOICE_DETAILS]
     selected: list[CleanupAction] = []
 
     for action in available:
@@ -208,7 +348,10 @@ def actions_filter_prompt(
                 case_sensitive=False,
             )
 
-        if answer == CHOICE_NO:
+        if answer == CHOICE_DETAILS:
+            console.print(action.display())
+            continue
+        elif answer == CHOICE_NO:
             console.print(f"\t[yellow]Skipping[/yellow] {action.name!r} deletion")
             continue
 
@@ -217,13 +360,11 @@ def actions_filter_prompt(
     return selected
 
 
-def get_run_action(context: typer.Context, run_id: str) -> str:
-    """Load run information into the typer context, if necessary.
+def runid_callback(_context: typer.Context, run_id: str) -> str:
+    """Clean and validate the run-id format.
 
     Parameters
     ----------
-    context : typer.Context
-        The typer context
     run_id : str
         The run-id value received from the user
 
@@ -231,30 +372,85 @@ def get_run_action(context: typer.Context, run_id: str) -> str:
     -------
     str
     """
-    run_id = run_id.strip()
-
-    if not run_id:
+    if run_id and not run_id.strip():
         log.debug("Skipping run loading; run-id was not specified")
-        return run_id
+        raise typer.Exit(1)
 
-    preload_run(context, run_id)
+    return run_id.strip()
 
-    run = get_from_ctxmap(context, "run", WorkplanRun)
 
-    tracking_repo = TrackingRepository()
-    run_paths = tracking_repo.list_run_paths(run_id)
+def get_run_actions(run_id: str) -> list[CleanupAction]:
+    """Create a list of cleanup actions to be performed for a run.
 
-    action = CleanupAction(
-        name=f"Run {run_id!r} Assets",
-        description="All state information, datasets, and code assets used in the run(s)",
-        asset_paths=[
-            run.state_dir,
-            *run_paths,
-        ],
-    )
-    set_ctxmap(context, "action", action)
+    Parameters
+    ----------
+    run_id : str
+        The run-id value received from the user
 
-    return run_id
+    Returns
+    -------
+    list[CleanupAction]
+    """
+    cache_paths: list[Path] = []
+    runstate_paths: list[Path] = []
+    rundata_paths: list[Path] = []
+
+    run_repo = TrackingRepository()
+    workplan: Workplan | None = None
+
+    if run := asyncio.run(run_repo.get_workplan_run(run_id)):
+        workplan = deserialize(run.trx_workplan_path, Workplan)
+        rundata_paths.append(run.output_path)
+    else:
+        # if we can't load a run, check the default data path.
+        data_dir = StateDirectoryManager.data_dir(run_id=run_id)
+        rundata_paths.append(data_dir)
+        log.debug(f"Run {run_id!r} not found")
+
+    storage_root: t.Final[Path] = get_prefect_storage_path()
+    if workplan:
+        fn_name: t.Final[str] = "_submit"
+
+        for step in workplan.steps:
+            cache_key = f"{run_id}_{step.name}_{fn_name}"
+            cache_paths.append(storage_root / cache_key)
+    else:
+        cache_paths.extend(
+            p
+            for p in storage_root.iterdir()
+            if p.is_dir() and p.name.startswith(run_id)
+        )
+
+    if run_paths := run_repo.list_runtracking_paths(run_id, all_history=True):
+        runstate_paths.extend(run_paths)
+
+    actions: list[CleanupAction] = []
+
+    if cache_paths:
+        actions.append(
+            FileSystemCleanupAction(
+                name=f"{run_id!r} Cached Results",
+                description="Cached outputs from successful steps",
+                asset_paths=cache_paths,
+            ),
+        )
+    if runstate_paths:
+        actions.append(
+            FileSystemCleanupAction(
+                name=f"{run_id!r} State",
+                description="Internal C-Star state information related to run history.",
+                asset_paths=runstate_paths,
+            ),
+        )
+    if rundata_paths:
+        actions.append(
+            FileSystemCleanupAction(
+                name=f"{run_id!r} Data",
+                description="All datasets and assets created during a run.",
+                asset_paths=rundata_paths,
+            ),
+        )
+    return actions
 
 
 @app.command(
@@ -276,7 +472,7 @@ def clean(
         typer.Option(
             "--run-id",
             help=run_help,
-            callback=get_run_action,
+            callback=cb_pipeline(runid_callback, set_env(ENV_CSTAR_RUNID)),
             min=1,
             autocompletion=list_runs,
         ),
@@ -303,8 +499,11 @@ def clean(
         all_actions = get_default_cleanup_actions()
         todo = actions_filter_prompt(all_actions, yes)
     else:
-        todo = actions_filter_prompt(
-            [get_from_ctxmap(context, "action", CleanupAction)], yes
-        )
+        run_actions = get_run_actions(run_id)
+        todo = actions_filter_prompt(run_actions, yes)
 
     asyncio.run(perform_actions(todo))
+
+
+if __name__ == "__main__":
+    app()

--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -1,0 +1,60 @@
+import shutil
+import typing as t
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+
+from cstar.execution.file_system import DirectoryManager
+
+app = typer.Typer()
+console = Console()
+
+short_help: t.Final[str] = "Clean up leftover data and files written to disk."
+help: t.Final[str] = (
+    f"{short_help}. WARNING: This will execute a destructive wipe "
+    "of C-Star directories. Your data may be lost."
+)
+
+yes_help: t.Final[str] = "Execute clean operations without confirmation."
+
+
+@app.command(
+    name="clean",
+    help="Clean up leftover data and files written to disk.",
+    short_help=short_help,
+)
+def clean(
+    yes: t.Annotated[bool, typer.Option("--yes", help=yes_help)] = False,
+) -> None:
+    """Clean up leftover data and files written to disk.
+
+    Returns
+    -------
+    None
+    """
+    cstar_dir: t.Final[str] = "cstar"
+
+    actions = {
+        "C-Star package cache": [DirectoryManager.cache_home() / cstar_dir],
+        "C-Star state files": [
+            DirectoryManager.state_home() / cstar_dir,
+            Path("~/.prefect/storage").expanduser().resolve(),
+        ],
+        "C-Star outputs and input datasets": [DirectoryManager.data_home() / cstar_dir],
+        "C-Star user-level configuration": [DirectoryManager.config_home() / cstar_dir],
+    }
+
+    for prompt, paths in actions.items():
+        if not yes:
+            answer = Prompt.ask(
+                f"Type y(es) and <enter> to delete {prompt!r} in ({', '.join(str(p) for p in paths)})"
+            )
+            if "y" not in answer:
+                console.print(f"\t[yellow]Skipping[/yellow] {prompt!r} deletion\n")
+                continue
+
+        for path in paths:
+            shutil.rmtree(path, ignore_errors=True)
+            console.print(f"[red]Removed[/red] {str(path)} directory\n")

--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -404,8 +404,10 @@ def get_run_actions(run_id: str) -> list[CleanupAction]:
     else:
         # if we can't load a run, check the default data path.
         data_dir = StateDirectoryManager.data_dir(run_id=run_id)
-        rundata_paths.append(data_dir)
-        log.debug(f"Run {run_id!r} not found")
+        if data_dir.exists():
+            rundata_paths.append(data_dir)
+        else:
+            log.debug(f"Run {run_id!r} not found")
 
     storage_root: t.Final[Path] = get_prefect_storage_path()
     if workplan:

--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -1,32 +1,297 @@
+import asyncio
+import itertools
 import shutil
 import typing as t
+from collections.abc import Sequence
 from pathlib import Path
 
 import typer
+from pydantic import BaseModel
 from rich.console import Console
 from rich.prompt import Prompt
 
+from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN
+from cstar.base.feature import is_flag_enabled
+from cstar.base.log import get_logger
+from cstar.cli.common import cb_pipeline, get_from_ctxmap, set_ctxmap, set_flag
+from cstar.cli.workplan.shared import colored, list_runs, preload_run
+from cstar.entrypoint.utils import ARG_DRY_RUN
 from cstar.execution.file_system import DirectoryManager
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
 
+log = get_logger(__name__)
 app = typer.Typer()
 console = Console()
 
 short_help: t.Final[str] = "Clean up leftover data and files written to disk."
 help: t.Final[str] = (
     f"{short_help}. WARNING: This will execute a destructive wipe "
-    "of C-Star directories. Your data may be lost."
+    "of C-Star directories. Data will be unrecoverable"
 )
+yes_help: t.Final[str] = (
+    "Perform clean operations for all stored assets without user interaction."
+)
+run_help: t.Final[str] = "Clean up stored assets for a specific run"
 
-yes_help: t.Final[str] = "Execute clean operations without confirmation."
+
+ARG_YES: t.Final[str] = "--yes"
+
+
+class CleanupAction(BaseModel):
+    """A resource managed by C-Star that can be cleaned up."""
+
+    name: str
+    """The user-friendly name of the resource."""
+    description: str | None = None
+    """An extended description of the resource to display to a user."""
+    asset_paths: list[Path]
+    """The paths containing the resources to be cleaned up."""
+
+    def mitigated(self) -> bool:
+        """Return `True` when all underlying assets are not found."""
+        return all(not p.exists() for p in self.asset_paths)
+
+
+def get_prefect_storage_path() -> Path:
+    """Return the path to the directory containing cached assets in prefect.
+
+    Returns
+    -------
+    Path
+    """
+    return Path("~/.prefect/storage").expanduser().resolve()
+
+
+def get_default_cleanup_actions() -> list[CleanupAction]:
+    """Return a list of all available clean-up actions.
+
+    Performing cleanup on these folders is _the nuclear option_ and will
+    wipe out all stored state.
+
+    Returns
+    -------
+    list[CleanupAction]
+    """
+    return list(
+        sorted(
+            [
+                CleanupAction(
+                    name="C-Star package cache",
+                    description="Cached copies of previously retrieved github repositories",
+                    asset_paths=[DirectoryManager.cache_home()],
+                ),
+                CleanupAction(
+                    name="C-Star state files",
+                    description="Internal C-Star state information related to run history.",
+                    asset_paths=[
+                        DirectoryManager.state_home(),
+                        get_prefect_storage_path(),
+                    ],
+                ),
+                CleanupAction(
+                    name="C-Star Data",
+                    description="All datasets and assets created during a run.",
+                    asset_paths=[DirectoryManager.data_home()],
+                ),
+                CleanupAction(
+                    name="C-Star configuration",
+                    description="Local user-specific C-Star configuration files",
+                    asset_paths=[DirectoryManager.config_home()],
+                ),
+            ],
+            key=lambda x: x.name,
+        )
+    )
+
+
+def remove_asset(action: CleanupAction) -> list[Path]:
+    """Clean up the files and directories for the action.
+
+    Returns
+    -------
+    list[Path]
+        A list of all paths that were removed.
+    """
+    removed: list[Path] = []
+
+    try:
+        for path in action.asset_paths:
+            if path.exists() and path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            elif path.exists() and path.is_file():
+                path.unlink()
+
+            removed.append(path)
+    except Exception:
+        log.exception(f"Unable to remove assets for {action.name!r}")
+
+    return removed
+
+
+async def perform_actions(actions: Sequence[CleanupAction]) -> int:
+    """Perform all specified clean-up actions.
+
+    Parameters
+    ----------
+    actions : Sequence[CleanupAction]
+        The cleanup actions that will be processed.
+
+    Returns
+    -------
+    int
+        The total number of actions taken
+    """
+    COLOR_WHITE: t.Final[str] = "white"
+    COLOR_RED: t.Final[str] = "red"
+    dry_run = is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN)
+    msg, color = "Removed", COLOR_RED
+
+    if dry_run:
+        msg = "Will remove"
+        color = COLOR_WHITE
+        removal_results = [a.asset_paths for a in actions]
+    else:
+        removal_coros = [
+            asyncio.to_thread(remove_asset, a) for a in actions if a.asset_paths
+        ]
+        removal_results = await asyncio.gather(*removal_coros)
+
+    for i, dirs in enumerate(removal_results):
+        descriptor = colored(msg, color)
+
+        if len(dirs) == 1:
+            path_csv = ", ".join(str(d) for d in dirs)
+            console.print(f"{descriptor} {actions[i].name!r}: {path_csv}")
+        else:
+            console.print(f"{descriptor} {actions[i].name!r}:")
+            for d in dirs:
+                console.print(f"* {d}")
+
+    return len(list(itertools.chain.from_iterable(removal_results)))
+
+
+def actions_filter_prompt(
+    available: list[CleanupAction],
+    yes: bool,
+) -> list[CleanupAction]:
+    """Perform interactive action filtering with the user.
+
+    Parameters
+    ----------
+    available : list[CleanupAction]
+        List of the available cleanup actions the user can select.
+    yes : bool
+        Pass `True` to auto-accept available actions without user interaction.
+
+    Returns
+    -------
+    list[CleanupAction]
+    """
+    CHOICE_YES: t.Final[str] = "y"
+    CHOICE_NO: t.Final[str] = "n"
+
+    choices: t.Final[list[str]] = [CHOICE_YES, CHOICE_NO]
+    selected: list[CleanupAction] = []
+
+    for action in available:
+        prompt = f"Delete {action.name!r}"
+        if action.description:
+            prompt = f"{prompt} ({action.description})"
+
+        if yes:
+            answer = CHOICE_YES
+        else:
+            answer = Prompt.ask(
+                prompt,
+                default=CHOICE_NO,
+                choices=choices,
+                case_sensitive=False,
+            )
+
+        if answer == CHOICE_NO:
+            console.print(f"\t[yellow]Skipping[/yellow] {action.name!r} deletion")
+            continue
+
+        selected.append(action)
+
+    return selected
+
+
+def get_run_action(context: typer.Context, run_id: str) -> str:
+    """Load run information into the typer context, if necessary.
+
+    Parameters
+    ----------
+    context : typer.Context
+        The typer context
+    run_id : str
+        The run-id value received from the user
+
+    Returns
+    -------
+    str
+    """
+    run_id = run_id.strip()
+
+    if not run_id:
+        log.debug("Skipping run loading; run-id was not specified")
+        return run_id
+
+    preload_run(context, run_id)
+
+    run = get_from_ctxmap(context, "run", WorkplanRun)
+
+    tracking_repo = TrackingRepository()
+    run_paths = tracking_repo.list_run_paths(run_id)
+
+    action = CleanupAction(
+        name=f"Run {run_id!r} Assets",
+        description="All state information, datasets, and code assets used in the run(s)",
+        asset_paths=[
+            run.state_dir,
+            *run_paths,
+        ],
+    )
+    set_ctxmap(context, "action", action)
+
+    return run_id
 
 
 @app.command(
     name="clean",
-    help="Clean up leftover data and files written to disk.",
+    help=help,
     short_help=short_help,
 )
 def clean(
-    yes: t.Annotated[bool, typer.Option("--yes", help=yes_help)] = False,
+    context: typer.Context,
+    yes: t.Annotated[
+        bool,
+        typer.Option(
+            ARG_YES,
+            help=yes_help,
+        ),
+    ] = False,
+    run_id: t.Annotated[
+        str,
+        typer.Option(
+            "--run-id",
+            help=run_help,
+            callback=get_run_action,
+            min=1,
+            autocompletion=list_runs,
+        ),
+    ] = "",
+    dry_run: t.Annotated[
+        bool,
+        typer.Option(
+            ARG_DRY_RUN,
+            help="Enumerate the assets that will be removed without performing any deletions",
+            callback=cb_pipeline(
+                set_flag(ENV_CSTAR_CLI_DRY_RUN),
+            ),
+            envvar=ENV_CSTAR_CLI_DRY_RUN,
+        ),
+    ] = False,
 ) -> None:
     """Clean up leftover data and files written to disk.
 
@@ -34,27 +299,12 @@ def clean(
     -------
     None
     """
-    cstar_dir: t.Final[str] = "cstar"
+    if not run_id:
+        all_actions = get_default_cleanup_actions()
+        todo = actions_filter_prompt(all_actions, yes)
+    else:
+        todo = actions_filter_prompt(
+            [get_from_ctxmap(context, "action", CleanupAction)], yes
+        )
 
-    actions = {
-        "C-Star package cache": [DirectoryManager.cache_home() / cstar_dir],
-        "C-Star state files": [
-            DirectoryManager.state_home() / cstar_dir,
-            Path("~/.prefect/storage").expanduser().resolve(),
-        ],
-        "C-Star outputs and input datasets": [DirectoryManager.data_home() / cstar_dir],
-        "C-Star user-level configuration": [DirectoryManager.config_home() / cstar_dir],
-    }
-
-    for prompt, paths in actions.items():
-        if not yes:
-            answer = Prompt.ask(
-                f"Type y(es) and <enter> to delete {prompt!r} in ({', '.join(str(p) for p in paths)})"
-            )
-            if "y" not in answer:
-                console.print(f"\t[yellow]Skipping[/yellow] {prompt!r} deletion\n")
-                continue
-
-        for path in paths:
-            shutil.rmtree(path, ignore_errors=True)
-            console.print(f"[red]Removed[/red] {str(path)} directory\n")
+    asyncio.run(perform_actions(todo))

--- a/cstar/cli/cli.py
+++ b/cstar/cli/cli.py
@@ -1,6 +1,7 @@
 import typer
 
 from cstar.applications import *  # noqa: F403
+from cstar.cli.admin import app as app_admin
 from cstar.cli.blueprint import app as app_blueprint
 from cstar.cli.common import common_callback
 from cstar.cli.environment import app as app_env
@@ -17,6 +18,7 @@ def attach_subcommands(app: typer.Typer) -> None:
         (app_env, "env"),
         (app_template, "template"),
         (app_workplan, "workplan"),
+        (app_admin, "admin"),
     ]
 
     try:

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -15,7 +15,7 @@ from cstar.base.env import (
     FLAG_ON,
 )
 from cstar.base.feature import is_flag_enabled
-from cstar.base.log import LogLevelChoices, reset_log_level
+from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
 from cstar.execution.file_system import DirectoryManager, is_remote_resource
 from cstar.orchestration.models import Blueprint
 from cstar.orchestration.serialization import (
@@ -32,6 +32,7 @@ from cstar.system.migration import (
 )
 
 app = typer.Typer()
+log = get_logger(__name__)
 
 HELP_SHORT = "Print the current version of the C-Star package and exit."
 
@@ -381,20 +382,22 @@ def get_from_ctxmap(context: typer.Context, key: str, klass: type[_TValue]) -> _
     context_map: dict[str, t.Any] | None = context.obj
 
     if not context_map:
-        print("Unable to retrieve value from empty context map")
+        log.error("Unable to retrieve value from empty context map")
         raise typer.Exit(100)
 
     if key not in context_map:
         items = ", ".join(context_map.keys())
-        print(f"Unable to retrieve key {key!r} from context. Available data: {items}")
+        log.warning(
+            f"Unable to retrieve key {key!r} from context. Available data: {items}"
+        )
 
     value: _TValue | None = context.obj[key]
     if value is None:
-        print(f"Context map contains null value for key: {key}")
+        log.debug(f"Context map contains null value for key: {key}")
         raise typer.Exit(101)
 
     if not isinstance(value, klass):
-        print(
+        log.warning(
             "Context map contains value with type mismatch. "
             f"Expected {klass.__name__!r} but received {value.__class__.__name__!r}."
         )

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -349,6 +349,7 @@ def preload_run(context: typer.Context, run_id: str) -> str:
     Returns
     -------
     str
+        The run-id for the loaded run
 
     Raises
     ------
@@ -363,7 +364,7 @@ def preload_run(context: typer.Context, run_id: str) -> str:
     wp_run = asyncio.run(repo.get_workplan_run(run_id))
     if not wp_run:
         raise typer.BadParameter(
-            f"Unable to monitor logs for unknown run-id: {run_id}",
+            f"Unable to locate run with unknown run-id: {run_id}",
             param_hint="run_id",
         )
     set_ctxmap(context, "run", wp_run)

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -16,7 +16,10 @@ from cstar.base.log import get_logger
 from cstar.cli.common import set_ctxmap
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
-from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+from cstar.execution.file_system import (
+    JobFileSystemManager,
+    StateDirectoryManager,
+)
 from cstar.orchestration.dag_runner import DagDetailRecord
 from cstar.orchestration.models import Blueprint, Workplan
 from cstar.orchestration.serialization import deserialize, try_deserialize
@@ -95,7 +98,7 @@ async def list_steps(run_id: str, incomplete: str) -> list[str]:
             log.debug(msg)
 
     # run state may be cleaned up. fallback to directory search
-    run_dir = DirectoryManager.data_home() / run_id
+    run_dir = StateDirectoryManager.data_dir()
     tasks_dir = JobFileSystemManager(run_dir).tasks_dir
 
     if not tasks_dir.exists():

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -418,6 +418,20 @@ class StateDirectoryManager:
         root = cls.root_dir()
         return root / cls._RUN_TRACKING_NAME
 
+    @classmethod
+    def data_dir(cls, run_id: str | None = None) -> Path:
+        """The directory for data files used by a run.
+
+        The result is a _run-specific_ directory.
+
+        Returns
+        -------
+        Path
+        """
+        data_home = DirectoryManager.data_home()
+        run_id = run_id or get_env_item(ENV_CSTAR_RUNID).value
+        return data_home / run_id
+
 
 def is_remote_resource(uri: str) -> bool:
     """Determine if the supplied string contains a local or remote path.

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field, computed_field
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, capture_environment
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
-from cstar.execution.file_system import DirectoryManager, StateDirectoryManager
+from cstar.execution.file_system import StateDirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmLauncher
 from cstar.orchestration.models import Step, UserDefinedVariables, Workplan
@@ -558,7 +558,8 @@ async def build_and_run_dag(
         The path to the workplan that was executed after any tranformations
         were applied.
     """
-    output_dir = (output_dir or DirectoryManager.data_home()).expanduser().resolve()
+    default_output_dir = StateDirectoryManager.data_dir()
+    output_dir = (output_dir or default_output_dir).expanduser().resolve()
     configure_environment(output_dir, run_id)
 
     launcher = get_launcher()

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -16,8 +16,8 @@ from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LoggingMixin
 from cstar.base.utils import lazy_import, slugify
 from cstar.execution.file_system import (
-    DirectoryManager,
     JobFileSystemManager,
+    StateDirectoryManager,
 )
 from cstar.orchestration.converter.converter import (
     convert_step_to_blueprint_run_command,
@@ -238,9 +238,7 @@ class LiveStep(Step):
             if self.parent:
                 root_fsm = self.parent.fsm
             else:
-                root_dir = DirectoryManager.data_home()
-                if run_id := os.environ.get(ENV_CSTAR_RUNID, ""):
-                    root_dir = root_dir.joinpath(run_id)
+                root_dir = StateDirectoryManager.data_dir()
                 root_fsm = JobFileSystemManager(root_dir)
 
             self.working_dir = root_fsm.tasks_dir / self.safe_name

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -1,12 +1,13 @@
 import asyncio
+import os
 import typing as t
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from cstar.base.log import LoggingMixin
+from cstar.base.log import LoggingMixin, get_logger
 from cstar.base.utils import slugify, utc_now
 from cstar.execution.file_system import (
     StateDirectoryManager,
@@ -14,6 +15,8 @@ from cstar.execution.file_system import (
 )
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
+
+log = get_logger(__name__)
 
 
 class WorkplanRun(BaseModel):
@@ -160,6 +163,21 @@ class TrackingRepository(LoggingMixin):
         runfile_name = self._runfile_name(run_id)
         return self.latest_dir / runfile_name
 
+    def _run_root_dir(self, run_id: str) -> Path:
+        """Generate the path to the directory used to store tracking information
+        related to a run-id.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+
+        Returns
+        -------
+        Path
+        """
+        return self.history_dir / run_id
+
     def _history_path(self, run_id: str, run_date: datetime) -> Path:
         """Generate the full path for persisting a `WorkplanRun` to disk as
         a history record.
@@ -177,7 +195,7 @@ class TrackingRepository(LoggingMixin):
         """
         formatted_dt = self._format_run_date(run_date)
         runfile_name = self._runfile_name(formatted_dt)
-        return self.history_dir / run_id / runfile_name
+        return self._run_root_dir(run_id) / runfile_name
 
     def _find_run_path(self, run_id: str, run_date: datetime | None) -> Path:
         """Identify a path where a `WorkplanRun` is persisted to disk.
@@ -209,6 +227,49 @@ class TrackingRepository(LoggingMixin):
             self.log.trace(msg)
 
         return path
+
+    def list_run_paths(
+        self,
+        run_id: str,
+        all_history: bool = False,
+    ) -> Sequence[Path]:
+        """Identify all paths to state information for a specific run-id.
+
+        Returns all paths previously used with the run-id, regardless of the
+        associated workplan.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+        all_history : bool
+            Pass `True` to return the paths for any run that shares the run-id. Otherwise,
+            only the latest path from the history collection is returned.
+
+        Returns
+        -------
+        Sequence[Path]
+        """
+        run_paths: list[Path] = []
+
+        latest = self._latest_path(run_id)
+        if latest.exists():
+            run_paths.append(latest)
+
+        root_dir = self._run_root_dir(run_id)
+        all_runs = root_dir.iterdir()
+
+        if all_history:
+            run_paths.extend(all_runs)
+        else:
+            if ordered_runs := sorted(
+                all_runs,
+                key=lambda p: os.path.getctime(p),
+                reverse=True,
+            ):
+                run_paths.append(ordered_runs[0])
+
+        return tuple(filter(lambda p: p.exists(), run_paths))
 
     async def get_workplan_run(
         self, run_id: str, run_date: datetime | None = None
@@ -272,7 +333,7 @@ class TrackingRepository(LoggingMixin):
         self.log.debug(msg)
         return run_path
 
-    async def list_latest_runs(self, run_id_filter: str) -> list[WorkplanRun]:
+    async def list_latest_runs(self, run_id_filter: str) -> Sequence[WorkplanRun]:
         """Retrieve a list of the latest WorkplanRun for all known run-id's.
 
         run_id_filter : str
@@ -280,7 +341,7 @@ class TrackingRepository(LoggingMixin):
 
         Returns
         -------
-        list[WorkplanRun]
+        Sequence[WorkplanRun]
         """
         run_paths = list(self.latest_dir.glob(f"{run_id_filter}*.{self._MODE}"))
         coros = [
@@ -289,15 +350,15 @@ class TrackingRepository(LoggingMixin):
         ]
         return await asyncio.gather(*coros)
 
-    async def list_history_runs(self, run_id_filter: str) -> list[WorkplanRun]:
-        """Retrieve a list of the latest WorkplanRun for all known run-id's.
+    async def list_history_runs(self, run_id_filter: str) -> Sequence[WorkplanRun]:
+        """Retrieve a list of all WorkplanRun instances executed with a given run-id.
 
         run_id_filter : str
             A run-id used to filter records. Matches will be included in results.
 
         Returns
         -------
-        list[WorkplanRun]
+        Sequence[WorkplanRun]
         """
         # Filter run-id subfolder w/filename format YYYYMMDDHHMMSS.XXXXXX.yaml
         glob_pattern = f"{run_id_filter}*/??????????????.??????.{self._MODE}"

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -288,6 +288,8 @@ class TrackingRepository(LoggingMixin):
         WorkplanRun | None
             The record when it can be located in history or latest runs, otherwise `None`.
         """
+        run_id = run_id.strip()
+
         if not run_id:
             msg = "A valid run-id was not provided; unable to retrieve run"
             raise ValueError(msg)

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from cstar.base.log import LoggingMixin, get_logger
+from cstar.base.log import LoggingMixin
 from cstar.base.utils import slugify, utc_now
 from cstar.execution.file_system import (
     StateDirectoryManager,
@@ -15,8 +15,6 @@ from cstar.execution.file_system import (
 )
 from cstar.orchestration.models import Workplan
 from cstar.orchestration.serialization import PersistenceMode, deserialize, serialize
-
-log = get_logger(__name__)
 
 
 class WorkplanRun(BaseModel):
@@ -133,7 +131,22 @@ class TrackingRepository(LoggingMixin):
         """
         return run_date.strftime("%Y%m%d%H%M%S.%f")
 
-    def _runfile_name(self, run_id: str) -> str:
+    def _runfile_name(self, run_date: datetime) -> str:
+        """Generate the file name for persisting a `WorkplanRun` to disk.
+
+        Parameters
+        ----------
+        run_id : str
+            The run_id of the WorkplanRun
+
+        Returns
+        -------
+        str
+        """
+        formatted_dt = self._format_run_date(run_date)
+        return f"{formatted_dt}.{TrackingRepository._MODE.value}"
+
+    def _latestfile_name(self, run_id: str) -> str:
         """Generate the file name for persisting a `WorkplanRun` to disk.
 
         Parameters
@@ -147,7 +160,7 @@ class TrackingRepository(LoggingMixin):
         """
         return f"{run_id}.{TrackingRepository._MODE.value}"
 
-    def _latest_path(self, run_id: str) -> Path:
+    def latest_path(self, run_id: str) -> Path:
         """Generate the full path for persisting a `WorkplanRun` to disk as
         the "latest run" record.
 
@@ -160,25 +173,14 @@ class TrackingRepository(LoggingMixin):
         -------
         Path
         """
-        runfile_name = self._runfile_name(run_id)
+        runfile_name = self._latestfile_name(run_id)
         return self.latest_dir / runfile_name
 
-    def _run_root_dir(self, run_id: str) -> Path:
-        """Generate the path to the directory used to store tracking information
-        related to a run-id.
-
-        Parameters
-        ----------
-        run_id : str
-            The run_id of the WorkplanRun
-
-        Returns
-        -------
-        Path
-        """
+    def run_history_dir(self, run_id: str) -> Path:
+        """Generate the path to the history directory."""
         return self.history_dir / run_id
 
-    def _history_path(self, run_id: str, run_date: datetime) -> Path:
+    def history_path(self, run_id: str, run_date: datetime) -> Path:
         """Generate the full path for persisting a `WorkplanRun` to disk as
         a history record.
 
@@ -193,9 +195,8 @@ class TrackingRepository(LoggingMixin):
         -------
         Path
         """
-        formatted_dt = self._format_run_date(run_date)
-        runfile_name = self._runfile_name(formatted_dt)
-        return self._run_root_dir(run_id) / runfile_name
+        runfile_name = self._runfile_name(run_date)
+        return self.run_history_dir(run_id) / runfile_name
 
     def _find_run_path(self, run_id: str, run_date: datetime | None) -> Path:
         """Identify a path where a `WorkplanRun` is persisted to disk.
@@ -215,20 +216,20 @@ class TrackingRepository(LoggingMixin):
         Path
         """
         if run_date:
-            path = self._history_path(run_id, run_date)
+            path = self.history_path(run_id, run_date)
             if path.exists():
                 msg = f"Located workplan run in history for {run_id!r} at: {path}"
                 self.log.trace(msg)
                 return path
 
-        path = self._latest_path(run_id)
+        path = self.latest_path(run_id)
         if path.exists():
             msg = f"Located latest run of {run_id!r} at: {path}"
             self.log.trace(msg)
 
         return path
 
-    def list_run_paths(
+    def list_runtracking_paths(
         self,
         run_id: str,
         all_history: bool = False,
@@ -252,12 +253,12 @@ class TrackingRepository(LoggingMixin):
         """
         run_paths: list[Path] = []
 
-        latest = self._latest_path(run_id)
+        latest = self.latest_path(run_id)
         if latest.exists():
             run_paths.append(latest)
 
-        root_dir = self._run_root_dir(run_id)
-        all_runs = root_dir.iterdir()
+        search_dir = self.run_history_dir(run_id=run_id)
+        all_runs = search_dir.iterdir() if search_dir.exists() else list[Path]()
 
         if all_history:
             run_paths.extend(all_runs)
@@ -299,7 +300,7 @@ class TrackingRepository(LoggingMixin):
         if not run_path.exists():
             rd_out = run_date or "latest"
             msg = f"No run file for `{run_id}` on `{rd_out}` found in {run_path}`"
-            self.log.warning(msg)
+            self.log.debug(msg)
             return None
 
         return deserialize(run_path, WorkplanRun)
@@ -319,8 +320,8 @@ class TrackingRepository(LoggingMixin):
         Path
             The path to the persisted history record
         """
-        run_path = self._history_path(run.run_id, run.start_at)
-        latest_path = self._latest_path(run.run_id)
+        run_path = self.history_path(run.run_id, run.start_at)
+        latest_path = self.latest_path(run.run_id)
 
         if not serialize(run_path, run):
             self.log.warning("Run could not be persisted")

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -132,12 +132,12 @@ class TrackingRepository(LoggingMixin):
         return run_date.strftime("%Y%m%d%H%M%S.%f")
 
     def _runfile_name(self, run_date: datetime) -> str:
-        """Generate the file name for persisting a `WorkplanRun` to disk.
+        """Generate the file name for persisting a `WorkplanRun` history entry to disk.
 
         Parameters
         ----------
-        run_id : str
-            The run_id of the WorkplanRun
+        run_date : datetime
+            The start time of the run.
 
         Returns
         -------
@@ -147,7 +147,7 @@ class TrackingRepository(LoggingMixin):
         return f"{formatted_dt}.{TrackingRepository._MODE.value}"
 
     def _latestfile_name(self, run_id: str) -> str:
-        """Generate the file name for persisting a `WorkplanRun` to disk.
+        """Generate the file name for persisting the latest `WorkplanRun` history entry to disk.
 
         Parameters
         ----------

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME
+from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
 from cstar.execution.file_system import JobFileSystemManager, RomsFileSystemManager
 from cstar.orchestration.models import Step
 from cstar.orchestration.orchestration import LiveStep
@@ -139,35 +139,35 @@ def test_live_step(tmp_path: Path) -> None:
     ls_5_name = "child of ls 2"
     ls_5 = LiveStep.from_step(ls_1, update={"name": ls_5_name})  # override attributes
 
+    run_id = "fake-run-id"
+    task_dir_name = JobFileSystemManager._TASKS_NAME  # type: ignore # noqa: SLF001
+
     with mock.patch.dict(
         os.environ,
-        {ENV_CSTAR_DATA_HOME: data_home.as_posix()},
+        {
+            ENV_CSTAR_DATA_HOME: data_home.as_posix(),
+            ENV_CSTAR_RUNID: run_id,
+        },
         clear=True,
     ):
         actual = ls_1.get_working_dir
-        expected = data_home / JobFileSystemManager._TASKS_NAME / ls_1.safe_name  # noqa: SLF001
+        expected = data_home / run_id / task_dir_name / ls_1.safe_name
         assert actual == expected
 
         actual = ls_2.get_working_dir
-        expected = (
-            ls_1.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_2.safe_name
-        )  # noqa: SLF001
+        expected = ls_1.get_working_dir / task_dir_name / ls_2.safe_name
         assert actual == expected
 
         actual = ls_3.get_working_dir
-        expected = (
-            ls_2.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_3.safe_name
-        )  # noqa: SLF001
+        expected = ls_2.get_working_dir / task_dir_name / ls_3.safe_name
         assert actual == expected
 
         actual = ls_4.get_working_dir
         # confirm the parent carries over and ls4 is a child of ls2
-        expected = (
-            ls_2.get_working_dir / JobFileSystemManager._TASKS_NAME / ls_4.safe_name
-        )  # noqa: SLF001
+        expected = ls_2.get_working_dir / task_dir_name / ls_4.safe_name
         assert actual == expected
 
         actual = ls_5.get_working_dir
-        expected = data_home / JobFileSystemManager._TASKS_NAME / ls_5.safe_name  # noqa: SLF001
+        expected = data_home / run_id / task_dir_name / ls_5.safe_name
         assert actual == expected
         assert ls_5.name == ls_5_name  # confirm the update was honored

--- a/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
+++ b/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
@@ -157,7 +157,7 @@ async def test_cli_admin_clean_perform_actions(
 
 
 @pytest.mark.parametrize(
-    "num_assets",
+    "num_actions",
     range(5),
 )
 async def test_cli_admin_clean_perform_actions_dryrun(

--- a/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
+++ b/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
@@ -1,0 +1,273 @@
+import itertools
+import os
+from collections.abc import Generator
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, FLAG_ON
+from cstar.cli.admin.clean import (
+    ARG_YES,
+    CleanupAction,
+    app,
+    get_default_cleanup_actions,
+    get_run_action,
+    perform_actions,
+)
+from cstar.entrypoint.utils import ARG_DRY_RUN
+from cstar.execution.file_system import DirectoryManager
+from cstar.orchestration.models import Workplan
+from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
+
+
+@pytest.fixture(autouse=True)
+def prefect_path(tmp_path: Path) -> Generator[Path]:
+    """Replace the function returning the path to the prefect storage location
+    to avoid wiping out "real data" during tests.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+
+    Returns
+    -------
+    Path
+    """
+    path = tmp_path / "prefect-test-storage"
+    path.mkdir(parents=True, exist_ok=True)
+
+    with mock.patch(
+        "cstar.cli.admin.clean.get_prefect_storage_path",
+        mock.Mock(return_value=path),
+    ):
+        yield path
+
+
+def test_cli_admin_clean_get_default_cleanup_actions(prefect_path: Path) -> None:
+    """Verify that the default cleanup actions include all 4 XDG-compliant directories.
+
+    Parameters
+    ----------
+    prefect_path : Path
+        The path returned by the mocked `get_prefect_storage_path` function.
+    """
+    default_actions = get_default_cleanup_actions()
+
+    default_paths = set(
+        itertools.chain.from_iterable(a.asset_paths for a in default_actions)
+    )
+
+    assert DirectoryManager.cache_home() in default_paths
+    assert DirectoryManager.config_home() in default_paths
+    assert DirectoryManager.data_home() in default_paths
+    assert DirectoryManager.state_home() in default_paths
+    assert prefect_path in default_paths
+
+
+@pytest.mark.parametrize(
+    ("existing", "missing", "exp_mitigated"),
+    [
+        pytest.param(["f0"], [], False, id="File exists, no DNE"),
+        pytest.param(["d0"], [], False, id="Dir exists, no DNE"),
+        pytest.param(["f0", "d0"], [], False, id="File & dir exist, no DNE"),
+        pytest.param(["f0", "d0"], ["f1"], False, id="File & dir exist, file DNE"),
+        pytest.param(["f0", "d0"], ["d1"], False, id="File & dir exist, dir DNE"),
+        pytest.param(
+            ["f0", "d0"], ["d1", "f1"], False, id="File & dir exist, file & dir DNE"
+        ),
+        pytest.param([], ["f0"], True, id="Empty, file DNE"),
+        pytest.param([], ["d0"], True, id="Empty, dir DNE"),
+        pytest.param([], ["f0", "d0"], True, id="Empty, file & dir DNE"),
+    ],
+)
+def test_cli_admin_cleanupaction_mitigated(
+    tmp_path: Path,
+    existing: list[str],
+    missing: list[str],
+    exp_mitigated: bool,
+) -> None:
+    """Verify that the cleanup action correctly determines the right
+    result in `CleanupAction.mitigated`
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    existing : str
+        Asset paths that will be created and available to be cleaned up
+    missing : str
+        Asset paths that will be contained in the actions but don't exist.
+
+        Used to confirm no bad behavior if file/dir paths aren't found.
+    exp_mitigated : bool
+        Boolean indicating if the action is expected to evaluate as mitigated.
+    """
+    all_assets = [tmp_path / e for e in existing]
+    for asset in all_assets:
+        if asset.name.startswith("f"):
+            asset.touch()
+        if asset.name.startswith("d"):
+            asset.mkdir(parents=True, exist_ok=True)
+
+    # add any paths that are already "cleaned up"
+    all_assets.extend(tmp_path / e for e in missing)
+
+    action = CleanupAction(
+        name="action",
+        asset_paths=all_assets,
+    )
+
+    assert action.mitigated() == exp_mitigated
+
+
+@pytest.mark.parametrize(
+    "num_actions",
+    range(5),
+)
+async def test_cli_admin_clean_perform_actions(
+    tmp_path: Path,
+    num_actions: int,
+) -> None:
+    """Verify that the correct action is performed.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    num_actions : int
+        The number of cleanup actions to create and execute via `perform_action`
+    """
+    actions = [
+        CleanupAction(
+            name=f"action-{i}",
+            asset_paths=[tmp_path / f"action-{i}-{j}" for j in range(3)],
+        )
+        for i in range(num_actions)
+    ]
+
+    await perform_actions(actions)
+
+    for action in actions:
+        # confirm the cleanup action says cleanup is done
+        assert action.mitigated()
+
+
+@pytest.mark.parametrize(
+    "num_assets",
+    range(5),
+)
+async def test_cli_admin_clean_perform_actions_dryrun(
+    tmp_path: Path,
+    num_actions: int,
+) -> None:
+    """Verify that no actions are performed if dry-run is specified.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test assets
+    num_actions : int
+        The number of cleanup actions to create and execute via `perform_action`
+    """
+    action = CleanupAction(
+        name="action",
+        asset_paths=[tmp_path / str(i) for i in range(num_actions)],
+    )
+    for i, path in enumerate(action.asset_paths):
+        if i % 2:
+            path.touch()
+        else:
+            path.mkdir(parents=True, exist_ok=False)
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_CLI_DRY_RUN: FLAG_ON}):
+        await perform_actions([action])
+
+    # confirm the deletions didn't occur
+    assert all(path.exists() for path in action.asset_paths)
+
+
+@pytest.mark.asyncio
+async def test_cli_admin_clean_get_run_action(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that `get_run_action` results in the population of the typer
+    context object with a `CleanupRequest` for the specified run.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, run_id = executed_workplan
+    repo = TrackingRepository()
+    run = await repo.get_workplan_run(run_id)
+    mock_ctx = mock.MagicMock(spec=typer.Context)
+    mock_ctx.obj = {"run": run, "workplan": wp}
+
+    # ensure `get_run_action` handles whitespace
+    run_id = f" {run_id}\n\t"
+
+    assert run is not None
+
+    with (
+        mock.patch(
+            "cstar.cli.admin.clean.get_from_ctxmap", return_value=run
+        ) as mock_get,
+        mock.patch("cstar.cli.admin.clean.preload_run", return_value=run_id),
+    ):
+        actual_run_id = get_run_action(mock_ctx, run_id)
+
+    # confirm the run-id is returned with any callback cleaning appleid
+    mock_get.assert_called_once_with(mock_ctx, "run", WorkplanRun)
+    assert actual_run_id == run_id.strip()
+
+    # confirm the action was set
+    action: CleanupAction | None = mock_ctx.obj.get("action", None)
+    assert isinstance(action, CleanupAction)
+    assert run.state_dir in action.asset_paths
+
+    # confirm only run-specific asset paths (none of the defaults)
+    assets = [str(p) for p in action.asset_paths]
+    assert all(actual_run_id in p for p in assets)
+
+
+@pytest.mark.parametrize(
+    ("dry_run"),
+    [
+        pytest.param(True, id="dry-run enabled"),
+        pytest.param(False, id="dry-run disabled"),
+    ],
+)
+def test_cli_admin_clean_default_cleanup(dry_run: bool) -> None:
+    """Verify that the default _nuclear option_ cleanup is executed when
+    a run-id is not specified.
+
+    Parameters
+    ----------
+    dry_run : bool
+        dynamically configures dry-run mode.
+    """
+    # create an asset in each of the default locations
+    actions = get_default_cleanup_actions()
+    asset_idx = 0
+    for action in actions:
+        for path in action.asset_paths:
+            asset_path = path / f"{asset_idx}.mock"
+            asset_path.touch()
+            asset_idx += 1
+
+    # use non-interactive mode
+    args: list[str] = [ARG_YES]
+    if dry_run:
+        args.append(ARG_DRY_RUN)
+
+    runner = CliRunner()
+    result = runner.invoke(app, args, color=False)
+
+    key = "will remove" if dry_run else "removed"
+
+    assert key in result.stdout.lower()

--- a/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
+++ b/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import typing as t
 from collections.abc import Generator
 from pathlib import Path
 from unittest import mock
@@ -12,10 +13,11 @@ from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, FLAG_ON
 from cstar.cli.admin.clean import (
     ARG_YES,
     CleanupAction,
+    FileSystemCleanupAction,
     app,
     get_default_cleanup_actions,
-    get_run_action,
     perform_actions,
+    runid_callback,
 )
 from cstar.entrypoint.utils import ARG_DRY_RUN
 from cstar.execution.file_system import DirectoryManager
@@ -55,7 +57,9 @@ def test_cli_admin_clean_get_default_cleanup_actions(prefect_path: Path) -> None
     prefect_path : Path
         The path returned by the mocked `get_prefect_storage_path` function.
     """
-    default_actions = get_default_cleanup_actions()
+    default_actions = t.cast(
+        "list[FileSystemCleanupAction]", get_default_cleanup_actions()
+    )
 
     default_paths = set(
         itertools.chain.from_iterable(a.asset_paths for a in default_actions)
@@ -116,7 +120,7 @@ def test_cli_admin_cleanupaction_mitigated(
     # add any paths that are already "cleaned up"
     all_assets.extend(tmp_path / e for e in missing)
 
-    action = CleanupAction(
+    action = FileSystemCleanupAction(
         name="action",
         asset_paths=all_assets,
     )
@@ -142,7 +146,7 @@ async def test_cli_admin_clean_perform_actions(
         The number of cleanup actions to create and execute via `perform_action`
     """
     actions = [
-        CleanupAction(
+        FileSystemCleanupAction(
             name=f"action-{i}",
             asset_paths=[tmp_path / f"action-{i}-{j}" for j in range(3)],
         )
@@ -158,7 +162,7 @@ async def test_cli_admin_clean_perform_actions(
 
 @pytest.mark.parametrize(
     "num_actions",
-    range(5),
+    range(1, 5),
 )
 async def test_cli_admin_clean_perform_actions_dryrun(
     tmp_path: Path,
@@ -173,7 +177,7 @@ async def test_cli_admin_clean_perform_actions_dryrun(
     num_actions : int
         The number of cleanup actions to create and execute via `perform_action`
     """
-    action = CleanupAction(
+    action = FileSystemCleanupAction(
         name="action",
         asset_paths=[tmp_path / str(i) for i in range(num_actions)],
     )
@@ -219,14 +223,14 @@ async def test_cli_admin_clean_get_run_action(
         ) as mock_get,
         mock.patch("cstar.cli.admin.clean.preload_run", return_value=run_id),
     ):
-        actual_run_id = get_run_action(mock_ctx, run_id)
+        actual_run_id = runid_callback(mock_ctx, run_id)
 
     # confirm the run-id is returned with any callback cleaning appleid
     mock_get.assert_called_once_with(mock_ctx, "run", WorkplanRun)
     assert actual_run_id == run_id.strip()
 
     # confirm the action was set
-    action: CleanupAction | None = mock_ctx.obj.get("action", None)
+    action: FileSystemCleanupAction | None = mock_ctx.obj.get("action", None)
     assert isinstance(action, CleanupAction)
     assert run.state_dir in action.asset_paths
 
@@ -252,7 +256,7 @@ def test_cli_admin_clean_default_cleanup(dry_run: bool) -> None:
         dynamically configures dry-run mode.
     """
     # create an asset in each of the default locations
-    actions = get_default_cleanup_actions()
+    actions = t.cast("list[FileSystemCleanupAction]", get_default_cleanup_actions())
     asset_idx = 0
     for action in actions:
         for path in action.asset_paths:

--- a/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
+++ b/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
@@ -12,7 +12,6 @@ from typer.testing import CliRunner
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, FLAG_ON
 from cstar.cli.admin.clean import (
     ARG_YES,
-    CleanupAction,
     FileSystemCleanupAction,
     app,
     get_default_cleanup_actions,
@@ -22,7 +21,7 @@ from cstar.cli.admin.clean import (
 from cstar.entrypoint.utils import ARG_DRY_RUN
 from cstar.execution.file_system import DirectoryManager
 from cstar.orchestration.models import Workplan
-from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
+from cstar.orchestration.tracking import TrackingRepository
 
 
 @pytest.fixture(autouse=True)
@@ -195,7 +194,7 @@ async def test_cli_admin_clean_perform_actions_dryrun(
 
 
 @pytest.mark.asyncio
-async def test_cli_admin_clean_get_run_action(
+async def test_cli_admin_clean_runid_callback(
     executed_workplan: tuple[Path, Workplan, str],
 ) -> None:
     """Verify that `get_run_action` results in the population of the typer
@@ -217,26 +216,10 @@ async def test_cli_admin_clean_get_run_action(
 
     assert run is not None
 
-    with (
-        mock.patch(
-            "cstar.cli.admin.clean.get_from_ctxmap", return_value=run
-        ) as mock_get,
-        mock.patch("cstar.cli.admin.clean.preload_run", return_value=run_id),
-    ):
-        actual_run_id = runid_callback(mock_ctx, run_id)
+    actual_run_id = runid_callback(mock_ctx, run_id)
 
     # confirm the run-id is returned with any callback cleaning appleid
-    mock_get.assert_called_once_with(mock_ctx, "run", WorkplanRun)
     assert actual_run_id == run_id.strip()
-
-    # confirm the action was set
-    action: FileSystemCleanupAction | None = mock_ctx.obj.get("action", None)
-    assert isinstance(action, CleanupAction)
-    assert run.state_dir in action.asset_paths
-
-    # confirm only run-specific asset paths (none of the defaults)
-    assets = [str(p) for p in action.asset_paths]
-    assert all(actual_run_id in p for p in assets)
 
 
 @pytest.mark.parametrize(

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -12,7 +12,10 @@ import pytest
 
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
 from cstar.base.env import ENV_CSTAR_RUNID
-from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+from cstar.execution.file_system import (
+    JobFileSystemManager,
+    StateDirectoryManager,
+)
 from cstar.orchestration.launch.local import LocalHandle
 from cstar.orchestration.models import Application, Step, Workplan
 from cstar.orchestration.serialization import deserialize
@@ -642,7 +645,7 @@ async def executed_workplan_with_sideeffects(
     the run directories with logs.
     """
     wp_path, wp, fake_run_id = executed_workplan
-    root_fsm = JobFileSystemManager(DirectoryManager.data_home() / fake_run_id)
+    root_fsm = JobFileSystemManager(StateDirectoryManager.data_dir())
 
     for i, step in enumerate(wp.steps):
         step_fsm = root_fsm.get_subtask_manager(step.safe_name)

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -9,7 +9,10 @@ import pytest
 
 from cstar.applications.hello_world import HelloWorldBlueprint
 from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
-from cstar.execution.file_system import DirectoryManager, JobFileSystemManager
+from cstar.execution.file_system import (
+    JobFileSystemManager,
+    StateDirectoryManager,
+)
 from cstar.orchestration.dag_runner import get_status_detail_map, load_run_state
 from cstar.orchestration.launch.local import LocalHandle, LocalLauncher
 from cstar.orchestration.models import BlueprintState, Step, Workplan, WorkplanState
@@ -64,7 +67,7 @@ async def layered_workplan(
             step_name = f"Step {idx}"
             target = f"@{idx}"
             fsm_map[step_name] = JobFileSystemManager(
-                DirectoryManager.data_home() / fake_run_id
+                StateDirectoryManager.data_dir(run_id=fake_run_id)
             )
 
             bp = HelloWorldBlueprint(

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -369,8 +369,6 @@ async def test_tracking_list_history_run_id(
         (2, False),
         (4, True),
         (4, False),
-        (8, True),
-        (8, False),
     ],
 )
 @pytest.mark.asyncio

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -335,3 +335,74 @@ async def test_tracking_list_history_run_id(
 
         # confirm 2 separate run-ids had the same number of runs inserted.
         assert len(base_matches) == num_unique * num_runs
+
+
+@pytest.mark.parametrize(
+    ("num_runs", "all_history"),
+    [
+        (1, True),
+        (1, False),
+        (2, True),
+        (2, False),
+        (4, True),
+        (4, False),
+        (8, True),
+        (8, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tracking_get_run_paths(
+    tmp_path: Path,
+    num_runs: int,
+    all_history: bool,
+) -> None:
+    """Verify that using the `get_run_paths` method locates
+    all directories for the specified run-id
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    num_runs : int
+        The number of runs to insert for a given run id
+    all_history : bool
+        Pass `True` to test retrieval of all historical run paths.
+    """
+    state_dir = tmp_path / "state"
+    output_path = tmp_path / "output"
+    wp_path = tmp_path / "fake_workplan.yaml"
+    wp_trx_path = tmp_path / "mock_transformed_workplan.yaml"
+    run_id = "test-get-run-paths-run-id"
+    captured_env = {"foo": "foo-value"}
+
+    with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
+        repo = TrackingRepository()
+        expected_paths = [repo._latest_path(run_id=run_id)]  # type: ignore
+
+        # insert some runs that re-use the same run-id
+        for _ in range(num_runs):
+            expected_paths.append(
+                await repo.put_workplan_run(
+                    WorkplanRun(
+                        workplan_path=wp_path,
+                        trx_workplan_path=wp_trx_path,
+                        output_path=output_path,
+                        run_id=run_id,
+                        environment=captured_env,
+                    )
+                )
+            )
+
+        # retrieve the list of run paths
+        actual_paths = repo.list_run_paths(run_id, all_history)
+
+    if all_history:
+        # run path for latest plus each history entry
+        exp_num_paths = num_runs + 1
+    else:
+        # only the latest history entry and corresponding symlink, e.g. latest/<run-id>
+        exp_num_paths = 2
+        expected_paths = [expected_paths[0], expected_paths[-1]]
+
+    assert len(actual_paths) == exp_num_paths
+    assert set(actual_paths).issuperset(expected_paths)

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -60,6 +60,29 @@ async def test_tracking_create(tmp_path: Path) -> None:
     assert found_files
 
 
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "",
+        " ",
+        "\t \n",
+    ],
+)
+@pytest.mark.asyncio
+async def test_tracking_retrieve_no_runid(run_id: str) -> None:
+    """Verify that run-tracking reports an invalid run-id.
+
+    Parameters
+    ----------
+    run_id : str
+        Parameterized "bad values" for the run-id that should result in exceptions.
+    """
+    repo = TrackingRepository()
+
+    with pytest.raises(ValueError, match="run-id was not provided"):
+        await repo.get_workplan_run(run_id=run_id)
+
+
 @pytest.mark.asyncio
 async def test_tracking_retrieve(tmp_path: Path) -> None:
     """Verify that run-tracking retrieves a persisted record and deserializes it

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -159,13 +159,13 @@ async def test_tracking_retrieve_variant(
     )
 
     # manually serialize so i have access to a known, working path for mocks
-    mock_doc_path = tmp_path / repo._runfile_name(run_id)
+    mock_doc_path = tmp_path / repo._runfile_name(datetime.now())  # type: ignore
     assert serialize(mock_doc_path, wp_run)
 
     with (
         mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}),
-        mock.patch.object(repo, "_history_path", return_value=mock_doc_path) as hp_fn,
-        mock.patch.object(repo, "_latest_path", return_value=mock_doc_path) as lp_fn,
+        mock.patch.object(repo, "history_path", return_value=mock_doc_path) as hp_fn,
+        mock.patch.object(repo, "latest_path", return_value=mock_doc_path) as lp_fn,
     ):
         latest = await repo.get_workplan_run(wp_run.run_id, None)
         assert latest
@@ -400,7 +400,7 @@ async def test_tracking_get_run_paths(
 
     with mock.patch.dict(os.environ, {ENV_CSTAR_STATE_HOME: state_dir.as_posix()}):
         repo = TrackingRepository()
-        expected_paths = [repo._latest_path(run_id=run_id)]  # type: ignore
+        expected_paths = [repo.latest_path(run_id=run_id)]  # type: ignore
 
         # insert some runs that re-use the same run-id
         for _ in range(num_runs):
@@ -417,7 +417,7 @@ async def test_tracking_get_run_paths(
             )
 
         # retrieve the list of run paths
-        actual_paths = repo.list_run_paths(run_id, all_history)
+        actual_paths = repo.list_runtracking_paths(run_id, all_history)
 
     if all_history:
         # run path for latest plus each history entry
@@ -428,4 +428,5 @@ async def test_tracking_get_run_paths(
         expected_paths = [expected_paths[0], expected_paths[-1]]
 
     assert len(actual_paths) == exp_num_paths
-    assert set(actual_paths).issuperset(expected_paths)
+    mismatched = set(actual_paths).difference(expected_paths)
+    assert not mismatched  # set(actual_paths).issuperset(expected_paths)


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change enables users to remove downloaded assets and those created during execution of a blueprint/workplan for troubleshooting and/or resource management. The feature is exposed as the CLI command `cstar admin clean`. It is disabled by default and can be enabled by setting the `CSTAR_FF_DEVELOPER_MODE` feature flag.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- added `cstar admin clean` CLI command

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #CSD-1021
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

