### PR TITLE
Add support for registering external apps

### DIFF
--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 import typing as t
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -8,12 +7,14 @@ from itertools import chain
 from pathlib import Path
 
 from cstar.base.adapter import SchemaAdapter
+from cstar.base.env import get_env_item
 from cstar.base.log import get_logger
 from cstar.entrypoint.config import JOBFILE_DATE_FORMAT
 from cstar.execution.file_system import local_copy
 from cstar.execution.handler import ExecutionStatus
 from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import SerializableModel, deserialize
+from cstar.orchestration.utils import ENV_CSTAR_APP_MODULES
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
@@ -375,7 +376,8 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     before lookup so its ``@register_application`` decorators run.
     """
     if name not in _registry:
-        for module in filter(None, os.environ.get("CSTAR_APP_MODULES", "").split(",")):
+        modules = get_env_item(ENV_CSTAR_APP_MODULES).value
+        for module in filter(None, modules.split(",")):
             importlib.import_module(module.strip())
 
     if name not in _registry:

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -376,11 +376,10 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     before lookup so its ``@register_application`` decorators run.
     """
     if name not in _registry:
-        modules = get_env_item(ENV_CSTAR_APP_MODULES).value
-        for module in filter(None, modules.split(",")):
-            importlib.import_module(module.strip())
+        if modules := get_env_item(ENV_CSTAR_APP_MODULES).value:
+            for module in filter(lambda x: name in x, modules.split(",")):
+                importlib.import_module(module.strip())
 
-    if name not in _registry:
         try:
             importlib.import_module(f"cstar.applications.{name}")
         except ModuleNotFoundError:

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -377,13 +377,27 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     """
     if name not in _registry:
         if modules := get_env_item(ENV_CSTAR_APP_MODULES).value:
-            for module in filter(lambda x: name in x, modules.split(",")):
-                importlib.import_module(module.strip())
+            if matches := {m.strip() for m in modules.split(",") if name in m}:
+                if len(matches) > 1:
+                    msg = f"An application name collision may occur using {name!r} for modules {','.join(matches)}"
+                    log.warning(msg)
+
+                module = next(iter(matches))
+
+                try:
+                    importlib.import_module(module)
+                except ModuleNotFoundError:
+                    log.warning(
+                        f"Unable to load external application {name!r} from {module!r}"
+                    )
+                    raise
+
+        module = f"cstar.applications.{name}"
 
         try:
-            importlib.import_module(f"cstar.applications.{name}")
+            importlib.import_module(module)
         except ModuleNotFoundError:
-            pass
+            log.warning(f"Unable to load C-Star application {name!r} from {module!r}")
 
     if application := _registry.get(name):
         log.trace(f"Located application context {application.__name__!r} for {name!r}")

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import typing as t
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -365,9 +366,23 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     ------
     ValueError
         if no registered application is associated with this classification
+
+    Notes
+    -----
+    Applications defined outside the ``cstar.applications`` package can be made
+    discoverable by setting the ``CSTAR_APP_MODULES`` environment variable to a
+    comma-separated list of importable module paths. Each module is imported
+    before lookup so its ``@register_application`` decorators run.
     """
     if name not in _registry:
-        importlib.import_module(f"cstar.applications.{name}")
+        for module in filter(None, os.environ.get("CSTAR_APP_MODULES", "").split(",")):
+            importlib.import_module(module.strip())
+
+    if name not in _registry:
+        try:
+            importlib.import_module(f"cstar.applications.{name}")
+        except ModuleNotFoundError:
+            pass
 
     if application := _registry.get(name):
         log.trace(f"Located application context {application.__name__!r} for {name!r}")

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -17,6 +17,18 @@ ENV_CSTAR_ORCH_DELAYS: t.Annotated[
 ] = "CSTAR_ORCH_DELAYS"
 """Environment variable containing configurable delay for the orchestrator."""
 
