### PR TITLE
Adopt in-flight SLURM jobs on reload instead of duplicating submission

### DIFF
--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, computed_field
 from cstar.base.env import (
     ENV_CSTAR_CLI_DRY_RUN,
     ENV_CSTAR_CLOBBER_WORKING_DIR,
+    FLAG_OFF,
     capture_environment,
     unset,
 )
@@ -550,11 +551,10 @@ def _ignore_ambient_clobber_env() -> None:
     Called before the environment is configured and captured into the run
     record; warns when the value would have had an effect.
     """
-    if os.environ.get(ENV_CSTAR_CLOBBER_WORKING_DIR, ""):
-        unset(ENV_CSTAR_CLOBBER_WORKING_DIR)
-
+    value = unset(ENV_CSTAR_CLOBBER_WORKING_DIR)
+    if value is not None and value != FLAG_OFF:
         msg = (
-            f"{ENV_CSTAR_CLOBBER_WORKING_DIR} is unset and ignored by workplan "
+            f"{ENV_CSTAR_CLOBBER_WORKING_DIR} is set but is ignored by workplan "
             "runs; select the steps to clear and re-run explicitly instead "
             "(`--clobber <step-name|all>` on the command line)."
         )
@@ -740,9 +740,8 @@ async def run_dag(
 
     Returns
     -------
-    Path
-        The path to the workplan that was executed after any tranformations
-        were applied.
+    WorkplanRun
+        The persisted record describing the run.
     """
     steps = t.cast("list[LiveStep]", planner.flatten())
     output_dir = StateDirectoryManager.data_dir(run_id)
@@ -801,9 +800,8 @@ async def build_and_run_dag(
 
     Returns
     -------
-    Path
-        The path to the workplan that was executed after any tranformations
-        were applied.
+    WorkplanRun
+        The persisted record describing the run.
     """
     planner, prepared_wp_path = await build_dag(
         wp_path,

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -306,23 +306,6 @@ class SlurmLauncher(Launcher[SlurmHandle]):
         raise RuntimeError(msg)
 
     @staticmethod
-    async def _get_status(job_id: str) -> ExecutionStatus:
-        """Retrieve the status of a step running in SLURM.
-
-        Parameters
-        ----------
-        job_id : str
-            The slurm job ID to retrieve status for.
-
-        Returns
-        -------
-        ExecutionStatus
-            The current status of the step.
-        """
-        batch = await get_slurm_batch(job_id)
-        return batch.status
-
-    @staticmethod
     async def _prune_completed_dependencies(
         dependencies: list[SlurmHandle],
     ) -> list[SlurmHandle]:
@@ -395,15 +378,18 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             name = prior_handle.name
 
             if Status.is_failure(last_status):
-                # force cache refresh for any tasks that didn't succeed
+                # clear prior state and re-run any tasks that didn't succeed
                 log.debug(f"Prior run of {name!r} in fail state. Re-running.")
-                # step.fsm.clear_prior()
                 step.workflow_overrides[KEY_CLOBBER] = True
-            elif Status.is_terminal(last_status):
-                # re-use the result from a prior run if it terminated
-                # successfully and isn't configured to be clobbered
+            elif Status.is_terminal(last_status) or Status.is_in_progress(last_status):
+                # re-use the result from a run that terminated successfully, or
+                # adopt a job that is still queued/running instead of submitting
+                # a duplicate, unless the step is configured to be clobbered
                 reuse_prior = not step.clobber
-                log.debug(f"Prior run of {name!r} in term state. Re-use: {reuse_prior}")
+                log.debug(
+                    f"Prior run of {name!r} in {last_status.name!r} state. "
+                    f"Re-use: {reuse_prior}"
+                )
 
         if not reuse_prior or not prior_handle:
             dependencies = await cls._prune_completed_dependencies(dependencies)

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -890,6 +890,94 @@ def test_workplan_run_reload_prior_run(
     assert statuses == {Status.Done}
 
 
+@pytest.mark.parametrize("status", [Status.Submitted, Status.Running, Status.Ending])
+@pytest.mark.usefixtures("read_yaml_intercept")
+def test_workplan_run_reload_prior_run_in_progress(
+    tmp_path: Path,
+    wp_templates_dir: Path,
+    mock_run_id: str,
+    status: Status,
+) -> None:
+    """Verify that reloading a run whose jobs are still queued or running
+    adopts the in-flight jobs instead of submitting duplicates.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    wp_templates_dir : Path
+        Fixture providing the path to a directory containing template workplans
+    """
+    run_id = mock_run_id
+    wp_path = wp_templates_dir / "workplan.yaml"
+    wp = deserialize(wp_path, Workplan)
+    live_steps = [LiveStep.from_step(step) for step in wp.steps]
+    lwp = LiveWorkplan(**wp.model_dump(exclude={"steps"}), steps=live_steps)
+    lwp_path = tmp_path / f"live-{wp_path.name}"
+    assert serialize(lwp_path, lwp), "serializing live workplan failed in test"
+
+    sentinel_paths = set[Path]()
+    for i, s in enumerate(lwp.steps):
+        n = -len(lwp.steps) + i
+        h = LocalHandle(
+            pid=str(1000 + n),
+            name=s.safe_name,
+            run_id=run_id,
+            status=Status.Submitted,
+            start_at=datetime.now() + timedelta(days=n),
+        )
+        p = StateRepository.sentinel_path(h)
+        assert serialize(p, h), "serializing the mock handles failed in test"
+        sentinel_paths.add(p)
+
+    fake_run = WorkplanRun(
+        workplan_path=wp_path,
+        trx_workplan_path=lwp_path,
+        output_path=lwp_path.parent,
+        run_id=run_id,
+        environment={"CSTAR_LOG_LEVEL": "TRACE"},
+        sentinels=sentinel_paths,
+    )
+
+    repo = TrackingRepository()
+    repo.put_workplan_run_sync(fake_run)
+
+    def typer_exit(*args, **kwargs) -> None:  # type: ignore # noqa: ANN002, ANN003, ARG001
+        raise typer.Exit(1)
+
+    runner = CliRunner()
+    with (
+        mock.patch(
+            "cstar.orchestration.dag_runner.get_launcher",
+            SlurmLauncher,
+        ),
+        mock.patch(
+            "cstar.orchestration.launch.slurm.SlurmLauncher.query_status",
+            mock.AsyncMock(return_value=status),
+        ) as mock_query_status,
+        mock.patch(
+            "cstar.orchestration.launch.slurm.SlurmLauncher._submit",
+            side_effect=typer_exit,
+        ) as mock_submit,
+    ):
+        result = runner.invoke(
+            app,
+            ["--run-id", mock_run_id],
+            color=False,
+        )
+
+    # RC would be 1 if submit was called for any task due to side_effect
+    assert result.exit_code == 0
+
+    # confirm the attempt to load the old record was made
+    assert mock_query_status.call_count == 4  # always query status for each step
+    assert not mock_submit.called  # in-flight jobs are adopted, not re-submitted
+
+    # confirm the status-change handler fires to update the persisted record
+    statuses = {deserialize(p, SlurmHandle).status for p in sentinel_paths}
+    assert statuses == {status}
+
+
 @pytest.mark.parametrize("status", [Status.Cancelled, Status.Failed])
 @pytest.mark.usefixtures("read_yaml_intercept")
 def test_workplan_run_reload_prior_run_repeat_failures(

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -349,7 +349,7 @@ def _make_workplan(steps: list[Step]) -> Workplan:
     )
 
 
-@pytest.mark.parametrize("value", [FLAG_OFF, FLAG_ON, "boo", "  "])
+@pytest.mark.parametrize("value", [FLAG_ON, "boo", "  "])
 def test_ignore_ambient_clobber_env_pops_and_warns(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -367,6 +367,22 @@ def test_ignore_ambient_clobber_env_pops_and_warns(
     assert len(caplog.records) == 1
     assert ENV_CSTAR_CLOBBER_WORKING_DIR in caplog.text
     assert ARG_CLOBBER in caplog.text
+
+
+def test_ignore_ambient_clobber_env_silent_when_off(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit "off" value is scrubbed without a warning (it would have
+    had no effect on the steps).
+    """
+    monkeypatch.setenv(ENV_CSTAR_CLOBBER_WORKING_DIR, FLAG_OFF)
+
+    with caplog.at_level("WARNING"):
+        _ignore_ambient_clobber_env()
+
+    assert ENV_CSTAR_CLOBBER_WORKING_DIR not in os.environ
+    assert not caplog.records
 
 
 def test_ignore_ambient_clobber_env_noop_when_unset(

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -76,7 +76,7 @@ Example HPC Deployment
 
 This diagram illustrates a user-initiated workflow on a HPC. It assumes that the user has already prepared their blueprints and a workplan, with all relevant input data in their HPC storage. An example roms-marbl blueprint would specify the location of compile-time files, run-time files, and input data files such as surface forcing, initial conditions, etc. Again, see `blueprints page <blueprints.rst>`_ for an example. In this example, the user has already generated the aforementioned files and the blueprint points to them.  
 
-The user logs into the login node and initiate the workplan via the ``cstar cli``. This creates an orchestrator instance (an ephemeral prefect server) that reads their workplan, identifies the tasks that need to be executed, organizes per-task blueprints, and submits the entire set of tasks to SLURM.
+The user logs into the login node and initiate the workplan via the ``cstar cli``. This creates an orchestrator instance that reads their workplan, identifies the tasks that need to be executed, organizes per-task blueprints, and submits the entire set of tasks to SLURM.
 
 SLURM allocates the requested compute resources, schedules jobs, enforces dependencies, and monitors job status. Each task gets its own allocation and initiates a worker to read the blueprint for that task and executes the appropriate application.
 


### PR DESCRIPTION
* fix a bug where in-flight / in-queue jobs would get resubmitted
* fix a few docstring return types
* remove docs mention of prefect server
* ...maybe addressed a potentially noisy log message? here's the reasoning on that one, we can change this back if it seems wrong:

> _ignore_ambient_clobber_env is silent again for CSTAR_CLOBBER_WORKING_DIR=0 (the #635 behavior), still using the branch's new unset() helper, and the warning says "is set but is ignored" instead of "is unset and  ignored". Restored test_ignore_ambient_clobber_env_silent_when_off and dropped FLAG_OFF from the warn-test parametrize