### PR TITLE
Local launcher fixes and promotion

### DIFF
--- a/cstar/additional_files/templates/launchers/local_job_proxy.sh
+++ b/cstar/additional_files/templates/launchers/local_job_proxy.sh
@@ -2,6 +2,7 @@
 SENTINEL_PATH="{sentinel_path}"
 BLUEPRINT_PATH="{blueprint_path}"
 DEP_PIDS=({pids})
+DEP_SENTINELS=({dep_sentinels})
 
 {env_vars}
 
@@ -19,12 +20,22 @@ update_status() {{
     fi
 }}
 
-# wait for dependencies to complete.
-for DEP_PID in "${{DEP_PIDS[@]}}"; do
+# wait for each dependency to complete, then verify that it succeeded --
+# a dependency that exited without reaching `Done` must abort this step.
+for i in "${{!DEP_PIDS[@]}}"; do
+    DEP_PID="${{DEP_PIDS[$i]}}"
     while kill -0 "$DEP_PID" 2>/dev/null; do
         echo "Awaiting process $DEP_PID"
         sleep {delay}
     done
+
+    DEP_SENTINEL="${{DEP_SENTINELS[$i]}}"
+    DEP_STATUS=$(sed -n 's/^status: *//p' "$DEP_SENTINEL" 2>/dev/null)
+    if [ "$DEP_STATUS" != "$DONE" ]; then
+        echo "Dependency (pid $DEP_PID) ended with status '$DEP_STATUS'; aborting."
+        update_status $FAILED $SENTINEL_PATH
+        exit 1
+    fi
 done
 
 # update status to running

