### PR TITLE
Reduce unnecessary usage of remote blueprints

### DIFF
--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -112,7 +112,7 @@ def test_blueprint_run_remote_blueprint() -> None:
         "https://www.google.com/directive-dne.json",
     ],
 )
-def test_blueprint_run_apply_directive_dne(tmp_path: Path, directive_path: str) -> None:
+def test_blueprint_run_apply_directive_dne(directive_path: str) -> None:
     """Verify that an exception is raised if a path to a non-existent directive file is passed."""
     bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
 
@@ -138,9 +138,12 @@ def test_blueprint_run_apply_directive_dne(tmp_path: Path, directive_path: str) 
     mock_exec.assert_not_called()
 
 
-def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
+def test_blueprint_run_apply_directive_empty(
+    tmp_path: Path,
+    package_path: Path,
+) -> None:
     """Verify that an exception is raised if an empty directive file is passed."""
-    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    bp_path = str(package_path / "docs/tutorials/wales_toy_blueprint.yaml")
     directive_file_path = tmp_path / "directive-dne.json"
     directive_file_path.touch()
 
@@ -160,12 +163,14 @@ def test_blueprint_run_apply_directive_empty(tmp_path: Path) -> None:
 
 
 def test_blueprint_run_apply_directives(
-    tmp_path: Path, mocked_simulation_outputs: tuple[Path, Path, Path]
+    tmp_path: Path,
+    mocked_simulation_outputs: tuple[Path, Path, Path],
+    package_path: Path,
 ) -> None:
     """Verify that a URL to a remote blueprint is handled properly and the
     blueprint is executed.
     """
-    bp_path = "https://raw.githubusercontent.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/refs/heads/main/wales-toy-domain/wales_toy_blueprint.yaml"
+    bp_path = str(package_path / "docs/tutorials/wales_toy_blueprint.yaml")
     _, step_dir, _ = mocked_simulation_outputs
 
     temp_step = LiveStep(


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request reduces the usage of remote blueprints in the test suite. The remote blueprints occasionally fail due to rate limits and slow the execution of the tests.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduce usage of remote blueprints in test suite

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

