### PR TITLE
Delay CStarSytemManager instantiation to run-time

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from cstar.base.log import LoggingMixin
 from cstar.io.source_data import SourceData
 from cstar.io.staged_data import StagedRepository
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 
 class ExternalCodeBase(ABC, LoggingMixin):
@@ -53,6 +53,8 @@ class ExternalCodeBase(ABC, LoggingMixin):
         ExternalCodeBase
             An initialized ExternalCodeBase object
         """
+        cstar_sysmgr = get_sysmgr()
+
         if not source_repo:
             source_repo = self._default_source_repo
         if not checkout_target:
@@ -153,6 +155,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
             return
 
         if not target_dir:
+            cstar_sysmgr = get_sysmgr()
             target_dir = Path(
                 cstar_sysmgr.environment.package_root
                 / f"externals/{self.source.basename.replace('.git', '')}"

--- a/cstar/entrypoint/config.py
+++ b/cstar/entrypoint/config.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, ValidationError
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import parse_log_level_name
 from cstar.system.environment import SlurmSettingsBase
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 JOBFILE_DATE_FORMAT: t.Final[str] = "%Y%m%d_%H%M%S"
 
@@ -104,7 +104,7 @@ def get_job_config() -> JobConfig:
     """
     account_id, walltime, priority = "", "", ""
 
