### PR TITLE
Add CDF5 conversion for nesting app with PIO

### DIFF
--- a/cstar/applications/nest_ic.py
+++ b/cstar/applications/nest_ic.py
@@ -1,3 +1,4 @@
+import subprocess
 import typing as t
 from pathlib import Path
 
@@ -38,6 +39,13 @@ class NestIcBlueprint(Blueprint):
     """Path to a netCDF file defining the parent grid attributes."""
     child_grid: Path
     """Path to a netCDF file defining the child grid attributes."""
+    pio: bool = True
+    """Whether the target ROMS build reads its inputs via ParallelIO, which requires
+    CDF-5 (``NETCDF3_64BIT_DATA``) files. When True (the default), the initial
+    conditions are written in roms-tools' default NETCDF4 format (fast) under an
+    ``_nc4``-suffixed name, then converted to CDF-5 at the intended filename via an
+    ``nccopy -k cdf5`` subprocess instead of roms-tools' native (much slower at
+    scale) CDF-5 writer. When False, roms-tools' default save is used unchanged."""
 
 
 class NestIcRunner(BlueprintRunner[NestIcBlueprint]):
@@ -134,10 +142,27 @@ class NestIcRunner(BlueprintRunner[NestIcBlueprint]):
         ic = roms_tools.InitialConditions(**ic_kwargs)
 
         # Write out initial conditions file for child
-        ic.save(path)
+        if self.blueprint.pio:
+            nc4_path = path.with_name(path.stem + "_nc4" + path.suffix)
+            ic.save(nc4_path)
+            self._convert_to_cdf5(nc4_path, path)
+        else:
+            ic.save(path)
         self.log.debug(f"Initial conditions created and persisted to: {path}")
 
         return path
+
+    @staticmethod
+    def _convert_to_cdf5(nc4_path: Path, final_path: Path) -> None:
+        """Convert a NETCDF4 file to CDF-5 via ``nccopy -k cdf5``, then delete the
+        source. Raises on a non-zero ``nccopy`` exit; the source file is left in
+        place (and the final name unclaimed) so a re-run regenerates cleanly.
+        """
+        subprocess.run(
+            ["nccopy", "-k", "cdf5", str(nc4_path), str(final_path)],
+            check=True,
+        )
+        nc4_path.unlink()
 
 
 @register_application

--- a/cstar/applications/roms_marbl/transforms.py
+++ b/cstar/applications/roms_marbl/transforms.py
@@ -432,7 +432,7 @@ class BoundaryFile(BaseModel):
     """The expected file extension for a boundary file."""
     FMT_TS: t.ClassVar[t.Literal["%Y%m%d%H%M%S"]] = "%Y%m%d%H%M%S"
     """The expected timestamp format in the boundary file name"""
-    PATTERN_RST: t.ClassVar[t.Literal[r"^(.*?)_bry\.(\d{14})(?:\.(\d{1,9}))?\.nc$"]] = (
+    PATTERN_BRY: t.ClassVar[t.Literal[r"^(.*?)_bry\.(\d{14})(?:\.(\d{1,9}))?\.nc$"]] = (
         r"^(.*?)_bry\.(\d{14})(?:\.(\d{1,9}))?\.nc$"
     )
     """A regex identifying full boundary or partitioned files."""
@@ -532,7 +532,7 @@ class BoundaryFile(BaseModel):
             msg = f"File extension does not match expected naming convention: {value.suffix}"
             raise ValueError(msg)
 
-        if re.fullmatch(BoundaryFile.PATTERN_RST, value.name, flags=re.ASCII):
+        if re.fullmatch(BoundaryFile.PATTERN_BRY, value.name, flags=re.ASCII):
             return value
 
         msg = f"File name does not match expected naming convention: {value}"
@@ -547,7 +547,7 @@ class BoundaryFile(BaseModel):
         BoundaryFile
         """
         matches = re.fullmatch(
-            BoundaryFile.PATTERN_RST, self.path.as_posix(), flags=re.ASCII
+            BoundaryFile.PATTERN_BRY, self.path.as_posix(), flags=re.ASCII
         )
         if not matches:
             msg = f"File name does not match expected naming convention: {self.path}"

--- a/cstar/tests/unit_tests/applications/test_nest_ic.py
+++ b/cstar/tests/unit_tests/applications/test_nest_ic.py
@@ -1,0 +1,216 @@
+import logging
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from cstar.applications.core import RunnerRequest
+from cstar.applications.nest_ic import NestIcBlueprint, NestIcRunner
+from cstar.entrypoint.config import JobConfig, ServiceConfiguration
+
+
+@pytest.fixture
+def blueprint_kwargs(tmp_path: Path) -> dict[str, Any]:
+    """Minimal valid keyword arguments for constructing a `NestIcBlueprint`.
+
+    Paths need not exist on disk; the blueprint model itself performs no
+    existence checks on `parent_rst`, `parent_grid`, or `child_grid`.
+    """
+    return {
+        "name": "test-nest-ic",
+        "description": "A test nest_ic blueprint.",
+        "working_dir": tmp_path,
+        "parent_rst": tmp_path / "parent_rst.nc",
+        "parent_grid": tmp_path / "parent_grid.nc",
+        "child_grid": tmp_path / "child_grid.nc",
+    }
+
+
+def _make_runner(blueprint: NestIcBlueprint) -> NestIcRunner:
+    """Construct a `NestIcRunner` wired to *blueprint* without touching disk.
+
+    `RunnerRequest.blueprint` normally deserializes from a URI on first
+    access; setting the private `_bp` cache directly lets the request return
+    an in-memory blueprint instance instead.
+
+    Parameters
+    ----------
+    blueprint : NestIcBlueprint
+        The blueprint the runner should operate on.
+
+    Returns
+    -------
+    NestIcRunner
+    """
+    request: RunnerRequest[NestIcBlueprint] = RunnerRequest(
+        "unused://blueprint", NestIcBlueprint
+    )
+    request._bp = blueprint
+
+    service_config = ServiceConfiguration(
+        as_service=False,
+        loop_delay=0,
+        health_check_frequency=None,
+        log_level=logging.DEBUG,
+        health_check_log_threshold=10,
+        name="test_nest_ic_runner",
+    )
+    job_config = JobConfig(account_id="", walltime="", priority="")
+
+    return NestIcRunner(request, service_config, job_config)
+
+
+class TestNestIcBlueprintPio:
+    """Tests for the `pio` field on `NestIcBlueprint`."""
+
+    def test_pio_defaults_true(self, blueprint_kwargs: dict[str, Any]) -> None:
+        """Verify that `pio` defaults to True when omitted."""
+        bp = NestIcBlueprint(**blueprint_kwargs)
+        assert bp.pio is True
+
+    def test_pio_false_validates(self, blueprint_kwargs: dict[str, Any]) -> None:
+        """Verify that `pio=False` is accepted."""
+        bp = NestIcBlueprint(**blueprint_kwargs, pio=False)
+        assert bp.pio is False
+
+    def test_pio_defaults_true_via_model_validate(
+        self, blueprint_kwargs: dict[str, Any]
+    ) -> None:
+        """Verify that `pio` defaults to True when validated from a dict lacking
+        the key, as would happen deserializing a blueprint YAML without it.
+        """
+        data = {
+            k: str(v) if isinstance(v, Path) else v for k, v in blueprint_kwargs.items()
+        }
+        bp = NestIcBlueprint.model_validate(data)
+        assert bp.pio is True
+
+
+class TestConvertToCdf5:
+    """Tests for `NestIcRunner._convert_to_cdf5`."""
+
+    def test_success_invokes_nccopy_and_removes_source(self, tmp_path: Path) -> None:
+        """Verify the exact `nccopy` command is invoked and the nc4 source file
+        is removed once the conversion succeeds.
+        """
+        nc4_path = tmp_path / "ic_nc4.nc"
+        final_path = tmp_path / "ic.nc"
+        nc4_path.write_bytes(b"fake netcdf4 content")
+
+        with mock.patch("cstar.applications.nest_ic.subprocess.run") as mock_run:
+            NestIcRunner._convert_to_cdf5(nc4_path, final_path)
+
+        mock_run.assert_called_once_with(
+            ["nccopy", "-k", "cdf5", str(nc4_path), str(final_path)],
+            check=True,
+        )
+        assert not nc4_path.exists()
+
+    def test_failure_propagates_and_keeps_source(self, tmp_path: Path) -> None:
+        """Verify that a `nccopy` failure propagates as `CalledProcessError`
+        and leaves the nc4 source file untouched.
+        """
+        nc4_path = tmp_path / "ic_nc4.nc"
+        final_path = tmp_path / "ic.nc"
+        nc4_path.write_bytes(b"fake netcdf4 content")
+
+        with mock.patch(
+            "cstar.applications.nest_ic.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "nccopy"),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                NestIcRunner._convert_to_cdf5(nc4_path, final_path)
+
+        assert nc4_path.exists()
+        assert not final_path.exists()
+
+
+class TestCreateInitialConditionsRouting:
+    """Tests for the PIO-conditional save/convert routing in
+    `NestIcRunner._create_initial_conditions`.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_ic(self, monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+        """Replace the lazily-imported `roms_tools` module attribute with a
+        mock, so no real netCDF/dask work happens, and return the mocked
+        `InitialConditions` instance for assertions.
+        """
+        mock_roms_tools = mock.Mock()
+        mock_ic = mock.Mock()
+        mock_roms_tools.InitialConditions.return_value = mock_ic
+        monkeypatch.setattr("cstar.applications.nest_ic.roms_tools", mock_roms_tools)
+        return mock_ic
+
+    @pytest.fixture(autouse=True)
+    def _mock_restart_file(self, monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+        """Replace `RestartFile` with a mock exposing a fixed timestamp, so no
+        real file needs to exist at `parent_rst`.
+        """
+        mock_rst = mock.Mock()
+        mock_rst.timestamp = "2024-01-01T00:00:00"
+        mock_rst.formatted_timestamp = "20240101000000"
+        monkeypatch.setattr(
+            "cstar.applications.nest_ic.RestartFile",
+            mock.Mock(return_value=mock_rst),
+        )
+        return mock_rst
+
+    @pytest.fixture(autouse=True)
+    def _mock_has_bgc(self) -> Generator[mock.Mock, None, None]:
+        """Stub `_has_bgc` so it never inspects a (nonexistent) netCDF file."""
+        with mock.patch.object(NestIcRunner, "_has_bgc", return_value=False) as mocked:
+            yield mocked
+
+    def _expected_final_path(
+        self, blueprint: NestIcBlueprint, formatted_timestamp: str
+    ) -> Path:
+        fname = f"ic_from_parent_rst.{formatted_timestamp}.nc"
+        return Path(blueprint.working_dir).expanduser() / "output" / fname
+
+    def test_pio_true_saves_to_mangled_path_and_converts(
+        self,
+        blueprint_kwargs: dict[str, Any],
+        mock_ic: mock.Mock,
+    ) -> None:
+        """Verify that with `pio=True`, the `InitialConditions` is saved to the
+        `_nc4`-mangled path, `_convert_to_cdf5` is invoked with the mangled and
+        final paths, and the unmangled final path is returned.
+        """
+        bp = NestIcBlueprint(**blueprint_kwargs, pio=True)
+        runner = _make_runner(bp)
+
+        final_path = self._expected_final_path(bp, "20240101000000")
+        # Hardcoded (not derived via the production mangling expression) so a
+        # botched change to the mangling scheme fails this assertion.
+        nc4_path = final_path.with_name("ic_from_parent_rst.20240101000000_nc4.nc")
+
+        with mock.patch.object(NestIcRunner, "_convert_to_cdf5") as mock_convert:
+            result = runner._create_initial_conditions()
+
+        mock_ic.save.assert_called_once_with(nc4_path)
+        mock_convert.assert_called_once_with(nc4_path, final_path)
+        assert result == final_path
+
+    def test_pio_false_saves_directly_without_conversion(
+        self,
+        blueprint_kwargs: dict[str, Any],
+        mock_ic: mock.Mock,
+    ) -> None:
+        """Verify that with `pio=False`, the `InitialConditions` is saved
+        directly to the final path and no conversion is attempted.
+        """
+        bp = NestIcBlueprint(**blueprint_kwargs, pio=False)
+        runner = _make_runner(bp)
+
+        final_path = self._expected_final_path(bp, "20240101000000")
+
+        with mock.patch.object(NestIcRunner, "_convert_to_cdf5") as mock_convert:
+            result = runner._create_initial_conditions()
+
+        mock_ic.save.assert_called_once_with(final_path)
+        mock_convert.assert_not_called()
+        assert result == final_path


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- The NestIc app will now do CDF-5 conversion of the new IC file if PIO is enabled (default: true)

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

