### PR TITLE
Change continue dir for PIO; fix latent sorting bug

### DIFF
--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -202,6 +202,8 @@ class RestartFile(BaseModel):
     """The expected file extension for a restart file."""
     FMT_TS: t.ClassVar[t.Literal["%Y%m%d%H%M%S"]] = "%Y%m%d%H%M%S"
     """The expected timestamp format in the restart file name"""
+    TS_GLOB: t.ClassVar[str] = "[0-9]" * 14
+    """Glob fragment matching the fixed-width (14-digit) timestamp (see `FMT_TS`)."""
     PATTERN_RST: t.ClassVar[t.Literal[r"^(.*?)_rst\.(\d{14})(?:\.(\d{1,9}))?\.nc$"]] = (
         r"^(.*?)_rst\.(\d{14})(?:\.(\d{1,9}))?\.nc$"
     )
@@ -245,29 +247,30 @@ class RestartFile(BaseModel):
             msg = f"No directory or file found at path: {search_path!r}"
             raise ValueError(msg)
 
-        # filter to names that actually parse before constructing (a stray file matching
-        # the glob shape but not `PATTERN_RST` should be skipped, not fatal).
-        matches = [
-            match
-            for match in search_path.rglob(f"*{cls.SUFFIX}.*.*.{cls.EXT}")
-            if re.fullmatch(cls.PATTERN_RST, match.name, flags=re.ASCII)
-        ]
-        if matches:
-            # Prefer pre-partitioned data when available. `matches` may span
-            # several restart timestamps, each with a full set of partition
-            # files, so continue from partition 0 of the most recent timestamp.
-            rst_files = [RestartFile(path=match) for match in matches]
-            latest_ts = max(rst.timestamp for rst in rst_files)
-            return min(
-                (rst for rst in rst_files if rst.timestamp == latest_ts),
-                key=lambda rst: rst.partition or 0,
-            )
+        # Prefer pre-partitioned files (avoids re-partitioning), falling back to
+        # joined (unpartitioned) files. Both globs pin the fixed-width timestamp
+        # but not the variable-width partition segment, so `PATTERN_RST` still
+        # validates each candidate -- skipping stray files that match the glob
+        # shape but not the naming convention rather than treating them as fatal.
+        partitioned_glob = f"*{cls.SUFFIX}.{cls.TS_GLOB}.*.{cls.EXT}"
+        joined_glob = f"*{cls.SUFFIX}.{cls.TS_GLOB}.{cls.EXT}"
 
-        # Joined (unpartitioned) restart files carry no partition segment;
-        # continue from the most recent timestamp.
-        matches = sorted(search_path.rglob(f"*{cls.SUFFIX}*.{cls.EXT}"), reverse=True)
-        if matches:
-            return RestartFile(path=matches.pop(0))
+        for glob_pattern in (partitioned_glob, joined_glob):
+            rst_files = [
+                RestartFile(path=match)
+                for match in search_path.rglob(glob_pattern)
+                if re.fullmatch(cls.PATTERN_RST, match.name, flags=re.ASCII)
+            ]
+            if rst_files:
+                # A directory may hold several restart timestamps (each a full
+                # partition set); continue from partition 0 of the most recent.
+                # Partition 0 is required: downstream reconstructs the remaining
+                # partitions by substituting its suffix in the file name.
+                latest_ts = max(rst.timestamp for rst in rst_files)
+                return min(
+                    (rst for rst in rst_files if rst.timestamp == latest_ts),
+                    key=lambda rst: rst.partition or 0,
+                )
 
         if not notfound_ok:
             msg = f"No restart files located. Unable to continue from {search_path!r}"
@@ -704,6 +707,9 @@ class ContinuanceDirective(OverrideDirective):
             if name in self.workplan:
                 step = self.workplan[name]
                 fsm = RomsFileSystemManager(step.fsm.root_dir)
+
+                search_path = fsm.output_dir
+
                 # With ParallelIO there are no partitioned restart files to
                 # reuse; the joined restart files live in `joined_output`.
                 blueprint = step.blueprint
