### PR TITLE
Normalize run-id casing at intake to fix mixed-case run breakage

### DIFF
--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -17,6 +17,7 @@ from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
 from cstar.cli.common import (
     cb_pipeline,
+    normalize_runid,
     set_env,
     set_flag,
 )
@@ -474,7 +475,9 @@ def clean(
         typer.Option(
             "--run-id",
             help=run_help,
-            callback=cb_pipeline(runid_callback, set_env(ENV_CSTAR_RUNID)),
+            callback=cb_pipeline(
+                runid_callback, normalize_runid, set_env(ENV_CSTAR_RUNID)
+            ),
             min=1,
             autocompletion=list_runs,
         ),

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -16,6 +16,7 @@ from cstar.base.env import (
 )
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
+from cstar.base.utils import slugify
 from cstar.execution.file_system import DirectoryManager, is_remote_resource
 from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import (
@@ -127,6 +128,35 @@ def set_flag(
         return value
 
     return _callback
+
+
+def normalize_runid(_context: typer.Context, run_id: str) -> str:
+    """Normalize a user-supplied run-id (slugify) so the same identifier is
+    used everywhere (directories, tracking records, environment).
+
+    Empty values are returned unchanged so callers can apply their own
+    presence/default handling.
+
+    Parameters
+    ----------
+    _context : typer.Context
+        The typer context (unused).
+    run_id : str
+        The run-id value received from the user.
+
+    Returns
+    -------
+    str
+    """
+    if not (run_id := run_id.strip()):
+        return run_id
+
+    normalized = slugify(run_id)
+    if normalized != run_id:
+        msg = f"Normalized run-id `{run_id}` to `{normalized}`"
+        log.info(msg)
+
+    return normalized
 
 
 def set_env(

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -154,7 +154,7 @@ def normalize_runid(_context: typer.Context, run_id: str) -> str:
     normalized = slugify(run_id)
     if normalized != run_id:
         msg = f"Normalized run-id `{run_id}` to `{normalized}`"
-        log.info(msg)
+        log.debug(msg)
 
     return normalized
 

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -5,7 +5,7 @@ import typer
 
 from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import cb_pipeline, get_from_ctxmap, set_env
+from cstar.cli.common import cb_pipeline, get_from_ctxmap, normalize_runid, set_env
 from cstar.cli.workplan.shared import (
     autocomplete_step_list,
     list_runs,
@@ -83,7 +83,9 @@ def workplan_log(
         typer.Argument(
             help="The unique identifier of a specific workplan execution.",
             autocompletion=list_runs,
-            callback=cb_pipeline(set_env(ENV_CSTAR_RUNID), preload_run),
+            callback=cb_pipeline(
+                normalize_runid, set_env(ENV_CSTAR_RUNID), preload_run
+            ),
         ),
     ],
     step_name: t.Annotated[

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -15,6 +15,7 @@ from cstar.base.env import (
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
+from cstar.base.utils import slugify
 from cstar.cli.common import (
     cb_pipeline,
     set_env,
@@ -266,6 +267,8 @@ def preprocess_runid(ctx: typer.Context, run_id: str) -> str:
     """Perform validation and formatting of the run-id argument.
 
     - verify blueprint path or run-id is supplied
+    - normalize a user-supplied run-id (slugify) so the same identifier is
+      used everywhere (directories, tracking records, environment)
     - generate a default run id from a blueprint if run-id is not supplied
 
     Parameters
@@ -280,7 +283,11 @@ def preprocess_runid(ctx: typer.Context, run_id: str) -> str:
     str
     """
     if run_id := run_id.strip():
-        return run_id
+        normalized = slugify(run_id)
+        if normalized != run_id:
+            msg = f"Normalized run-id `{run_id}` to `{normalized}`"
+            log.info(msg)
+        return normalized
 
     path: str | None = ctx.params.get("path", None)
     if isinstance(path, str):

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -15,9 +15,9 @@ from cstar.base.env import (
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
-from cstar.base.utils import slugify
 from cstar.cli.common import (
     cb_pipeline,
+    normalize_runid,
     set_env,
     set_flag,
     update_loggers,
@@ -282,11 +282,7 @@ def preprocess_runid(ctx: typer.Context, run_id: str) -> str:
     -------
     str
     """
-    if run_id := run_id.strip():
-        normalized = slugify(run_id)
-        if normalized != run_id:
-            msg = f"Normalized run-id `{run_id}` to `{normalized}`"
-            log.info(msg)
+    if normalized := normalize_runid(ctx, run_id):
         return normalized
 
     path: str | None = ctx.params.get("path", None)

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -267,23 +267,24 @@ def preprocess_runid(ctx: typer.Context, run_id: str) -> str:
     """Perform validation and formatting of the run-id argument.
 
     - verify blueprint path or run-id is supplied
-    - normalize a user-supplied run-id (slugify) so the same identifier is
-      used everywhere (directories, tracking records, environment)
     - generate a default run id from a blueprint if run-id is not supplied
+
+    Expects a run-id already normalized by the `normalize_runid` stage that
+    precedes this one in the callback pipeline.
 
     Parameters
     ----------
     ctx : typer.Context
         A context object containing state for the typer app.
     run_id : str
-        The user-supplied run-id.
+        The normalized user-supplied run-id, or an empty string.
 
     Returns
     -------
     str
     """
-    if normalized := normalize_runid(ctx, run_id):
-        return normalized
+    if run_id:
+        return run_id
 
     path: str | None = ctx.params.get("path", None)
     if isinstance(path, str):
@@ -368,7 +369,9 @@ def run(
         typer.Option(
             help="The unique identifier for an execution of the workplan.",
             autocompletion=list_runs,
-            callback=cb_pipeline(preprocess_runid, set_env(ENV_CSTAR_RUNID)),
+            callback=cb_pipeline(
+                normalize_runid, preprocess_runid, set_env(ENV_CSTAR_RUNID)
+            ),
         ),
     ] = "",
     user_variables: t.Annotated[

--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, computed_field
 from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, capture_environment
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
+from cstar.base.utils import slugify
 from cstar.execution.file_system import StateDirectoryManager
 from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.launch.slurm import SlurmLauncher
@@ -559,7 +560,10 @@ async def build_and_run_dag(
         The path to the workplan that was executed after any tranformations
         were applied.
     """
-    default_output_dir = StateDirectoryManager.data_dir()
+    if run_id:
+        run_id = slugify(run_id)
+
+    default_output_dir = StateDirectoryManager.data_dir(run_id or None)
     output_dir = (output_dir or default_output_dir).expanduser().resolve()
     configure_environment(output_dir, run_id)
 

--- a/cstar/orchestration/tracking.py
+++ b/cstar/orchestration/tracking.py
@@ -295,6 +295,8 @@ class TrackingRepository(LoggingMixin):
             msg = "A valid run-id was not provided; unable to retrieve run"
             raise ValueError(msg)
 
+        run_id = slugify(run_id)
+
         run_path = self._find_run_path(run_id, run_date)
 
         if not run_path.exists():
@@ -325,6 +327,8 @@ class TrackingRepository(LoggingMixin):
         if not run_id:
             msg = "A valid run-id was not provided; unable to retrieve run"
             raise ValueError(msg)
+
+        run_id = slugify(run_id)
 
         run_path = self._find_run_path(run_id, run_date)
 

--- a/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
+++ b/cstar/tests/unit_tests/orchestration/cli/admin/test_clean.py
@@ -9,7 +9,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, FLAG_ON
+from cstar.base.env import ENV_CSTAR_CLI_DRY_RUN, ENV_CSTAR_RUNID, FLAG_ON
 from cstar.cli.admin.clean import (
     ARG_YES,
     FileSystemCleanupAction,
@@ -220,6 +220,35 @@ async def test_cli_admin_clean_runid_callback(
 
     # confirm the run-id is returned with any callback cleaning appleid
     assert actual_run_id == run_id.strip()
+
+
+def test_cli_admin_clean_normalizes_mixed_case_runid(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify a mixed-case run-id is normalized before it reaches the
+    environment, so cleanup targets the directories the run actually used.
+
+    Regression test: the clean command previously placed the raw user-typed
+    run-id in the environment, so a mixed-case run-id resolved cleanup paths
+    in a nonexistent (wrong-case) run directory.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    *_, run_id = executed_workplan
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--run-id", run_id.upper(), ARG_YES, ARG_DRY_RUN],
+        color=False,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert os.environ[ENV_CSTAR_RUNID] == run_id
 
 
 @pytest.mark.parametrize(

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -6,10 +6,10 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from cstar.base.env import ENV_CSTAR_STATE_HOME
+from cstar.base.env import ENV_CSTAR_RUNID, ENV_CSTAR_STATE_HOME
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.cli.common import normalize_runid
-from cstar.cli.workplan.run import app, preprocess_runid
+from cstar.cli.workplan.run import app
 from cstar.orchestration.dag_runner import get_launcher
 from cstar.orchestration.models import UserDefinedVariables
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
@@ -669,33 +669,41 @@ async def test_workplan_run_reload_prior_run(
     mock_get_wp.assert_called()
 
 
-@pytest.mark.parametrize(
-    ("raw_run_id", "expected"),
-    [
-        ("MyRun", "myrun"),
-        ("  MyRun_01  ", "myrun_01"),
-        ("My Run!", "my-run"),
-        ("already-lowercase", "already-lowercase"),
-    ],
-)
-def test_preprocess_runid_normalizes_case(raw_run_id: str, expected: str) -> None:
-    """Verify a user-supplied run-id is slugified (lowercased) at intake.
+@pytest.mark.usefixtures("read_yaml_intercept")
+def test_cli_workplan_run_normalizes_mixed_case_runid() -> None:
+    """Verify a user-supplied run-id is slugified (lowercased) by the run-id
+    callback pipeline before it reaches the environment or the dag runner.
 
     Mixed-case run-ids previously produced two run directories (one raw, one
     slugified) and mismatched tracking/cache entries because the environment
     variable was slugified while directories and tracking records used the
     raw value.
-
-    Parameters
-    ----------
-    raw_run_id : str
-        The run-id as typed by the user.
-    expected : str
-        The normalized run-id expected after preprocessing.
     """
-    ctx = mock.MagicMock(spec=typer.Context)
+    wp_uri = "https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/cstar/additional_files/templates/wp/workplan.yaml"
 
-    assert preprocess_runid(ctx, raw_run_id) == expected
+    mock_build_and_run_dag = mock.AsyncMock(
+        return_value=mock.MagicMock(
+            dry_run=True,
+            name="sample-workplan",
+            run_id="myrun_01",
+            state_dir="/tmp/state",
+        )
+    )
+
+    with mock.patch(
+        "cstar.cli.workplan.run.build_and_run_dag",
+        mock_build_and_run_dag,
+    ) as mock_exec:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["--run-id", "  MyRun_01  ", wp_uri],
+            color=False,
+        )
+
+    assert result.exit_code == 0
+    assert os.environ[ENV_CSTAR_RUNID] == "myrun_01"
+    assert mock_exec.call_args.args[1] == "myrun_01"
 
 
 @pytest.mark.parametrize(

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from cstar.base.env import ENV_CSTAR_STATE_HOME
 from cstar.base.exceptions import CstarExpectationFailed
-from cstar.cli.workplan.run import app
+from cstar.cli.workplan.run import app, preprocess_runid
 from cstar.orchestration.dag_runner import get_launcher
 from cstar.orchestration.models import UserDefinedVariables
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
@@ -666,3 +666,32 @@ async def test_workplan_run_reload_prior_run(
 
     # confirm the attempt to load the old record was made
     mock_get_wp.assert_called()
+
+
+@pytest.mark.parametrize(
+    ("raw_run_id", "expected"),
+    [
+        ("MyRun", "myrun"),
+        ("  MyRun_01  ", "myrun_01"),
+        ("My Run!", "my-run"),
+        ("already-lowercase", "already-lowercase"),
+    ],
+)
+def test_preprocess_runid_normalizes_case(raw_run_id: str, expected: str) -> None:
+    """Verify a user-supplied run-id is slugified (lowercased) at intake.
+
+    Mixed-case run-ids previously produced two run directories (one raw, one
+    slugified) and mismatched tracking/cache entries because the environment
+    variable was slugified while directories and tracking records used the
+    raw value.
+
+    Parameters
+    ----------
+    raw_run_id : str
+        The run-id as typed by the user.
+    expected : str
+        The normalized run-id expected after preprocessing.
+    """
+    ctx = mock.MagicMock(spec=typer.Context)
+
+    assert preprocess_runid(ctx, raw_run_id) == expected

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from cstar.base.env import ENV_CSTAR_STATE_HOME
 from cstar.base.exceptions import CstarExpectationFailed
+from cstar.cli.common import normalize_runid
 from cstar.cli.workplan.run import app, preprocess_runid
 from cstar.orchestration.dag_runner import get_launcher
 from cstar.orchestration.models import UserDefinedVariables
@@ -695,3 +696,31 @@ def test_preprocess_runid_normalizes_case(raw_run_id: str, expected: str) -> Non
     ctx = mock.MagicMock(spec=typer.Context)
 
     assert preprocess_runid(ctx, raw_run_id) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw_run_id", "expected"),
+    [
+        ("MyRun", "myrun"),
+        ("  MyRun_01  ", "myrun_01"),
+        ("My Run!", "my-run"),
+        ("already-lowercase", "already-lowercase"),
+        ("", ""),
+        ("   ", ""),
+    ],
+)
+def test_normalize_runid(raw_run_id: str, expected: str) -> None:
+    """Verify the shared run-id normalization callback slugifies non-empty
+    values and passes empty values through unchanged (so callers keep their
+    own presence/default handling).
+
+    Parameters
+    ----------
+    raw_run_id : str
+        The run-id as typed by the user.
+    expected : str
+        The normalized run-id expected from the callback.
+    """
+    ctx = mock.MagicMock(spec=typer.Context)
+
+    assert normalize_runid(ctx, raw_run_id) == expected

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_workplan_log.py
@@ -81,6 +81,36 @@ def test_cli_workplan_log_step_with_logs(
         assert f"{step.name} message" in result.stdout
 
 
+def test_cli_workplan_log_step_with_logs_mixed_case_runid(
+    executed_workplan_with_sideeffects: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that logs are loaded successfully when a user passes the run-id
+    with different casing than it was created with.
+
+    Regression test: the log command previously placed the raw user-typed
+    run-id in the environment, so a mixed-case run-id resolved log paths in a
+    nonexistent run directory.
+
+    Parameters
+    ----------
+    executed_workplan_with_sideeffects : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan_with_sideeffects
+
+    runner = CliRunner()
+    step = wp.steps[0]
+
+    result = runner.invoke(
+        app,
+        [fake_run_id.upper(), step.name],
+        color=False,
+        catch_exceptions=False,
+    )
+
+    assert f"{step.name} message" in result.stdout
+
+
 def test_cli_workplan_log_step_with_logs_via_slug(
     executed_workplan_with_sideeffects: tuple[Path, Workplan, str],
 ) -> None:

--- a/cstar/tests/unit_tests/orchestration/test_tracking.py
+++ b/cstar/tests/unit_tests/orchestration/test_tracking.py
@@ -434,3 +434,35 @@ async def test_tracking_get_run_paths(
     assert len(actual_paths) == exp_num_paths
     mismatched = set(actual_paths).difference(expected_paths)
     assert not mismatched  # set(actual_paths).issuperset(expected_paths)
+
+
+@pytest.mark.asyncio
+async def test_tracking_retrieve_mixed_case_runid(tmp_path: Path) -> None:
+    """Verify a mixed-case run-id query resolves to the slugified run record.
+
+    Run records are persisted with slugified (lowercase) run-ids; the lookup
+    must normalize the same way so `cstar workplan status MYRUN` finds the
+    record created for `myrun`.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory for test outputs
+    """
+    wp_run = WorkplanRun(
+        workplan_path=tmp_path / "fake_workplan.yaml",
+        trx_workplan_path=tmp_path / "mock_transformed_workplan.yaml",
+        output_path=tmp_path / "output",
+        run_id="mixed-case-run-id",
+    )
+
+    repo = TrackingRepository()
+    _ = await repo.put_workplan_run(wp_run)
+
+    found = await repo.get_workplan_run(run_id="MIXED-Case-Run-ID")
+    assert found
+    assert found.run_id == "mixed-case-run-id"
+
+    found_sync = repo.get_workplan_run_sync(run_id="MIXED-Case-Run-ID")
+    assert found_sync
+    assert found_sync.run_id == "mixed-case-run-id"


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
A mixed-case --run-id was used raw for run directories and tracking records but casefolded (slugify) for CSTAR_RUNID by configure_environment, producing two runs directories, mismatched cache/tracking entries, and status/rerun lookups that could not find the run record. Slugify the run-id once at CLI intake and in build_and_run_dag, and normalize TrackingRepository lookups so mixed-case queries resolve to the stored record.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Normalize run-id casing at intake to fix mixed-case run breakage

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

