### PR TITLE
Add support for PIO_SETTINGS namelist block; fix test bugs

### DIFF
--- a/cstar/additional_files/templates/launchers/local_job_proxy.sh
+++ b/cstar/additional_files/templates/launchers/local_job_proxy.sh
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 SENTINEL_PATH="{sentinel_path}"
 BLUEPRINT_PATH="{blueprint_path}"
-DEP_PIDS=({pids})
-DEP_SENTINELS=({dep_sentinels})
 
 {env_vars}
 
@@ -12,24 +10,26 @@ DONE={done}
 FAILED={failed}
 
 update_status() {{
-    local status=$1
     if [ "$(uname)" = "Darwin" ]; then
-        sed -i '' "s/^status:.*$/status: $status/" "$2"
+        sed -i '' "s/^status:.*$/status: $1/" "$2"
     else
-        sed -i "s/^status:.*$/status: $status/" "$2"
+        sed -i "s/^status:.*$/status: $1/" "$2"
     fi
 }}
 
 # wait for each dependency to complete, then verify that it succeeded --
 # a dependency that exited without reaching `Done` must abort this step.
-for i in "${{!DEP_PIDS[@]}}"; do
-    DEP_PID="${{DEP_PIDS[$i]}}"
+# POSIX sh has no arrays: the sentinel paths sit in the positional
+# parameters and are consumed in step with the pid list.
+set -- {dep_sentinels}
+for DEP_PID in {pids}; do
+    DEP_SENTINEL=$1
+    shift
     while kill -0 "$DEP_PID" 2>/dev/null; do
         echo "Awaiting process $DEP_PID"
         sleep {delay}
     done
 
-    DEP_SENTINEL="${{DEP_SENTINELS[$i]}}"
     DEP_STATUS=$(sed -n 's/^status: *//p' "$DEP_SENTINEL" 2>/dev/null)
     if [ "$DEP_STATUS" != "$DONE" ]; then
         echo "Dependency (pid $DEP_PID) ended with status '$DEP_STATUS'; aborting."

--- a/cstar/roms/namelist.py
+++ b/cstar/roms/namelist.py
@@ -14,7 +14,9 @@ subclasses:
 - :class:`RomsNamelist` — the schema for ucla-roms **< 0.5.0**. Kept
   unversioned (no suffix) for backward compatibility: this is the name
   historically imported by C-Star Forge and other consumers.
-- :class:`RomsNamelistV0_5_0` — the schema for ucla-roms **>= 0.5.0**.
+- :class:`RomsNamelistV0_5_0` — the schema for ucla-roms **>= 0.5.0, < 0.6.0**.
+- :class:`RomsNamelistV0_6_0` — the schema for ucla-roms **>= 0.6.0**. Adds
+  the ``&PIO_SETTINGS`` group (ucla-roms PR #346) on top of 0.5.0.
 
 Later breaking releases add a further ``RomsNamelistV<major>_<minor>_<patch>``
 subclass following the same ``V<major>_<minor>_<patch>`` suffix convention.
@@ -166,6 +168,13 @@ class ParamSettings(_NmlGroup):
     """Number of passive tracers"""
     nt_bgc: int
     """Number of BGC tracers"""
+
+
+class PioSettings(_NmlGroup):
+    """Parallel-IO (PIO) library run-time settings (ucla-roms `&PIO_SETTINGS`)."""
+
+    pio_stride: int = Field(default=1, ge=1)
+    """Stride between MPI ranks assigned as PIO I/O tasks (requires PARALLEL_IO)"""
 
 
 class InitialConditions(_NmlGroup):
@@ -693,8 +702,9 @@ class RomsNamelistBase(BaseModel):
 
     Not meant to be instantiated directly: use a versioned subclass
     (:class:`RomsNamelist` for ucla-roms < 0.5.0, :class:`RomsNamelistV0_5_0`
-    for ucla-roms >= 0.5.0) or select one automatically with
-    :func:`namelist_schema_for_ref`.
+    for ucla-roms >= 0.5.0, < 0.6.0, or :class:`RomsNamelistV0_6_0` for
+    ucla-roms >= 0.6.0, which adds ``&PIO_SETTINGS``) or select one
+    automatically with :func:`namelist_schema_for_ref`.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
@@ -879,10 +889,20 @@ class RomsNamelist(RomsNamelistBase):
 
 
 class RomsNamelistV0_5_0(RomsNamelistBase):
-    """The ROMS namelist schema for ucla-roms >= 0.5.0 (PR #336)."""
+    """The ROMS namelist schema for ucla-roms >= 0.5.0, < 0.6.0 (PR #336)."""
 
     basic_output_settings: BasicOutputSettingsV0_5_0
     particles_settings: ParticlesSettingsV0_5_0
+
+
+class RomsNamelistV0_6_0(RomsNamelistV0_5_0):
+    """The ROMS namelist schema for ucla-roms >= 0.6.0.
+
+    Adds `&PIO_SETTINGS` (ucla-roms PR #346) on top of the 0.5.0 schema;
+    otherwise unchanged.
+    """
+
+    pio_settings: PioSettings = Field(default_factory=PioSettings)
 
 
 # ---- Schema version selection ----
@@ -890,6 +910,7 @@ class RomsNamelistV0_5_0(RomsNamelistBase):
 # ucla-roms releases with breaking namelist changes, as comparable version
 # tuples (named so registry entries read as versions, not bare tuples).
 UCLA_ROMS_0_5_0: Final[tuple[int, int, int]] = (0, 5, 0)
+UCLA_ROMS_0_6_0: Final[tuple[int, int, int]] = (0, 6, 0)
 
 # Half-open ucla-roms version ranges ``[lower, upper)`` mapped to the schema
 # class that applies; `None` bounds are unbounded. Ranges must be contiguous
@@ -900,7 +921,7 @@ UCLA_ROMS_0_5_0: Final[tuple[int, int, int]] = (0, 5, 0)
 #   1. Add the release constant:
 #        UCLA_ROMS_0_8_0: Final[tuple[int, int, int]] = (0, 8, 0)
 #   2. Cap the current last entry's upper bound at the new version:
-#        (UCLA_ROMS_0_5_0, UCLA_ROMS_0_8_0, RomsNamelistV0_5_0),
+#        (UCLA_ROMS_0_6_0, UCLA_ROMS_0_8_0, RomsNamelistV0_6_0),
 #   3. Append a new open-ended entry for the new schema:
 #        (UCLA_ROMS_0_8_0, None, RomsNamelistV0_8_0),
 NAMELIST_SCHEMA_REGISTRY: tuple[
@@ -910,7 +931,8 @@ NAMELIST_SCHEMA_REGISTRY: tuple[
     ...,
 ] = (
     (None, UCLA_ROMS_0_5_0, RomsNamelist),
-    (UCLA_ROMS_0_5_0, None, RomsNamelistV0_5_0),
+    (UCLA_ROMS_0_5_0, UCLA_ROMS_0_6_0, RomsNamelistV0_5_0),
+    (UCLA_ROMS_0_6_0, None, RomsNamelistV0_6_0),
 )
 
 

--- a/cstar/tests/unit_tests/applications/test_roms_marbl_models.py
+++ b/cstar/tests/unit_tests/applications/test_roms_marbl_models.py
@@ -220,6 +220,34 @@ class TestNamelistOverrides:
         }
         RomsMarblBlueprint.model_validate(complete_blueprint_dict)
 
+    def test_pio_settings_override_valid_for_unpinned_ref(
+        self, complete_blueprint_dict
+    ):
+        """Test that a `pio_settings` override validates silently for an
+        unpinned `code.roms` ref: the fallback schema for an unpinned ref is
+        the latest (`RomsNamelistV0_6_0`), which has `&pio_settings`.
+        """
+        complete_blueprint_dict["namelist_overrides"] = {
+            "pio_settings": {"pio_stride": 4}
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            bp = RomsMarblBlueprint.model_validate(complete_blueprint_dict)
+        assert bp.namelist_overrides == {"pio_settings": {"pio_stride": 4}}
+
+    def test_pio_settings_override_rejected_for_0_5_0_pin(
+        self, complete_blueprint_dict
+    ):
+        """Test that a `pio_settings` override is rejected for a `code.roms`
+        pin at 0.5.0, since `&pio_settings` was added in ucla-roms 0.6.0.
+        """
+        complete_blueprint_dict["code"]["roms"]["branch"] = "v0.5.0"
+        complete_blueprint_dict["namelist_overrides"] = {
+            "pio_settings": {"pio_stride": 4}
+        }
+        with pytest.raises(ValidationError, match="pio_settings"):
+            RomsMarblBlueprint.model_validate(complete_blueprint_dict)
+
 
 class TestPartitioningParameterSet:
     """Tests for the `PartitioningParameterSet` validation rules."""

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -59,8 +59,11 @@ def test_blueprint_migrate_file_dne(tmp_path: Path) -> None:
         color=False,
     )
 