-    if klass := cstar_sysmgr.environment.settings_klass:
+    if klass := get_sysmgr().environment.settings_klass:
         try:
             system_env = klass()
             if isinstance(system_env, SlurmSettingsBase):

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -19,7 +19,7 @@ from cstar.base.feature import (
 )
 from cstar.base.utils import _run_cmd
 from cstar.execution.handler import ExecutionHandler, ExecutionStatus
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 from cstar.system.scheduler import (
     PBSScheduler,
     SlurmPartition,
@@ -408,18 +408,17 @@ def create_scheduler_job(
     """
     # mypy assigns type based on first condition, assigning explicitly:
     job_type: type[SlurmJob] | type[PBSJob]
+    scheduler = get_sysmgr().scheduler
 
-    if isinstance(cstar_sysmgr.scheduler, SlurmScheduler):
+    if isinstance(scheduler, SlurmScheduler):
         job_type = SlurmJob
-    elif isinstance(cstar_sysmgr.scheduler, PBSScheduler):
+    elif isinstance(scheduler, PBSScheduler):
         job_type = PBSJob
     else:
-        raise TypeError(
-            f"Unsupported scheduler type: {type(cstar_sysmgr.scheduler).__name__}"
-        )
+        raise TypeError(f"Unsupported scheduler type: {type(scheduler).__name__}")
 
     return job_type(
-        scheduler=cstar_sysmgr.scheduler,
+        scheduler=scheduler,
         commands=commands,
         cpus=cpus,
         nodes=nodes,

--- a/cstar/marbl/external_codebase.py
+++ b/cstar/marbl/external_codebase.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.gitutils import _check_local_repo_changed_from_remote
 from cstar.base.utils import _run_cmd
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 
 class MARBLExternalCodeBase(ExternalCodeBase):
@@ -36,6 +36,8 @@ class MARBLExternalCodeBase(ExternalCodeBase):
 
         This method compiles MARBL and adds necessary  variables to the environment.
         """
+        cstar_sysmgr = get_sysmgr()
+
         assert self.working_copy is not None  # Has been verified by `configure()``
         marbl_root = self.working_copy.path
         # Set env var:
@@ -60,6 +62,8 @@ class MARBLExternalCodeBase(ExternalCodeBase):
         - The repository has not changed from that described by `source`.
         - MARBL's `lib` and `inc` dirs exist and are populated
         """
+        cstar_sysmgr = get_sysmgr()
+
         # Check MARBL_ROOT env var is set:
         marbl_root = cstar_sysmgr.environment.environment_variables.get(
             self.root_env_var

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -36,7 +36,7 @@ from cstar.orchestration.transforms import (
     WorkplanTransformer,
 )
 from cstar.orchestration.utils import ENV_CSTAR_ORCH_DELAYS
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 log = get_logger(__name__)
 
@@ -180,7 +180,7 @@ def get_launcher() -> Launcher[t.Any]:
     -------
     Launcher[t.Any]
     """
-    launcher = SlurmLauncher() if cstar_sysmgr.scheduler else LocalLauncher()
+    launcher = SlurmLauncher() if get_sysmgr().scheduler else LocalLauncher()
     launcher.check_preconditions()
     return launcher
 

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -29,7 +29,7 @@ from cstar.orchestration.serialization import (
     register_representer,
 )
 from cstar.system.environment import get_envfield_alias
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 nx = lazy_import("networkx")
 
@@ -562,6 +562,8 @@ class Launcher(t.Protocol, t.Generic[_THandle]):
         CstarExpectationFailed
             If an environment variable required by the launcher cannot be found.
         """
+        cstar_sysmgr = get_sysmgr()
+
         if klass := cstar_sysmgr.environment.settings_klass:
             try:
                 _ = klass()

--- a/cstar/roms/external_codebase.py
+++ b/cstar/roms/external_codebase.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from cstar.base.external_codebase import ExternalCodeBase
 from cstar.base.gitutils import _check_local_repo_changed_from_remote
 from cstar.base.utils import _run_cmd
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 
 class ROMSExternalCodeBase(ExternalCodeBase):
@@ -36,6 +36,8 @@ class ROMSExternalCodeBase(ExternalCodeBase):
         # Set env vars:
         assert self.working_copy is not None  # verified by ExternalCodeBase.configure()
         roms_root = self.working_copy.path
+
+        cstar_sysmgr = get_sysmgr()
         cstar_sysmgr.environment.set_env_var(self.root_env_var, str(roms_root))
         cstar_sysmgr.environment.set_env_var(
             "PATH", f"{roms_root / 'Tools-Roms'}:{os.environ.get('PATH')}"
@@ -54,6 +56,7 @@ class ROMSExternalCodeBase(ExternalCodeBase):
     @property
     def is_configured(self) -> bool:
         # Check ROMS_ROOT env var is set:
+        cstar_sysmgr = get_sysmgr()
         roms_root = cstar_sysmgr.environment.environment_variables.get(
             self.root_env_var
         )

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -64,7 +64,7 @@ from cstar.roms.input_dataset import (
 )
 from cstar.roms.namelist import RomsNamelist
 from cstar.simulation import Simulation
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 if TYPE_CHECKING:
     from cstar.base.external_codebase import ExternalCodeBase
@@ -1447,6 +1447,8 @@ class ROMSSimulation(Simulation):
         if is_feature_enabled(ENV_FF_DEBUG_BUILD_MODE):
             mode_clause = "BUILD_MODE=debug "
 
+        cstar_sysmgr = get_sysmgr()
+
         _run_cmd(
             f"make {mode_clause}COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=build_dir,
@@ -1611,6 +1613,8 @@ class ROMSSimulation(Simulation):
         self.fs_manager.run_dir.mkdir(parents=True, exist_ok=True)
         self.fs_manager.logs_dir.mkdir(parents=True, exist_ok=True)
         self.fs_manager.output_dir.mkdir(parents=True, exist_ok=True)
+
+        cstar_sysmgr = get_sysmgr()
 
         if (queue_name is None) and (cstar_sysmgr.scheduler is not None):
             queue_name = cstar_sysmgr.scheduler.primary_queue_name

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -563,4 +563,7 @@ class CStarSystemManager:
         return self._scheduler
 
 
-cstar_sysmgr = CStarSystemManager()
+@functools.lru_cache
+def get_sysmgr() -> CStarSystemManager:
+    """Return a cached system manager instance."""
+    return CStarSystemManager()

--- a/cstar/tests/unit_tests/entrypoint/test_worker.py
+++ b/cstar/tests/unit_tests/entrypoint/test_worker.py
@@ -111,7 +111,7 @@ def sim_runner(
     service_config = ServiceConfiguration(
         as_service=False,
         loop_delay=0,
-        health_check_frequency=0,
+        health_check_frequency=0,  # None
         log_level=logging.DEBUG,
         health_check_log_threshold=10,
         name="test_simulation_runner",
@@ -348,7 +348,7 @@ def test_start_runner(
 
     service_config = ServiceConfiguration(
         as_service=False,
-        health_check_frequency=0,
+        health_check_frequency=0,  # None
         log_level=logging.DEBUG,
         name="test_start_runner",
         loop_delay=0,

--- a/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
+++ b/cstar/tests/unit_tests/marbl/test_marbl_external_codebase.py
@@ -6,7 +6,7 @@ import unittest.mock as mock
 import pytest
 
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 
 class TestMARBLExternalCodeBaseInit:
@@ -76,6 +76,8 @@ class TestMARBLExternalCodeBaseConfigure:
         ## Check that environment was updated correctly
         actual_value = os.getenv(mecb.root_env_var)
         assert actual_value == str(mecb.working_copy.path)
+
+        cstar_sysmgr = get_sysmgr()
 
         mock_run_cmd.assert_called_once_with(
             f"make {cstar_sysmgr.environment.compiler} USEMPI=TRUE",

--- a/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
+++ b/cstar/tests/unit_tests/roms/test_roms_external_codebase.py
@@ -6,7 +6,7 @@ import unittest.mock as mock
 import pytest
 
 from cstar.roms.external_codebase import ROMSExternalCodeBase
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 
 class TestROMSExternalCodeBaseInit:
@@ -79,6 +79,8 @@ class TestROMSExternalCodeBaseConfigure:
             # Assertions:
             ## Check environment variables
             assert os.environ[recb.root_env_var] == str(recb.working_copy.path)
+
+        cstar_sysmgr = get_sysmgr()
 
         mock_run_cmd.assert_any_call(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -30,7 +30,7 @@ from cstar.roms.input_dataset import (
 from cstar.roms.namelist import RomsNamelist
 from cstar.roms.simulation import ROMSSimulation
 from cstar.system.environment import CStarEnvironment
-from cstar.system.manager import cstar_sysmgr
+from cstar.system.manager import get_sysmgr
 
 # A complete, forge-produced runtime namelist used to back the
 # roms_runtime_settings tests (RomsNamelist is a strict 40-group schema).
@@ -1325,6 +1325,7 @@ class TestProcessingAndExecution:
             capture_output=True,
             text=True,
         )
+        cstar_sysmgr = get_sysmgr()
         mock_subprocess.assert_any_call(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=build_dir,
@@ -1473,7 +1474,7 @@ class TestProcessingAndExecution:
                 sim.build()
 
         assert mock_subprocess.call_count == 1
-
+        cstar_sysmgr = get_sysmgr()
         mock_subprocess.assert_any_call(
             f"make COMPILER={cstar_sysmgr.environment.compiler}",
             cwd=build_dir,
@@ -1622,6 +1623,7 @@ class TestProcessingAndExecution:
             execution_handler = sim.run()
 
             # Check LocalProcess was instantiated correctly
+            cstar_sysmgr = get_sysmgr()
             mock_local_process.assert_called_once_with(
                 commands=f"{cstar_sysmgr.environment.mpi_exec_prefix} -n {sim.discretization.n_procs_tot} ./roms cstar_generated_roms.nml",
                 run_path=sim.fs_manager.run_dir,

--- a/docs/python_api_guides/8_handling_jobs_on_hpc_systems.ipynb
+++ b/docs/python_api_guides/8_handling_jobs_on_hpc_systems.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1caec1e1-8cf5-4988-8d78-72280ecaf293",
    "metadata": {},
    "outputs": [],
@@ -73,7 +73,7 @@
     "example_simulation_1 = ROMSSimulation.from_blueprint(blueprint  = \"https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/main/cstar_blueprint_example_with_netcdf_inputs.yaml\",\n",
     "                                                     directory  = \"../../examples/example_case/\", \n",
     "                                                     start_date = \"2012-01-03 12:00:00\", \n",
-    "                                                     end_date   = \"2012-01-06 12:00:00\")"
+    "                                                     end_date   = \"2012-01-06 12:00:00\")\n"
    ]
   },
   {
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "0563b510-8932-4203-9bb3-9533cffe95c2",
    "metadata": {
     "tags": []
@@ -119,8 +119,9 @@
     }
    ],
    "source": [
-    "from cstar.system.manager import cstar_sysmgr\n",
-    "print(cstar_sysmgr.scheduler)"
+    "from cstar.system.manager import get_sysmgr\n",
+    "\n",
+    "print(get_sysmgr().scheduler)\n"
    ]
   },
   {
@@ -135,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d6d2dacb-0025-458d-bbfc-a10068c56f6e",
    "metadata": {
     "tags": []
@@ -154,7 +155,7 @@
     }
    ],
    "source": [
-    "print(cstar_sysmgr.scheduler.get_queue(\"shared\"))"
+    "print(get_sysmgr().scheduler.get_queue(\"shared\"))\n"
    ]
   },
   {
@@ -168,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "82cb820a-0353-4146-9e01-2e425a615fa2",
    "metadata": {},
    "outputs": [
@@ -286,7 +287,7 @@
     "example_simulation_1.build()\n",
     "example_simulation_1.pre_run()\n",
     "\n",
-    "hpc_job = example_simulation_1.run(account_key=\"m4746\", walltime=\"00:10:00\", queue_name=\"shared\")"
+    "hpc_job = example_simulation_1.run(account_key=\"m4746\", walltime=\"00:10:00\", queue_name=\"shared\")\n"
    ]
   },
   {
@@ -301,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "f99e3515-2c1a-4b8c-89b4-985aea931be1",
    "metadata": {},
    "outputs": [
@@ -325,7 +326,7 @@
     }
    ],
    "source": [
-    "print(hpc_job.script)"
+    "print(hpc_job.script)\n"
    ]
   },
   {
@@ -338,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "12824aab-af63-4343-9314-99572ab0a44c",
    "metadata": {},
    "outputs": [
@@ -354,7 +355,7 @@
     }
    ],
    "source": [
-    "hpc_job.script_path"
+    "hpc_job.script_path\n"
    ]
   },
   {
@@ -376,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "699300f3-efc9-44d9-ac91-efcf01e6947c",
    "metadata": {},
    "outputs": [
@@ -392,7 +393,7 @@
     }
    ],
    "source": [
-    "hpc_job.id"
+    "hpc_job.id\n"
    ]
   },
   {
@@ -416,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "41630183-ecde-4dc2-bfba-41a1457ede1a",
    "metadata": {},
    "outputs": [
@@ -432,7 +433,7 @@
     }
    ],
    "source": [
-    "hpc_job.status"
+    "hpc_job.status\n"
    ]
   },
   {
@@ -446,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "216bbc79-f578-44d2-867b-7da38b252778",
    "metadata": {},
    "outputs": [
@@ -462,7 +463,7 @@
     }
    ],
    "source": [
-    "hpc_job.output_file"
+    "hpc_job.output_file\n"
    ]
   },
   {
@@ -478,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "0a79a7cc-9281-4bd8-ad4e-ecb32e17a1c0",
    "metadata": {},
    "outputs": [
@@ -508,7 +509,7 @@
     }
    ],
    "source": [
-    "hpc_job.updates(seconds=0.5)"
+    "hpc_job.updates(seconds=0.5)\n"
    ]
   },
   {
@@ -522,17 +523,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "428f25ea-43d8-4462-9b80-d912552aa403",
    "metadata": {},
    "outputs": [],
    "source": [
-    "hpc_job.cancel()"
+    "hpc_job.cancel()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "10926495-2da3-4a20-b663-d238d6d96a43",
    "metadata": {},
    "outputs": [
@@ -548,7 +549,7 @@
     }
    ],
    "source": [
-    "hpc_job.status"
+    "hpc_job.status\n"
    ]
   },
   {


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change modifies the instantiation of the `CStarSystemManager` singleton to occur at runtime instead of at import time. It is useful to avoid time consuming environment-related calls (e.g. loading lmod modules) until they are necessary.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce startup time by instantiating `CStarSystemManager` at runtime.

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

