### PR TITLE
Mitigate use of deprecated typing.Optional and partial type warnings

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import yaml
 
@@ -232,19 +232,19 @@ class ROMSSimulation(Simulation):
         directory: str | Path,
         discretization: "ROMSDiscretization",
         runtime_code: "AdditionalCode",
-        compile_time_code: Optional["AdditionalCode"] = None,
-        codebase: Optional["ROMSExternalCodeBase"] = None,
+        compile_time_code: "AdditionalCode | None" = None,
+        codebase: "ROMSExternalCodeBase | None" = None,
         start_date: str | datetime | None = None,
         end_date: str | datetime | None = None,
         valid_start_date: str | datetime | None = None,
         valid_end_date: str | datetime | None = None,
-        marbl_codebase: Optional["MARBLExternalCodeBase"] = None,
-        model_grid: Optional["ROMSModelGrid"] = None,
-        initial_conditions: Optional["ROMSInitialConditions"] = None,
-        tidal_forcing: Optional["ROMSTidalForcing"] = None,
-        river_forcing: Optional["ROMSRiverForcing"] = None,
-        cdr_forcing: Optional["ROMSCdrForcing"] = None,
-        nesting_info: Optional["ROMSNestingInfo"] = None,
+        marbl_codebase: "MARBLExternalCodeBase | None" = None,
+        model_grid: "ROMSModelGrid | None" = None,
+        initial_conditions: "ROMSInitialConditions | None" = None,
+        tidal_forcing: "ROMSTidalForcing | None" = None,
+        river_forcing: "ROMSRiverForcing | None" = None,
+        cdr_forcing: "ROMSCdrForcing | None" = None,
+        nesting_info: "ROMSNestingInfo | None" = None,
         boundary_forcing: list["ROMSBoundaryForcing"] | None = None,
         surface_forcing: list["ROMSSurfaceForcing"] | None = None,
         forcing_corrections: list["ROMSForcingCorrections"] | None = None,

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -515,7 +515,7 @@ class Simulation(ABC, LoggingMixin):
 
     def __getstate__(self):
         """Return a pickle-able representation of the object."""
-        state = self.__dict__.copy()
+        state = vars(self).copy()
 
         # Remove the un-pickleable logger attribute
         state.pop("_log", None)
@@ -524,7 +524,7 @@ class Simulation(ABC, LoggingMixin):
 
     def __setstate__(self, state: dict[str, Any]):
         """Restore the object from a pickle."""
-        self.__dict__.update(state)
+        vars(self).update(state)
 
     def persist(self) -> None:
         """Save the current state of the simulation to a file.

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -3,7 +3,7 @@ import pickle
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import dateutil
 
@@ -84,9 +84,9 @@ class Simulation(ABC, LoggingMixin):
         name: str,
         directory: str | Path,
         discretization: "Discretization",
-        runtime_code: Optional["AdditionalCode"] = None,
-        compile_time_code: Optional["AdditionalCode"] = None,
-        codebase: Optional["ExternalCodeBase"] = None,
+        runtime_code: "AdditionalCode | None" = None,
+        compile_time_code: "AdditionalCode | None" = None,
+        codebase: "ExternalCodeBase | None" = None,
         start_date: str | datetime | None = None,
         end_date: str | datetime | None = None,
         valid_start_date: str | datetime | None = None,
@@ -405,7 +405,7 @@ class Simulation(ABC, LoggingMixin):
 
     @classmethod
     @abstractmethod
-    def from_dict(cls, simulation_dict: dict, directory: str | Path):
+    def from_dict(cls, simulation_dict: dict[str, Any], directory: str | Path):
         """Abstract method to create a Simulation instance from a dictionary.
 
         This method must be implemented by subclasses to construct a simulation
@@ -430,7 +430,7 @@ class Simulation(ABC, LoggingMixin):
         """
         pass
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the Simulation instance into a dictionary representation.
 
         This method serializes the attributes of the Simulation instance into a
@@ -447,7 +447,7 @@ class Simulation(ABC, LoggingMixin):
         from_dict : Constructs a Simulation instance from a dictionary.
         to_blueprint: Writes an equivalent representation to a yaml file.
         """
-        simulation_dict: dict[Any, Any] = {}
+        simulation_dict: dict[str, Any] = {}
 
         # Top-level information
         simulation_dict["name"] = self.name

--- a/cstar/simulation.py
+++ b/cstar/simulation.py
@@ -522,7 +522,7 @@ class Simulation(ABC, LoggingMixin):
 
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]):
         """Restore the object from a pickle."""
         self.__dict__.update(state)
 
@@ -593,7 +593,7 @@ class Simulation(ABC, LoggingMixin):
         return simulation
 
     @abstractmethod
-    def build(self, rebuild=False) -> None:
+    def build(self, rebuild: bool = False) -> None:
         """Abstract method to compile any necessary code for this simulation.
 
         This method should be implemented by subclasses to handle steps


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR contains a minor QoL improvement that removes the remaining use of the deprecated `typing.Optional` typehint.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Mitigate use of deprecated `typing.Optional`. 

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

