### PR TITLE
Change child boundary output path

### DIFF
--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -792,9 +792,12 @@ class ROMSSimulation(Simulation):
 
         # Relative to the run directory, like output_root_name above, so ROMS
         # writes child extraction files to the output directory rather than its
-        # working directory. Must stay short: ucla-roms builds the extraction
-        # filename in a fixed character(len=99) buffer (create_edata_file in
-        # extract_data.F90), so an absolute path could silently truncate.
+        # working directory. Only PARALLEL_IO builds honor extract_root_name;
+        # non-PIO builds name extraction files from output_root_name (already
+        # pointing at the output directory). Must stay short: ucla-roms builds
+        # the extraction filename in a fixed character(len=99) buffer
+        # (create_edata_file in extract_data.F90), so an absolute path could
+        # silently truncate.
         nml.extract_data_settings.extract_root_name = "../output/child"
 
         return nml

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -788,16 +788,14 @@ class ROMSSimulation(Simulation):
                 self.nesting_info.working_copy.path  # type: ignore[union-attr]
             )
 
+        # These next values must stay short: ucla-roms builds
+        # the extraction filename in a fixed character(len=99) buffer
+        # so an absolute path could silently truncate.
         nml.simulation_name_settings.output_root_name = "../output/output"
 
-        # Relative to the run directory, like output_root_name above, so ROMS
-        # writes child extraction files to the output directory rather than its
-        # working directory. Only PARALLEL_IO builds honor extract_root_name;
+        # Note: only PARALLEL_IO builds honor extract_root_name;
         # non-PIO builds name extraction files from output_root_name (already
-        # pointing at the output directory). Must stay short: ucla-roms builds
-        # the extraction filename in a fixed character(len=99) buffer
-        # (create_edata_file in extract_data.F90), so an absolute path could
-        # silently truncate.
+        # pointing at the output directory).
         nml.extract_data_settings.extract_root_name = "../output/child"
 
         return nml

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -727,7 +727,7 @@ class ROMSSimulation(Simulation):
         :class:`~cstar.roms.namelist.RomsNamelist`, and overrides key parameters
         based on the current simulation configuration: time step, number of time
         steps, grid path, initial conditions, forcing datasets, MARBL/CDR/nesting
-        files, and output root.
+        files, output root, and extract root.
 
         Returns
         -------
@@ -789,6 +789,13 @@ class ROMSSimulation(Simulation):
             )
 
         nml.simulation_name_settings.output_root_name = "../output/output"
+
+        # Relative to the run directory, like output_root_name above, so ROMS
+        # writes child extraction files to the output directory rather than its
+        # working directory. Must stay short: ucla-roms builds the extraction
+        # filename in a fixed character(len=99) buffer (create_edata_file in
+        # extract_data.F90), so an absolute path could silently truncate.
+        nml.extract_data_settings.extract_root_name = "../output/child"
 
         return nml
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -474,10 +474,15 @@ class TestROMSSimulationInitialization:
         result_no_cdr = sim.roms_runtime_settings
         assert result_no_cdr.cdr_frc_settings.cdr_file == "cdr.nc"
 
-        # Test with no nesting info — extract_file keeps the namelist's value
+        # Test with no nesting info — extract_file keeps the namelist's value,
+        # but extract_root_name is still overridden (it is set unconditionally)
         sim.nesting_info = None
         result_no_nesting = sim.roms_runtime_settings
         assert result_no_nesting.extract_data_settings.extract_file == "sample_edata.nc"
+        assert (
+            result_no_nesting.extract_data_settings.extract_root_name
+            == "../output/child"
+        )
 
     def test_roms_runtime_settings_raises_if_no_runtime_code_working_copy(
         self, stub_romssimulation

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -448,6 +448,9 @@ class TestROMSSimulationInitialization:
         assert tested_settings.extract_data_settings.extract_file == str(
             fake_nesting_path
         )
+        assert (
+            tested_settings.extract_data_settings.extract_root_name == "../output/child"
+        )
 
         # Test with no MARBL files — marbl_config_file keeps the namelist's value
         sim.runtime_code = additionalcode_local(


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- PIO-enabled builds now output extracted child boundaries in the `output` directory instead of the `work` directory
 
## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

