### PR TITLE
Fix test regression

### DIFF
--- a/cstar/base/external_codebase.py
+++ b/cstar/base/external_codebase.py
@@ -94,7 +94,7 @@ class ExternalCodeBase(ABC, LoggingMixin):
         repr_str += "\n)"
         return repr_str
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, str | None]:
         """Return this ExternalCodeBase as a dictionary of kwargs to ExternalCodeBase.__init__"""
         return {
             "source_repo": self.source.location,

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 
 import cstar.base.external_codebase as external_codebase
-from cstar.system.manager import CStarSystemManager
 from cstar.tests.unit_tests.fake_abc_subclasses import FakeExternalCodeBase
 
 
@@ -109,7 +108,7 @@ class TestSetup:
         staged_repo = mock.Mock(spec=external_codebase.StagedRepository)
         fakeexternalcodebase.source.stage = mock.Mock(return_value=staged_repo)
 
-        mock_mgr = mock.Mock(spec=CStarSystemManager)
+        mock_mgr = mock.Mock()
         mock_mgr.environment.package_root = tmp_path
         mock_getsysmgr = mock.Mock(return_value=mock_mgr)
 

--- a/cstar/tests/unit_tests/base/test_external_codebase.py
+++ b/cstar/tests/unit_tests/base/test_external_codebase.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 import cstar.base.external_codebase as external_codebase
+from cstar.system.manager import CStarSystemManager
 from cstar.tests.unit_tests.fake_abc_subclasses import FakeExternalCodeBase
 
 
@@ -108,8 +109,13 @@ class TestSetup:
         staged_repo = mock.Mock(spec=external_codebase.StagedRepository)
         fakeexternalcodebase.source.stage = mock.Mock(return_value=staged_repo)
 
+        mock_mgr = mock.Mock(spec=CStarSystemManager)
+        mock_mgr.environment.package_root = tmp_path
+        mock_getsysmgr = mock.Mock(return_value=mock_mgr)
+
         with mock.patch(
-            "cstar.base.external_codebase.cstar_sysmgr._environment"
+            "cstar.system.manager.get_sysmgr",
+            mock_getsysmgr,
         ) as mock_env:
             mock_env.package_root = tmp_path
             fakeexternalcodebase._working_copy = None

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -199,6 +199,7 @@ async def test_build_and_run_dag_env(
     # mock the sys manager to engage the checks for Slurm env-vars
     mock_sys_manager = mock.Mock()
     mock_sys_manager.scheduler = mock.Mock()
+    mock_get_mgr = mock.Mock(return_value=mock_sys_manager)
 
     mock_env = {
         ENV_CSTAR_STATE_HOME: working_dir_override.as_posix(),
@@ -213,7 +214,7 @@ async def test_build_and_run_dag_env(
 
     with (
         mock.patch("cstar.orchestration.dag_runner.process_plan", mock_process),
-        mock.patch("cstar.orchestration.dag_runner.cstar_sysmgr", mock_sys_manager),
+        mock.patch("cstar.orchestration.dag_runner.get_sysmgr", mock_get_mgr),
         mock.patch.dict(os.environ, mock_env, clear=True),
         mock.patch(
             "cstar.system.environment.CStarEnvironment.settings_klass",


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change fixes two tests failing after the removal of the global `cstar_sysmgr` instance due to invalid mock specifications.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Mitigate test regressions

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

