### PR TITLE
Remove member performing duplicate liveness functionality

### DIFF
--- a/cstar/entrypoint/runner.py
+++ b/cstar/entrypoint/runner.py
@@ -171,7 +171,7 @@ class BlueprintRunner(Service, XRunner[TBlueprint]):
         RunnerResult
         """
         if ExecutionStatus.is_terminal(status):
-            self._running = False
+            self._stop_event.set()
 
         if isinstance(errors, str) and errors:
             errors = [errors]

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -30,10 +30,8 @@ class Service(ABC, LoggingMixin):
     """A thread for executing an unblocked healthcheck callback."""
     _hc_queue: Queue[str] | None = None
     """A queue for sending shutdown messages to the healthcheck thread."""
-    _hc_stop_event: Final[Event]
-    """An event triggering health-check thread termination."""
-    _running: bool = False
-    """Flag used to trigger service shutdown."""
+    _stop_event: Final[Event]
+    """An event triggering service termination."""
 
     def __init__(
         self,
@@ -47,7 +45,7 @@ class Service(ABC, LoggingMixin):
             Configuration to modify the behavior of the service.
         """
         self._config = config
-        self._hc_stop_event = Event()
+        self._stop_event = Event()
         self._register_signal_handlers()
 
     @property
@@ -144,7 +142,7 @@ class Service(ABC, LoggingMixin):
         logic.
         """
         self.log.trace(f"Starting {self._service_type}")
-        self._running = True
+        self._stop_event.clear()
 
     def _on_shutdown(self) -> None:
         """Empty hook method for use by subclasses.
@@ -237,9 +235,9 @@ class Service(ABC, LoggingMixin):
         last_health_check = time.time()  # timestamp of last health check
         num_missed = 0
 
-        while not self._hc_stop_event.is_set():
+        while not self._stop_event.is_set():
             remaining = _get_remaining_wait(last_health_check)
-            if self._hc_stop_event.wait(timeout=remaining):
+            if self._stop_event.wait(timeout=remaining):
                 return
 
             last_health_check = time.time()
@@ -251,7 +249,7 @@ class Service(ABC, LoggingMixin):
                 num_missed += 1
             except Exception:  # noqa: BLE001
                 # queue was shutdown on other side, exit HC loop
-                self._hc_stop_event.set()
+                self._stop_event.set()
                 num_missed = 0
 
             # only report consecutive gaps.
@@ -304,10 +302,10 @@ class Service(ABC, LoggingMixin):
         -------
         None
         """
-        self._hc_stop_event.set()
+        self._stop_event.set()
 
         if self._hc_thread is not None:
-            self._hc_thread.join(timeout=10)
+            self._hc_thread.join(timeout=1)
 
             if self._hc_thread.is_alive():
                 msg = "Health check thread did not terminate before timeout"
@@ -334,7 +332,6 @@ class Service(ABC, LoggingMixin):
         This method is called when the service has been cancelled via a term signal.
         """
         self.log.info("Shutting down service.")
-        self._running = False
         self._shutdown()
 
     async def execute(self) -> None:
@@ -350,30 +347,30 @@ class Service(ABC, LoggingMixin):
             self._on_start()
             self._start_healthcheck()
         except Exception as e:
+            self._stop_event.set()
             self.log.exception("Unable to start service.")
-            self._running = False
             exc = e
 
-        while self._running:
+        while not self._stop_event.is_set():
             try:
                 self.acknowledge_hc()
                 await self._on_iteration()
                 self._on_iteration_complete()
             except Exception:
-                self._running = False
+                self._stop_event.set()
                 self.log.exception("Terminating service due to failure in event loop.")
                 continue
 
             # shutdown if not set to run as a service
             if not self._config.as_service:
+                self._stop_event.set()
                 self.log.debug("Service has completed its work and will exit.")
-                self._running = False
                 continue
 
             # shutdown if service reports completion
             if self.can_shutdown:
+                self._stop_event.set()
                 self.log.trace("Service is ready for shutdown.")
-                self._running = False
                 continue
 
             # execute delay before next iteration
@@ -382,7 +379,7 @@ class Service(ABC, LoggingMixin):
                     self._on_delay()
                     await asyncio.sleep(max(self._config.loop_delay, 0))
                 except Exception as e:
-                    self._running = False
+                    self._stop_event.set()
                     self.log.exception(
                         "Terminating service due to failure in _on_delay."
                     )
@@ -409,6 +406,7 @@ class Service(ABC, LoggingMixin):
         None
         """
         self.log.info(f"Received signal: {sig_num}")
+        self._stop_event.set()
 
         try:
             # perform sub-class specific clean-up

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -331,7 +331,7 @@ class Service(ABC, LoggingMixin):
 
         This method is called when the service has been cancelled via a term signal.
         """
-        self.log.info("Shutting down service.")
+        self.log.info("Performing service cancellation.")
         self._shutdown()
 
     async def execute(self) -> None:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change removes a member of the `Service` class that has a duplicate purpose (tracking service shutdown state).

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Rely on `threading.Event` alone during service shutdown to avoid inconsistent behavior / service hangs.

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