+ENV_CSTAR_APP_MODULES: t.Annotated[
+    t.Literal["CSTAR_APP_MODULES"],
+    EnvVar(
+        "A comma-separated list of importable module paths for applications defined "
+        "outside the `cstar.applications` package. Each module is imported before "
+        "application lookup so its `@register_application` decorators run.",
+        _GROUP_ORCH,
+        "",
+    ),
+] = "CSTAR_APP_MODULES"
+"""A comma-separated list of importable module paths for externally-defined applications."""
+
 ENV_CSTAR_ORCH_TRX_FREQ: t.Annotated[
     t.Literal["CSTAR_ORCH_TRX_FREQ"],
     EnvVar(

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -27,7 +27,7 @@ ENV_CSTAR_APP_MODULES: t.Annotated[
         "",
     ),
 ] = "CSTAR_APP_MODULES"
-"""A comma-separated list of importable module paths for externally-defined applications."""
+"""A comma-separated list of package names where external applications are defined."""
 
 ENV_CSTAR_ORCH_TRX_FREQ: t.Annotated[
     t.Literal["CSTAR_ORCH_TRX_FREQ"],

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -1,11 +1,78 @@
 # ruff: noqa: S101
+import textwrap
 from pathlib import Path
 
 import pytest
 
-from cstar.applications.core import RunnerRequest, RunnerResult, RunnerState
+from cstar.applications.core import (
+    RunnerRequest,
+    RunnerResult,
+    RunnerState,
+    _registry,
+    get_application,
+)
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
 from cstar.execution.handler import ExecutionStatus
+
+
+def test_get_application_unknown_name_raises_value_error() -> None:
+    """Verify that an unregistered application name raises ValueError."""
+    with pytest.raises(ValueError, match="No application for"):
+        get_application("no_such_application")
+
+
+def test_get_application_from_external_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that applications defined outside `cstar.applications` are discovered
+    via the CSTAR_APP_MODULES environment variable.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs. Used to create the
+        external application module.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to set the environment variable and import path.
+    """
+    app_name = "external_test_app"
+    module = tmp_path / f"{app_name}_module.py"
+    module.write_text(
+        textwrap.dedent(
+            f"""
+            from cstar.applications.core import (
+                ApplicationDefinition,
+                register_application,
+            )
+            from cstar.applications.hello_world import (
+                HelloWorldBlueprint,
+                HelloWorldRunner,
+            )
+
+
+            @register_application
+            class ExternalApplication(
+                ApplicationDefinition[HelloWorldBlueprint, HelloWorldRunner]
+            ):
+                name: str = "{app_name}"
+                long_name: str = "Externally Defined App"
+                runner = HelloWorldRunner
+                blueprint = HelloWorldBlueprint
+                applicable_transforms = ()
+            """
+        )
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("CSTAR_APP_MODULES", f"{app_name}_module")
+
+    try:
+        app = get_application(app_name)
+        assert app.name == app_name
+        assert app.blueprint.__name__ == "HelloWorldBlueprint"
+    finally:
+        _registry.pop(app_name, None)
 
 
 def test_runnerresult_initial_state(tmp_path: Path) -> None:

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -72,7 +72,7 @@ def test_get_application_from_external_module(
     )
 
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.setenv("CSTAR_APP_MODULES", f"{app_name}_module")
+    monkeypatch.setenv(ENV_CSTAR_APP_MODULES, f"{app_name}_module")
 
     try:
         app = get_application(app_name)

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -12,13 +12,20 @@ from cstar.applications.core import (
     get_application,
 )
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
+from cstar.base.env import discover_env_vars
 from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.utils import ENV_CSTAR_APP_MODULES
 
 
 def test_get_application_unknown_name_raises_value_error() -> None:
     """Verify that an unregistered application name raises ValueError."""
     with pytest.raises(ValueError, match="No application for"):
         get_application("no_such_application")
+
+
+def test_app_modules_env_var_is_registered() -> None:
+    """Verify that CSTAR_APP_MODULES is discoverable for CLI display and docs."""
+    assert ENV_CSTAR_APP_MODULES in discover_env_vars()
 
 
 def test_get_application_from_external_module(


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This feature is currently needed to for some in-development work in Forge.

## New Features
<!-- List any new capabilities added -->
- Add support for registration of external apps via the CSTAR_APP_MODULES env-var


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

