### PR TITLE
Fix repeated-migration-fails bug

### DIFF
--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -3,13 +3,13 @@ import typing as t
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from copy import deepcopy
+from pathlib import Path
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
     FilePath,
-    NewPath,
 )
 
 from cstar.base.adapter import SchemaAdapter
@@ -50,7 +50,7 @@ class MigrationRequest(BaseModel):
         description="Path to a file containing a serialized blueprint",
         alias="path",
     )
-    target: NewPath | None = Field(
+    target: Path | None = Field(
         default=None,
         description="Path where the migrated blueprint will be serialized",
         frozen=True,


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR fixes a bug where attempting to re-run a migration results in an error. The migration model is updated to avoid use of `NewPath` that requires the output path to not exist.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

