### PR TITLE
Version the ROMS namelist schema by ucla-roms release

### DIFF
--- a/cstar/base/gitutils.py
+++ b/cstar/base/gitutils.py
@@ -172,6 +172,43 @@ def _get_repo_head_hash(local_path: str | Path) -> str:
     )
 
 
+def _describe_nearest_tag(local_path: str | Path, ref: str) -> tuple[str, int] | None:
+    """Resolve `ref` to its nearest ancestor release tag in a local repository.
+
+    Runs ``git describe --tags <ref>`` and parses the output (``<tag>`` or
+    ``<tag>-<N>-g<hash>``) into the tag and the number of commits `ref` is
+    ahead of it. Only release-shaped tags (``[v]<digits>.<digits>.<digits>``,
+    e.g. ``0.4.2`` or ``v1.10.0``) are considered, so stray non-release tags
+    (e.g. an experiment marker) cannot shadow the nearest release.
+
+    Parameters
+    ----------
+    local_path : str or Path
+        The path to a local directory where a git repository is cloned.
+    ref : str
+        Any commit-ish accepted by ``git describe`` (typically a commit hash).
+
+    Returns
+    -------
+    tuple[str, int] or None
+        The ``(tag, commits_ahead)`` pair, or `None` if `ref` has no
+        release-tagged ancestor or the command fails.
+    """
+    match_glob = "[0-9]*.[0-9]*.[0-9]*"
+    described = _run_cmd(
+        f"git -C {local_path} describe --tags "
+        f"--match '{match_glob}' --match 'v{match_glob}' {ref}",
+        msg_pre=f"Resolving `{ref}` to its nearest release tag in `{local_path}`.",
+        msg_err=f"Could not resolve {ref} to a release tag in repository {local_path}.",
+    ).strip()
+    if not described:
+        return None
+    match = re.fullmatch(r"(?P<tag>.+?)(?:-(?P<ahead>\d+)-g[0-9a-f]+)?", described)
+    if match is None:
+        return None
+    return match.group("tag"), int(match.group("ahead") or 0)
+
+
 def _get_hash_from_checkout_target(repo_url: str, checkout_target: str) -> str:
     """Take a git checkout target (any `arg` accepted by `git checkout arg`) and return
     a commit hash.

--- a/cstar/roms/namelist.py
+++ b/cstar/roms/namelist.py
@@ -48,6 +48,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Final, Self
 import f90nml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cstar.base.gitutils import _describe_nearest_tag
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -895,7 +897,14 @@ def _parse_semver(ref: str) -> tuple[int, int, int] | None:
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
-def namelist_schema_for_ref(checkout_target: str | None) -> type[RomsNamelistBase]:
+_COMMIT_HASH_RE = re.compile(r"[0-9a-fA-F]{7,40}")
+"""A plausible (possibly abbreviated) git commit hash — used to decide whether
+an unparseable ref is worth resolving to a release tag via the local clone."""
+
+
+def namelist_schema_for_ref(
+    checkout_target: str | None, repo_path: str | Path | None = None
+) -> type[RomsNamelistBase]:
     """Select the ``RomsNamelistBase`` subclass matching a ucla-roms ref.
 
     Parameters
@@ -903,19 +912,48 @@ def namelist_schema_for_ref(checkout_target: str | None) -> type[RomsNamelistBas
     checkout_target : str or None
         The ucla-roms git ref (tag, branch, or commit hash) C-Star is pinned
         to, e.g. from ``ExternalCodeBase.source.checkout_target``.
+    repo_path : str or Path, optional
+        Path to a local clone of ucla-roms. When given and `checkout_target`
+        looks like a commit hash, the hash is resolved to its nearest
+        ancestor release tag (``git describe --tags``) and that release's
+        schema is selected — a commit hash pins the ucla-roms source exactly,
+        so its namelist layout is the one of the release it descends from. A
+        `UserWarning` is emitted if the commit is ahead of the tag (it could
+        contain unreleased namelist changes).
 
     Returns
     -------
     type[RomsNamelistBase]
         The namelist schema class whose ucla-roms version range contains
         `checkout_target`, if it parses as a strict ``major.minor.patch``
-        semantic version (an optional leading ``v`` is stripped first). If
-        `checkout_target` is `None` or is not a release tag (a branch name,
-        commit hash, or otherwise unparsable string), a `UserWarning` is
-        emitted and the last (most recent) registry entry's class is
-        returned.
+        semantic version (an optional leading ``v`` is stripped first) or is
+        a commit hash resolvable to a release tag via `repo_path`. Otherwise
+        (`None`, a branch name, an unresolvable hash, or an unparsable
+        string), a `UserWarning` is emitted and the last (most recent)
+        registry entry's class is returned.
     """
     version = _parse_semver(checkout_target) if checkout_target is not None else None
+
+    if (
+        version is None
+        and checkout_target is not None
+        and repo_path is not None
+        and _COMMIT_HASH_RE.fullmatch(checkout_target)
+    ):
+        described = _describe_nearest_tag(repo_path, checkout_target)
+        if described is not None:
+            tag, commits_ahead = described
+            version = _parse_semver(tag)
+            if version is not None and commits_ahead:
+                warnings.warn(
+                    f"ucla-roms commit {checkout_target!r} is {commits_ahead} "
+                    f"commit(s) after release {tag}; using that release's "
+                    f"namelist schema. If the commit contains unreleased "
+                    f"breaking namelist changes, C-Star may not match them.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
     last_cls = NAMELIST_SCHEMA_REGISTRY[-1][2]
     if version is None:
         warnings.warn(

--- a/cstar/roms/namelist.py
+++ b/cstar/roms/namelist.py
@@ -1,11 +1,28 @@
 """
 Pydantic model of the ROMS Fortran ``namelist.nml``.
 
-:class:`RomsNamelist` mirrors the namelist's ``&group`` structure (one nested
-model per group, exact ROMS key names). It round-trips through ``f90nml``:
-:meth:`RomsNamelist.read` parses a ``namelist.nml`` into a validated model,
-edits are type-checked (``validate_assignment``), and :meth:`RomsNamelist.write`
-serializes it back. ``ROMSSimulation.roms_runtime_settings`` uses it to read the
+The namelist schema is **versioned**: ucla-roms occasionally makes breaking
+namelist changes, and C-Star must validate against the schema matching the
+pinned ucla-roms ref rather than a single fixed model.
+
+``RomsNamelistBase`` mirrors the namelist's ``&group`` structure (one nested
+model per group, exact ROMS key names) and holds the shared f90nml round-trip
+machinery (:meth:`RomsNamelistBase.read` / :meth:`RomsNamelistBase.write`
+etc.). It is not meant to be instantiated directly — use one of its versioned
+subclasses:
+
+- :class:`RomsNamelist` — the schema for ucla-roms **< 0.5.0**. Kept
+  unversioned (no suffix) for backward compatibility: this is the name
+  historically imported by C-Star Forge and other consumers.
+- :class:`RomsNamelistV0_5_0` — the schema for ucla-roms **>= 0.5.0**.
+
+Later breaking releases add a further ``RomsNamelistV<major>_<minor>_<patch>``
+subclass following the same ``V<major>_<minor>_<patch>`` suffix convention.
+:data:`NAMELIST_SCHEMA_REGISTRY` maps ``[lower, upper)`` ucla-roms version
+ranges to the schema class that applies, and
+:func:`namelist_schema_for_ref` selects the right class given a
+``checkout_target`` (e.g. from :class:`~cstar.io.source_data.SourceData`).
+``ROMSSimulation.roms_runtime_settings`` uses this selection to read the
 runtime namelist, apply simulation overrides, and write the run-time copy.
 
 Every group of a forge-produced namelist (which mirrors the pinned ucla-roms
@@ -24,11 +41,12 @@ that this model reads back.)
 
 from __future__ import annotations
 
