### PR TITLE
Fix slurm compute overrides bug

### DIFF
--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -253,7 +253,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         """
         default_compute = SlurmLauncher._get_default_compute_spec(step)
         compute = default_compute
-        compute.num_cpus = step.blueprint.cpus_needed
 
         if step.compute_overrides:
             try:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -103,6 +103,24 @@ class SlurmComputeSpec(BaseModel):
     model_config: t.ClassVar[ConfigDict] = ConfigDict(str_strip_whitespace=True)
     """Configure model to ignore empty strings."""
 
+    @property
+    def environment(self) -> dict[str, str]:
+        environment: dict[str, str] = {}
+        if self.account_name and self.account_name != os.getenv(
+            ENV_CSTAR_SLURM_ACCOUNT
+        ):
+            environment[ENV_CSTAR_SLURM_ACCOUNT] = self.account_name
+
+        if self.queue_name and self.queue_name != os.getenv(ENV_CSTAR_SLURM_QUEUE):
+            environment[ENV_CSTAR_SLURM_QUEUE] = self.queue_name
+
+        if self.max_walltime and self.max_walltime != os.getenv(
+            ENV_CSTAR_SLURM_MAX_WALLTIME
+        ):
+            environment[ENV_CSTAR_SLURM_MAX_WALLTIME] = self.max_walltime
+
+        return environment
+
 
 class SlurmComputeAdapter(ConfiguredModelAdapter[KeyValueStore, SlurmComputeSpec]):
     """Adapts a `KeyValueStore` containing optional overrides into a `SlurmComputeSpec`."""
@@ -220,6 +238,36 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         )
 
     @staticmethod
+    def _get_compute_spec(step: "LiveStep") -> SlurmComputeSpec:
+        """Return a compute spec that has been customized with any
+        overrides specified in the step.
+
+        Parameters
+        ----------
+        step : LiveStep
+            The step to use for configuring overrides
+
+        Returns
+        -------
+        SlurmComputeSpec
+        """
+        default_compute = SlurmLauncher._get_default_compute_spec(step)
+        compute = default_compute
+        compute.num_cpus = step.blueprint.cpus_needed
+
+        if step.compute_overrides:
+            try:
+                overrides = SlurmComputeAdapter().adapt(step.compute_overrides)
+                compute = default_compute.model_copy(
+                    update=overrides.model_dump(exclude_defaults=True)
+                )
+
+            except CstarAdaptationError:
+                msg = f"SLURM overrides did not result in valid compute spec: {step.compute_overrides}"
+                log.warning(msg, exc_info=True)
+        return compute
+
+    @staticmethod
     def adapt_step(
         step: "LiveStep",
         dependencies: list[SlurmHandle],
@@ -231,23 +279,15 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         -------
         str
         """
+        compute = SlurmLauncher._get_compute_spec(step)
+
         job_dep_ids = [d.pid for d in dependencies]
-
         request_adapter = StepToRunRequestAdapter()
-        command = RunRequestCommandFormatter().format(request_adapter.adapt(step))
+        run_request = request_adapter.adapt(step)
+        if compute.environment:
+            run_request.environment.update(compute.environment)
 
