### PR TITLE
Auto-publish tagged GitHub release when the finalize-notes PR merges

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,119 @@
+name: Publish Release
+
+# Auto-creates the tagged GitHub release when the "Finalize release notes for
+# <tag>" PR (opened by finalize_release_notes.yaml from the next_release_notes
+# branch) is merged into main. The release body is the curated notes we just
+# merged, extracted by ci/release_body.py.
+#
+# The release is created with a Personal Access Token (secrets.RELEASE_PAT),
+# NOT the default GITHUB_TOKEN: releases created by GITHUB_TOKEN do not fire
+# `on: release` workflows, which would silently skip PyPI trusted publishing
+# (pypipublish.yaml). A PAT-created release cascades normally.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish-release:
+    # Only the finalize-release-notes PR, and only when actually merged.
+    # head.ref == next_release_notes is the unique signal: finalize_release_notes.yaml
+    # is the only workflow that opens a PR from that branch into main. The
+    # head.repo == base.repo check rejects a look-alike PR opened from a fork
+    # (defense in depth — fork PRs also get no secrets, so RELEASE_PAT is empty).
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'next_release_notes' &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
+      startsWith(github.event.pull_request.title, 'Finalize release notes for ')
+    runs-on: ubuntu-latest
+    # Serialize duplicate webhook deliveries / manual re-runs for the same PR so
+    # the "release already exists?" check and the create step cannot race.
+    concurrency:
+      group: publish-release-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    # Note: this job creates the release with RELEASE_PAT, not GITHUB_TOKEN, so
+    # this permissions block does not bound its writes — scope RELEASE_PAT itself
+    # to `contents: write` on these repos. It is kept for correctness of any
+    # future GITHUB_TOKEN use.
+    permissions:
+      contents: write
+
+    steps:
+      - name: Guard against a missing merge commit
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::error::merge_commit_sha is empty — cannot target the release."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          # Check out the exact merge commit, not `main`: another PR could merge
+          # between this event and the checkout, and the release must target the
+          # tree whose release notes we are publishing.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          # PAT so the created release cascades to on:release workflows (see header).
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Derive and validate release tag
+        id: tag
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          raw="${PR_TITLE#Finalize release notes for }"
+          # Standardized convention: tags have no leading v (e.g. 0.5.0).
+          tag="$(printf '%s' "$raw" | tr -d '`[:space:]')"
+          tag="${tag#v}"
+          tag="${tag#V}"
+          if ! printf '%s' "$tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)*$'; then
+            echo "::error::Could not parse a semver tag from PR title: '$PR_TITLE'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Derived release tag: $tag"
+
+      - name: Cross-check tag against finalized release notes
+        # Fails loudly if the PR title disagrees with the newest finalized
+        # release in the docs (retitled PR, or finalize didn't actually run).
+        run: python ci/release_body.py "${{ steps.tag.outputs.tag }}" --check-only
+
+      - name: Skip if the release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if gh release view "${{ steps.tag.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.tag.outputs.tag }} already exists — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release body from finalized notes
+        if: steps.exists.outputs.skip == 'false'
+        run: python ci/release_body.py "${{ steps.tag.outputs.tag }}" > "$RUNNER_TEMP/release_body.md"
+
+      - name: Create the GitHub release
+        if: steps.exists.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          # To also append GitHub's auto-generated contributor list below the
+          # curated notes, add: --generate-notes
+          gh release create "$TAG" \
+            --target "$MERGE_SHA" \
+            --title "$TAG" \
+            --notes-file "$RUNNER_TEMP/release_body.md"