@@ -712,10 +718,7 @@ class ContinuanceDirective(OverrideDirective):
                     and blueprint.model_params.use_pio
                 ):
                     search_path = fsm.joined_output_dir
-                else:
-                    # fall back to regular output_dir for non-roms blueprints.
-                    # seems unlikely this is a relevant use case, but easy to guard
-                    search_path = fsm.output_dir
+
             else:
                 msg = f"Unable to locate step {name!r} in workplan"
                 raise KeyError(msg)

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -26,6 +26,7 @@ from cstar.base.utils import (
     min_padded_index,
     slugify,
 )
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import serialize
 from cstar.orchestration.transforms import (
@@ -244,10 +245,26 @@ class RestartFile(BaseModel):
             msg = f"No directory or file found at path: {search_path!r}"
             raise ValueError(msg)
 
-        if matches := sorted(search_path.rglob(f"*{cls.SUFFIX}.*.*.{cls.EXT}")):
-            # prefer use of pre-partitioned data when available
-            return RestartFile(path=matches[0])
+        # filter to names that actually parse before constructing (a stray file matching
+        # the glob shape but not `PATTERN_RST` should be skipped, not fatal).
+        matches = [
+            match
+            for match in search_path.rglob(f"*{cls.SUFFIX}.*.*.{cls.EXT}")
+            if re.fullmatch(cls.PATTERN_RST, match.name, flags=re.ASCII)
+        ]
+        if matches:
+            # Prefer pre-partitioned data when available. `matches` may span
+            # several restart timestamps, each with a full set of partition
+            # files, so continue from partition 0 of the most recent timestamp.
+            rst_files = [RestartFile(path=match) for match in matches]
+            latest_ts = max(rst.timestamp for rst in rst_files)
+            return min(
+                (rst for rst in rst_files if rst.timestamp == latest_ts),
+                key=lambda rst: rst.partition or 0,
+            )
 
+        # Joined (unpartitioned) restart files carry no partition segment;
+        # continue from the most recent timestamp.
         matches = sorted(search_path.rglob(f"*{cls.SUFFIX}*.{cls.EXT}"), reverse=True)
         if matches:
             return RestartFile(path=matches.pop(0))
@@ -686,7 +703,19 @@ class ContinuanceDirective(OverrideDirective):
         if name := self._config.get(self.KEY_STEP, None):
             if name in self.workplan:
                 step = self.workplan[name]
-                search_path = step.fsm.output_dir
+                fsm = RomsFileSystemManager(step.fsm.root_dir)
+                # With ParallelIO there are no partitioned restart files to
+                # reuse; the joined restart files live in `joined_output`.
+                blueprint = step.blueprint
+                if (
+                    isinstance(blueprint, RomsMarblBlueprint)
+                    and blueprint.model_params.use_pio
+                ):
+                    search_path = fsm.joined_output_dir
+                else:
+                    # fall back to regular output_dir for non-roms blueprints.
+                    # seems unlikely this is a relevant use case, but easy to guard
+                    search_path = fsm.output_dir
             else:
                 msg = f"Unable to locate step {name!r} in workplan"
                 raise KeyError(msg)

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -215,10 +215,11 @@ class RestartFile(BaseModel):
     def find(cls, search_path: Path, notfound_ok: bool = True) -> "RestartFile | None":
         """Search for a restart file in the specified location.
 
-        If `search_path` identifies a directory, the first item matching the `RestartFile`
-        naming convention is returned.
+        If `search_path` identifies a directory, the item matching the _latest_
+        timestamp and the 0th partition piece (if partitioned) is returned.
 
         If `search_path` identifies a file, that `RestartFile` will be returned.
+
 
         Parameters
         ----------
@@ -247,11 +248,6 @@ class RestartFile(BaseModel):
             msg = f"No directory or file found at path: {search_path!r}"
             raise ValueError(msg)
 
-        # Prefer pre-partitioned files (avoids re-partitioning), falling back to
-        # joined (unpartitioned) files. Both globs pin the fixed-width timestamp
-        # but not the variable-width partition segment, so `PATTERN_RST` still
-        # validates each candidate -- skipping stray files that match the glob
-        # shape but not the naming convention rather than treating them as fatal.
         partitioned_glob = f"*{cls.SUFFIX}.{cls.TS_GLOB}.*.{cls.EXT}"
         joined_glob = f"*{cls.SUFFIX}.{cls.TS_GLOB}.{cls.EXT}"
 
@@ -262,10 +258,6 @@ class RestartFile(BaseModel):
                 if re.fullmatch(cls.PATTERN_RST, match.name, flags=re.ASCII)
             ]
             if rst_files:
-                # A directory may hold several restart timestamps (each a full
-                # partition set); continue from partition 0 of the most recent.
-                # Partition 0 is required: downstream reconstructs the remaining
-                # partitions by substituting its suffix in the file name.
                 latest_ts = max(rst.timestamp for rst in rst_files)
                 return min(
                     (rst for rst in rst_files if rst.timestamp == latest_ts),

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -2057,10 +2057,13 @@ def mocked_simulation_outputs(
 
     joined_dir = fsm.joined_output_dir
 
+    # Restart timestamps must fall within the continue-from blueprint's
+    # simulation window; `find` continues from the most recent one
+    # (00:20:00 here).
     reset_files = [
         joined_dir / "output_rst.20120101000000.000.nc",
-        joined_dir / "output_rst.20120110000000.001.nc",
-        joined_dir / "output_rst.20120120000000.002.nc",
+        joined_dir / "output_rst.20120101001000.001.nc",
+        joined_dir / "output_rst.20120101002000.002.nc",
     ]
     for file in reset_files:
         file.write_text(info_msg)
@@ -2127,21 +2130,22 @@ def create_mocked_simulation_outputs(
 
             output_dir = step.fsm.output_dir
 
-            # create some mocked "partitioned" restart files
-            reset_files = [
-                output_dir / "output_rst.20120101000000.000.nc",
-                output_dir / "output_rst.20120110000000.001.nc",
-                output_dir / "output_rst.20120120000000.002.nc",
-            ]
-            for file in reset_files:
-                file.write_text(info_msg)
+            # A real run leaves partitioned restart files for every restart
+            # timestamp it wrote, each as a full set of partition files. Mock
+            # two timestamps so the "continue from the latest restart" logic is
+            # actually exercised (20120201... is the most recent).
+            for timestamp in ("20120101000000", "20120201000000"):
+                for segment in ("000", "001", "002"):
+                    (output_dir / f"output_rst.{timestamp}.{segment}.nc").write_text(
+                        info_msg
+                    )
 
-            # create a joined restart file.
-            reset_files = [
-                roms_fsm.joined_output_dir / "output_rst.20120101000000.nc",
-            ]
-            for file in reset_files:
-                file.write_text(info_msg)
+            # With ParallelIO the restart files are joined (no partition segment)
+            # and live in `joined_output`; mock the same two timestamps.
+            for timestamp in ("20120101000000", "20120201000000"):
+                (roms_fsm.joined_output_dir / f"output_rst.{timestamp}.nc").write_text(
+                    info_msg
+                )
 
     return _inner
 

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -260,9 +260,21 @@ def test_override_transform_system_precedence(
 
 @pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.asyncio
-@pytest.mark.parametrize("use_pio", [False, True])
+@pytest.mark.parametrize(
+    ("use_pio", "expected_dir_attr", "expected_name"),
+    [
+        pytest.param(
+            False, "output_dir", "output_rst.20120201000000.000.nc", id="no_pio"
+        ),
+        pytest.param(
+            True, "joined_output_dir", "output_rst.20120201000000.nc", id="pio"
+        ),
+    ],
+)
 async def test_continuance_directive_step_resolution(
     use_pio: bool,
+    expected_dir_attr: str,
+    expected_name: str,
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
@@ -350,15 +362,10 @@ async def test_continuance_directive_step_resolution(
             assert ContinuanceDirective.KEY_PATH not in config
 
             # confirm the initial conditions were overridden to continue from the
-            # latest restart of the named step: under PIO the joined restart file
-            # in `joined_output`, otherwise partition 0 in `output`.
+            # latest restart of the named step (see parametrization for the
+            # expected directory and file per PIO mode).
             prior_fsm = RomsFileSystemManager(prior_step.fsm.root_dir)
-            if use_pio:
-                expected_dir = prior_fsm.joined_output_dir
-                expected_name = "output_rst.20120201000000.nc"
-            else:
-                expected_dir = prior_fsm.output_dir
-                expected_name = "output_rst.20120201000000.000.nc"
+            expected_dir = getattr(prior_fsm, expected_dir_attr)
 
             bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)
             location = Path(bp.initial_conditions.data[0].location)
@@ -1058,8 +1065,9 @@ def test_restart_file_find_skips_malformed(tmp_path: Path) -> None:
     search_path.mkdir(parents=True)
 
     (search_path / "foo_rst.20120101000000.000.nc").touch()
-    # matches the loose glob `*_rst.*.*.nc` but not `PATTERN_RST` (bad timestamp)
-    (search_path / "foo_rst.notadate.xyz.nc").touch()
+    # matches the glob (valid timestamp) but not `PATTERN_RST` (non-numeric
+    # partition segment), so it must be filtered out rather than constructed
+    (search_path / "foo_rst.20120101000000.xyz.nc").touch()
 
     reset_file = RestartFile.find(search_path, notfound_ok=False)
     assert reset_file

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -331,9 +331,7 @@ async def test_continuance_directive_step_resolution(
 
     await create_mocked_simulation_outputs(wp_template_path, live_wp_path, run_id)
 
-    # `read_yaml_intercept` rewrites `local_bp` with the default template on every
-    # workplan read (the last of which is inside `create_mocked_simulation_outputs`),
-    # so inject `use_pio` here to ensure it survives into the directive's blueprint read.
+    # inject `use_pio` here to ensure it survives into the directive's blueprint read.
     bp = deserialize(local_bp, RomsMarblBlueprint)
     bp.model_params.use_pio = use_pio
     assert serialize(local_bp, bp)

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -19,6 +19,7 @@ from cstar.applications.roms_marbl.transforms import (
 from cstar.base.env import FLAG_OFF
 from cstar.base.exceptions import CstarError
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
+from cstar.execution.file_system import RomsFileSystemManager
 from cstar.orchestration.models import (
     Application,
     BlueprintState,
@@ -259,7 +260,9 @@ def test_override_transform_system_precedence(
 
 @pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_pio", [False, True])
 async def test_continuance_directive_step_resolution(
+    use_pio: bool,
     tmp_path: Path,
     bp_templates_dir: Path,
     wp_templates_dir: Path,
@@ -269,8 +272,14 @@ async def test_continuance_directive_step_resolution(
     """Verify that a continuance directive uses context information to identify
     the search path when a step name is provided.
 
+    When `use_pio` is enabled the prior step writes joined (unpartitioned)
+    restart files to `joined_output`, so the directive must search there
+    instead of `output`.
+
     Parameters
     ----------
+    use_pio : bool
+        Whether the prior step ran with ParallelIO enabled.
     tmp_path : Path
         Temporary directory for test outputs
     bp_templates_dir: Path
@@ -310,6 +319,13 @@ async def test_continuance_directive_step_resolution(
 
     await create_mocked_simulation_outputs(wp_template_path, live_wp_path, run_id)
 
+    # `read_yaml_intercept` rewrites `local_bp` with the default template on every
+    # workplan read (the last of which is inside `create_mocked_simulation_outputs`),
+    # so inject `use_pio` here to ensure it survives into the directive's blueprint read.
+    bp = deserialize(local_bp, RomsMarblBlueprint)
+    bp.model_params.use_pio = use_pio
+    assert serialize(local_bp, bp)
+
     for i, step in enumerate(t.cast("list[LiveStep]", live_plan.steps)):
         if i > 0:
             prior_step = live_plan.steps[i - 1]
@@ -333,11 +349,21 @@ async def test_continuance_directive_step_resolution(
             assert ContinuanceDirective.KEY_STEP in config
             assert ContinuanceDirective.KEY_PATH not in config
 
-            # confirm the initial conditions have been overridden to reference the named step
+            # confirm the initial conditions were overridden to continue from the
+            # latest restart of the named step: under PIO the joined restart file
+            # in `joined_output`, otherwise partition 0 in `output`.
+            prior_fsm = RomsFileSystemManager(prior_step.fsm.root_dir)
+            if use_pio:
+                expected_dir = prior_fsm.joined_output_dir
+                expected_name = "output_rst.20120201000000.nc"
+            else:
+                expected_dir = prior_fsm.output_dir
+                expected_name = "output_rst.20120201000000.000.nc"
+
             bp = deserialize(altered.blueprint_path, RomsMarblBlueprint)
-            assert Path(bp.initial_conditions.data[0].location).is_relative_to(
-                prior_step.fsm.output_dir
-            )
+            location = Path(bp.initial_conditions.data[0].location)
+            assert location.is_relative_to(expected_dir)
+            assert location.name == expected_name
 
 
 @pytest.mark.asyncio
@@ -1003,6 +1029,41 @@ def test_restart_file_find(tmp_path: Path, pad_size: int) -> None:
     reset_file = RestartFile.find(tmp_path)
     assert reset_file
     assert reset_file.path == Path(reset_path).expanduser().resolve()
+
+
+def test_restart_file_find_selects_latest_partition_zero(tmp_path: Path) -> None:
+    """Verify that `RestartFile.find` continues from partition 0 of the most
+    recent restart timestamp when the directory holds several timestamps, each
+    with a full set of partition files.
+    """
+    search_path = tmp_path / "output"
+    search_path.mkdir(parents=True)
+
+    # two timestamps, each with a 3-partition set (deliberately created out of
+    # chronological / partition order to prove the selection, not the order)
+    for timestamp in ("20120201000000", "20120101000000"):
+        for segment in ("002", "000", "001"):
+            (search_path / f"foo_rst.{timestamp}.{segment}.nc").touch()
+
+    reset_file = RestartFile.find(search_path, notfound_ok=False)
+    assert reset_file
+    assert reset_file.path.name == "foo_rst.20120201000000.000.nc"
+
+
+def test_restart_file_find_skips_malformed(tmp_path: Path) -> None:
+    """Verify that a stray file matching the restart glob shape but not the
+    strict naming convention is skipped rather than aborting the search.
+    """
+    search_path = tmp_path / "output"
+    search_path.mkdir(parents=True)
+
+    (search_path / "foo_rst.20120101000000.000.nc").touch()
+    # matches the loose glob `*_rst.*.*.nc` but not `PATTERN_RST` (bad timestamp)
+    (search_path / "foo_rst.notadate.xyz.nc").touch()
+
+    reset_file = RestartFile.find(search_path, notfound_ok=False)
+    assert reset_file
+    assert reset_file.path.name == "foo_rst.20120101000000.000.nc"
 
 
 def test_restart_file_find_dne(tmp_path: Path) -> None:


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

Previous behavior was to use pre-partitioned restart files from the `output` directory when continuing. With PIO, those outputs never get made, and we should instead look in the `joined_outputs` directory for whole restart files.

While fixing this behavior, another bug was discovered -- we pulled the first file from a presumed list of partition-indexed files (getting the `.000.nc` one), but we needed an additional filter for the last timestamp if multiple timestamps were being listed.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fixes a bug where the `continue-from` directive would look in the wrong directory if PIO is enabled
- Fixes a bug where the `continue-from` directive would obtain the wrong file if partitioning was enabled and multiple restart file timestamps were present

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