+import re
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Self
 
 import f90nml
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -193,7 +211,7 @@ class TidalFrcSettings(_NmlGroup):
     """Number of tidal constituents"""
 
 
-class BasicOutputSettings(_NmlGroup):
+class _BasicOutputSettingsCommon(_NmlGroup):
     wrt_file_his: bool
     """Write instantaneous ocean physical state to output"""
     output_period_his: float
@@ -264,8 +282,21 @@ class BasicOutputSettings(_NmlGroup):
     """Write restart files at start of calendar month"""
     output_period_rst: float
     """Write restart files at regular frequency (s)"""
+
+
+class BasicOutputSettings(_BasicOutputSettingsCommon):
+    """``&BASIC_OUTPUT_SETTINGS`` for ucla-roms < 0.5.0."""
+
     nrpf_rst: int
     """Number of time records in restart files"""
+
+
+class BasicOutputSettingsV0_5_0(_BasicOutputSettingsCommon):
+    """``&BASIC_OUTPUT_SETTINGS`` for ucla-roms >= 0.5.0.
+
+    ``nrpf_rst`` was removed in ucla-roms 0.5.0 (PR #336): the restart
+    record count is now hardcoded in Fortran rather than namelist-configurable.
+    """
 
 
 class TsOutputSettings(_NmlGroup):
@@ -606,7 +637,7 @@ class PipeFrcSettings(_NmlGroup):
     """Number of pipe inputs"""
 
 
-class ParticlesSettings(_NmlGroup):
+class _ParticlesSettingsCommon(_NmlGroup):
     floats: bool
     """Release Lagrangian particles (T) or not (F)"""
     np: int
@@ -619,25 +650,71 @@ class ParticlesSettings(_NmlGroup):
     """Maximum number of particles for transfer in E-W"""
     exchange_facc: float
     """Maximum number of particles for transfer in corners"""
-    output_period: float
-    """Frequency of outputs"""
-    nrpf: int
-    """Number of records per file"""
     ppm3: float
     """Target particles per cubic meter"""
     pmin: int
     """Minimum of allocated space for particle array"""
 
 
-class RomsNamelist(BaseModel):
-    """A complete ROMS ``namelist.nml``, round-trippable via ``f90nml``.
+class ParticlesSettings(_ParticlesSettingsCommon):
+    """``&PARTICLES_SETTINGS`` for ucla-roms < 0.5.0.
+
+    ``output_period``/``nrpf`` are appended after the common fields, which
+    moves them to the end of the written ``&PARTICLES_SETTINGS`` group
+    relative to the original field order. This is a cosmetic-only change:
+    Fortran namelist reads are key-order-independent.
+    """
+
+    output_period: float
+    """Frequency of outputs"""
+    nrpf: int
+    """Number of records per file"""
+
+
+class ParticlesSettingsV0_5_0(_ParticlesSettingsCommon):
+    """``&PARTICLES_SETTINGS`` for ucla-roms >= 0.5.0.
+
+    ucla-roms 0.5.0 (PR #336) renamed ``output_period`` to
+    ``output_period_particles`` and ``nrpf`` to ``nrpf_particles``.
+    """
+
+    output_period_particles: float
+    """Frequency of outputs"""
+    nrpf_particles: int
+    """Number of records per file"""
+
+
+class RomsNamelistBase(BaseModel):
+    """Base model for a complete ROMS ``namelist.nml``, round-trippable via ``f90nml``.
 
     Group order matches ``write_roms_namelist`` / the reference namelist.
+
+    Not meant to be instantiated directly: use a versioned subclass
+    (:class:`RomsNamelist` for ucla-roms < 0.5.0, :class:`RomsNamelistV0_5_0`
+    for ucla-roms >= 0.5.0) or select one automatically with
+    :func:`namelist_schema_for_ref`.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid", validate_assignment=True, use_attribute_docstrings=True
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_direct_use(cls, data: Any) -> Any:
+        """Reject validation against the base class itself.
+
+        The base's version-varying groups are typed as the loose ``_*Common``
+        models, so validating against it directly would silently accept a
+        namelist that no actual ucla-roms version reads.
+        """
+        if cls is RomsNamelistBase:
+            raise TypeError(
+                "RomsNamelistBase is not a usable schema; use a versioned "
+                "subclass (e.g. RomsNamelist, RomsNamelistV0_5_0) or select "
+                "one with namelist_schema_for_ref()."
+            )
+        return data
 
     simulation_name_settings: SimulationNameSettings
     time_stepping: TimeStepping
@@ -652,7 +729,7 @@ class RomsNamelist(BaseModel):
     surf_frc_settings: SurfFrcSettings
     river_frc_settings: RiverFrcSettings
     tidal_frc_settings: TidalFrcSettings
-    basic_output_settings: BasicOutputSettings
+    basic_output_settings: _BasicOutputSettingsCommon
     ts_output_settings: TsOutputSettings
     frc_output_settings: FrcOutputSettings
     extract_data_settings: ExtractDataSettings
@@ -681,11 +758,11 @@ class RomsNamelist(BaseModel):
     random_output_settings: RandomOutputSettings
     surf_flx_output_settings: SurfFlxOutputSettings
     pipe_frc_settings: PipeFrcSettings
-    particles_settings: ParticlesSettings
+    particles_settings: _ParticlesSettingsCommon
 
     # ---- f90nml round-trip ----
     @classmethod
-    def from_f90nml(cls, nml: f90nml.Namelist) -> RomsNamelist:
+    def from_f90nml(cls, nml: f90nml.Namelist) -> Self:
         """Build a validated model from a parsed ``f90nml.Namelist``.
 
         Each ``&group`` in the namelist becomes a nested model; group and key
@@ -699,13 +776,13 @@ class RomsNamelist(BaseModel):
 
         Returns
         -------
-        RomsNamelist
+        Self
             The validated model.
         """
         return cls.model_validate({k: dict(v) for k, v in nml.items()})
 
     @classmethod
-    def read(cls, path: str | Path) -> RomsNamelist:
+    def read(cls, path: str | Path) -> Self:
         """Read and validate a ``namelist.nml`` file from disk.
 
         Parameters
@@ -715,7 +792,7 @@ class RomsNamelist(BaseModel):
 
         Returns
         -------
-        RomsNamelist
+        Self
             The validated model parsed from the file.
         """
         return cls.from_f90nml(f90nml.read(str(path)))
@@ -747,3 +824,113 @@ class RomsNamelist(BaseModel):
             Destination path for the written namelist.
         """
         f90nml.Namelist(self.to_f90nml_dict()).write(str(path), force=True)
+
+
+class RomsNamelist(RomsNamelistBase):
+    """The ROMS namelist schema for ucla-roms < 0.5.0.
+
+    Kept unversioned (no suffix) for backward compatibility: this is the name
+    historically imported by C-Star Forge and other consumers.
+    """
+
+    basic_output_settings: BasicOutputSettings
+    particles_settings: ParticlesSettings
+
+
+class RomsNamelistV0_5_0(RomsNamelistBase):
+    """The ROMS namelist schema for ucla-roms >= 0.5.0 (PR #336)."""
+
+    basic_output_settings: BasicOutputSettingsV0_5_0
+    particles_settings: ParticlesSettingsV0_5_0
+
+
+# ---- Schema version selection ----
+
+# ucla-roms releases with breaking namelist changes, as comparable version
+# tuples (named so registry entries read as versions, not bare tuples).
+UCLA_ROMS_0_5_0: Final[tuple[int, int, int]] = (0, 5, 0)
+
+# Half-open ucla-roms version ranges ``[lower, upper)`` mapped to the schema
+# class that applies; `None` bounds are unbounded. Ranges must be contiguous
+# and non-overlapping, ordered oldest-first; the last entry's upper bound
+# must be `None` (it covers "latest known release and beyond").
+#
+# Recipe for the next breaking namelist release (e.g. 0.8.0):
+#   1. Add the release constant:
+#        UCLA_ROMS_0_8_0: Final[tuple[int, int, int]] = (0, 8, 0)
+#   2. Cap the current last entry's upper bound at the new version:
+#        (UCLA_ROMS_0_5_0, UCLA_ROMS_0_8_0, RomsNamelistV0_5_0),
+#   3. Append a new open-ended entry for the new schema:
+#        (UCLA_ROMS_0_8_0, None, RomsNamelistV0_8_0),
+NAMELIST_SCHEMA_REGISTRY: tuple[
+    tuple[
+        tuple[int, int, int] | None, tuple[int, int, int] | None, type[RomsNamelistBase]
+    ],
+    ...,
+] = (
+    (None, UCLA_ROMS_0_5_0, RomsNamelist),
+    (UCLA_ROMS_0_5_0, None, RomsNamelistV0_5_0),
+)
+
+
+def _parse_semver(ref: str) -> tuple[int, int, int] | None:
+    r"""Parse a strict ``major.minor.patch`` version out of a git ref.
+
+    Parameters
+    ----------
+    ref : str
+        A git ref/tag string, e.g. ``"v0.5.0"`` or ``"0.5.0"``.
+
+    Returns
+    -------
+    tuple[int, int, int] or None
+        The parsed ``(major, minor, patch)`` tuple, or `None` if `ref` is not
+        strictly of the form ``\d+\.\d+\.\d+`` (with at most one leading
+        ``v`` stripped).
+    """
+    stripped = ref.removeprefix("v")
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", stripped)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def namelist_schema_for_ref(checkout_target: str | None) -> type[RomsNamelistBase]:
+    """Select the ``RomsNamelistBase`` subclass matching a ucla-roms ref.
+
+    Parameters
+    ----------
+    checkout_target : str or None
+        The ucla-roms git ref (tag, branch, or commit hash) C-Star is pinned
+        to, e.g. from ``ExternalCodeBase.source.checkout_target``.
+
+    Returns
+    -------
+    type[RomsNamelistBase]
+        The namelist schema class whose ucla-roms version range contains
+        `checkout_target`, if it parses as a strict ``major.minor.patch``
+        semantic version (an optional leading ``v`` is stripped first). If
+        `checkout_target` is `None` or is not a release tag (a branch name,
+        commit hash, or otherwise unparsable string), a `UserWarning` is
+        emitted and the last (most recent) registry entry's class is
+        returned.
+    """
+    version = _parse_semver(checkout_target) if checkout_target is not None else None
+    last_cls = NAMELIST_SCHEMA_REGISTRY[-1][2]
+    if version is None:
+        warnings.warn(
+            f"ucla-roms ref {checkout_target!r} is not a release tag; using the "
+            f"latest known namelist schema ({last_cls.__name__}). If this ref "
+            f"contains unreleased breaking namelist changes, C-Star may not "
+            f"match them — use at your own risk. Pin a ucla-roms release tag "
+            f"(e.g. 'v0.5.0') to get version-matched validation.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return last_cls
+    for lower, upper, cls in NAMELIST_SCHEMA_REGISTRY:
+        if (lower is None or version >= lower) and (upper is None or version < upper):
+            return cls
+    # Unreachable given a well-formed, contiguous registry with an
+    # open-ended last entry, but keeps mypy happy about the return type.
+    return last_cls

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import yaml
+from pydantic import ValidationError
 
 from cstar.applications.roms_marbl.adapter import (
     AddtlCodeAdapter,
@@ -71,7 +72,7 @@ from cstar.roms.input_dataset import (
     ROMSSurfaceForcing,
     ROMSTidalForcing,
 )
-from cstar.roms.namelist import RomsNamelist
+from cstar.roms.namelist import RomsNamelistBase, namelist_schema_for_ref
 from cstar.simulation import Simulation
 from cstar.system.manager import get_sysmgr
 
@@ -185,7 +186,7 @@ class ROMSSimulation(Simulation):
         The repository containing the source code for the ParallelIO library (if use_pio is True).
     runtime_code : AdditionalCode
         Additional code needed by ROMS at runtime (e.g. a `.nml` Fortran namelist)
-    roms_runtime_settings : RomsNamelist
+    roms_runtime_settings : RomsNamelistBase
         A validated namelist read from the runtime_code, with key parameters overridden
         from the simulation configuration.
     compile_time_code : AdditionalCode
@@ -720,28 +721,34 @@ class ROMSSimulation(Simulation):
         return run_length_seconds // self.discretization.time_step
 
     @property
-    def roms_runtime_settings(self) -> "RomsNamelist":
-        """Generate and return a :class:`RomsNamelist` for the simulation.
+    def roms_runtime_settings(self) -> "RomsNamelistBase":
+        """Generate and return a :class:`RomsNamelistBase` for the simulation.
 
-        Reads the Fortran namelist from the `runtime_code`, validates it into a
-        :class:`~cstar.roms.namelist.RomsNamelist`, and overrides key parameters
+        Reads the Fortran namelist from the `runtime_code`, validates it into
+        the :class:`~cstar.roms.namelist.RomsNamelistBase` subclass selected
+        by :func:`~cstar.roms.namelist.namelist_schema_for_ref` for this
+        simulation's ucla-roms `checkout_target`, and overrides key parameters
         based on the current simulation configuration: time step, number of time
         steps, grid path, initial conditions, forcing datasets, MARBL/CDR/nesting
         files, output root, and extract root.
 
         Returns
         -------
-        RomsNamelist
+        RomsNamelistBase
             A validated namelist with simulation-specific parameters applied.
 
         Raises
         ------
         ValueError
             If the runtime namelist has not been retrieved locally via `setup()` or
-            `runtime_code.get()`.
+            `runtime_code.get()`, or if it fails validation against the schema
+            selected for this simulation's ucla-roms `checkout_target` (the
+            original `pydantic.ValidationError` is chained as `__cause__`) —
+            this can happen if the namelist file targets a different ucla-roms
+            version than the one this simulation pins.
         pydantic.ValidationError
-            If the runtime namelist is missing a required group/key or contains an
-            invalid value (RomsNamelist is a strict, fully-typed schema).
+            If a simulation-derived override value is invalid for its namelist
+            field (the namelist models re-validate on assignment).
         """
         if self.runtime_code.working_copy is None:
             raise ValueError(
@@ -750,9 +757,20 @@ class ROMSSimulation(Simulation):
                 + "ROMSSimulation.runtime_code.get() and try again."
             )
 
-        nml = RomsNamelist.read(
+        checkout_target = self.codebase.source.checkout_target
+        schema = namelist_schema_for_ref(checkout_target)
+        namelist_path = (
             self.runtime_code.working_copy.common_parent / self._namelist_file
         )
+        try:
+            nml = schema.read(namelist_path)
+        except ValidationError as err:
+            raise ValueError(
+                f"namelist at {namelist_path} failed validation against "
+                f"{schema.__name__} (selected for ucla-roms ref "
+                f"{checkout_target!r}). The namelist file may target a "
+                f"different ucla-roms version than the one this simulation pins."
+            ) from err
 
         nml.time_stepping.dt = self.discretization.time_step
         nml.time_stepping.ntimes = self._n_time_steps
@@ -1321,18 +1339,13 @@ class ROMSSimulation(Simulation):
             if not (inp.exists_locally):
                 # If it can't be found locally, check whether it should by matching dataset dates with simulation dates:
                 # If no start or end date, it should be found locally:
-                if (not isinstance(inp.start_date, datetime)) or (
-                    not isinstance(inp.end_date, datetime)
-                ):
-                    return False
-                # If no start or end date for case, all files should be found locally:
-                elif (not isinstance(self.start_date, datetime)) or (
-                    not isinstance(self.end_date, datetime)
-                ):
-                    return False
-                # If inp and case start and end dates overlap, should be found locally:
-                elif (inp.start_date <= self.end_date) and (
-                    inp.end_date >= self.start_date
+                if (
+                    (not isinstance(inp.start_date, datetime))
+                    or (not isinstance(inp.end_date, datetime))
+                    or (not isinstance(self.start_date, datetime))
+                    or (not isinstance(self.end_date, datetime))
+                    or (inp.start_date <= self.end_date)
+                    and (inp.end_date >= self.start_date)
                 ):
                     return False
         return True

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -758,7 +758,11 @@ class ROMSSimulation(Simulation):
             )
 
         checkout_target = self.codebase.source.checkout_target
-        schema = namelist_schema_for_ref(checkout_target)
+        codebase_copy = self.codebase.working_copy
+        schema = namelist_schema_for_ref(
+            checkout_target,
+            repo_path=codebase_copy.path if codebase_copy is not None else None,
+        )
         namelist_path = (
             self.runtime_code.working_copy.common_parent / self._namelist_file
         )

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -285,6 +285,15 @@ class BlueprintMigration(Migration):
         )
 
 
+def _version_key(version: str) -> tuple[int, ...]:
+    """Return a numeric sort key for a dotted-integer schema version.
+
+    Schema versions must compare numerically per component: lexicographic
+    string comparison would order ``"10.0.0"`` before ``"2.0.0"``.
+    """
+    return tuple(int(part) for part in version.split("."))
+
+
 def identify_bounds(
     adapters: Sequence[type[SchemaAdapter]],
 ) -> dict[str, SchemaBounds]:
@@ -309,11 +318,8 @@ def identify_bounds(
     schema_bounds: dict[str, SchemaBounds] = {}
 
     for app_name, adapter_list in app_adapters.items():
-        sources = sorted(x.source() for x in adapter_list)
-        targets = sorted((x.target() for x in adapter_list), reverse=True)
-
-        vmin = next(iter(sources))
-        vmax = next(iter(targets))
+        vmin = min((x.source() for x in adapter_list), key=_version_key)
+        vmax = max((x.target() for x in adapter_list), key=_version_key)
 
         schema_bounds[app_name] = SchemaBounds(min=vmin, max=vmax)
     return schema_bounds

--- a/cstar/tests/integration_tests/blueprints/blueprint_template.yaml
+++ b/cstar/tests/integration_tests/blueprints/blueprint_template.yaml
@@ -12,7 +12,8 @@ valid_end_date: 2012-12-31 12:00:00
 code:
   roms:
     location: https://github.com/CWorthy-ocean/ucla-roms.git
-    commit: 585512b63b31dea2a7fba12b5d3de1cbd6b0546c
+    # release 0.4.2 — namelist schema selection resolves this hash to that tag
+    commit: 7c99a5d04c2ed5014cad28ab975e6a3eeac77d2a
     documentation: cworthy fork
   marbl:
     location: https://github.com/marbl-ecosys/MARBL.git

--- a/cstar/tests/unit_tests/orchestration/test_migration.py
+++ b/cstar/tests/unit_tests/orchestration/test_migration.py
@@ -157,6 +157,34 @@ def test_migration_identify_bounds() -> None:
     assert bounds["max"] != global_max
 
 
+def test_migration_identify_bounds_orders_versions_numerically() -> None:
+    """Verify bounds discovery compares versions numerically per component.
+
+    Lexicographic string comparison would order "10.0.0" before "2.0.0",
+    yielding min="10.0.0" and max="9.0.0" for the adapters below.
+    """
+    mock_adapter0 = mock.MagicMock(spec=type[SchemaAdapter])
+    type(mock_adapter0).application = lambda _cls: APP_ROMS
+    type(mock_adapter0).source = lambda _cls: "2.0.0"
+    type(mock_adapter0).target = lambda _cls: "9.0.0"
+
+    mock_adapter1 = mock.MagicMock(spec=type[SchemaAdapter])
+    type(mock_adapter1).application = lambda _cls: APP_ROMS
+    type(mock_adapter1).source = lambda _cls: "10.0.0"
+    type(mock_adapter1).target = lambda _cls: "10.1.0"
+
+    adapters: list[type[SchemaAdapter]] = [
+        mock_adapter0,
+        mock_adapter1,
+    ]  # type: ignore  # noqa: PGH003
+
+    migrator = BlueprintMigration(adapters=adapters)
+
+    bounds = migrator.schema_bounds[APP_ROMS]
+    assert bounds["min"] == "2.0.0"
+    assert bounds["max"] == "10.1.0"
+
+
 @pytest.mark.parametrize(
     ("dumped", "exp_min", "exp_max"),
     [

--- a/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_5_0.nml
+++ b/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_5_0.nml
@@ -1,0 +1,311 @@
+&basic_output_settings
+    monthly_restarts = .false.
+    nrpf_avg = 1
+    nrpf_his = 7
+    output_period_avg = 604800.0
+    output_period_his = 86400.0
+    output_period_rst = 86400.0
+    wrt_aks = .false.
+    wrt_akt = .false.
+    wrt_akv = .false.
+    wrt_avg_aks = .true.
+    wrt_avg_akt = .true.
+    wrt_avg_akv = .true.
+    wrt_avg_hbbl = .true.
+    wrt_avg_hbls = .true.
+    wrt_avg_o = .true.
+    wrt_avg_r = .true.
+    wrt_avg_u = .true.
+    wrt_avg_ub = .true.
+    wrt_avg_v = .true.
+    wrt_avg_vb = .true.
+    wrt_avg_w = .true.
+    wrt_avg_z = .true.
+    wrt_file_avg = .false.
+    wrt_file_his = .false.
+    wrt_file_rst = .true.
+    wrt_hbbl = .false.
+    wrt_hbls = .false.
+    wrt_o = .false.
+    wrt_r = .false.
+    wrt_u = .true.
+    wrt_ub = .true.
+    wrt_v = .true.
+    wrt_vb = .true.
+    wrt_w = .true.
+    wrt_z = .true.
+/
+
+&bgc_settings
+    interp_bgc_frc = .true.
+    nrpf_bgc_avg = 7
+    nrpf_bgc_avg_dia = 1
+    nrpf_bgc_his = 7
+    nrpf_bgc_his_dia = 7
+    output_period_bgc_avg = 86400.0
+    output_period_bgc_avg_dia = 60.0
+    output_period_bgc_his = 86400.0
+    output_period_bgc_his_dia = 86400.0
+    wrt_bgc_avg = .false.
+    wrt_bgc_dia_avg = .false.
+    wrt_bgc_dia_his = .false.
+    wrt_bgc_his = .false.
+    xco2air_default = 284.7
+/
+
+&bottom_drag_settings
+    rdrg = 0.0
+    rdrg2 = 0.001
+    zob = 0.01
+/
+
+&calc_pflx_settings
+    calc_pflx = .true.
+    pflx_timescale = 86400.0
+/
+
+&cdr_frc_settings
+    cdr_file = 'cdr.nc'
+    cdr_forcing_3d = .false.
+    cdr_forcing_depth_profiles = .false.
+    cdr_forcing_parameterized = .true.
+    cdr_ncdr_parm = 1
+    cdr_nz_chd = 50
+    cdr_relocate_to_wet_pts = .true.
+    cdr_source = .false.
+    cdr_time_interpolation = .false.
+    cdr_volume = .false.
+/
+
+&cdr_output_settings
+    cdr_monthly_averages = .false.
+    do_cdr_output = .false.
+    nrpf_cdr = 24
+    output_period_cdr = 3600.0
+    wrt_cdr_avg = .true.
+/
+
+&diagnostics_settings
+    diag_avg = .false.
+    diag_trc = .false.
+    diag_uv = .false.
+    nrpf_diag = 7
+    output_period_diag = 86400.0
+/
+
+&extract_data_settings
+    do_extract = .false.
+    extract_file = 'sample_edata.nc'
+    extract_root_name = 'child'
+    hc_chd = 250.0
+    n_chd = 90
+    nrpf_extract = 24
+    output_period_extract = 3600.0
+    theta_b_chd = 2.0
+    theta_s_chd = 5.0
+/
+
+&forcing_files
+/
+
+&frc_output_settings
+    nrpf_frc = 4
+    output_period_frc = 3600.0
+    wrt_frc = .false.
+    wrt_frc_avg = .false.
+/
+
+&gamma2_settings
+    gamma2 = 1.0
+/
+
+&grid_settings
+    grdname = ''
+/
+
+&initial_conditions
+    inifile = ''
+/
+
+&lateral_visc_settings
+    visc2 = 0.0
+/
+
+&lin_rho_eos_settings
+    s0 = 1.0
+    scoef = 0.822
+    t0 = 1.0
+    tcoef = 0.2
+/
+
+&marbl_biogeochemistry_settings
+    marbl_config_file = 'marbl_in'
+    marbl_diagnostics_to_write = 'PH', 'PH_ALT_CO2', 'pCO2SURF_ALT_CO2',
+                                 'pCO2SURF', 'FG_CO2', 'FG_ALT_CO2'
+    marbl_timestep = 3600.0
+    marbl_tracers_to_write = 'PO4', 'NO3', 'SiO3', 'NH4', 'Fe', 'O2', 'DIC',
+                             'ALK', 'spChl', 'diatChl'
+/
+
+&param_settings
+    llm = 512
+    mmm = 512
+    np_eta = 16
+    np_xi = 16
+    nt_bgc = 32
+    nt_passive = 0
+    nz = 60
+/
+
+&particles_settings
+    exchange_facc = 0.01
+    exchange_facx = 0.1
+    exchange_facy = 0.1
+    extra_space_fac = 1.5
+    floats = .false.
+    np = 50
+    nrpf_particles = 100
+    output_period_particles = 400.0
+    pmin = 200
+    ppm3 = 1e-06
+/
+
+&pipe_frc_settings
+    npip = 1
+    p_analytical = .false.
+    pipe_source = .false.
+/
+
+&random_output_settings
+    do_random = .false.
+    nrpf_random = 10
+    output_period_random = 3600.0
+/
+
+&reference_date_settings
+    reference_date = 2005, 6, 15
+/
+
+&rho0_settings
+    rho0 = 1000.0
+/
+
+&river_frc_settings
+    nriv = 0
+    river_analytical = .false.
+    river_source = .false.
+/
+
+&s_coord
+    hc = 250.0
+    theta_b = 2.0
+    theta_s = 5.0
+/
+
+&simulation_name_settings
+    output_root_name = 'roms'
+    title = 'test_settings'
+/
+
+&sponge_tune_settings
+    nrpf_sponge = 7
+    output_period_sponge = 86400.0
+    sponge_avg = .true.
+    sponge_timescale = 86400.0
+    ub_tune = .false.
+    wrt_sponge = .false.
+/
+
+&sss_correction
+    dsssdt = 7.777
+/
+
+&sst_correction
+    dsstdt = 7.777
+/
+
+&dic_alk_correction
+    dcdt = 7.777
+/
+
+&stdout_diag_settings
+    code_check_mode = .false.
+/
+
+&surf_flx_output_settings
+    nrpf_sflx = 10
+    output_period_sflx = 31536000.0
+    sflx_avg = .false.
+    wrt_smflx = .false.
+    wrt_stflx = .false.
+    wrt_rstflx = .false.
+    wrt_swflx = .false.
+/
+
+&surf_frc_settings
+    check_bulk_frc_units = .false.
+    interp_bulk_frc = .false.
+    interp_flux_frc = .true.
+/
+
+&tidal_frc_settings
+    ana_tides = .false.
+    bry_tides = .true.
+    ntides = 10
+    pot_tides = .true.
+/
+
+&time_stepping
+    dt = 2160.0
+    ndtfast = 60
+    ninfo = 1
+    ntimes = 1200
+/
+
+&tracer_diff2
+    tnu2 = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+/
+
+&ts_output_settings
+    wrt_salt = .false.
+    wrt_salt_dia = .false.
+    wrt_temp = .false.
+    wrt_temp_dia = .false.
+/
+
+&ubind_settings
+    ubind = 0.1
+/
+
+&upscale_settings
+    do_upscale = .false.
+    nrpf_uscl = 48
+    output_period_uscl = 3600.0
+/
+
+&v_sponge_settings
+    v_sponge = 0.0
+/
+
+&vertical_mixing_settings
+    akt_bak = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    akv_bak = 0.0
+/
+
+&zslice_settings
+    do_zslice = .false.
+    ndep = 2
+    nrpf_zslice = 72
+    nt_zslice = 2
+    output_period_zslice = 1200.0
+    trc2zsc = 1, 2
+    vecdep = -2.0, -15.0
+    wrt_t_zslice = .false.
+    wrt_u_zslice = .false.
+    wrt_v_zslice = .false.
+    zslice_avg = .false.
+/

--- a/cstar/tests/unit_tests/roms/test_namelist.py
+++ b/cstar/tests/unit_tests/roms/test_namelist.py
@@ -1,0 +1,91 @@
+"""Tests for the versioned ROMS namelist schemas in `cstar.roms.namelist`."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from cstar.roms.namelist import (
+    RomsNamelist,
+    RomsNamelistBase,
+    RomsNamelistV0_5_0,
+    namelist_schema_for_ref,
+)
+
+OLD_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist.nml"
+NEW_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_5_0.nml"
+
+
+@pytest.mark.parametrize(
+    "checkout_target",
+    ["0.4.9", "v0.4.9", "0.0.1"],
+)
+def test_namelist_schema_for_ref_pre_0_5_0(checkout_target):
+    """Refs below the 0.5.0 breaking release select the unversioned `RomsNamelist`."""
+    assert namelist_schema_for_ref(checkout_target) is RomsNamelist
+
+
+@pytest.mark.parametrize(
+    "checkout_target",
+    ["0.5.0", "v0.5.0", "0.7.3", "12.0.0"],
+)
+def test_namelist_schema_for_ref_post_0_5_0(checkout_target):
+    """Refs at or above 0.5.0 select `RomsNamelistV0_5_0`."""
+    assert namelist_schema_for_ref(checkout_target) is RomsNamelistV0_5_0
+
+
+@pytest.mark.parametrize(
+    "checkout_target",
+    [
+        "main",
+        "roms_branch",
+        "abc123def456",
+        "a" * 40,
+        "1.2",
+        "v1.2.3.4",
+        None,
+    ],
+)
+def test_namelist_schema_for_ref_fallback_warns(checkout_target):
+    """Non-release-tag refs fall back to the latest schema and warn about it."""
+    with pytest.warns(UserWarning, match="use at your own risk"):
+        schema = namelist_schema_for_ref(checkout_target)
+    assert schema is RomsNamelistV0_5_0
+
+
+def test_roms_namelist_round_trip():
+    """`RomsNamelist.read` parses the pre-0.5.0 fixture and keeps `nrpf_rst`."""
+    nml = RomsNamelist.read(OLD_NAMELIST)
+    d = nml.to_f90nml_dict()
+    assert "nrpf_rst" in d["basic_output_settings"]
+
+
+def test_roms_namelist_v0_5_0_round_trip():
+    """`RomsNamelistV0_5_0.read` parses the 0.5.0 fixture with the renamed keys."""
+    nml = RomsNamelistV0_5_0.read(NEW_NAMELIST)
+    d = nml.to_f90nml_dict()
+    assert "output_period_particles" in d["particles_settings"]
+    assert "nrpf_particles" in d["particles_settings"]
+    assert "nrpf_rst" not in d["basic_output_settings"]
+
+
+def test_roms_namelist_v0_5_0_rejects_old_fixture():
+    """`RomsNamelistV0_5_0` is strict: the pre-0.5.0 fixture has now-extra/missing keys."""
+    with pytest.raises(ValidationError):
+        RomsNamelistV0_5_0.read(OLD_NAMELIST)
+
+
+def test_roms_namelist_rejects_new_fixture():
+    """`RomsNamelist` is strict: the 0.5.0 fixture has now-extra/missing keys."""
+    with pytest.raises(ValidationError):
+        RomsNamelist.read(NEW_NAMELIST)
+
+
+def test_roms_namelist_base_rejects_direct_use():
+    """`RomsNamelistBase` refuses validation against itself.
+
+    Its version-varying groups are typed as the loose common models, so using
+    it directly would silently accept a namelist no ucla-roms version reads.
+    """
+    with pytest.raises(TypeError, match="not a usable schema"):
+        RomsNamelistBase.read(OLD_NAMELIST)

--- a/cstar/tests/unit_tests/roms/test_namelist.py
+++ b/cstar/tests/unit_tests/roms/test_namelist.py
@@ -1,6 +1,8 @@
 """Tests for the versioned ROMS namelist schemas in `cstar.roms.namelist`."""
 
+import subprocess
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from pydantic import ValidationError
@@ -50,6 +52,116 @@ def test_namelist_schema_for_ref_fallback_warns(checkout_target):
     """Non-release-tag refs fall back to the latest schema and warn about it."""
     with pytest.warns(UserWarning, match="use at your own risk"):
         schema = namelist_schema_for_ref(checkout_target)
+    assert schema is RomsNamelistV0_5_0
+
+
+@pytest.fixture
+def tagged_ucla_roms_clone(tmp_path: Path) -> dict[str, str | Path]:
+    """A tiny local git repo mimicking ucla-roms release-tag history.
+
+    History: commit tagged ``0.4.2`` -> commit tagged only ``exp-marker`` (a
+    non-release tag, which release resolution must ignore) -> commit tagged
+    ``0.5.0``. Returns the repo path and the three commit hashes.
+    """
+    repo = tmp_path / "ucla-roms"
+    repo.mkdir()
+
+    def _git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    _git("init", "-q")
+    (repo / "f").write_text("1")
+    _git("add", "f")
+    _git("commit", "-q", "-m", "release 0.4.2")
+    hash_0_4_2 = _git("rev-parse", "HEAD")
+    _git("tag", "0.4.2")
+
+    (repo / "f").write_text("2")
+    _git("commit", "-aq", "-m", "post-0.4.2 work")
+    hash_after_0_4_2 = _git("rev-parse", "HEAD")
+    _git("tag", "exp-marker")
+
+    (repo / "f").write_text("3")
+    _git("commit", "-aq", "-m", "release 0.5.0")
+    hash_0_5_0 = _git("rev-parse", "HEAD")
+    _git("tag", "0.5.0")
+
+    return {
+        "repo": repo,
+        "hash_0_4_2": hash_0_4_2,
+        "hash_after_0_4_2": hash_after_0_4_2,
+        "hash_0_5_0": hash_0_5_0,
+    }
+
+
+def test_namelist_schema_for_ref_resolves_hash_at_release_tag(
+    tagged_ucla_roms_clone,
+    recwarn,
+):
+    """A commit hash sitting exactly on a release tag selects that release's
+    schema, without any warning.
+    """
+    info = tagged_ucla_roms_clone
+    assert (
+        namelist_schema_for_ref(info["hash_0_4_2"], repo_path=info["repo"])
+        is RomsNamelist
+    )
+    assert (
+        namelist_schema_for_ref(info["hash_0_5_0"], repo_path=info["repo"])
+        is RomsNamelistV0_5_0
+    )
+    assert len(recwarn) == 0
+
+
+def test_namelist_schema_for_ref_resolves_hash_ahead_of_release_tag(
+    tagged_ucla_roms_clone,
+):
+    """A commit hash between releases selects the nearest ancestor release's
+    schema and warns that the commit may contain unreleased changes.
+
+    The commit carries a non-release tag (``exp-marker``) that resolution
+    must skip over in favor of the release tag ``0.4.2``.
+    """
+    info = tagged_ucla_roms_clone
+    with pytest.warns(UserWarning, match="commit\\(s\\) after release 0.4.2"):
+        schema = namelist_schema_for_ref(
+            info["hash_after_0_4_2"], repo_path=info["repo"]
+        )
+    assert schema is RomsNamelist
+
+
+def test_namelist_schema_for_ref_branch_ignores_repo_path(tagged_ucla_roms_clone):
+    """A branch name is never resolved via the local clone: it falls back to
+    the latest schema with the use-at-your-own-risk warning even when a repo
+    path is available.
+    """
+    info = tagged_ucla_roms_clone
+    with pytest.warns(UserWarning, match="use at your own risk"):
+        schema = namelist_schema_for_ref("main", repo_path=info["repo"])
+    assert schema is RomsNamelistV0_5_0
+
+
+def test_namelist_schema_for_ref_unresolvable_hash_falls_back():
+    """A hash that resolves to a non-release tag (or fails to resolve) falls
+    back to the latest schema with the use-at-your-own-risk warning.
+    """
+    with mock.patch(
+        "cstar.roms.namelist._describe_nearest_tag", return_value=("not-semver", 0)
+    ):
+        with pytest.warns(UserWarning, match="use at your own risk"):
+            schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
+    assert schema is RomsNamelistV0_5_0
+
+    with mock.patch("cstar.roms.namelist._describe_nearest_tag", return_value=None):
+        with pytest.warns(UserWarning, match="use at your own risk"):
+            schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
     assert schema is RomsNamelistV0_5_0
 
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -585,7 +585,9 @@ class TestROMSSimulationInitialization:
         with pytest.warns(UserWarning, match="use at your own risk"):
             result = sim.roms_runtime_settings
 
-        mock_schema_for_ref.assert_called_once_with(checkout_target)
+        # the stub's codebase has no working copy, so no repo path is available
+        # for commit-hash-to-release-tag resolution
+        mock_schema_for_ref.assert_called_once_with(checkout_target, repo_path=None)
         assert isinstance(result, RomsNamelistV0_5_0)
         assert result.time_stepping.ntimes == sim._n_time_steps
 

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
 from cstar.base.additional_code import AdditionalCode
 from cstar.base.external_codebase import ExternalCodeBase
@@ -27,7 +28,11 @@ from cstar.roms.input_dataset import (
     ROMSSurfaceForcing,
     ROMSTidalForcing,
 )
-from cstar.roms.namelist import RomsNamelist
+from cstar.roms.namelist import (
+    RomsNamelist,
+    RomsNamelistV0_5_0,
+    namelist_schema_for_ref,
+)
 from cstar.roms.simulation import ROMSSimulation
 from cstar.system.environment import CStarEnvironment
 from cstar.system.manager import get_sysmgr
@@ -35,9 +40,14 @@ from cstar.system.manager import get_sysmgr
 # A complete, forge-produced runtime namelist used to back the
 # roms_runtime_settings tests (RomsNamelist is a strict 40-group schema).
 EXAMPLE_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist.nml"
-# Captured before any test patches RomsNamelist.read, so side_effects can read a
-# fixture from disk without re-entering the mock (which would recurse).
+# Its ucla-roms >= 0.5.0 counterpart (nrpf_rst dropped, particles keys renamed).
+EXAMPLE_NAMELIST_V0_5_0 = (
+    Path(__file__).parent / "fixtures" / "example_namelist_v0_5_0.nml"
+)
+# Captured before any test patches the namelist read machinery, so side_effects
+# can read a fixture from disk without re-entering the mock (which would recurse).
 _REAL_NAMELIST_READ = RomsNamelist.read
+_REAL_NAMELIST_READ_V0_5_0 = RomsNamelistV0_5_0.read
 
 
 class TestROMSSimulationInitialization:
@@ -385,7 +395,7 @@ class TestROMSSimulationInitialization:
         assert sim._n_time_steps == 524160
         pass
 
-    @mock.patch("cstar.roms.simulation.RomsNamelist.read")
+    @mock.patch("cstar.roms.simulation.namelist_schema_for_ref")
     @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)
     @mock.patch.object(
         ROMSInitialConditions, "path_for_roms", new_callable=mock.PropertyMock
@@ -396,7 +406,7 @@ class TestROMSSimulationInitialization:
         mock_grid_path,
         mock_ini_path,
         mock_forcing_paths,
-        mock_namelist_read,
+        mock_schema_for_ref,
         stub_romssimulation,
         additionalcode_local,
         stageddatacollection_remote_files,
@@ -414,7 +424,9 @@ class TestROMSSimulationInitialization:
 
         # Each property access mutates the returned model, so hand out a fresh
         # RomsNamelist read from the fixture on every call.
-        mock_namelist_read.side_effect = lambda _: _REAL_NAMELIST_READ(EXAMPLE_NAMELIST)
+        mock_schema_for_ref.return_value.read.side_effect = lambda _: (
+            _REAL_NAMELIST_READ(EXAMPLE_NAMELIST)
+        )
 
         # Set up fake staged working copies for CDR forcing and nesting info
         fake_cdr_path = Path("/staged/input_datasets/cdr.nc")
@@ -502,13 +514,12 @@ class TestROMSSimulationInitialization:
         stub_romssimulation,
         stageddatacollection_remote_files,
     ):
-        """Test that ``roms_runtime_settings`` surfaces a pydantic ``ValidationError``
-        naming the missing group when the runtime namelist omits a section C-Star
-        must populate. ``RomsNamelist`` is a strict schema, so an incomplete namelist
-        fails validation on read rather than producing a partial object.
+        """Test that ``roms_runtime_settings`` wraps the pydantic ``ValidationError``
+        in a ``ValueError`` naming the missing group when the runtime namelist omits
+        a section C-Star must populate. ``RomsNamelist`` is a strict schema, so an
+        incomplete namelist fails validation on read rather than producing a partial
+        object.
         """
-        from pydantic import ValidationError
-
         sim = stub_romssimulation
         sim.runtime_code._working_copy = stageddatacollection_remote_files()
 
@@ -517,12 +528,66 @@ class TestROMSSimulationInitialization:
         empty_nml = tmp_path / "empty.nml"
         empty_nml.write_text("")
 
-        with mock.patch(
-            "cstar.roms.simulation.RomsNamelist.read",
-            side_effect=lambda _: _REAL_NAMELIST_READ(empty_nml),
-        ):
-            with pytest.raises(ValidationError, match=r"time_stepping"):
+        with mock.patch("cstar.roms.simulation.namelist_schema_for_ref") as mock_schema:
+            mock_schema.return_value.__name__ = "MockRomsNamelistSchema"
+            mock_schema.return_value.read.side_effect = lambda _: _REAL_NAMELIST_READ(
+                empty_nml
+            )
+            with pytest.raises(ValueError, match="failed validation against") as exc:
                 sim.roms_runtime_settings
+
+        assert isinstance(exc.value.__cause__, ValidationError)
+        assert "time_stepping" in str(exc.value.__cause__)
+
+    @mock.patch("cstar.roms.namelist.RomsNamelistBase.read")
+    @mock.patch(
+        "cstar.roms.simulation.namelist_schema_for_ref", wraps=namelist_schema_for_ref
+    )
+    @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)
+    @mock.patch.object(
+        ROMSInitialConditions, "path_for_roms", new_callable=mock.PropertyMock
+    )
+    @mock.patch.object(ROMSModelGrid, "path_for_roms", new_callable=mock.PropertyMock)
+    def test_roms_runtime_settings_consults_checkout_target(
+        self,
+        mock_grid_path,
+        mock_ini_path,
+        mock_forcing_paths,
+        mock_schema_for_ref,
+        mock_base_read,
+        stub_romssimulation,
+        stageddatacollection_remote_files,
+    ):
+        """Test that ``roms_runtime_settings`` consults the codebase's
+        ``checkout_target`` to select a namelist schema, and that a non-release
+        ``checkout_target`` (as set up by the ``stub_romssimulation`` fixture)
+        surfaces the ``namelist_schema_for_ref`` fallback warning through the
+        property while still returning a valid namelist.
+
+        The read is stubbed (the stub's working copy has no real files on
+        disk), but the stub performs a genuine ``RomsNamelistV0_5_0``
+        validation of the 0.5.0-style fixture — the schema the fallback
+        selects — so the property's overrides are exercised against the
+        selected schema, not the legacy one.
+        """
+        sim = stub_romssimulation
+        sim.runtime_code._working_copy = stageddatacollection_remote_files()
+        mock_grid_path.return_value = [Path("grid.nc")]
+        mock_ini_path.return_value = [Path("fake_ini.nc")]
+        mock_forcing_paths.return_value = [Path("forcing1.nc"), Path("forcing2.nc")]
+        mock_base_read.side_effect = lambda _: _REAL_NAMELIST_READ_V0_5_0(
+            EXAMPLE_NAMELIST_V0_5_0
+        )
+
+        checkout_target = sim.codebase.source.checkout_target
+        assert checkout_target == "roms_branch"  # not a release tag
+
+        with pytest.warns(UserWarning, match="use at your own risk"):
+            result = sim.roms_runtime_settings
+
+        mock_schema_for_ref.assert_called_once_with(checkout_target)
+        assert isinstance(result, RomsNamelistV0_5_0)
+        assert result.time_stepping.ntimes == sim._n_time_steps
 
     def test_input_datasets(self, stub_romssimulation):
         """Test that the `input_datasets` property returns the correct list of


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

Add RomsNamelistBase + a semver-range registry so roms_runtime_settings validates against the schema matching the pinned ucla-roms ref; non-release refs (branches, hashes) fall back to the latest schema with a warning. Add RomsNamelistV0_5_0 for ucla-roms 0.5.0 (PR #336): nrpf_rst removed, particles output_period/nrpf renamed to *_particles.

Also fix identify_bounds in cstar/system/migration.py to compare schema versions numerically instead of lexicographically (broke at double-digit versions, e.g. "10.0.0" < "2.0.0").

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Add ability to write different namelist versions based on ucla-roms codebase tag
- Add support for upcoming ucla-roms 0.5.0 namelist changes

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