--- a/.github/workflows/update_release_notes.yaml
+++ b/.github/workflows/update_release_notes.yaml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   update-release-notes:
-    # Only run when the PR was actually merged, not just closed
-    if: github.event.pull_request.merged == true
+    # Only run when the PR was actually merged, not just closed — and never for
+    # the finalize PR itself (from next_release_notes), whose merge is handled by
+    # publish_release.yaml; otherwise this would re-open a fresh Unreleased block.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref != 'next_release_notes'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/ci/release_body.py
+++ b/ci/release_body.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Print a Markdown release-notes body for a finalized release *tag*.
+
+Reads ``docs/releases/<tag>.rst`` — the per-version file produced by
+``finalize_release_notes.py`` — and converts it to GitHub-flavored Markdown for
+``gh release create --notes-file``. The conversion is deliberately narrow,
+handling only what these release-note files actually contain:
+
+* ``.. _anchor:`` target lines are dropped,
+* the release title and its underline are dropped (GitHub shows the tag),
+* every other underlined heading (category, e.g. "New features") becomes a
+  ``### `` Markdown heading,
+* RST inline links (the `text <url>`_ form) become [text](url),
+* RST inline literals (the double-backtick form) become single-backtick spans.
+
+Everything else (bullets, prose, blank lines) passes through unchanged. The
+``.. note::`` in-development banner is already removed by ``finalize`` before we
+run, so no directive handling is needed.
+
+With ``--check-only`` nothing is printed; instead ``docs/releases/<tag>.rst`` is
+required to exist and to be the newest ``.. include::`` in ``docs/releases.rst``,
+exiting non-zero on mismatch. This guards the publish workflow against a
+retitled PR or a finalize step that never ran.
+
+Release tags are stored without a leading ``v`` (e.g. ``0.7.0``); a ``v``-prefix
+on the argument is stripped before use.
+
+Usage:
+    python ci/release_body.py <tag> [--check-only]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+RELEASES_DIR = Path(__file__).resolve().parent.parent / "docs" / "releases"
+RELEASES_INDEX = Path(__file__).resolve().parent.parent / "docs" / "releases.rst"
+
+# RST section underlines are a run of one repeated punctuation char. Bullets
+# ("- foo") contain a space and so never match. '.' and ':' are deliberately
+# excluded so a bare ".." (comment) or "::" (literal-block marker) is not
+# mistaken for an underline.
+_UNDERLINE_CHARS = frozenset("-=~^\"+*#`'")
+# Bare anchor with no target on the same line, e.g. ".. _0.7.0:" — dropped.
+_ANCHOR_RE = re.compile(r"^\.\.\s+_\S+:\s*$")
+# Named hyperlink-target definition, e.g. ".. _v0.2.0 commit history: https://..."
+# (name may contain spaces). Captured into a name->url map, then the line dropped.
+_TARGET_RE = re.compile(r"^\.\.\s+_(.+?):\s+(\S.*?)\s*$")
+_INCLUDE_RE = re.compile(r"^\.\.\s+include::\s*releases/(\S+?\.rst)\s*$")
+# `text <url>`_  ->  [text](url). The URL class excludes backticks and
+# whitespace (a real RST link target has neither) so the match cannot bridge
+# out of an inline literal that happens to contain a '<' — e.g. ``compilers<2``.
+_LINK_RE = re.compile(r"`([^`<]+?)\s*<([^>`\s]+)>`_")
+# `name`_  ->  named reference resolved against the target map (or bare text).
+# The trailing `_` must sit at a word boundary (whitespace / sentence
+# punctuation / end of line) — this is what distinguishes a real named
+# reference from an inline literal that merely starts with an underscore
+# (e.g. `_private`, whose backtick+underscore is the OPENING, not a closer).
+_NAMED_REF_RE = re.compile(r"`([^`<]+?)`_(?=\s|[.,;:)\]]|$)")
+# ``code``  ->  `code`
+_CODE_RE = re.compile(r"``([^`]+?)``")
+
+
+def _ref_key(name: str) -> str:
+    """Normalize an RST reference name (case- and whitespace-insensitive)."""
+    return " ".join(name.split()).lower()
+
+
+def normalize_tag(tag: str) -> str:
+    """Strip a leading ``v``/``V`` from *tag* if present (``v0.7.0`` -> ``0.7.0``)."""
+    return tag[1:] if re.match(r"^[vV]\d", tag) else tag
+
+
+def _is_underline(line: str) -> bool:
+    """Return True if *line* is an RST section underline (all one punctuation char)."""
+    s = line.strip()
+    return len(s) >= 2 and all(c == s[0] for c in s) and s[0] in _UNDERLINE_CHARS
+
+
+def _inline(text: str, targets: dict[str, str]) -> str:
+    """
+    Convert RST inline roles to their Markdown equivalents.
+
+    Handles inline-URL links, named references (resolved against *targets*, or
+    reduced to bare text if the name is unknown), and double-backtick literals.
+    """
+    text = _LINK_RE.sub(r"[\1](\2)", text)
+
+    def _named(m: re.Match[str]) -> str:
+        name = m.group(1)
+        url = targets.get(_ref_key(name))
+        return f"[{name}]({url})" if url else name
+
+    text = _NAMED_REF_RE.sub(_named, text)
+    text = _CODE_RE.sub(r"`\1`", text)
+    return text
+
+
+def _collect_targets(lines: list[str]) -> dict[str, str]:
+    """Return a ``{normalized name: url}`` map of named hyperlink-target definitions."""
+    targets: dict[str, str] = {}
+    for line in lines:
+        if _ANCHOR_RE.match(line):
+            continue  # bare anchor, no URL
+        m = _TARGET_RE.match(line)
+        if m:
+            targets[_ref_key(m.group(1))] = m.group(2)
+    return targets
+
+
+def rst_to_markdown(rst: str) -> str:
+    """
+    Convert a finalized per-version release-note RST document to Markdown.
+
+    The first underlined heading is treated as the release title and dropped;
+    every subsequent underlined heading becomes a ``### `` category heading.
+    Anchor and target-definition lines are dropped (their URLs are inlined at
+    the reference site), as are stray transition markers.
+    """
+    lines = rst.splitlines()
+    targets = _collect_targets(lines)
+    out: list[str] = []
+    seen_title = False
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        # Drop anchors and named target definitions (folded into refs above).
+        if _ANCHOR_RE.match(line) or _TARGET_RE.match(line):
+            i += 1
+            continue
+        # A heading is a non-empty, non-underline line immediately followed by
+        # an underline. The first one is the release title (dropped); the rest
+        # are categories.
+        if (
+            line.strip()
+            and not _is_underline(line)
+            and i + 1 < n
+            and _is_underline(lines[i + 1])
+        ):
+            if seen_title:
+                out.append(f"### {_inline(line.strip(), targets)}")
+            else:
+                seen_title = True
+            i += 2
+            continue
+        # An underline reaching here belongs to no heading — a stray transition
+        # marker (e.g. a lone '---'); drop it so it does not render as an <hr>.
+        if _is_underline(line):
+            i += 1
+            continue
+        out.append(_inline(line, targets))
+        i += 1
+
+    text = "\n".join(out)
+    text = re.sub(r"\n{3,}", "\n\n", text).strip("\n")
+    return text + "\n"
+
+
+def _release_file(tag: str) -> Path | None:
+    """
+    Return the ``docs/releases/`` file for *tag*, or ``None`` if absent.
+
+    The naming convention dropped the leading ``v`` at 0.8.0, but older files
+    keep it (``v0.7.0.rst``), so both spellings are tried.
+    """
+    tag = normalize_tag(tag)
+    for name in (f"{tag}.rst", f"v{tag}.rst"):
+        path = RELEASES_DIR / name
+        if path.exists():
+            return path
+    return None
+
+
+def section_body(tag: str) -> str:
+    """
+    Return the Markdown body for the release file matching *tag*.
+
+    Raises ``SystemExit`` if that file does not exist or converts to an empty
+    body.
+    """
+    path = _release_file(tag)
+    if path is None:
+        sys.exit(f"Release notes file not found for tag '{normalize_tag(tag)}'.")
+    body = rst_to_markdown(path.read_text())
+    if not body.strip():
+        sys.exit(f"Release notes file {path} converts to an empty body.")
+    return body
+
+
+def check_newest(tag: str) -> None:
+    """
+    Validate that *tag*'s file exists and is the newest include in the index.
+
+    Raises ``SystemExit`` if the file is missing, the index has no includes, or
+    the newest include is some other version. Include filenames are compared
+    with a leading ``v`` stripped from both sides.
+    """
+    tag = normalize_tag(tag)
+    if _release_file(tag) is None:
+        sys.exit(f"Release notes file not found for tag '{tag}'.")
+    includes: list[str] = []
+    for ln in RELEASES_INDEX.read_text().splitlines():
+        m = _INCLUDE_RE.match(ln)
+        if m:
+            includes.append(m.group(1))
+    if not includes:
+        sys.exit(f"No '.. include::' entries found in {RELEASES_INDEX}")
+    newest = normalize_tag(Path(includes[0]).stem)
+    if newest != tag:
+        sys.exit(
+            f"Tag '{tag}' is not the newest release in "
+            f"{RELEASES_INDEX.name} (top include is '{includes[0]}')."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit release-notes body for a tag.")
+    parser.add_argument("tag", help="Release tag, e.g. 0.7.0")
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate the tag is the newest release; print nothing.",
+    )
+    args = parser.parse_args()
+
+    if args.check_only:
+        check_newest(args.tag)
+        return
+    sys.stdout.write(section_body(args.tag))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test_release_body.py
+++ b/ci/test_release_body.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for ``release_body.py`` (RST -> Markdown release-notes conversion).
+
+This ``ci/`` script has no existing pytest CI wiring in this repo; run
+directly with::
+
+    pytest ci/test_release_body.py
+
+Covers the four transforms the converter promises, and — as a guard against
+the converter silently degrading — runs it over every real
+``docs/releases/*.rst`` file and asserts no RST link/anchor syntax survives.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "release_body",
+    Path(__file__).resolve().parent / "release_body.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+_SAMPLE = (
+    ".. _0.11.1:\n"
+    "\n"
+    "0.11.1\n"
+    "----------\n"
+    "\n"
+    "\n"
+    "Breaking Changes\n"
+    "~~~~~~~~~~~~~~~~\n"
+    "\n"
+    "\n"
+    "- CSTAR_CLOBBER_WORKING_DIR is gone. Use ``--clobber all`` instead. "
+    "(`#635 <https://github.com/CWorthy-ocean/C-Star/pull/635>`_)\n"
+    "\n"
+    "New features\n"
+    "~~~~~~~~~~~~\n"
+    "\n"
+    "\n"
+    "- Add ``--clobber <step name>``. (`#635 <https://github.com/CWorthy-ocean/C-Star/pull/635>`_)\n"
+)
+
+
+def test_conversion_of_all_four_transforms():
+    md = _MODULE.rst_to_markdown(_SAMPLE)
+    # Anchor line dropped.
+    assert "_0.11.1" not in md
+    # Release title + underline dropped (GitHub shows the tag).
+    assert "0.11.1" not in md
+    assert "----" not in md and "~~~~" not in md
+    # Category headings -> ### .
+    assert "### Breaking Changes" in md
+    assert "### New features" in md
+    # `text <url>`_ -> [text](url)
+    assert "[#635](https://github.com/CWorthy-ocean/C-Star/pull/635)" in md
+    assert "<https://" not in md and "`_" not in md
+    # ``code`` -> `code`
+    assert "`--clobber all`" in md
+    assert "``" not in md
+    # Bullets pass through.
+    assert md.count("- ") == 2
+
+
+def test_first_heading_is_title_rest_are_categories():
+    md = _MODULE.rst_to_markdown(_SAMPLE)
+    # Exactly the two categories become headings; the title does not.
+    assert md.count("### ") == 2
+
+
+def test_inline_helpers():
+    assert _MODULE._inline("see (`#1 <http://x/1>`_)", {}) == "see ([#1](http://x/1))"
+    assert _MODULE._inline("run ``foo bar``", {}) == "run `foo bar`"
+
+
+def test_named_reference_footer_is_resolved():
+    # A "commit history" footer (named target definition + named reference)
+    # becomes an inline Markdown link, with no raw RST left behind.
+    rst = (
+        ".. _0.2.0:\n"
+        "\n"
+        "0.2.0\n"
+        "-----\n"
+        "\n"
+        "New features\n"
+        "~~~~~~~~~~~~\n"
+        "\n"
+        "- Did a thing.\n"
+        "\n"
+        "---\n"
+        "\n"
+        "For more details, see the `0.2.0 commit history`_.\n"
+        "\n"
+        ".. _0.2.0 commit history: https://github.com/x/compare/0.1.0...0.2.0\n"
+    )
+    md = _MODULE.rst_to_markdown(rst)
+    assert "[0.2.0 commit history](https://github.com/x/compare/0.1.0...0.2.0)" in md
+    # No raw RST leaks: no target-definition line, no stray transition marker,
+    # no unresolved `name`_ reference.
+    assert ".. _" not in md
+    assert not any(ln.strip() == "---" for ln in md.splitlines())
+    assert not _MODULE._NAMED_REF_RE.search(md)
+
+
+def test_unknown_named_reference_falls_back_to_text():
+    md = _MODULE.rst_to_markdown("x\n-\n\nSee `nowhere`_ for details.\n")
+    assert "See nowhere for details." in md
+    assert not _MODULE._NAMED_REF_RE.search(md)
+
+
+def test_is_underline():
+    assert _MODULE._is_underline("~~~~")
+    assert _MODULE._is_underline("----")
+    assert not _MODULE._is_underline("- a bullet")
+    assert not _MODULE._is_underline("Breaking Changes")
+    # '..' (comment) and '::' (literal-block marker) are not underlines.
+    assert not _MODULE._is_underline("..")
+    assert not _MODULE._is_underline("::")
+
+
+@pytest.mark.parametrize(
+    "rst_file", sorted(_MODULE.RELEASES_DIR.glob("*.rst")), ids=lambda p: p.name
+)
+def test_no_rst_syntax_survives_on_real_files(rst_file):
+    """Guard: converting any shipped release file leaves no raw RST syntax behind."""
+    md = _MODULE.rst_to_markdown(rst_file.read_text())
+    assert not _MODULE._LINK_RE.search(md)  # no `text <url>`_ inline links
+    lines = md.splitlines()
+    # Named references are searched per line: an inline literal like `_private`
+    # produces a lone backtick+underscore that would spuriously bridge across
+    # lines to a later one under a whole-document search.
+    assert not any(_MODULE._NAMED_REF_RE.search(ln) for ln in lines)  # no `name`_ refs
+    assert not any(_MODULE._ANCHOR_RE.match(ln) for ln in lines)  # no anchors
+    assert not any(_MODULE._TARGET_RE.match(ln) for ln in lines)  # no target defs
+    assert not any(ln.strip() == "---" for ln in lines)  # no stray transitions
+    assert "``" not in md  # no unconverted inline literals


### PR DESCRIPTION
# Summary

Automates the last manual step of the release process. Today, after the **Finalize Release Notes** PR is reviewed and merged, a maintainer manually creates the GitHub release — tagging main, titling it with the semver, and letting GitHub auto-generate notes (which are less descriptive than the ones we just curated). This PR adds a `Publish Release` workflow that fires when that finalize PR merges and does it automatically: it creates the tag and release on the new `main`, titles the release with the semver, and sets the release body to the **curated notes we just merged** (not GitHub's auto-generated summary).

## Miscellaneous
- The tagged GitHub release is now created automatically when the "Finalize release notes for `<tag>`" PR is merged, using the release notes just finalized in the docs as the release body — instead of the manual tag-and-publish step with GitHub's weaker auto-generated summary.
- Merging the release-notes finalization PR no longer causes the release-notes updater to re-open a spurious "Unreleased" section.

## Code Review Checklist
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing