### PR TITLE
Fix tests breaking on hpc

### DIFF
--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -22,7 +22,12 @@ from cstar.orchestration.orchestration import (
     Status,
 )
 from cstar.orchestration.serialization import deserialize
-from cstar.orchestration.transforms import WorkplanTransformer, get_time_slices
+from cstar.orchestration.transforms import (
+    SplitFrequency,
+    WorkplanTransformer,
+    get_time_slices,
+)
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_TRX_FREQ
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -318,6 +323,7 @@ def test_workplan_transformation(diamond_workplan: Workplan) -> None:
             {
                 ENV_CSTAR_RUNID: str(uuid.uuid4()),
                 ENV_FF_ORCH_TRX_TIMESPLIT: FLAG_ON,
+                ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
             },
         ),
     ):

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -14,9 +14,11 @@ from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME
 from cstar.orchestration.models import Application, Step, Workplan
 from cstar.orchestration.orchestration import LiveStep
 from cstar.orchestration.transforms import (
+    SplitFrequency,
     get_time_slices,
     get_transforms,
 )
+from cstar.orchestration.utils import ENV_CSTAR_ORCH_TRX_FREQ
 
 N_MONTHS: t.Final[int] = 12
 
@@ -80,8 +82,6 @@ def test_sleep_transform_registry(application: str) -> None:
 
 def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
     """Verify the splitter returns the expected steps for a given time range."""
-    transform = RomsMarblTimeSplitter()
-
     original_step = LiveStep.from_step(single_step_workplan.steps[0])
 
     # mock data home to ensure test works on HPC if scratch directories are identified
@@ -92,9 +92,12 @@ def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
             ENV_CSTAR_RUNID: "12345",
             ENV_CSTAR_DATA_HOME: data_home.as_posix(),
             ENV_FF_ORCH_TRX_TIMESPLIT: "1",
+            ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
         },
         clear=True,
     ):
+        transform = RomsMarblTimeSplitter()
+
         transformed_steps = list(transform(original_step))
 
         # one step transforms into 12 monthly steps

--- a/cstar/tests/unit_tests/roms/test_build_verification.py
+++ b/cstar/tests/unit_tests/roms/test_build_verification.py
@@ -129,8 +129,9 @@ class TestExplicitMpiWrapper:
 
     def test_returns_none_when_mpihome_unset(self):
         sysmgr = _fake_sysmgr(environment_variables={}, compiler="gnu")
-        with mock.patch(
-            "cstar.roms.build_verification.get_sysmgr", return_value=sysmgr
+        with (
+            mock.patch("cstar.roms.build_verification.get_sysmgr", return_value=sysmgr),
+            mock.patch.dict(os.environ, {"MPIHOME": ""}),
         ):
             assert explicit_mpi_wrapper() is None
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR contains a quick hotfix for 3 unit tests that pass when run locally but fail on HPC systems where the environment variables may be set up differently (e.g. MPIHOME env var is set.)

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix unit tests failing in HPC environment

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [x] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

