### PR TITLE
Update default workplan output directory

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -273,7 +273,7 @@ ENV_CSTAR_DATA_HOME: t.Annotated[
     EnvVar(
         "Environment variable used to override the home directory for C-Star dataset storage.",
         GROUP_FS,
-        "~/.local/share",
+        "~/cstar",
         indirect_var="XDG_DATA_HOME",
         default_factory=lambda x: hpc_data_directory() or indirect_default_factory(x),
     ),

--- a/cstar/tests/integration_tests/workplans/test_run_dag.py
+++ b/cstar/tests/integration_tests/workplans/test_run_dag.py
@@ -1,11 +1,9 @@
 import os
 import subprocess
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME
 from cstar.orchestration.dag_runner import build_dag, run_dag
 from cstar.orchestration.models import Step, Workplan
 
@@ -111,9 +109,9 @@ async def test_build_and_run_local(
 
     # create unique run name only once per hour, cache otherwise.
     my_run_name = f"{tmp_path.stem}_{workplan_name}"
-    with mock.patch.dict(os.environ, {ENV_CSTAR_DATA_HOME: tmp_path}):
-        planner, path = await build_dag(wp_path, my_run_name)
-        await run_dag(path, my_run_name, planner)
+
+    planner, path = await build_dag(wp_path, my_run_name)
+    await run_dag(path, my_run_name, planner)
 
 
 # @pytest.mark.skipif(not slurm())
@@ -152,6 +150,5 @@ async def test_build_and_run(
 
     # create unique run name only once per hour, cache otherwise.
     my_run_name = f"{tmp_path.stem}_{workplan_name}"
-    with mock.patch.dict(os.environ, {ENV_CSTAR_DATA_HOME: tmp_path}):
-        planner, path = await build_dag(wp_path, my_run_name)
-        await run_dag(path, my_run_name, planner)
+    planner, path = await build_dag(wp_path, my_run_name)
+    await run_dag(path, my_run_name, planner)

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -5,8 +5,9 @@ from unittest import mock
 
 import pytest
 
-from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.execution.file_system import (
+    DirectoryManager,
     JobFileSystemManager,
     RomsFileSystemManager,
     is_remote_resource,
@@ -132,7 +133,6 @@ def test_live_step(tmp_path: Path) -> None:
     bp = tmp_path / "bp.yml"
     bp.touch()
 
-    data_home = tmp_path / "data"
     run_id = "fake-run-id"
 
     step_1 = Step(name="A", application="roms_marbl", blueprint=bp)
@@ -142,7 +142,6 @@ def test_live_step(tmp_path: Path) -> None:
     with mock.patch.dict(
         os.environ,
         {
-            ENV_CSTAR_DATA_HOME: data_home.as_posix(),
             ENV_CSTAR_RUNID: run_id,
         },
         clear=True,
@@ -163,6 +162,9 @@ def test_live_step(tmp_path: Path) -> None:
 
         task_dir_name = JobFileSystemManager._TASKS_NAME  # type: ignore
         actual = ls_1.working_dir
+
+        directory_mgr = DirectoryManager()
+        data_home = directory_mgr.data_home()
         expected = data_home / run_id / task_dir_name / ls_1.safe_name  # noqa: SLF001
         assert actual == expected
 

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -10,13 +10,13 @@ import pytest
 from cstar.applications.hello_world import HelloWorldBlueprint
 from cstar.base.env import (
     ENV_CSTAR_CLOBBER_WORKING_DIR,
-    ENV_CSTAR_DATA_HOME,
     ENV_CSTAR_RUNID,
     FLAG_OFF,
     FLAG_ON,
 )
 from cstar.entrypoint.utils import ARG_CLOBBER
 from cstar.execution.file_system import (
+    DirectoryManager,
     JobFileSystemManager,
     StateDirectoryManager,
 )
@@ -75,7 +75,7 @@ async def layered_workplan(
     last_parent: str | None = None
     asset_path = tmp_path / "assets"
     handles: dict[str, LocalHandle] = {}
-    mock_data_dir = Path(str(os.getenv(ENV_CSTAR_DATA_HOME)))
+    mock_data_dir = DirectoryManager.data_home()
 
     with mock.patch.dict(os.environ, {ENV_CSTAR_RUNID: fake_run_id}):
         fsm_map = {"": JobFileSystemManager(mock_data_dir)}

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 
 from cstar.applications.roms_marbl.transforms import RomsMarblTimeSplitter
-from cstar.base.env import ENV_CSTAR_DATA_HOME, ENV_CSTAR_RUNID
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.feature import ENV_FF_ORCH_TRX_TIMESPLIT
 from cstar.base.utils import DEFAULT_OUTPUT_ROOT_NAME
 from cstar.orchestration.models import Application, Step, Workplan
@@ -85,12 +85,10 @@ def test_splitter(single_step_workplan: Workplan, tmp_path: Path) -> None:
     original_step = LiveStep.from_step(single_step_workplan.steps[0])
 
     # mock data home to ensure test works on HPC if scratch directories are identified
-    data_home = tmp_path / "data"
     with mock.patch.dict(
         os.environ,
         {
             ENV_CSTAR_RUNID: "12345",
-            ENV_CSTAR_DATA_HOME: data_home.as_posix(),
             ENV_FF_ORCH_TRX_TIMESPLIT: "1",
             ENV_CSTAR_ORCH_TRX_FREQ: SplitFrequency.Monthly.value,
         },


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This change modifies the default output location for orchestrated workplans from `~/.local/share` to `~/cstar`. 

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- Change creates a variation from XDG spec for `CSTAR_DATA_HOME` 

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Avoid default user-facing output directory that is hidden.
- Avoid changing env var in tests where an autouse fixture already handles it

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [x] Closes #CSD-1120
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

