### PR TITLE
Reduce input manipulation in workplan/blueprint tests

### DIFF
--- a/cstar/tests/integration_tests/workplans/test_run_dag.py
+++ b/cstar/tests/integration_tests/workplans/test_run_dag.py
@@ -79,6 +79,7 @@ def test_dep_keys(tmp_path: Path) -> None:
 
 
 @pytest.mark.skip(reason="Fix LocalLauncher infinite loop bug in schedule mode")
+@pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "workplan_name",
@@ -88,8 +89,6 @@ async def test_build_and_run_local(
     tmp_path: Path,
     workplan_name: str,
     wp_templates_dir: Path,
-    bp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Test the dag runner with a local launcher.
 
@@ -101,26 +100,12 @@ async def test_build_and_run_local(
         The name of a workplan template file to use during workplan creation
     wp_templates_dir : Path
         Fixture returning the path to the directory containing workplan template files
-    bp_templates_dir : Path
-        Fixture returning the path to the directory containing blueprint template files
-    default_blueprint_path : str
-        Fixture returning the default blueprint path contained in template workplans
     """
     # avoid running sims during tests
     os.environ["CSTAR_CMD_CONVERTER_OVERRIDE"] = "sleep"
 
     template_file = f"{workplan_name}.yaml"
-    template_path = wp_templates_dir / template_file
-
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
-    bp_path.write_text(bp_tpl_path.read_text())
-
-    wp_content = template_path.read_text()
-    wp_content = wp_content.replace(default_blueprint_path, bp_path.as_posix())
-
-    wp_path = tmp_path / template_file
-    wp_path.write_text(wp_content)
+    wp_path = wp_templates_dir / template_file
 
     # create unique run name only once per hour, cache otherwise.
     my_run_name = f"{tmp_path.stem}_{workplan_name}"
@@ -128,6 +113,7 @@ async def test_build_and_run_local(
 
 
 # @pytest.mark.skipif(not slurm())
+@pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.skip(reason="tests are very slow when scheduling many tasks with slurm")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -138,8 +124,6 @@ async def test_build_and_run(
     tmp_path: Path,
     workplan_name: str,
     wp_templates_dir: Path,
-    bp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Test the dag runner with a SlurmLauncher.
 
@@ -160,17 +144,7 @@ async def test_build_and_run(
     os.environ["CSTAR_CMD_CONVERTER_OVERRIDE"] = "sleep"
 
     template_file = f"{workplan_name}.yaml"
-    template_path = wp_templates_dir / template_file
-
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
-    bp_path.write_text(bp_tpl_path.read_text())
-
-    wp_content = template_path.read_text()
-    wp_content = wp_content.replace(default_blueprint_path, bp_path.as_posix())
-
-    wp_path = tmp_path / template_file
-    wp_path.write_text(wp_content)
+    wp_path = wp_templates_dir / template_file
 
     # create unique run name only once per hour, cache otherwise.
     my_run_name = f"{tmp_path.stem}_{workplan_name}"

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -261,11 +261,9 @@ async def test_prepare_composed_dag(
     bp_template_path = bp_templates_dir / bp_template_file
 
     working_dir = tmp_path / "original-output-dir"
-    working_dir_override = tmp_path / "overridden-output-dir"
     run_id = "my-run"
 
     mock_env = {
-        ENV_CSTAR_STATE_HOME: working_dir_override.as_posix(),
         ENV_CSTAR_SLURM_ACCOUNT: "xyz",
         ENV_CSTAR_SLURM_QUEUE: "wholenode",
         ENV_CSTAR_SLURM_MAX_WALLTIME: "00:5:00",
@@ -279,7 +277,7 @@ async def test_prepare_composed_dag(
 
     with (
         mock.patch("cstar.orchestration.orchestration.Planner.__init__", _raise_ex),
-        mock.patch.dict(os.environ, mock_env, clear=True),
+        mock.patch.dict(os.environ, mock_env),
     ):
         generated_wp_path = compose(
             wp_template_path.as_posix(),

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_plan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_plan.py
@@ -8,6 +8,7 @@ from cstar.orchestration.orchestration import Planner
 from cstar.orchestration.serialization import deserialize
 
 
+@pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "workplan_name",
@@ -17,7 +18,6 @@ async def test_cli_plan_action(
     tmp_path: Path,
     workplan_name: str,
     wp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Verify that CLI plan action generates an output image from a workplan.
 
@@ -29,20 +29,9 @@ async def test_cli_plan_action(
         The name of a workplan fixture to use for workplan creation
     wp_templates_dir: Path
         Fixture returning the path to the directory containing workplan template files
-    default_blueprint_path : str
-        Fixture returning the default blueprint path contained in template workplans
     """
     template_file = f"{workplan_name}.yaml"
-    template_path = wp_templates_dir / template_file
-
-    empty_bp_path = tmp_path / "blueprint.yaml"
-    empty_bp_path.touch()
-
-    content = template_path.read_text()
-    content = content.replace(default_blueprint_path, empty_bp_path.as_posix())
-
-    wp_path = tmp_path / template_file
-    wp_path.write_text(content)
+    wp_path = wp_templates_dir / template_file
 
     wp = deserialize(wp_path, Workplan)
     planner = Planner(wp)

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -105,12 +105,9 @@ def test_workplan_run_remote_workplan(wp_uri: str) -> None:
     mock_exec.assert_called_once()
 
 
-@pytest.mark.usefixtures("prefect_server_url")
+@pytest.mark.usefixtures("prefect_server_url", "read_yaml_intercept")
 def test_workplan_run_variable_unknown(
-    tmp_path: Path,
-    bp_templates_dir: Path,
     wp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Verify that attempting to run a workplan with runtime variables that are
     not declared by the workplan results in a failure.
@@ -122,16 +119,7 @@ def test_workplan_run_variable_unknown(
     wp_templates_dir : Path
         Fixture providing the path to a directory containing template workplans
     """
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
-    bp_path.write_text(bp_tpl_path.read_text())
-
-    wp_template = wp_templates_dir / "workplan.yaml"
-    wp_path = tmp_path / "workplan.yaml"
-
-    wp_content = wp_template.read_text()
-    wp_content = wp_content.replace(default_blueprint_path, bp_path.as_posix())
-    wp_path.write_text(wp_content)
+    wp_path = wp_templates_dir / "workplan.yaml"
 
     # template `workplan.yaml` declares: `runtime_vars: [var1, var2]`
     runtime_vars = ["--var", "undeclared=AAA"]
@@ -545,8 +533,6 @@ def test_workplan_run_nonexistent_runid(
 def test_workplan_run_default_run_id(
     tmp_path: Path,
     wp_templates_dir: Path,
-    bp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Verify that attempting to run without a run-id causes a default run-id to be
     reused.
@@ -557,19 +543,9 @@ def test_workplan_run_default_run_id(
         Temporary directory to read/write test inputs and outputs
     wp_templates_dir : Path
         Fixture providing the path to a directory containing template workplans
-    wp_templates_dir : Path
-        Fixture providing the path to a directory containing template blueprints
-    default_blueprint_path : str
-        The default path found in sample blueprints that must be replaced
     """
     state_dir = tmp_path / "state"
-    bp_path = bp_templates_dir / "blueprint.yaml"
-    wp_template = wp_templates_dir / "workplan.yaml"
-    wp_path = tmp_path / "workplan.yml"
-
-    content = wp_template.read_text()
-    content = content.replace(default_blueprint_path, bp_path.as_posix())
-    wp_path.write_text(content)
+    wp_path = wp_templates_dir / "workplan.yaml"
 
     runner = CliRunner()
 
@@ -642,8 +618,6 @@ def test_workplan_run_invalid_file_content(
 async def test_workplan_run_reload_prior_run(
     tmp_path: Path,
     wp_templates_dir: Path,
-    bp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Verify that passing a valid run-id and no path causes the prior run to be loaded.
 
@@ -653,19 +627,9 @@ async def test_workplan_run_reload_prior_run(
         Temporary directory to read/write test inputs and outputs
     wp_templates_dir : Path
         Fixture providing the path to a directory containing template workplans
-    wp_templates_dir : Path
-        Fixture providing the path to a directory containing template blueprints
-    default_blueprint_path : str
-        The default path found in sample blueprints that must be replaced
     """
     state_dir = tmp_path / "state"
-    bp_path = bp_templates_dir / "blueprint.yaml"
-    wp_template = wp_templates_dir / "workplan.yaml"
-    wp_path = tmp_path / "workplan.yml"
-
-    content = wp_template.read_text()
-    content = content.replace(default_blueprint_path, bp_path.as_posix())
-    wp_path.write_text(content)
+    wp_path = wp_templates_dir / "workplan.yaml"
 
     fake_run = WorkplanRun(
         workplan_path=wp_path,
@@ -678,7 +642,7 @@ async def test_workplan_run_reload_prior_run(
     repo = TrackingRepository()
     await repo.put_workplan_run(fake_run)
 
-    def typer_exit(*args, **kwargs) -> None:  # noqa: ANN002, ANN003, ARG001
+    def typer_exit(*args, **kwargs) -> None:  # type: ignore # noqa: ANN002, ANN003, ARG001
         raise typer.Exit(0)
 
     mock_get_wp = mock.Mock(return_value=fake_run)

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -557,10 +557,8 @@ def mock_env(
 @pytest.fixture(params=["fanout", "linear", "parallel", "single_step"])
 def prepared_workplan(
     request: pytest.FixtureRequest,
-    tmp_path: Path,
     wp_templates_dir: Path,
-    default_blueprint_path: str,
-    bp_templates_dir: Path,
+    read_yaml_intercept: None,
 ) -> tuple[Path, Workplan]:
     """Verify that CLI plan action generates an output image from a workplan.
 
@@ -568,28 +566,12 @@ def prepared_workplan(
     ----------
     tmp_path : Path
         Temporary directory for test outputs
-    workplan_name : str
-        The name of a workplan fixture to use for workplan creation
     wp_templates_dir: Path
         Fixture returning the path to the directory containing workplan template files
-    default_blueprint_path : str
-        Fixture returning the default blueprint path contained in template workplans
     """
     workplan_name = request.param
-    template_file = f"{workplan_name}.yaml"  # "single_step.yaml"
-    template_path = wp_templates_dir / template_file
-
-    bp_template_path = bp_templates_dir / "blueprint.yaml"
-    bp_content = bp_template_path.read_text()
-
-    test_bp_path = tmp_path / "blueprint.yaml"
-    test_bp_path.write_text(bp_content)
-
-    content = template_path.read_text()
-    content = content.replace(default_blueprint_path, test_bp_path.as_posix())
-
-    wp_path = tmp_path / template_file
-    wp_path.write_text(content)
+    template_file = f"{workplan_name}.yaml"
+    wp_path = wp_templates_dir / template_file
 
     wp = deserialize(wp_path, Workplan)
 

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -157,28 +157,16 @@ def test_serialization_workplan_happy_path(
     assert workplan.steps[0].compute_overrides["num_nodes"] == 4
 
 
-@pytest.mark.skip(reason="unskip after LiveWorkplan is merged")
+@pytest.mark.usefixtures("read_yaml_intercept")
 def test_serialization_polymorphic_workplan(
     tmp_path: Path,
     wp_templates_dir: Path,
-    bp_templates_dir: Path,
-    default_blueprint_path: str,
 ) -> None:
     """Verify that a workplan serialized with steps of a subclass of `Step` results
     in deserialization to the correct subclass/type.
     """
     template_file = "workplan.yaml"
-    template_path = wp_templates_dir / template_file
-
-    bp_path = tmp_path / "blueprint.yaml"
-    bp_tpl_path = bp_templates_dir / "blueprint.yaml"
-    bp_path.write_text(bp_tpl_path.read_text())
-
-    wp_content = template_path.read_text()
-    wp_content = wp_content.replace(default_blueprint_path, bp_path.as_posix())
-
-    wp_path = tmp_path / template_file
-    wp_path.write_text(wp_content)
+    wp_path = wp_templates_dir / template_file
 
     wp = deserialize(wp_path, Workplan)
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request re-uses the `read_yaml_intercept` fixture to further reduce repetitive modification of template workplans and blueprints within tests.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduced manual input manipulation of blueprints and workplans in tests

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