-        default_compute = SlurmLauncher._get_default_compute_spec(step)
-        compute = default_compute
-
-        if step.compute_overrides:
-            try:
-                overrides = SlurmComputeAdapter().adapt(step.compute_overrides)
-                compute = default_compute.model_copy(
-                    update=overrides.model_dump(exclude_defaults=True)
-                )
-            except CstarAdaptationError:
-                msg = f"SLURM overrides did not result in valid compute spec: {step.compute_overrides}"
-                log.warning(msg, exc_info=True)
+        command = RunRequestCommandFormatter().format(run_request)
 
         return create_scheduler_job(
             commands=command,

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -260,7 +260,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
                 compute = default_compute.model_copy(
                     update=overrides.model_dump(exclude_defaults=True)
                 )
-
             except CstarAdaptationError:
                 msg = f"SLURM overrides did not result in valid compute spec: {step.compute_overrides}"
                 log.warning(msg, exc_info=True)

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -46,8 +46,8 @@ def test_slurmlauncher_adapt_step_no_overrides(
     mock_mgr = mock.Mock()
     mock_mgr.environment.package_root = tmp_path
     mock_mgr.scheduler = SlurmScheduler(
-        queues=[fake_get_queue("a"), fake_get_queue("b")],
-        primary_queue_name="a",
+        queues=[fake_get_queue("default-q"), fake_get_queue("alt-q")],
+        primary_queue_name="default-q",
         other_scheduler_directives={},
         requires_task_distribution=False,
         documentation="fake slurm scheduduler",
@@ -192,7 +192,7 @@ def test_slurmlauncher_adapt_step_with_overrides(
     mock_mgr.environment.package_root = tmp_path
     mock_mgr.scheduler = SlurmScheduler(
         queues=[fake_get_queue("default-q"), fake_get_queue("alt-q")],
-        primary_queue_name="a",
+        primary_queue_name="default-q",
         other_scheduler_directives={},
         requires_task_distribution=False,
         documentation="fake slurm scheduduler",

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -63,7 +63,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
 
     # confirm that no job attributes have been overridden from the minimal spec
     assert minimum_spec.account_name == job.account_key
-    assert minimum_spec.num_cpus == 128
+    assert minimum_spec.num_cpus == job.cpus
     assert minimum_spec.queue_name == job.queue_name
     assert minimum_spec.max_walltime == job.walltime
 

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -63,7 +63,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
 
     # confirm that no job attributes have been overridden from the minimal spec
     assert minimum_spec.account_name == job.account_key
-    assert minimum_spec.num_cpus == job.cpus
+    assert minimum_spec.num_cpus == 128
     assert minimum_spec.queue_name == job.queue_name
     assert minimum_spec.max_walltime == job.walltime
 
@@ -74,23 +74,112 @@ def test_slurmlauncher_adapt_step_no_overrides(
 
 @pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.parametrize(
-    ("overrides",),
+    (
+        "overrides",
+        "exp_account",
+        "exp_queue",
+        "exp_walltime",
+        "exp_ncpus",
+        "exp_nnodes",
+        "exp_cpus_per_node",
+    ),
     [
-        pytest.param({"slurm": {"queue_name": "b"}}, id="queue-name"),
-        pytest.param({"slurm": {"num_cpus": "42"}}, id="num-cpus"),
-        pytest.param({"slurm": {"num_nodes": "99"}}, id="num-nodes"),
-        pytest.param({"slurm": {"max_walltime": "01:00:00"}}, id="walltime"),
-        pytest.param({"slurm": {"cpus_per_node": "32"}}, id="cpus-per-node"),
-        pytest.param({"slurm": {"account_name": "alt-acct"}}, id="account-name"),
+        pytest.param(
+            {"slurm": {"queue_name": "alt-q"}},
+            "default-account",
+            "alt-q",
+            "42:00:00",
+            128,
+            None,
+            None,
+            id="queue-name",
+        ),
+        pytest.param(
+            {"slurm": {"num_cpus": "42"}},
+            "default-account",
+            "default-q",
+            "42:00:00",
+            42,
+            None,
+            None,
+            id="num-cpus",
+        ),
+        pytest.param(
+            {"slurm": {"num_nodes": "99"}},
+            "default-account",
+            "default-q",
+            "42:00:00",
+            128,
+            99,
+            None,
+            id="num-nodes",
+        ),
+        pytest.param(
+            {"slurm": {"max_walltime": "01:00:00"}},
+            "default-account",
+            "default-q",
+            "01:00:00",
+            128,
+            None,
+            None,
+            id="walltime",
+        ),
+        pytest.param(
+            {"slurm": {"cpus_per_node": "32"}},
+            "default-account",
+            "default-q",
+            "42:00:00",
+            128,
+            None,
+            32,
+            id="cpus-per-node",
+        ),
+        pytest.param(
+            {"slurm": {"account_name": "alt-account"}},
+            "alt-account",
+            "default-q",
+            "42:00:00",
+            128,
+            None,
+            None,
+            id="account-name",
+        ),
+        pytest.param(
+            {
+                "slurm": {
+                    "account_name": "alt-account",
+                    "queue_name": "alt-q",
+                    "num_cpus": 10,
+                    "num_nodes": 20,
+                    "max_walltime": "02:00:00",
+                    "cpus_per_node": 30,
+                }
+            },
+            "alt-account",
+            "alt-q",
+            "02:00:00",
+            10,
+            20,
+            30,
+            id="all",
+        ),
     ],
 )
 def test_slurmlauncher_adapt_step_with_overrides(
     tmp_path: Path,
     wp_templates_dir: Path,
     overrides: dict[str, dict[str, str]],
+    exp_account: str,
+    exp_queue: str,
+    exp_walltime: str,
+    exp_ncpus: int,
+    exp_nnodes: int | None,
+    exp_cpus_per_node: int | None,
 ) -> None:
     """Verify that the `SlurmLauncher` correctly converts a step into a `SchedulerJob`
     that includes any provided per-step compute overrides.
+
+    NOTE: num_cpus is populated from the template bp, resulting in 128: `return xi * eta`
     """
     wp_path = wp_templates_dir / "single_step.yaml"
     workplan = deserialize(wp_path, Workplan)
@@ -102,7 +191,7 @@ def test_slurmlauncher_adapt_step_with_overrides(
     mock_mgr = mock.Mock()
     mock_mgr.environment.package_root = tmp_path
     mock_mgr.scheduler = SlurmScheduler(
-        queues=[fake_get_queue("a"), fake_get_queue("b")],
+        queues=[fake_get_queue("default-q"), fake_get_queue("alt-q")],
         primary_queue_name="a",
         other_scheduler_directives={},
         requires_task_distribution=False,
@@ -115,9 +204,9 @@ def test_slurmlauncher_adapt_step_with_overrides(
         mock.patch.dict(
             os.environ,
             {
-                ENV_CSTAR_SLURM_ACCOUNT: "og-account",
-                ENV_CSTAR_SLURM_MAX_WALLTIME: "00:42:00",
-                ENV_CSTAR_SLURM_QUEUE: "a",
+                ENV_CSTAR_SLURM_ACCOUNT: "default-account",
+                ENV_CSTAR_SLURM_MAX_WALLTIME: "42:00:00",
+                ENV_CSTAR_SLURM_QUEUE: "default-q",
             },
         ),
         mock.patch("cstar.execution.scheduler_job.get_sysmgr", mock_getsysmgr),
@@ -126,23 +215,28 @@ def test_slurmlauncher_adapt_step_with_overrides(
         minimum_spec = SlurmLauncher._get_default_compute_spec(live_step)  # type: ignore
         job = SlurmLauncher.adapt_step(live_step, [])
 
-    # confirm that no job attributes have been overridden from the minimal spec
-    if value := overrides["slurm"].get("account_name", ""):
-        assert job.account_key == value
-    else:
-        assert job.account_key == minimum_spec.account_name
+    # confirm defaults as baseline
+    assert minimum_spec.account_name == "default-account"
+    assert minimum_spec.cpus_per_node is None
+    assert minimum_spec.max_walltime == "42:00:00"
+    assert minimum_spec.num_cpus == 128
+    assert minimum_spec.num_nodes is None
+    assert minimum_spec.queue_name == "default-q"
 
-    if value := overrides["slurm"].get("num_cpus", ""):
-        assert job.cpus == int(value)
-    else:
-        assert job.cpus == minimum_spec.num_cpus
+    # confirm the job varies from defaults as expected
+    assert job.account_key == exp_account
+    assert job.cpus == exp_ncpus
+    assert job.walltime == exp_walltime
+    assert job.cpus_per_node == exp_cpus_per_node
+    assert job.nodes == exp_nnodes
+    assert job.queue.name == exp_queue
 
-    if value := overrides["slurm"].get("queue_name", ""):
-        assert job.queue_name == value
-    else:
-        assert job.queue_name == minimum_spec.queue_name
+    # confirm slurm-specific env vars are captured in the command
+    if exp_queue != minimum_spec.queue_name:
+        assert f"{ENV_CSTAR_SLURM_QUEUE}={exp_queue!r}" in job.commands
 
-    if value := overrides["slurm"].get("max_walltime", ""):
-        assert job.walltime == value
-    else:
-        assert job.walltime == minimum_spec.max_walltime
+    if exp_account != minimum_spec.account_name:
+        assert f"{ENV_CSTAR_SLURM_ACCOUNT}={exp_account!r}" in job.commands
+
+    if exp_walltime != minimum_spec.max_walltime:
+        assert f"{ENV_CSTAR_SLURM_MAX_WALLTIME}={exp_walltime!r}" in job.commands


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This pull request fixes an issue where SLURM compute overrides are not applied. The `SlurmComputeSpec` was correctly configured, however those settings carried via env var were being exported to SLURM via the original env vars.

The fix ensures the command includes the overridden environment variables.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix bug where slurm account, walltime, and queue env vars are not updated with compute customizations

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