-    assert "Invalid value for 'PATH'" in result.stderr
-    assert "was not found" in result.stderr
+    # Normalize away the rich error panel's hard wrapping, which can split
+    # the message at any point depending on the tmp path length.
+    plain_stderr = " ".join(result.stderr.replace("│", " ").split())
+    assert "Invalid value for 'PATH'" in plain_stderr
+    assert "was not found" in plain_stderr
 
 
 def test_blueprint_migrate_remote_blueprint_dne() -> None:

--- a/cstar/tests/unit_tests/orchestration/launch/local/test_proxiedrunrequestformatter.py
+++ b/cstar/tests/unit_tests/orchestration/launch/local/test_proxiedrunrequestformatter.py
@@ -137,7 +137,8 @@ def test_proxiedrunrequestformatter_minimal_tpl_fill(
     tokens = [
         'SENTINEL_PATH="{sentinel_path}"',
         'BLUEPRINT_PATH="{blueprint_path}"',
-        "DEP_PIDS=({pids})",
+        "set -- {dep_sentinels}",
+        "for DEP_PID in {pids}; do",
         "RUNNING={running}",
         "DONE={done}",
         "FAILED={failed}",
@@ -214,7 +215,7 @@ def test_proxiedrunrequestformatter_environment_formatting(
 def test_proxiedrunrequestformatter_dependency_formatting(
     wp_templates_dir: Path, mock_run_id: str
 ) -> None:
-    """Verify that a formatter correctly adds the dependency array into the template."""
+    """Verify that a formatter correctly adds the dependency pid list into the template."""
     wp_path = wp_templates_dir / "single_step.yaml"
     workplan = deserialize(wp_path, Workplan)
     live_step = LiveStep.from_step(workplan.steps[0])
@@ -231,7 +232,7 @@ def test_proxiedrunrequestformatter_dependency_formatting(
     formatter = ProxiedRunRequestFormatter(live_step, deps)
     cmd = ["python", "-m", "venv", ".venv"]
 
-    deps_array = 'DEP_PIDS=("12345" "54321")\n'
+    deps_list = 'for DEP_PID in "12345" "54321"; do\n'
 
     run_request = RunRequest(
         command=cmd,
@@ -239,4 +240,4 @@ def test_proxiedrunrequestformatter_dependency_formatting(
     script = formatter.format(run_request)
 
     # confirm the dependencies are listed
-    assert deps_array in script
+    assert deps_list in script

--- a/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_6_0.nml
+++ b/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_6_0.nml
@@ -1,0 +1,315 @@
+&basic_output_settings
+    monthly_restarts = .false.
+    nrpf_avg = 1
+    nrpf_his = 7
+    output_period_avg = 604800.0
+    output_period_his = 86400.0
+    output_period_rst = 86400.0
+    wrt_aks = .false.
+    wrt_akt = .false.
+    wrt_akv = .false.
+    wrt_avg_aks = .true.
+    wrt_avg_akt = .true.
+    wrt_avg_akv = .true.
+    wrt_avg_hbbl = .true.
+    wrt_avg_hbls = .true.
+    wrt_avg_o = .true.
+    wrt_avg_r = .true.
+    wrt_avg_u = .true.
+    wrt_avg_ub = .true.
+    wrt_avg_v = .true.
+    wrt_avg_vb = .true.
+    wrt_avg_w = .true.
+    wrt_avg_z = .true.
+    wrt_file_avg = .false.
+    wrt_file_his = .false.
+    wrt_file_rst = .true.
+    wrt_hbbl = .false.
+    wrt_hbls = .false.
+    wrt_o = .false.
+    wrt_r = .false.
+    wrt_u = .true.
+    wrt_ub = .true.
+    wrt_v = .true.
+    wrt_vb = .true.
+    wrt_w = .true.
+    wrt_z = .true.
+/
+
+&bgc_settings
+    interp_bgc_frc = .true.
+    nrpf_bgc_avg = 7
+    nrpf_bgc_avg_dia = 1
+    nrpf_bgc_his = 7
+    nrpf_bgc_his_dia = 7
+    output_period_bgc_avg = 86400.0
+    output_period_bgc_avg_dia = 60.0
+    output_period_bgc_his = 86400.0
+    output_period_bgc_his_dia = 86400.0
+    wrt_bgc_avg = .false.
+    wrt_bgc_dia_avg = .false.
+    wrt_bgc_dia_his = .false.
+    wrt_bgc_his = .false.
+    xco2air_default = 284.7
+/
+
+&bottom_drag_settings
+    rdrg = 0.0
+    rdrg2 = 0.001
+    zob = 0.01
+/
+
+&calc_pflx_settings
+    calc_pflx = .true.
+    pflx_timescale = 86400.0
+/
+
+&cdr_frc_settings
+    cdr_file = 'cdr.nc'
+    cdr_forcing_3d = .false.
+    cdr_forcing_depth_profiles = .false.
+    cdr_forcing_parameterized = .true.
+    cdr_ncdr_parm = 1
+    cdr_nz_chd = 50
+    cdr_relocate_to_wet_pts = .true.
+    cdr_source = .false.
+    cdr_time_interpolation = .false.
+    cdr_volume = .false.
+/
+
+&cdr_output_settings
+    cdr_monthly_averages = .false.
+    do_cdr_output = .false.
+    nrpf_cdr = 24
+    output_period_cdr = 3600.0
+    wrt_cdr_avg = .true.
+/
+
+&diagnostics_settings
+    diag_avg = .false.
+    diag_trc = .false.
+    diag_uv = .false.
+    nrpf_diag = 7
+    output_period_diag = 86400.0
+/
+
+&extract_data_settings
+    do_extract = .false.
+    extract_file = 'sample_edata.nc'
+    extract_root_name = 'child'
+    hc_chd = 250.0
+    n_chd = 90
+    nrpf_extract = 24
+    output_period_extract = 3600.0
+    theta_b_chd = 2.0
+    theta_s_chd = 5.0
+/
+
+&forcing_files
+/
+
+&frc_output_settings
+    nrpf_frc = 4
+    output_period_frc = 3600.0
+    wrt_frc = .false.
+    wrt_frc_avg = .false.
+/
+
+&gamma2_settings
+    gamma2 = 1.0
+/
+
+&grid_settings
+    grdname = ''
+/
+
+&initial_conditions
+    inifile = ''
+/
+
+&lateral_visc_settings
+    visc2 = 0.0
+/
+
+&lin_rho_eos_settings
+    s0 = 1.0
+    scoef = 0.822
+    t0 = 1.0
+    tcoef = 0.2
+/
+
+&marbl_biogeochemistry_settings
+    marbl_config_file = 'marbl_in'
+    marbl_diagnostics_to_write = 'PH', 'PH_ALT_CO2', 'pCO2SURF_ALT_CO2',
+                                 'pCO2SURF', 'FG_CO2', 'FG_ALT_CO2'
+    marbl_timestep = 3600.0
+    marbl_tracers_to_write = 'PO4', 'NO3', 'SiO3', 'NH4', 'Fe', 'O2', 'DIC',
+                             'ALK', 'spChl', 'diatChl'
+/
+
+&param_settings
+    llm = 512
+    mmm = 512
+    np_eta = 16
+    np_xi = 16
+    nt_bgc = 32
+    nt_passive = 0
+    nz = 60
+/
+
+&particles_settings
+    exchange_facc = 0.01
+    exchange_facx = 0.1
+    exchange_facy = 0.1
+    extra_space_fac = 1.5
+    floats = .false.
+    np = 50
+    nrpf_particles = 100
+    output_period_particles = 400.0
+    pmin = 200
+    ppm3 = 1e-06
+/
+
+&pio_settings
+    pio_stride = 1
+/
+
+&pipe_frc_settings
+    npip = 1
+    p_analytical = .false.
+    pipe_source = .false.
+/
+
+&random_output_settings
+    do_random = .false.
+    nrpf_random = 10
+    output_period_random = 3600.0
+/
+
+&reference_date_settings
+    reference_date = 2005, 6, 15
+/
+
+&rho0_settings
+    rho0 = 1000.0
+/
+
+&river_frc_settings
+    nriv = 0
+    river_analytical = .false.
+    river_source = .false.
+/
+
+&s_coord
+    hc = 250.0
+    theta_b = 2.0
+    theta_s = 5.0
+/
+
+&simulation_name_settings
+    output_root_name = 'roms'
+    title = 'test_settings'
+/
+
+&sponge_tune_settings
+    nrpf_sponge = 7
+    output_period_sponge = 86400.0
+    sponge_avg = .true.
+    sponge_timescale = 86400.0
+    ub_tune = .false.
+    wrt_sponge = .false.
+/
+
+&sss_correction
+    dsssdt = 7.777
+/
+
+&sst_correction
+    dsstdt = 7.777
+/
+
+&dic_alk_correction
+    dcdt = 7.777
+/
+
+&stdout_diag_settings
+    code_check_mode = .false.
+/
+
+&surf_flx_output_settings
+    nrpf_sflx = 10
+    output_period_sflx = 31536000.0
+    sflx_avg = .false.
+    wrt_smflx = .false.
+    wrt_stflx = .false.
+    wrt_rstflx = .false.
+    wrt_swflx = .false.
+/
+
+&surf_frc_settings
+    check_bulk_frc_units = .false.
+    interp_bulk_frc = .false.
+    interp_flux_frc = .true.
+/
+
+&tidal_frc_settings
+    ana_tides = .false.
+    bry_tides = .true.
+    ntides = 10
+    pot_tides = .true.
+/
+
+&time_stepping
+    dt = 2160.0
+    ndtfast = 60
+    ninfo = 1
+    ntimes = 1200
+/
+
+&tracer_diff2
+    tnu2 = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+/
+
+&ts_output_settings
+    wrt_salt = .false.
+    wrt_salt_dia = .false.
+    wrt_temp = .false.
+    wrt_temp_dia = .false.
+/
+
+&ubind_settings
+    ubind = 0.1
+/
+
+&upscale_settings
+    do_upscale = .false.
+    nrpf_uscl = 48
+    output_period_uscl = 3600.0
+/
+
+&v_sponge_settings
+    v_sponge = 0.0
+/
+
+&vertical_mixing_settings
+    akt_bak = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    akv_bak = 0.0
+/
+
+&zslice_settings
+    do_zslice = .false.
+    ndep = 2
+    nrpf_zslice = 72
+    nt_zslice = 2
+    output_period_zslice = 1200.0
+    trc2zsc = 1, 2
+    vecdep = -2.0, -15.0
+    wrt_t_zslice = .false.
+    wrt_u_zslice = .false.
+    wrt_v_zslice = .false.
+    zslice_avg = .false.
+/

--- a/cstar/tests/unit_tests/roms/test_namelist.py
+++ b/cstar/tests/unit_tests/roms/test_namelist.py
@@ -8,14 +8,19 @@ import pytest
 from pydantic import ValidationError
 
 from cstar.roms.namelist import (
+    PioSettings,
     RomsNamelist,
     RomsNamelistBase,
     RomsNamelistV0_5_0,
+    RomsNamelistV0_6_0,
     namelist_schema_for_ref,
 )
 
 OLD_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist.nml"
 NEW_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_5_0.nml"
+V0_6_0_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_6_0.nml"
+
+PIO_SETTINGS_BLOCK = "&pio_settings\n    pio_stride = 1\n/\n\n"
 
 
 @pytest.mark.parametrize(
@@ -29,11 +34,20 @@ def test_namelist_schema_for_ref_pre_0_5_0(checkout_target):
 
 @pytest.mark.parametrize(
     "checkout_target",
-    ["0.5.0", "v0.5.0", "0.7.3", "12.0.0"],
+    ["0.5.0", "v0.5.0", "0.5.9"],
 )
-def test_namelist_schema_for_ref_post_0_5_0(checkout_target):
-    """Refs at or above 0.5.0 select `RomsNamelistV0_5_0`."""
+def test_namelist_schema_for_ref_0_5_0_range(checkout_target):
+    """Refs in `[0.5.0, 0.6.0)` select `RomsNamelistV0_5_0`."""
     assert namelist_schema_for_ref(checkout_target) is RomsNamelistV0_5_0
+
+
+@pytest.mark.parametrize(
+    "checkout_target",
+    ["0.6.0", "v0.6.0", "0.6.1", "0.7.3", "12.0.0"],
+)
+def test_namelist_schema_for_ref_post_0_6_0(checkout_target):
+    """Refs at or above 0.6.0 select `RomsNamelistV0_6_0`."""
+    assert namelist_schema_for_ref(checkout_target) is RomsNamelistV0_6_0
 
 
 @pytest.mark.parametrize(
@@ -52,7 +66,7 @@ def test_namelist_schema_for_ref_fallback_warns(checkout_target):
     """Non-release-tag refs fall back to the latest schema and warn about it."""
     with pytest.warns(UserWarning, match="use at your own risk"):
         schema = namelist_schema_for_ref(checkout_target)
-    assert schema is RomsNamelistV0_5_0
+    assert schema is RomsNamelistV0_6_0
 
 
 @pytest.fixture
@@ -145,7 +159,7 @@ def test_namelist_schema_for_ref_branch_ignores_repo_path(tagged_ucla_roms_clone
     info = tagged_ucla_roms_clone
     with pytest.warns(UserWarning, match="use at your own risk"):
         schema = namelist_schema_for_ref("main", repo_path=info["repo"])
-    assert schema is RomsNamelistV0_5_0
+    assert schema is RomsNamelistV0_6_0
 
 
 def test_namelist_schema_for_ref_unresolvable_hash_falls_back():
@@ -157,12 +171,12 @@ def test_namelist_schema_for_ref_unresolvable_hash_falls_back():
     ):
         with pytest.warns(UserWarning, match="use at your own risk"):
             schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
-    assert schema is RomsNamelistV0_5_0
+    assert schema is RomsNamelistV0_6_0
 
     with mock.patch("cstar.roms.namelist._describe_nearest_tag", return_value=None):
         with pytest.warns(UserWarning, match="use at your own risk"):
             schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
-    assert schema is RomsNamelistV0_5_0
+    assert schema is RomsNamelistV0_6_0
 
 
 def test_roms_namelist_round_trip():
@@ -181,6 +195,18 @@ def test_roms_namelist_v0_5_0_round_trip():
     assert "nrpf_rst" not in d["basic_output_settings"]
 
 
+def test_roms_namelist_v0_6_0_round_trip():
+    """`RomsNamelistV0_6_0.read` parses the 0.6.0 fixture, keeping the 0.5.0
+    renamed keys and adding `pio_settings`.
+    """
+    nml = RomsNamelistV0_6_0.read(V0_6_0_NAMELIST)
+    d = nml.to_f90nml_dict()
+    assert "output_period_particles" in d["particles_settings"]
+    assert "nrpf_particles" in d["particles_settings"]
+    assert "nrpf_rst" not in d["basic_output_settings"]
+    assert d["pio_settings"] == {"pio_stride": 1}
+
+
 def test_roms_namelist_v0_5_0_rejects_old_fixture():
     """`RomsNamelistV0_5_0` is strict: the pre-0.5.0 fixture has now-extra/missing keys."""
     with pytest.raises(ValidationError):
@@ -193,6 +219,15 @@ def test_roms_namelist_rejects_new_fixture():
         RomsNamelist.read(NEW_NAMELIST)
 
 
+def test_roms_namelist_v0_5_0_rejects_pio_settings_fixture():
+    """`RomsNamelistV0_5_0` is strict: `&pio_settings` was added in 0.6.0, so a
+    file carrying it (otherwise identical to the 0.5.0 fixture) is rejected as
+    an unknown group.
+    """
+    with pytest.raises(ValidationError):
+        RomsNamelistV0_5_0.read(V0_6_0_NAMELIST)
+
+
 def test_roms_namelist_base_rejects_direct_use():
     """`RomsNamelistBase` refuses validation against itself.
 
@@ -201,6 +236,53 @@ def test_roms_namelist_base_rejects_direct_use():
     """
     with pytest.raises(TypeError, match="not a usable schema"):
         RomsNamelistBase.read(OLD_NAMELIST)
+
+
+def test_pio_settings_defaults_when_group_missing(tmp_path):
+    """A 0.6.0-schema namelist without `&pio_settings` still validates,
+    defaulting `pio_stride` to 1.
+    """
+    text = V0_6_0_NAMELIST.read_text()
+    assert PIO_SETTINGS_BLOCK in text
+    trimmed = tmp_path / "no_pio_settings.nml"
+    trimmed.write_text(text.replace(PIO_SETTINGS_BLOCK, ""))
+
+    nml = RomsNamelistV0_6_0.read(trimmed)
+    assert nml.pio_settings.pio_stride == 1
+
+
+def test_pio_settings_reads_and_round_trips_through_write(tmp_path):
+    """`pio_settings.pio_stride` reads from the 0.6.0 fixture and a modified
+    value round-trips through `write`.
+    """
+    nml = RomsNamelistV0_6_0.read(V0_6_0_NAMELIST)
+    assert nml.pio_settings.pio_stride == 1
+
+    nml.pio_settings.pio_stride = 4
+    out = tmp_path / "namelist.nml"
+    nml.write(out)
+
+    reread = RomsNamelistV0_6_0.read(out)
+    assert reread.pio_settings.pio_stride == 4
+
+
+def test_pio_settings_always_written_even_when_constructed_without_it(tmp_path):
+    """`pio_settings` is present in written output even when the model was
+    constructed without an explicit `&pio_settings` group (using the default).
+    """
+    text = V0_6_0_NAMELIST.read_text().replace(PIO_SETTINGS_BLOCK, "")
+    trimmed = tmp_path / "no_pio_settings.nml"
+    trimmed.write_text(text)
+
+    nml = RomsNamelistV0_6_0.read(trimmed)
+    d = nml.to_f90nml_dict()
+    assert d["pio_settings"] == {"pio_stride": 1}
+
+
+def test_pio_settings_rejects_non_positive_stride():
+    """`pio_stride` must be >= 1."""
+    with pytest.raises(ValidationError):
+        PioSettings(pio_stride=0)
 
 
 class TestUnknownOverrideKeys:
@@ -237,3 +319,19 @@ class TestUnknownOverrideKeys:
         """The base class is not a usable schema for key checks."""
         with pytest.raises(TypeError, match="not a usable schema"):
             RomsNamelistBase.unknown_override_keys({"time_stepping": {"dt": 1}})
+
+    def test_pio_settings_key(self):
+        """`pio_settings.pio_stride` is only a known group/key from 0.6.0 on:
+        `RomsNamelistV0_6_0` accepts it, but `RomsNamelist` and
+        `RomsNamelistV0_5_0` (which lack the group) report it as unknown.
+        """
+        overrides = {"pio_settings": {"pio_stride": 4}}
+        assert RomsNamelistV0_6_0.unknown_override_keys(overrides) == []
+
+        violations = RomsNamelist.unknown_override_keys(overrides)
+        assert len(violations) == 1
+        assert "pio_settings" in violations[0]
+
+        violations = RomsNamelistV0_5_0.unknown_override_keys(overrides)
+        assert len(violations) == 1
+        assert "pio_settings" in violations[0]

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -32,6 +32,7 @@ from cstar.roms.input_dataset import (
 from cstar.roms.namelist import (
     RomsNamelist,
     RomsNamelistV0_5_0,
+    RomsNamelistV0_6_0,
     namelist_schema_for_ref,
 )
 from cstar.roms.simulation import ROMSSimulation
@@ -562,13 +563,18 @@ class TestROMSSimulationInitialization:
         ``checkout_target`` to select a namelist schema, and that a non-release
         ``checkout_target`` (as set up by the ``stub_romssimulation`` fixture)
         surfaces the ``namelist_schema_for_ref`` fallback warning through the
-        property while still returning a valid namelist.
+        property, actually selects the latest schema (``RomsNamelistV0_6_0``),
+        while still returning a valid namelist.
 
         The read is stubbed (the stub's working copy has no real files on
-        disk), but the stub performs a genuine ``RomsNamelistV0_5_0``
-        validation of the 0.5.0-style fixture — the schema the fallback
-        selects — so the property's overrides are exercised against the
-        selected schema, not the legacy one.
+        disk) to always perform a genuine ``RomsNamelistV0_5_0`` validation of
+        the 0.5.0-style fixture — so the property's overrides are exercised
+        against a real versioned schema, not the legacy one — but which class
+        was actually *selected* is captured separately via the
+        ``namelist_schema_for_ref`` wrap below, since ``RomsNamelistV0_6_0``
+        is a subclass of ``RomsNamelistV0_5_0`` and the stubbed read makes
+        ``isinstance(result, RomsNamelistV0_5_0)`` true regardless of which
+        class was selected.
         """
         sim = stub_romssimulation
         sim.runtime_code._working_copy = stageddatacollection_remote_files()
@@ -579,6 +585,19 @@ class TestROMSSimulationInitialization:
             EXAMPLE_NAMELIST_V0_5_0
         )
 
+        # namelist_schema_for_ref is wrapped (not stubbed), so it still runs
+        # the real selection logic; capture what it actually returns so we can
+        # assert on the selected class itself, not just on isinstance() of the
+        # (separately stubbed) read result.
+        selected_schemas = []
+
+        def _select_and_record(*args, **kwargs):
+            cls = namelist_schema_for_ref(*args, **kwargs)
+            selected_schemas.append(cls)
+            return cls
+
+        mock_schema_for_ref.side_effect = _select_and_record
+
         checkout_target = sim.codebase.source.checkout_target
         assert checkout_target == "roms_branch"  # not a release tag
 
@@ -588,6 +607,7 @@ class TestROMSSimulationInitialization:
         # the stub's codebase has no working copy, so no repo path is available
         # for commit-hash-to-release-tag resolution
         mock_schema_for_ref.assert_called_once_with(checkout_target, repo_path=None)
+        assert selected_schemas == [RomsNamelistV0_6_0]
         assert isinstance(result, RomsNamelistV0_5_0)
         run_length_seconds = int((sim.end_date - sim.start_date).total_seconds())
         assert result.time_stepping.ntimes == run_length_seconds // 2160.0


### PR DESCRIPTION
# Summary

Adds support for the `&PIO_SETTINGS` namelist group introduced in ucla-roms 0.6.0 (ucla-roms PR #346) via a new version-gated namelist schema, and fixes a shell-portability bug in the local launcher's job proxy script that broke local runs (and the Ubuntu CI) on systems where `sh` is not bash.

## Breaking Changes
- N/A

## New Features
- ROMS namelists now support the `&PIO_SETTINGS` group (`pio_stride`) added in ucla-roms 0.6.0. 

## Bug Fixes
- The local launcher's job proxy script used bash-only syntax (arrays) but is executed with `sh`, so every local step failed immediately with a syntax error on systems where `sh` is dash (Ubuntu/Debian, including CI). The script is now POSIX sh.

## Improvements
- N/A

## Miscellaneous
- Made a migrate-CLI test assertion robust to console line-wrapping, which could split the expected error message at an arbitrary point depending on the tmp-path length (flaky in CI).

## Notes for Reviewers
- POSIX sh has no arrays, so the proxy script keeps the dependency pid/sentinel pairing by loading the sentinel paths into the positional parameters (`set -- <sentinels>`) and `shift`-ing one per pid. Verified under `/bin/dash` across all dependency outcomes (done / failed / vanished), the no-dependency case, command-failure propagation, and multi-dependency pairing alignment.
- Downstream: cstar-forge pins that move to ucla-roms >= 0.6.0 will start generating namelists containing `&PIO_SETTINGS`; forge golden fixtures may need a matching update at that point.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing
