### PR TITLE
Prune already-completed SLURM dependency jobs on every launch

### DIFF
--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import typing as t
-from collections.abc import Mapping
 
 from prefect import State, task
 from prefect import Task as PrefectTask
@@ -33,10 +32,7 @@ from cstar.orchestration.orchestration import (
     Status,
     Task,
 )
-from cstar.orchestration.state import (
-    StateRepository,
-    load_sentinels,
-)
+from cstar.orchestration.state import StateRepository
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -372,17 +368,44 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         return batch.status
 
     @staticmethod
-    async def _locate_priors() -> Mapping[str, SlurmHandle]:
-        """Retrieve all task sentinels discovered in the output path.
+    async def _prune_completed_dependencies(
+        dependencies: list[SlurmHandle],
+    ) -> list[SlurmHandle]:
+        """Remove dependencies whose SLURM jobs have already completed successfully.
 
+        SLURM cannot use dependencies on previously completed jobs: submitting
+        with `--dependency=afterok:<jobid>` referencing a job that already
+        finished (e.g. a step satisfied by a prior run and not resubmitted)
+        causes the submission to fail or the job to be killed for an invalid
+        dependency. Such dependencies are already satisfied and can be dropped.
+
+        Parameters
+        ----------
+        dependencies : list[SlurmHandle]
+            The dependency handles for a step about to be submitted.
 
         Returns
         -------
-        Mapping[str, Task[SlurmHandle]]
-            Mapping of all previously run PIDs to their sentinel content.
+        list[SlurmHandle]
+            The dependencies whose jobs have not yet completed.
         """
-        sentinels = await load_sentinels(SlurmHandle)
-        return {h.pid: h for h in sentinels}
+        if not dependencies:
+            return dependencies
+
+        batch_map = await get_slurm_batches([d.pid for d in dependencies])
+        successes = {
+            k for k, v in batch_map.items() if v.status == ExecutionStatus.COMPLETED
+        }
+
+        if not successes:
+            return dependencies
+
+        satisfied = {d.pid for d in dependencies}.intersection(successes)
+        msg = f"Dependencies previously satisfied: {', '.join(sorted(satisfied))}"
+        log.info(msg)
+
+        # only keep dependencies that are not already satisfied
+        return [d for d in dependencies if d.pid not in successes]
 
     @classmethod
     async def launch(
@@ -418,22 +441,10 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 step.fsm.clear_prior()
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
-                # SLURM cannot use dependencies on previously completed jobs
-                pid_to_task = await cls._locate_priors()
-                batch_map = await get_slurm_batches(pid_to_task.keys())
-                successes = {
-                    k
-                    for k, v in batch_map.items()
-                    if v.status == ExecutionStatus.COMPLETED
-                }
-                if dependencies and successes:
-                    reusable = set(x.pid for x in dependencies).intersection(successes)
-                    msg = f"Dependencies previously satisfied: {', '.join(reusable)}"
-                    log.info(msg)
-
-                    # only keep dependencies that are not re-usable
-                    active = set(x.pid for x in dependencies).difference(successes)
-                    dependencies = list(filter(lambda x: x.pid in active, dependencies))
+        # always drop dependencies on jobs that already completed successfully
+        # (e.g. steps satisfied by a prior run) so SLURM does not reject the
+        # submission over an already-finished job id
+        dependencies = await cls._prune_completed_dependencies(dependencies)
 
         handle = await submit_fn(step, dependencies)
         await SlurmLauncher.update_status(handle)

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -441,9 +441,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 step.fsm.clear_prior()
                 submit_fn = SlurmLauncher._submit.with_options(refresh_cache=True)
 
-        # always drop dependencies on jobs that already completed successfully
-        # (e.g. steps satisfied by a prior run) so SLURM does not reject the
-        # submission over an already-finished job id
         dependencies = await cls._prune_completed_dependencies(dependencies)
 
         handle = await submit_fn(step, dependencies)

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -5,9 +5,11 @@ from unittest import mock
 
 import pytest
 
-from cstar.orchestration.launch.slurm import SlurmLauncher
+from cstar.execution.handler import ExecutionStatus
+from cstar.orchestration.launch.slurm import SlurmHandle, SlurmLauncher
 from cstar.orchestration.orchestration import LiveStep, Workplan
 from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.state import StateRepository
 from cstar.orchestration.utils import (
     ENV_CSTAR_SLURM_ACCOUNT,
     ENV_CSTAR_SLURM_MAX_WALLTIME,
@@ -240,3 +242,105 @@ def test_slurmlauncher_adapt_step_with_overrides(
 
     if exp_walltime != minimum_spec.max_walltime:
         assert f"{ENV_CSTAR_SLURM_MAX_WALLTIME}={exp_walltime!r}" in job.commands
+
+
+async def test_prune_completed_dependencies_drops_completed_jobs() -> None:
+    """Verify dependencies on already-completed SLURM jobs are removed."""
+    completed_dep = SlurmHandle(pid="111", name="step_1", run_id="test-run")
+    running_dep = SlurmHandle(pid="222", name="step_0", run_id="test-run")
+
+    batch_map = {
+        "111": mock.Mock(status=ExecutionStatus.COMPLETED),
+        "222": mock.Mock(status=ExecutionStatus.RUNNING),
+    }
+    get_batches_mock = mock.AsyncMock(return_value=batch_map)
+
+    with mock.patch(
+        "cstar.orchestration.launch.slurm.get_slurm_batches", get_batches_mock
+    ):
+        pruned = await SlurmLauncher._prune_completed_dependencies(
+            [completed_dep, running_dep]
+        )
+
+    get_batches_mock.assert_awaited_once_with(["111", "222"])
+    assert [d.pid for d in pruned] == ["222"]
+
+
+async def test_prune_completed_dependencies_keeps_unfinished_jobs() -> None:
+    """Verify dependencies are unchanged when no dependency job has completed."""
+    pending_dep = SlurmHandle(pid="111", name="step_1", run_id="test-run")
+
+    batch_map = {"111": mock.Mock(status=ExecutionStatus.PENDING)}
+
+    with mock.patch(
+        "cstar.orchestration.launch.slurm.get_slurm_batches",
+        mock.AsyncMock(return_value=batch_map),
+    ):
+        pruned = await SlurmLauncher._prune_completed_dependencies([pending_dep])
+
+    assert pruned == [pending_dep]
+
+
+async def test_prune_completed_dependencies_no_deps_skips_query() -> None:
+    """Verify an empty dependency list does not trigger a SLURM query."""
+    get_batches_mock = mock.AsyncMock()
+
+    with mock.patch(
+        "cstar.orchestration.launch.slurm.get_slurm_batches", get_batches_mock
+    ):
+        pruned = await SlurmLauncher._prune_completed_dependencies([])
+
+    get_batches_mock.assert_not_awaited()
+    assert pruned == []
+
+
+@pytest.mark.usefixtures("read_yaml_intercept")
+async def test_launch_prunes_stale_deps_without_prior_sentinel(
+    wp_templates_dir: Path,
+) -> None:
+    """Verify a never-before-submitted step does not submit with a SLURM
+    dependency on a job that already completed (e.g. a step satisfied by a
+    prior run and skipped on re-run).
+
+    Regression test: previously the pruning only ran when the step itself had
+    a failed prior sentinel, so re-running a workplan where step_1 was already
+    Done caused step_2 to be submitted with `--dependency=afterok:<old job>`,
+    which SLURM rejects or kills once the old job is gone.
+    """
+    wp_path = wp_templates_dir / "single_step.yaml"
+    workplan = deserialize(wp_path, Workplan)
+    live_step = LiveStep.from_step(workplan.steps[0])
+
+    completed_dep = SlurmHandle(pid="111", name="step_1", run_id="test-run")
+    running_dep = SlurmHandle(pid="222", name="step_0", run_id="test-run")
+
+    new_handle = SlurmHandle(pid="333", name=live_step.name, run_id="test-run")
+    submit_mock = mock.AsyncMock(return_value=new_handle)
+
+    batch_map = {
+        "111": mock.Mock(status=ExecutionStatus.COMPLETED),
+        "222": mock.Mock(status=ExecutionStatus.RUNNING),
+    }
+
+    with (
+        mock.patch.object(
+            StateRepository, "get_sentinel", mock.AsyncMock(return_value=None)
+        ),
+        mock.patch.object(SlurmLauncher, "_submit", submit_mock),
+        mock.patch.object(
+            SlurmLauncher,
+            "update_status",
+            mock.AsyncMock(return_value=(False, new_handle)),
+        ),
+        mock.patch(
+            "cstar.orchestration.launch.slurm.get_slurm_batches",
+            mock.AsyncMock(return_value=batch_map),
+        ),
+    ):
+        task = await SlurmLauncher.launch(live_step, [completed_dep, running_dep])
+
+    submit_mock.assert_awaited_once()
+    assert submit_mock.await_args is not None
+    _, submitted_deps = submit_mock.await_args.args
+    assert [d.pid for d in submitted_deps] == ["222"]
+    assert task.handle.pid == "333"


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

On workplan rerun, a finished step is not resubmitted (Prefect cache returns its old job id), but a dependent step submitted for the first time still passed `--dependency=afterok:<old_jobid>`, which SLURM rejectsor kills once the job is gone. The completed-dependency pruning only ran when the dependent step itself had a failed prior sentinel; it now runs unconditionally before every submission, querying the dependency job ids directly.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Depending on already-completed SLURM jobs should now seamlessly drop the dependencies

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