--- a/cstar/base/feature.py
+++ b/cstar/base/feature.py
@@ -120,17 +120,6 @@ ENV_FF_SLURM_DISABLE_MT: t.Annotated[
 """Enable passing a hint to SLURM to disable multi-threading."""
 
 
-ENV_FF_ENABLE_LOCAL_PROXY: t.Annotated[
-    t.Literal["CSTAR_FF_ENABLE_LOCAL_PROXY"],
-    EnvVar(
-        "Enable experimental support for asynchronous status updates in the local launcher.",
-        GROUP_FF,
-        default=FLAG_OFF,
-    ),
-] = "CSTAR_FF_ENABLE_LOCAL_PROXY"
-"""Enable experimental support for asynchronous status updates in the local launcher."""
-
-
 def is_flag_enabled(flag: str) -> bool:
     """Determine if a boolean environment varible is enabled.
 

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -367,7 +367,10 @@ class LocalLauncher(Launcher[LocalHandle]):
                 return "RUNNING"
             return "COMPLETED"
 
-        rc = handle.process.returncode
+        # poll() reaps the child and records its exit code; reading
+        # `returncode` alone never observes an exit the process made on
+        # its own, leaving the task RUNNING forever.
+        rc = handle.process.poll()
 
         if rc is None:
             status = "RUNNING"

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -17,7 +17,6 @@ from cstar.base.adapter import (
 )
 from cstar.base.env import ENV_CSTAR_ORCH_LOCAL_DELAY, ENV_CSTAR_RUNID, get_env_item
 from cstar.base.exceptions import CstarExpectationFailed
-from cstar.base.feature import ENV_FF_ENABLE_LOCAL_PROXY, is_feature_enabled
 from cstar.base.log import get_logger
 from cstar.base.utils import WALLTIME_RE, additional_files_dir
 from cstar.orchestration.adapter import StepToRunRequestAdapter
@@ -28,7 +27,6 @@ from cstar.orchestration.orchestration import (
     LiveStep,
     ProcessHandle,
     RunRequest,
-    RunRequestScriptFormatter,
     Status,
     Task,
 )
@@ -236,8 +234,6 @@ class LocalLauncher(Launcher[LocalHandle]):
 
     tasks: t.ClassVar[dict[str, str]] = {}
     """Mapping of task name to process ID."""
-    use_proxy: t.ClassVar[bool] = is_feature_enabled(ENV_FF_ENABLE_LOCAL_PROXY)
-    """Set flag to `True` to use a proxy script to enable asynchronous scheduling."""
 
     @classmethod
     def check_preconditions(cls) -> None:
@@ -255,9 +251,9 @@ class LocalLauncher(Launcher[LocalHandle]):
         -------
         str
         """
-        formatter: ModelFormatter[RunRequest] = RunRequestScriptFormatter()
-        if LocalLauncher.use_proxy:
-            formatter = ProxiedRunRequestFormatter(step, dependencies)
+        formatter: ModelFormatter[RunRequest] = ProxiedRunRequestFormatter(
+            step, dependencies
+        )
 
         enricher: ModelEnricher[RunRequest] | None = None
 
@@ -408,20 +404,8 @@ class LocalLauncher(Launcher[LocalHandle]):
         tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
         statuses = await asyncio.gather(*tasks)
 
+        # in-progress dependencies are awaited by the submitted proxy script
         failure_found = any(map(Status.is_failure, statuses))
-
-        if not LocalLauncher.use_proxy:
-            # without the proxy, the launcher must sit and wait for processes to end.
-            active_found = any(map(Status.is_in_progress, statuses))
-
-            # wait for the dependencies to complete before launching
-            while active_found and not failure_found:
-                await asyncio.sleep(1)
-
-                tasks = [asyncio.Task(cls.query_status(h)) for h in dependencies]
-                statuses = await asyncio.gather(*tasks)
-                active_found = any(map(Status.is_in_progress, statuses))
-                failure_found = any(map(Status.is_failure, statuses))
 
         if failure_found:
             msg = f"Dependency of step {step.name} failed. Unable to continue."
@@ -556,8 +540,15 @@ class ProxiedRunRequestFormatter(ModelFormatter[RunRequest]):
         str
         """
         pids = " "
+        dep_sentinels = " "
         if self.dependencies:
             pids = " ".join([f'"{h.pid}"' for h in self.dependencies])
+            dep_sentinels = " ".join(
+                [
+                    f'"{StateRepository.sentinel_path(h.name)}"'
+                    for h in self.dependencies
+                ]
+            )
 
         delay = get_env_item(ENV_CSTAR_ORCH_LOCAL_DELAY).value
         declarations = [f"export {k}='{v}'\n" for k, v in value.environment.items()]
@@ -567,6 +558,7 @@ class ProxiedRunRequestFormatter(ModelFormatter[RunRequest]):
             "sentinel_path": str(StateRepository.sentinel_path(self.step.name)),
             "blueprint_path": str(self.step.blueprint_path),
             "pids": pids,
+            "dep_sentinels": dep_sentinels,
             "running": str(Status.Running.value),
             "done": str(Status.Done.value),
             "failed": str(Status.Failed.value),

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -988,19 +988,6 @@ class RunRequestCommandFormatter(ModelFormatter[RunRequest]):
         return f"{variables} {cmd}".strip()
 
 
-class RunRequestScriptFormatter(ModelFormatter[RunRequest]):
-    """Format a `RunRequest` as script content."""
-
-    def _to_string(self, value: RunRequest) -> str:
-        command = " ".join(value.command)
-        exports = ";".join(f"export {k}='{v}'" for k, v in value.environment.items())
-
-        if exports:
-            return f"{exports}; {command};"
-
-        return f"{command};"
-
-
 def check_environment() -> None:
     """Verify the environment is configured correctly.
 

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -41,7 +41,6 @@ from cstar.io.staged_data import (
 )
 from cstar.io.stager import Stager
 from cstar.marbl.external_codebase import MARBLExternalCodeBase
-from cstar.orchestration.launch.local import LocalLauncher
 from cstar.orchestration.models import Step
 from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize
@@ -2263,8 +2262,6 @@ def mock_local_delay() -> float:
 
     NOTE: Allowing a "normal" delay may result in unit tests taking an excessive amount of time.
     """
-    LocalLauncher.use_proxy = False
-
     delay = 0.1
     os.environ[ENV_CSTAR_ORCH_LOCAL_DELAY] = str(delay)
     return delay

--- a/cstar/tests/unit_tests/orchestration/launch/local/test_locallauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/local/test_locallauncher.py
@@ -2,13 +2,17 @@ import asyncio
 import datetime
 import subprocess
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
-from cstar.orchestration.launch.local import LocalHandle, LocalLauncher
-from cstar.orchestration.orchestration import LiveStep, Status, Workplan
+from cstar.orchestration.launch.local import (
+    LocalHandle,
+    LocalLauncher,
+    ProxiedRunRequestFormatter,
+)
+from cstar.orchestration.orchestration import LiveStep, RunRequest, Status, Workplan
 from cstar.orchestration.serialization import deserialize
+from cstar.orchestration.state import StateRepository
 
 
 @pytest.mark.parametrize(
@@ -48,21 +52,77 @@ async def test_locallauncher_query_status_observes_exit(
 
 
 @pytest.mark.parametrize(
-    ("use_proxy", "overrides"),
+    ("dep_status", "exp_rc", "exp_status", "exp_ran"),
     [
-        pytest.param(True, {"local": {}}, id="Proxied; empty local overrides"),
-        pytest.param(True, {}, id="Proxied; no overrides"),
-        pytest.param(False, {"local": {}}, id="Unproxied; empty local overrides"),
-        pytest.param(False, {}, id="Proxied; no overrides"),
+        pytest.param(Status.Done, 0, Status.Done, True, id="done dependency runs"),
+        pytest.param(
+            Status.Failed, 1, Status.Failed, False, id="failed dependency aborts"
+        ),
+        pytest.param(
+            Status.Running, 1, Status.Failed, False, id="vanished dependency aborts"
+        ),
+    ],
+)
+def test_proxy_script_propagates_dependency_outcome(
+    tmp_path: Path,
+    wp_templates_dir: Path,
+    dep_status: Status,
+    exp_rc: int,
+    exp_status: Status,
+    exp_ran: bool,
+) -> None:
+    """Verify the proxy script inspects a finished dependency's recorded outcome.
+
+    A dependency whose process exited without reaching `Done` (it failed, or
+    died before recording a terminal status) must abort the step instead of
+    running it against incomplete upstream output.
+    """
+    wp_path = wp_templates_dir / "single_step.yaml"
+    workplan = deserialize(wp_path, Workplan)
+    live_step = LiveStep.from_step(workplan.steps[0])
+
+    dep_process = subprocess.Popen(["sh", "-c", "exit 0"])
+    dep_process.wait()
+    dep_handle = LocalHandle(
+        pid=str(dep_process.pid),
+        name="dep",
+        run_id="fake-run-id",
+        start_at=datetime.datetime.now(tz=datetime.UTC),
+        status=dep_status,
+    )
+
+    for name, status in (("dep", dep_status), (live_step.name, Status.Submitted)):
+        sentinel = StateRepository.sentinel_path(name)
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(f"name: {name}\nstatus: {status.value}\n")
+
+    marker = tmp_path / "step-ran.txt"
+    script = ProxiedRunRequestFormatter(live_step, [dep_handle]).format(
+        RunRequest(command=["touch", str(marker)])
+    )
+    script_path = tmp_path / "script.sh"
+    script_path.write_text(script)
+
+    result = subprocess.run(["sh", str(script_path)], capture_output=True, timeout=30)
+
+    assert result.returncode == exp_rc
+    assert marker.exists() == exp_ran
+    own_sentinel = StateRepository.sentinel_path(live_step.name)
+    assert f"status: {exp_status.value}" in own_sentinel.read_text()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"local": {}}, id="empty local overrides"),
+        pytest.param({}, id="no overrides"),
     ],
 )
 def test_locallauncher_adapt_step_formatter_selection(
     wp_templates_dir: Path,
-    use_proxy: bool,
     overrides: dict[str, dict[str, str]],
 ) -> None:
-    """Verify that the `LocalLauncher` correctly converts a step into a proxied (or
-    non-proxied) command script based on the value of `LocalLauncher.use_proxy`.
+    """Verify that the `LocalLauncher` converts a step into a proxied command script.
 
     The compute overrides are parameterized to ensure that empty overrides and not
     specifying overrides result in the same behavior.
@@ -78,71 +138,45 @@ def test_locallauncher_adapt_step_formatter_selection(
         },
     )
 
-    with mock.patch.object(
-        LocalLauncher, "use_proxy", mock.PropertyMock(return_value=use_proxy)
-    ):
-        step_command = LocalLauncher.adapt_step(live_step, [])
+    step_command = LocalLauncher.adapt_step(live_step, [])
 
-    if use_proxy:
-        assert "update_status" in step_command
-    else:
-        # confirm the command does not contain proxy-specific script elements
-        assert "update_status" not in step_command
+    assert "update_status" in step_command
 
     # confirm that compute overrides are required to modify the command
     assert "timeout" not in step_command
 
 
 @pytest.mark.parametrize(
-    ("use_proxy", "overrides", "exp_timeout", "exp_fk_timeout"),
+    ("overrides", "exp_timeout", "exp_fk_timeout"),
     [
         pytest.param(
-            True,
             {"local": {"max_walltime": "01:30"}},
             "90s",
             "2s",
-            id="Proxied; default fk-timeout",
+            id="default fk-timeout",
         ),
         pytest.param(
-            True,
             {"local": {"force_kill_timeout": "00:00:05"}},
             "600s",
             "5s",
-            id="Proxied; default duration",
+            id="default duration",
         ),
         pytest.param(
-            True,
             {"local": {"max_walltime": "00:01:00", "force_kill_timeout": "00:00:42"}},
             "60s",
             "42s",
-            id="Proxied; no defaults",
+            id="no defaults",
         ),
         pytest.param(
-            False,
-            {"local": {"max_walltime": "00:60"}},
-            "60s",
-            "2s",
-            id="Unproxied; default fk-timeout",
-        ),
-        pytest.param(
-            False,
-            {"local": {"force_kill_timeout": "00:01:00"}},
-            "600s",
-            "60s",
-            id="Unproxied; default duration",
-        ),
-        pytest.param(
-            False,
             {"local": {"max_walltime": "00:60:00", "force_kill_timeout": "00:00:00"}},
             "3600s",
             "0s",
-            id="Unproxied; no defaults",
+            id="zero fk-timeout",
         ),
     ],
 )
 def test_locallauncher_adapt_step_with_compute_overrides(
     wp_templates_dir: Path,
-    use_proxy: bool,
     overrides: dict[str, dict[str, str]],
     exp_timeout: str,
     exp_fk_timeout: str,
@@ -159,10 +193,7 @@ def test_locallauncher_adapt_step_with_compute_overrides(
         },
     )
 
-    with mock.patch.object(
-        LocalLauncher, "use_proxy", mock.PropertyMock(return_value=use_proxy)
-    ):
-        step_command = LocalLauncher.adapt_step(live_step, [])
+    step_command = LocalLauncher.adapt_step(live_step, [])
 
     # confirm that compute overrides are required to modify the command
     assert f"timeout {exp_timeout} -k {exp_fk_timeout}" in step_command

--- a/cstar/tests/unit_tests/orchestration/launch/local/test_locallauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/local/test_locallauncher.py
@@ -1,11 +1,50 @@
+import asyncio
+import datetime
+import subprocess
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from cstar.orchestration.launch.local import LocalLauncher
-from cstar.orchestration.orchestration import LiveStep, Workplan
+from cstar.orchestration.launch.local import LocalHandle, LocalLauncher
+from cstar.orchestration.orchestration import LiveStep, Status, Workplan
 from cstar.orchestration.serialization import deserialize
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected"),
+    [
+        pytest.param(0, Status.Done, id="clean exit"),
+        pytest.param(3, Status.Failed, id="failure exit"),
+    ],
+)
+async def test_locallauncher_query_status_observes_exit(
+    exit_code: int,
+    expected: Status,
+) -> None:
+    """Verify a process that exits on its own is reported as terminal.
+
+    Popen only records an exit when it is polled; a status query that reads
+    `returncode` without polling reports the task as running forever.
+    """
+    process = subprocess.Popen(["sh", "-c", f"exit {exit_code}"])
+    handle = LocalHandle(
+        pid=str(process.pid),
+        name="observed",
+        run_id="test-run",
+        start_at=datetime.datetime.now(tz=datetime.UTC),
+        status=Status.Running,
+    )
+    handle.process = process
+
+    status = Status.Running
+    for _ in range(100):
+        status = await LocalLauncher.query_status(handle)
+        if status != Status.Running:
+            break
+        await asyncio.sleep(0.05)
+
+    assert status == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary

Local workplan runs could hang forever and lost track of step status once `cstar workplan run` returned. This PR makes several fixes and promotes proxy features that were previously behind a feature flag: steps now run in sequence, failures stop the steps that depend on them, and `cstar workplan status` reports accurate progress at any time — during the run and after it finishes.

Verified with real two-step local workplan runs (forge → ROMS-MARBL); unit suite passes (1461 passed) and `pre-commit run --all-files` is clean.

## Breaking Changes
- `cstar workplan run` on a local machine now schedules all steps and returns; use `cstar workplan status` to follow progress.
- A step whose dependency fails is now aborted and marked Failed instead of running against incomplete upstream output.
- The experimental `CSTAR_FF_ENABLE_LOCAL_PROXY` flag is removed; its behavior is now the default.

## Bug Fixes
- Local workplan runs hung indefinitely because a step that finished was still reported as running.
- `cstar workplan status` showed local steps as Running forever after the launching process exited.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

## Notes for Reviewers
- Root causes: step status was read from `Popen.returncode` without ever calling `poll()` (so self-exited processes stayed "Running"), and a fresh status process had no way to observe outcomes at all. Each step now runs under the proxy script, which waits on its dependencies, checks their recorded outcome, and writes status transitions to per-run sentinel files that `load_run_state` reads back.
- An adversarial review caught that removing the in-parent dependency wait initially dropped failure propagation; the dependency-outcome check in the proxy script is the fix, tested by executing the generated script for done/failed/vanished dependencies. The unit suite now exercises the proxy path throughout.
- `test_blueprint_migrate_file_dne` fails on `main` as well; unrelated to this PR.
- Pairs with the deferred-blueprints PR: that feature schedules fine without this one, but real local multi-step runs need these fixes to track the producer step's completion. No coupling on SLURM.
