### PR TITLE
Fix doubled run-id directory for workplan artifacts

### DIFF
--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -323,7 +323,6 @@ async def process_plan(orchestrator: Orchestrator, mode: RunMode) -> DagStatus:
 async def prepare_workplan(
     wp_path: Path,
     output_dir: Path,
-    run_id: str,
     user_variables: Mapping[str, str] | None = None,
     clobber_steps: "Sequence[str] | None" = None,
 ) -> tuple[Workplan, Path]:
@@ -334,9 +333,7 @@ async def prepare_workplan(
     wp_path : Path
         The path to the workplan to load.
     output_dir : Path
-        The directory where workplan outputs will be written.
-    run_id : str
-        The unique ID for the current run.
+        The run-specific directory where workplan artifacts will be written.
     user_variables : Mapping | None
         User-defined variables specified at runtime
     clobber_steps : Sequence[str] | None
@@ -354,7 +351,6 @@ async def prepare_workplan(
         If the expected and provided user variables are not in agreement.
     """
     wp_orig = await asyncio.to_thread(deserialize, wp_path, Workplan)
-    run_root_dir = output_dir / run_id
 
     fill_transform: TemplateFillTransform | None = None
     file_io_extras: list[Awaitable[int]] = []
@@ -371,7 +367,7 @@ async def prepare_workplan(
         )
 
         persist_vars = WorkplanTransformer.derived_path(
-            wp_path, run_root_dir, suffix="", extension=".vars"
+            wp_path, output_dir, suffix="", extension=".vars"
         )
         file_io_extras.append(asyncio.to_thread(serialize, persist_vars, named_config))
     else:
@@ -387,9 +383,9 @@ async def prepare_workplan(
 
     # make a copy of the original and modified blueprint in the output directory
     persist_orig = WorkplanTransformer.derived_path(
-        wp_path, run_root_dir, "_original", ".bak"
+        wp_path, output_dir, "_original", ".bak"
     )
-    persist_as = WorkplanTransformer.derived_path(wp_path, run_root_dir, "_transformed")
+    persist_as = WorkplanTransformer.derived_path(wp_path, output_dir, "_transformed")
 
     file_io: list[Awaitable[int]] = [
         asyncio.to_thread(serialize, persist_orig, wp_orig),
@@ -708,7 +704,7 @@ async def build_dag(
 
     check_environment()
     wp, prepared_wp_path = await prepare_workplan(
-        wp_path, output_dir, run_id, user_variables, clobber_steps
+        wp_path, output_dir, user_variables, clobber_steps
     )
     planner = Planner(workplan=wp)
 

--- a/cstar/tests/unit_tests/execution/test_handler.py
+++ b/cstar/tests/unit_tests/execution/test_handler.py
@@ -114,7 +114,9 @@ class TestExecutionHandlerUpdates:
         Mocks
         -----
         MockExecutionHandler.status
-            Mocked to return `ExecutionStatus.RUNNING`, simulating a running job.
+            Starts as `ExecutionStatus.RUNNING` and is flipped to `COMPLETED` by the
+            writer thread once all output is written, so `updates()` drains the tail
+            and returns on its own rather than racing a wall-clock budget.
 
         Fixtures
         --------
@@ -148,13 +150,16 @@ class TestExecutionHandlerUpdates:
                     time.sleep(0.01)  # Ensure `updates()` is actively reading
                     f.write(line)
                     f.flush()  # Immediately write to disk
+            # finish the job; `updates()` exits via the terminal-tail path, so
+            # `seconds` is only an upper bound and no line can outrun the clock
+            handler._status = ExecutionStatus.COMPLETED
 
         # Start the live update simulation in a background thread
         updater_thread = threading.Thread(target=append_live_updates, daemon=True)
         updater_thread.start()
 
         # Run the `updates` method
-        await handler.updates(seconds=0.25)
+        await handler.updates(seconds=5)
 
         # Ensure both initial and live update lines are printed
         captured = caplog.text

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_compose.py
@@ -298,7 +298,7 @@ async def test_prepare_composed_dag(
         run_id = get_run_id()
         working_dir = DirectoryManager.data_home()
         check_environment()
-        wp, wp_path = await prepare_workplan(generated_wp_path, working_dir, run_id)
+        wp, wp_path = await prepare_workplan(generated_wp_path, working_dir / run_id)
 
     wp = deserialize(wp_path, LiveWorkplan)
     steps = list(wp.steps)

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -524,10 +524,9 @@ async def test_prepare_workplan_persists_clobber_overrides(
     """
     wp_path = wp_templates_dir / "workplan.yaml"
     output_dir = tmp_path / "output"
-    run_id = "clobber-persist-run"
 
     _, prepared_path = await prepare_workplan(
-        wp_path, output_dir, run_id, clobber_steps=["Prepare"]
+        wp_path, output_dir, clobber_steps=["Prepare"]
     )
 
     persisted = deserialize(prepared_path, LiveWorkplan)


### PR DESCRIPTION
# Summary

Workplan run artifacts (the `*_original.bak` and `*_transformed.yaml` workplan copies and the `.vars` file) were being written to a redundantly nested `<run_id>/<run_id>/` directory inside the run's data directory. They now land directly in the run root (e.g. `~/cstar/<run_id>/`), alongside `tasks/`.

## Breaking Changes


## Bug Fixes
- Transformed-workplan artifacts are no longer written to a doubled `<run_id>/<run_id>/` directory; they now appear directly under the run directory.
  - developer note: `prepare_workplan` no longer takes a `run_id` parameter; its `output_dir` argument is now the run-specific root directory where artifacts are written.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

## Notes for Reviewers
- Run-tracking consumers are unaffected: everything downstream reads the transformed-workplan location from the run record's `trx_workplan_path`, and `cstar admin clean` removes the whole run root, so records from runs made before this fix still resolve.
- The `deferred-blueprints` branch contains the same `prepare_workplan` signature and call-site text; whichever merges second will hit at most a trivial conflict in `dag_runner.py` with the same two-line resolution.
