### PR TITLE
Disable autouse for prefect server fixture

### DIFF
--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1793,7 +1793,7 @@ def prefect_server() -> Generator[str, None, None]:
                 process.terminate()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def prefect_server_url(prefect_server: str) -> Generator[str, None, None]:
     """Configure the Prefect API URL for the duration of the tests."""
     os.environ["PREFECT_API_URL"] = prefect_server

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -148,6 +148,7 @@ async def test_compose_host_run_parameter(
         mock_run.assert_not_called()
 
 
+@pytest.mark.usefixtures("prefect_server_url")
 @pytest.mark.parametrize(
     ("drop_var", "key", "settings_klass"),
     [
@@ -165,7 +166,6 @@ async def test_build_and_run_dag_env(
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
-    prefect_server_url: str,
 ) -> None:
     """Verify that the DAG runner fails when required environment variables are not passed.
 

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -103,12 +103,12 @@ def test_workplan_run_remote_workplan(wp_uri: str) -> None:
     mock_exec.assert_called_once()
 
 
+@pytest.mark.usefixtures("prefect_server_url")
 def test_workplan_run_variable_unknown(
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
     default_blueprint_path: str,
-    prefect_server_url: str,
 ) -> None:
     """Verify that attempting to run a workplan with runtime variables that are
     not declared by the workplan results in a failure.


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change removes `autouse=True` when instantiating the `prefect_server_url` fixture and ensures the actual locations where it is used are correctly configured. Previously, the prefect server was started even when a subset of tests may not use it.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Avoid starting prefect server unnecessarily when running tests

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

