### PR TITLE
Support external apps via entrypoints

### DIFF
--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -20,7 +20,15 @@ if t.TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
 
 APP_PLUGIN_GROUP: t.Final[str] = "cstar.applications"
-"""Entry-point group third-party packages use to register applications."""
+"""Entry-point group third-party packages use to register applications.
+
+A published packaging contract: installed plugins name this group in their own
+``pyproject.toml``, so it must not change when the package layout does. It
+coincides with :data:`BUILTIN_APP_PACKAGE` today only by convention.
+"""
+
+BUILTIN_APP_PACKAGE: t.Final[str] = "cstar.applications"
+"""Package holding the in-tree application modules, one per application name."""
 
 log = get_logger(__name__)
 
@@ -358,7 +366,7 @@ def register_application(
 
 
 def _load_builtin_application(name: str) -> None:
-    """Import the in-tree ``cstar.applications.{name}`` module, if it exists.
+    """Import the in-tree ``{BUILTIN_APP_PACKAGE}.{name}`` module, if it exists.
 
     Parameters
     ----------
@@ -372,7 +380,7 @@ def _load_builtin_application(name: str) -> None:
     import *is* an error: the ``ImportError`` propagates rather than being
     reported as a missing application.
     """
-    module = f"cstar.applications.{name}"
+    module = f"{BUILTIN_APP_PACKAGE}.{name}"
 
     if importlib.util.find_spec(module) is None:
         log.trace(f"No built-in application module {module!r} for {name!r}")
@@ -421,8 +429,8 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     -----
     Applications are discovered, in order, from:
 
-    1. The in-tree ``cstar.applications.{name}`` module.
-    2. The ``cstar.applications`` entry-point group -- installed third-party
+    1. The in-tree ``{BUILTIN_APP_PACKAGE}.{name}`` module.
+    2. The :data:`APP_PLUGIN_GROUP` entry-point group -- installed third-party
        plugins.
 
     Each step is attempted only while *name* is still unregistered. A plugin

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -392,6 +392,7 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
                     )
                     raise
 
+    if name not in _registry:
         module = f"cstar.applications.{name}"
 
         try:

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -1,24 +1,26 @@
 import importlib
+import importlib.util
 import typing as t
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from importlib.metadata import entry_points
 from itertools import chain
 from pathlib import Path
 
 from cstar.base.adapter import SchemaAdapter
-from cstar.base.env import get_env_item
 from cstar.base.log import get_logger
 from cstar.entrypoint.config import JOBFILE_DATE_FORMAT
 from cstar.execution.file_system import local_copy
 from cstar.execution.handler import ExecutionStatus
 from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import SerializableModel, deserialize
-from cstar.orchestration.utils import ENV_CSTAR_APP_MODULES
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
 
+APP_PLUGIN_GROUP: t.Final[str] = "cstar.applications"
+"""Entry-point group third-party packages use to register applications."""
 
 log = get_logger(__name__)
 
@@ -355,6 +357,42 @@ def register_application(
     return klass
 
 
+def _load_app_entry_point(name: str) -> None:
+    """Load a third-party application via the ``cstar.applications`` entry-point group.
+
+    Parameters
+    ----------
+    name : str
+        The application name being resolved.
+
+    Notes
+    -----
+    Skipped entirely when an in-tree module ``cstar.applications.{name}``
+    exists, so an installed plugin can never shadow a built-in application;
+    the in-tree import handles that case instead.
+    """
+    if importlib.util.find_spec(f"cstar.applications.{name}") is not None:
+        for ep in entry_points(group=APP_PLUGIN_GROUP):
+            if ep.name == name:
+                log.warning(
+                    f"Ignoring application plugin {name!r} ({ep.value!r}): a "
+                    "built-in application with this name already exists"
+                )
+        return
+
+    for ep in entry_points(group=APP_PLUGIN_GROUP):
+        if ep.name != name:
+            continue
+
+        try:
+            ep.load()
+        except Exception:
+            log.warning(f"Unable to load application plugin {name!r} from {ep.value!r}")
+
+        if name in _registry:
+            return
+
+
 def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     """Get an application from the application registry.
 
@@ -370,27 +408,19 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
 
     Notes
     -----
-    Applications defined outside the ``cstar.applications`` package can be made
-    discoverable by setting the ``CSTAR_APP_MODULES`` environment variable to a
-    comma-separated list of importable module paths. Each module is imported
-    before lookup so its ``@register_application`` decorators run.
+    Applications are discovered, in order, from:
+
+    1. The ``cstar.applications`` entry-point group -- installed third-party
+       plugins. A plugin can never shadow a built-in application: if an
+       in-tree module ``cstar.applications.{name}`` exists, the entry-point
+       is skipped (with a warning) and step 2 is used instead.
+    2. The in-tree ``cstar.applications.{name}`` module.
+
+    Each step is attempted only while *name* is still unregistered, so a
+    successful earlier step never triggers the warnings of a later one.
     """
     if name not in _registry:
-        if modules := get_env_item(ENV_CSTAR_APP_MODULES).value:
-            if matches := {m.strip() for m in modules.split(",") if name in m}:
-                if len(matches) > 1:
-                    msg = f"An application name collision may occur using {name!r} for modules {','.join(matches)}"
-                    log.warning(msg)
-
-                module = next(iter(matches))
-
-                try:
-                    importlib.import_module(module)
-                except ModuleNotFoundError:
-                    log.warning(
-                        f"Unable to load external application {name!r} from {module!r}"
-                    )
-                    raise
+        _load_app_entry_point(name)
 
     if name not in _registry:
         module = f"cstar.applications.{name}"

--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -357,6 +357,30 @@ def register_application(
     return klass
 
 
+def _load_builtin_application(name: str) -> None:
+    """Import the in-tree ``cstar.applications.{name}`` module, if it exists.
+
+    Parameters
+    ----------
+    name : str
+        The application name being resolved.
+
+    Notes
+    -----
+    A missing module is not an error -- the name may belong to an installed
+    plugin, which the caller tries next. A module that exists but fails to
+    import *is* an error: the ``ImportError`` propagates rather than being
+    reported as a missing application.
+    """
+    module = f"cstar.applications.{name}"
+
+    if importlib.util.find_spec(module) is None:
+        log.trace(f"No built-in application module {module!r} for {name!r}")
+        return
+
+    importlib.import_module(module)
+
+
 def _load_app_entry_point(name: str) -> None:
     """Load a third-party application via the ``cstar.applications`` entry-point group.
 
@@ -367,23 +391,10 @@ def _load_app_entry_point(name: str) -> None:
 
     Notes
     -----
-    Skipped entirely when an in-tree module ``cstar.applications.{name}``
-    exists, so an installed plugin can never shadow a built-in application;
-    the in-tree import handles that case instead.
+    Reached only once the in-tree lookup has come up empty, so an installed
+    plugin can never shadow a built-in application.
     """
-    if importlib.util.find_spec(f"cstar.applications.{name}") is not None:
-        for ep in entry_points(group=APP_PLUGIN_GROUP):
-            if ep.name == name:
-                log.warning(
-                    f"Ignoring application plugin {name!r} ({ep.value!r}): a "
-                    "built-in application with this name already exists"
-                )
-        return
-
-    for ep in entry_points(group=APP_PLUGIN_GROUP):
-        if ep.name != name:
-            continue
-
+    for ep in entry_points(group=APP_PLUGIN_GROUP, name=name):
         try:
             ep.load()
         except Exception:
@@ -410,25 +421,19 @@ def get_application(name: str) -> ApplicationDefinition[t.Any, t.Any]:
     -----
     Applications are discovered, in order, from:
 
-    1. The ``cstar.applications`` entry-point group -- installed third-party
-       plugins. A plugin can never shadow a built-in application: if an
-       in-tree module ``cstar.applications.{name}`` exists, the entry-point
-       is skipped (with a warning) and step 2 is used instead.
-    2. The in-tree ``cstar.applications.{name}`` module.
+    1. The in-tree ``cstar.applications.{name}`` module.
+    2. The ``cstar.applications`` entry-point group -- installed third-party
+       plugins.
 
-    Each step is attempted only while *name* is still unregistered, so a
-    successful earlier step never triggers the warnings of a later one.
+    Each step is attempted only while *name* is still unregistered. A plugin
+    therefore can never shadow a built-in application: a name that resolves in
+    step 1 never reaches step 2, and the plugin claiming it is never imported.
     """
     if name not in _registry:
-        _load_app_entry_point(name)
+        _load_builtin_application(name)
 
     if name not in _registry:
-        module = f"cstar.applications.{name}"
-
-        try:
-            importlib.import_module(module)
-        except ModuleNotFoundError:
-            log.warning(f"Unable to load C-Star application {name!r} from {module!r}")
+        _load_app_entry_point(name)
 
     if application := _registry.get(name):
         log.trace(f"Located application context {application.__name__!r} for {name!r}")

--- a/cstar/orchestration/utils.py
+++ b/cstar/orchestration/utils.py
@@ -17,18 +17,6 @@ ENV_CSTAR_ORCH_DELAYS: t.Annotated[
 ] = "CSTAR_ORCH_DELAYS"
 """Environment variable containing configurable delay for the orchestrator."""
 
-ENV_CSTAR_APP_MODULES: t.Annotated[
-    t.Literal["CSTAR_APP_MODULES"],
-    EnvVar(
-        "A comma-separated list of importable module paths for applications defined "
-        "outside the `cstar.applications` package. Each module is imported before "
-        "application lookup so its `@register_application` decorators run.",
-        _GROUP_ORCH,
-        "",
-    ),
-] = "CSTAR_APP_MODULES"
-"""A comma-separated list of package names where external applications are defined."""
-
 ENV_CSTAR_ORCH_TRX_FREQ: t.Annotated[
     t.Literal["CSTAR_ORCH_TRX_FREQ"],
     EnvVar(

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -82,6 +82,65 @@ def test_get_application_from_external_module(
         _registry.pop(app_name, None)
 
 
+def test_get_application_from_external_module_does_not_warn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify that resolving an application registered via CSTAR_APP_MODULES
+    does not also attempt (and warn about) the in-tree ``cstar.applications``
+    import, now that the name is already present in the registry.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture for writing per-test outputs. Used to create the
+        external application module.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to set the environment variable and import path.
+    caplog : pytest.LogCaptureFixture
+        Fixture used to assert no spurious "Unable to load" warning is logged.
+    """
+    app_name = "external_test_app_no_warn"
+    module = tmp_path / f"{app_name}_module.py"
+    module.write_text(
+        textwrap.dedent(
+            f"""
+            from cstar.applications.core import (
+                ApplicationDefinition,
+                register_application,
+            )
+            from cstar.applications.hello_world import (
+                HelloWorldBlueprint,
+                HelloWorldRunner,
+            )
+
+
+            @register_application
+            class ExternalApplication(
+                ApplicationDefinition[HelloWorldBlueprint, HelloWorldRunner]
+            ):
+                name: str = "{app_name}"
+                long_name: str = "Externally Defined App"
+                runner = HelloWorldRunner
+                blueprint = HelloWorldBlueprint
+                applicable_transforms = ()
+            """
+        )
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv(ENV_CSTAR_APP_MODULES, f"{app_name}_module")
+
+    try:
+        with caplog.at_level("WARNING"):
+            app = get_application(app_name)
+        assert app.name == app_name
+        assert "Unable to load C-Star application" not in caplog.text
+    finally:
+        _registry.pop(app_name, None)
+
+
 def test_runnerresult_initial_state(tmp_path: Path) -> None:
     """Verify that the RunnerResult returns the initial status, as expected."""
     fake_bp_path = tmp_path / "fake.yaml"

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -1,10 +1,12 @@
 # ruff: noqa: S101
 import textwrap
+from importlib.metadata import EntryPoint
 from pathlib import Path
 
 import pytest
 
 from cstar.applications.core import (
+    APP_PLUGIN_GROUP,
     RunnerRequest,
     RunnerResult,
     RunnerState,
@@ -12,9 +14,79 @@ from cstar.applications.core import (
     get_application,
 )
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
-from cstar.base.env import discover_env_vars
 from cstar.execution.handler import ExecutionStatus
-from cstar.orchestration.utils import ENV_CSTAR_APP_MODULES
+
+
+def _external_app_module_source(app_name: str) -> str:
+    """Return source for a throwaway module that registers a HelloWorld-based
+    application under *app_name* when imported.
+
+    Parameters
+    ----------
+    app_name : str
+        The unique application name the module will register.
+
+    Returns
+    -------
+    str
+    """
+    return textwrap.dedent(
+        f"""
+        from cstar.applications.core import (
+            ApplicationDefinition,
+            register_application,
+        )
+        from cstar.applications.hello_world import (
+            HelloWorldBlueprint,
+            HelloWorldRunner,
+        )
+
+
+        @register_application
+        class ExternalApplication(
+            ApplicationDefinition[HelloWorldBlueprint, HelloWorldRunner]
+        ):
+            name: str = "{app_name}"
+            long_name: str = "Externally Defined App"
+            runner = HelloWorldRunner
+            blueprint = HelloWorldBlueprint
+            applicable_transforms = ()
+        """
+    )
+
+
+def _write_dist_info(
+    tmp_path: Path,
+    dist_name: str,
+    version: str,
+    entry_name: str,
+    module: str,
+) -> None:
+    """Write a minimal ``*.dist-info`` directory so ``importlib.metadata``
+    discovers a ``cstar.applications`` entry point pointing at *module*.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Directory (expected to already be on ``sys.path``) in which to create
+        the dist-info directory.
+    dist_name : str
+        The distribution name used for the dist-info directory and METADATA.
+    version : str
+        The distribution version used for the dist-info directory and METADATA.
+    entry_name : str
+        The entry point name (the application name it will register under).
+    module : str
+        The importable module path the entry point resolves to.
+    """
+    dist_info = tmp_path / f"{dist_name}-{version}.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist_name}\nVersion: {version}\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        f"[{APP_PLUGIN_GROUP}]\n{entry_name} = {module}\n"
+    )
 
 
 def test_get_application_unknown_name_raises_value_error() -> None:
@@ -23,56 +95,28 @@ def test_get_application_unknown_name_raises_value_error() -> None:
         get_application("no_such_application")
 
 
-def test_app_modules_env_var_is_registered() -> None:
-    """Verify that CSTAR_APP_MODULES is discoverable for CLI display and docs."""
-    assert ENV_CSTAR_APP_MODULES in discover_env_vars()
-
-
-def test_get_application_from_external_module(
+def test_get_application_via_installed_entry_point(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verify that applications defined outside `cstar.applications` are discovered
-    via the CSTAR_APP_MODULES environment variable.
+    """Verify that applications registered via the ``cstar.applications``
+    entry-point group are discovered through real ``importlib.metadata``
+    dist-info discovery.
 
     Parameters
     ----------
     tmp_path : Path
-        Temporary path fixture for writing per-test outputs. Used to create the
-        external application module.
+        Temporary path fixture used to host both the module and a dist-info
+        directory so it is discoverable via ``sys.path``.
     monkeypatch : pytest.MonkeyPatch
-        Fixture used to set the environment variable and import path.
+        Fixture used to set the import path.
     """
-    app_name = "external_test_app"
-    module = tmp_path / f"{app_name}_module.py"
-    module.write_text(
-        textwrap.dedent(
-            f"""
-            from cstar.applications.core import (
-                ApplicationDefinition,
-                register_application,
-            )
-            from cstar.applications.hello_world import (
-                HelloWorldBlueprint,
-                HelloWorldRunner,
-            )
-
-
-            @register_application
-            class ExternalApplication(
-                ApplicationDefinition[HelloWorldBlueprint, HelloWorldRunner]
-            ):
-                name: str = "{app_name}"
-                long_name: str = "Externally Defined App"
-                runner = HelloWorldRunner
-                blueprint = HelloWorldBlueprint
-                applicable_transforms = ()
-            """
-        )
-    )
+    app_name = "entrypoint_disco_app"
+    module = f"{app_name}_module"
+    (tmp_path / f"{module}.py").write_text(_external_app_module_source(app_name))
+    _write_dist_info(tmp_path, app_name, "1.0.0", app_name, module)
 
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.setenv(ENV_CSTAR_APP_MODULES, f"{app_name}_module")
 
     try:
         app = get_application(app_name)
@@ -82,61 +126,140 @@ def test_get_application_from_external_module(
         _registry.pop(app_name, None)
 
 
-def test_get_application_from_external_module_does_not_warn(
+def test_get_application_via_entry_point_does_not_warn(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Verify that resolving an application registered via CSTAR_APP_MODULES
-    does not also attempt (and warn about) the in-tree ``cstar.applications``
-    import, now that the name is already present in the registry.
+    """Verify that resolving an application registered via the
+    ``cstar.applications`` entry-point group does not also attempt (and warn
+    about) the in-tree ``cstar.applications`` import.
 
     Parameters
     ----------
     tmp_path : Path
-        Temporary path fixture for writing per-test outputs. Used to create the
-        external application module.
+        Temporary path fixture used to host both the module and a dist-info
+        directory so it is discoverable via ``sys.path``.
     monkeypatch : pytest.MonkeyPatch
-        Fixture used to set the environment variable and import path.
+        Fixture used to set the import path.
     caplog : pytest.LogCaptureFixture
         Fixture used to assert no spurious "Unable to load" warning is logged.
     """
-    app_name = "external_test_app_no_warn"
-    module = tmp_path / f"{app_name}_module.py"
-    module.write_text(
-        textwrap.dedent(
-            f"""
-            from cstar.applications.core import (
-                ApplicationDefinition,
-                register_application,
-            )
-            from cstar.applications.hello_world import (
-                HelloWorldBlueprint,
-                HelloWorldRunner,
-            )
-
-
-            @register_application
-            class ExternalApplication(
-                ApplicationDefinition[HelloWorldBlueprint, HelloWorldRunner]
-            ):
-                name: str = "{app_name}"
-                long_name: str = "Externally Defined App"
-                runner = HelloWorldRunner
-                blueprint = HelloWorldBlueprint
-                applicable_transforms = ()
-            """
-        )
-    )
+    app_name = "entrypoint_disco_app_no_warn"
+    module = f"{app_name}_module"
+    (tmp_path / f"{module}.py").write_text(_external_app_module_source(app_name))
+    _write_dist_info(tmp_path, app_name, "1.0.0", app_name, module)
 
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.setenv(ENV_CSTAR_APP_MODULES, f"{app_name}_module")
 
     try:
         with caplog.at_level("WARNING"):
             app = get_application(app_name)
         assert app.name == app_name
         assert "Unable to load C-Star application" not in caplog.text
+    finally:
+        _registry.pop(app_name, None)
+
+
+def test_entry_point_cannot_shadow_builtin_application(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that an entry point named after a built-in application (e.g.
+    ``hello_world``) never replaces the built-in: the resolved application
+    must be the real, in-tree class, not the decoy the entry point points at.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to stub out ``entry_points`` with a decoy claiming the
+        built-in's name.
+    """
+    decoy = EntryPoint(
+        name="hello_world",
+        value="some.decoy.module:DecoyApplication",
+        group=APP_PLUGIN_GROUP,
+    )
+    monkeypatch.setattr(
+        "cstar.applications.core.entry_points",
+        lambda group=None: [decoy],
+    )
+
+    app = get_application("hello_world")
+
+    assert app.name == "hello_world"
+    assert app.blueprint.__name__ == "HelloWorldBlueprint"
+
+
+def test_get_application_broken_entry_point_does_not_abort_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify that an entry-point module which raises on import is skipped
+    (with a warning) rather than aborting resolution, and that resolution
+    still ends in the normal ``ValueError`` when nothing else registers the
+    application.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture used to host both the module and a dist-info
+        directory so it is discoverable via ``sys.path``.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to set the import path.
+    caplog : pytest.LogCaptureFixture
+        Fixture used to assert the expected warning is logged.
+    """
+    app_name = "broken_entry_point_app"
+    module = f"{app_name}_module"
+    (tmp_path / f"{module}.py").write_text(
+        'raise RuntimeError("this module cannot be imported")\n'
+    )
+    _write_dist_info(tmp_path, app_name, "1.0.0", app_name, module)
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        with caplog.at_level("WARNING"):
+            with pytest.raises(ValueError, match="No application for"):
+                get_application(app_name)
+        assert (
+            f"Unable to load application plugin {app_name!r} from {module!r}"
+            in caplog.text
+        )
+    finally:
+        _registry.pop(app_name, None)
+
+
+def test_get_application_entry_point_registers_nothing_raises_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that an entry point which imports successfully but does not
+    register the requested application name still ends resolution in the
+    normal ``ValueError``, rather than silently succeeding with a wrong
+    answer.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary path fixture used to host both the module and a dist-info
+        directory so it is discoverable via ``sys.path``.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to set the import path.
+    """
+    app_name = "empty_entry_point_app"
+    module = f"{app_name}_module"
+    (tmp_path / f"{module}.py").write_text(
+        "# importable module that registers no application\n"
+    )
+    _write_dist_info(tmp_path, app_name, "1.0.0", app_name, module)
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        with pytest.raises(ValueError, match="No application for"):
+            get_application(app_name)
     finally:
         _registry.pop(app_name, None)
 

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -1,6 +1,6 @@
 # ruff: noqa: S101
+import sys
 import textwrap
-from importlib.metadata import EntryPoint
 from pathlib import Path
 
 import pytest
@@ -162,32 +162,51 @@ def test_get_application_via_entry_point_does_not_warn(
 
 
 def test_entry_point_cannot_shadow_builtin_application(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify that an entry point named after a built-in application (e.g.
     ``hello_world``) never replaces the built-in: the resolved application
-    must be the real, in-tree class, not the decoy the entry point points at.
+    must be the real, in-tree class, and the decoy module must never even be
+    imported.
+
+    The decoy is a real, importable module that *would* register itself under
+    the built-in's name, so this fails if built-in precedence ever regresses.
 
     Parameters
     ----------
+    tmp_path : Path
+        Temporary path fixture used to host both the decoy module and a
+        dist-info directory so it is discoverable via ``sys.path``.
     monkeypatch : pytest.MonkeyPatch
-        Fixture used to stub out ``entry_points`` with a decoy claiming the
-        built-in's name.
+        Fixture used to set the import path.
     """
-    decoy = EntryPoint(
-        name="hello_world",
-        value="some.decoy.module:DecoyApplication",
-        group=APP_PLUGIN_GROUP,
-    )
-    monkeypatch.setattr(
-        "cstar.applications.core.entry_points",
-        lambda group=None: [decoy],
-    )
+    app_name = "hello_world"
+    module = "shadow_decoy_module"
+    (tmp_path / f"{module}.py").write_text(_external_app_module_source(app_name))
+    _write_dist_info(tmp_path, "shadow-decoy", "1.0.0", app_name, module)
 
-    app = get_application("hello_world")
+    monkeypatch.syspath_prepend(str(tmp_path))
 
-    assert app.name == "hello_world"
-    assert app.blueprint.__name__ == "HelloWorldBlueprint"
+    # Force resolution through the loaders rather than a registry hit left
+    # behind by an earlier test, and drop the cached module so the in-tree
+    # import actually re-runs its @register_application decorator.
+    registered = _registry.pop(app_name, None)
+    builtin = sys.modules.pop(f"cstar.applications.{app_name}", None)
+
+    try:
+        app = get_application(app_name)
+
+        assert app.long_name != "Externally Defined App"
+        assert app.blueprint.__name__ == "HelloWorldBlueprint"
+        assert module not in sys.modules
+    finally:
+        if builtin is not None:
+            sys.modules[f"cstar.applications.{app_name}"] = builtin
+        if registered is not None:
+            _registry[app_name] = registered
+        else:
+            _registry.pop(app_name, None)
 
 
 def test_get_application_broken_entry_point_does_not_abort_resolution(
@@ -262,6 +281,33 @@ def test_get_application_entry_point_registers_nothing_raises_value_error(
             get_application(app_name)
     finally:
         _registry.pop(app_name, None)
+
+
+def test_broken_builtin_application_propagates_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that an in-tree application module which exists but fails to
+    import surfaces the real ``ImportError`` rather than being reported as a
+    missing application.
+
+    ``find_spec`` is stubbed so the module appears to exist; the subsequent
+    ``import_module`` then fails for real, standing in for an in-tree
+    application whose own imports are broken.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to stub out ``find_spec``.
+    """
+    app_name = "broken_builtin_app"
+
+    monkeypatch.setattr(
+        "cstar.applications.core.importlib.util.find_spec",
+        lambda target: object() if target == f"cstar.applications.{app_name}" else None,
+    )
+
+    with pytest.raises(ModuleNotFoundError, match=app_name):
+        get_application(app_name)
 
 
 def test_runnerresult_initial_state(tmp_path: Path) -> None:

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -7,6 +7,7 @@ import pytest
 
 from cstar.applications.core import (
     APP_PLUGIN_GROUP,
+    BUILTIN_APP_PACKAGE,
     RunnerRequest,
     RunnerResult,
     RunnerState,
@@ -192,7 +193,7 @@ def test_entry_point_cannot_shadow_builtin_application(
     # behind by an earlier test, and drop the cached module so the in-tree
     # import actually re-runs its @register_application decorator.
     registered = _registry.pop(app_name, None)
-    builtin = sys.modules.pop(f"cstar.applications.{app_name}", None)
+    builtin = sys.modules.pop(f"{BUILTIN_APP_PACKAGE}.{app_name}", None)
 
     try:
         app = get_application(app_name)
@@ -202,7 +203,7 @@ def test_entry_point_cannot_shadow_builtin_application(
         assert module not in sys.modules
     finally:
         if builtin is not None:
-            sys.modules[f"cstar.applications.{app_name}"] = builtin
+            sys.modules[f"{BUILTIN_APP_PACKAGE}.{app_name}"] = builtin
         if registered is not None:
             _registry[app_name] = registered
         else:
@@ -303,7 +304,9 @@ def test_broken_builtin_application_propagates_import_error(
 
     monkeypatch.setattr(
         "cstar.applications.core.importlib.util.find_spec",
-        lambda target: object() if target == f"cstar.applications.{app_name}" else None,
+        lambda target: (
+            object() if target == f"{BUILTIN_APP_PACKAGE}.{app_name}" else None
+        ),
     )
 
     with pytest.raises(ModuleNotFoundError, match=app_name):

--- a/docs/custom_applications.rst
+++ b/docs/custom_applications.rst
@@ -186,3 +186,38 @@ We have finally reached the point where we can execute the application using the
 
    > cstar blueprint run notify-scott.yaml
    Hello, @scott
+
+Making Your Application Discoverable
+------------------------------------
+
+The example above assumes ``HelloWorldApplication`` has already been imported (and
+therefore registered) by the time the CLI runs. Applications defined outside the
+``cstar.applications`` package need an explicit discovery mechanism so their
+``@register_application`` decorator actually runs.
+
+Declare a ``cstar.applications`` entry point pointing at the module containing
+your ``@register_application``-decorated class, e.g. in ``pyproject.toml``:
+
+.. code-block:: toml
+   :caption: Registering an application as an installed plugin
+
+   [project.entry-points."cstar.applications"]
+   my_app = "my_package.my_app"
+
+The entry-point name must be the application's ``name`` -- the same value your
+blueprints carry in their ``application`` field. *C-Star* imports that module
+(and only that module -- the entry point's return value is unused) the first
+time an application by that name is requested.
+
+Choose a name no built-in already uses. A plugin can never shadow a built-in
+application: if ``cstar.applications`` already defines a module with that name,
+the plugin is skipped (with a warning) and the built-in is used instead. Note
+that this tutorial's own ``hello_world`` is one such name, so an installed
+plugin could not claim it.
+
+The entry-point group is the only mechanism *C-Star* uses to discover
+applications defined outside ``cstar.applications``. For local development --
+e.g. iterating on an application in a worktree before it is published -- install
+your package in editable mode (``pip install -e .``) so its entry points are
+visible without a real release; re-running the install after editing
+``pyproject.toml`` is enough to pick up a changed or added entry point.

--- a/docs/custom_applications.rst
+++ b/docs/custom_applications.rst
@@ -190,10 +190,7 @@ We have finally reached the point where we can execute the application using the
 Making Your Application Discoverable
 ------------------------------------
 
-The example above assumes ``HelloWorldApplication`` has already been imported (and
-therefore registered) by the time the CLI runs. Applications defined outside the
-``cstar.applications`` package need an explicit discovery mechanism so their
-``@register_application`` decorator actually runs.
+C-Star automatically loads internal applications as-needed and makes use of python's ``entrypoints`` functionality to discover external applications.
 
 Declare a ``cstar.applications`` entry point pointing at the module containing
 your ``@register_application``-decorated class, e.g. in ``pyproject.toml``:

--- a/docs/custom_applications.rst
+++ b/docs/custom_applications.rst
@@ -209,15 +209,9 @@ blueprints carry in their ``application`` field. *C-Star* imports that module
 (and only that module -- the entry point's return value is unused) the first
 time an application by that name is requested.
 
-Choose a name no built-in already uses. A plugin can never shadow a built-in
-application: if ``cstar.applications`` already defines a module with that name,
-the plugin is skipped (with a warning) and the built-in is used instead. Note
-that this tutorial's own ``hello_world`` is one such name, so an installed
-plugin could not claim it.
-
-The entry-point group is the only mechanism *C-Star* uses to discover
-applications defined outside ``cstar.applications``. For local development --
-e.g. iterating on an application in a worktree before it is published -- install
-your package in editable mode (``pip install -e .``) so its entry points are
-visible without a real release; re-running the install after editing
-``pyproject.toml`` is enough to pick up a changed or added entry point.
+Choose a name no built-in already uses. *C-Star* resolves the in-tree
+``cstar.applications`` module first and only consults entry points when that
+comes up empty, so a plugin can never shadow a built-in application: if
+``cstar.applications`` already defines a module with that name, your plugin is
+silently never imported. Note that this tutorial's own ``hello_world`` is one
+such name, so an installed plugin could not claim it.


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR removes previous functionality supporting external apps via env-var, and instead utilizes the same entry-points approach as the recent CLI change.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Specifying external apps via `CSTAR_APP_MODULES` is no longer valid; use entry-point approach instead

## New Features
<!-- List any new capabilities added -->
- External apps can now be registered via entry-points

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

