### PR TITLE
Fix CI teardown hang on ubuntu-3.13

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -12,6 +12,9 @@ jobs:
   test:
     name: unit-${{ matrix.os }}-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # the suite runs in ~2 minutes; don't let a teardown hang hold a runner
+    # for the default 6 hours
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Final, Literal
 from cstar.base.log import LoggingMixin
 
 if TYPE_CHECKING:
+    from signal import _HANDLER
     from types import FrameType
 
     from cstar.entrypoint.config import ServiceConfiguration
@@ -46,6 +47,7 @@ class Service(ABC, LoggingMixin):
         """
         self._config = config
         self._stop_event = Event()
+        self._prior_signal_handlers: dict[int, _HANDLER] = {}
         self._register_signal_handlers()
 
     @property
@@ -325,6 +327,8 @@ class Service(ABC, LoggingMixin):
         except Exception:
             self.log.debug("Service shutdown may not have completed.")
             raise
+        finally:
+            self._restore_signal_handlers()
 
     def _cancel(self) -> None:
         """Handle a request to cancel the service.
@@ -417,7 +421,30 @@ class Service(ABC, LoggingMixin):
     def _register_signal_handlers(self) -> None:
         """Register termination signal handlers for the service.
 
-        Attempts to shutdown the simulation cleanly when interrupted.
+        Attempts to shutdown the simulation cleanly when interrupted. The
+        handlers being replaced are recorded so `_shutdown` can reinstall
+        them; without that, a host process that creates a service (e.g. a
+        test runner) is left with handlers that swallow SIGINT/SIGTERM.
         """
         for sig_num in [signal.SIGINT, signal.SIGTERM]:
-            signal.signal(sig_num, self._handle_signal)
+            self._prior_signal_handlers[sig_num] = signal.signal(
+                sig_num, self._handle_signal
+            )
+
+    def _restore_signal_handlers(self) -> None:
+        """Reinstall the signal handlers replaced by `_register_signal_handlers`.
+
+        Handlers registered by someone else after this service's were installed
+        are left in place.
+        """
+        while self._prior_signal_handlers:
+            sig_num, prior_handler = self._prior_signal_handlers.popitem()
+            try:
+                if signal.getsignal(sig_num) == self._handle_signal:
+                    signal.signal(sig_num, prior_handler)
+            except ValueError:
+                # signal.signal is only allowed in the main thread
+                self.log.debug(
+                    "Unable to restore handler for signal %s off the main thread.",
+                    sig_num,
+                )

--- a/cstar/entrypoint/service.py
+++ b/cstar/entrypoint/service.py
@@ -142,9 +142,13 @@ class Service(ABC, LoggingMixin):
         Called on initial entry into Service lifecycle before the main service logic
         begins execution. Allows for subclasses to perform any required initialization
         logic.
+
+        The stop event must not be cleared here: signal handlers are installed in
+        `__init__`, so a termination signal delivered before startup completes has
+        already set the event, and clearing it would silently drop that shutdown
+        request (the event is created fresh in `__init__`).
         """
         self.log.trace(f"Starting {self._service_type}")
-        self._stop_event.clear()
 
     def _on_shutdown(self) -> None:
         """Empty hook method for use by subclasses.

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import signal
 import uuid
 from collections.abc import Awaitable, Callable, Generator, Iterable, Sequence
 from contextlib import AbstractContextManager, contextmanager
@@ -2218,3 +2219,24 @@ def mock_local_delay() -> float:
     delay = 0.1
     os.environ[ENV_CSTAR_ORCH_LOCAL_DELAY] = str(delay)
     return delay
+
+
+@pytest.fixture(autouse=True)
+def restore_signal_handlers() -> Generator[None, None, None]:
+    """Restore SIGINT/SIGTERM handlers replaced during a test.
+
+    Constructing a `Service` installs `Service._handle_signal` — which swallows
+    the signal without exiting — on the *current* process. A test that leaks
+    that handler leaves the pytest process unkillable by SIGINT/SIGTERM (CI
+    cancellation then needs SIGKILL and produces no traceback).
+    """
+    prior = {
+        sig_num: signal.getsignal(sig_num)
+        for sig_num in (signal.SIGINT, signal.SIGTERM)
+    }
+
+    yield
+
+    for sig_num, prior_handler in prior.items():
+        if signal.getsignal(sig_num) != prior_handler:
+            signal.signal(sig_num, prior_handler)

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import multiprocessing as mp
+import multiprocessing.synchronize as mp_sync
 import queue
 import time
 import types
@@ -166,28 +167,43 @@ class PrintingService(Service):
         self._shutdown()
 
 
-async def run_a_printer() -> None:
+async def _serve_printer(
+    started: "mp_sync.Event",
+    *,
+    fail_on_shutdown: bool,
+) -> None:
+    """Run a PrintingService until signalled, setting `started` once its
+    signal handlers are installed (they are registered in `__init__`).
+    """
+    service = PrintingService(as_service=True, hc_freq=1.0, max_duration=10)
+
+    if fail_on_shutdown:
+        patcher = mock.patch.object(
+            service,
+            "_on_shutdown",
+            side_effect=RuntimeError("Kaboom!"),
+        )
+        patcher.start()
+
+    started.set()
+    await service.execute()
+
+
+def run_a_printer(started: "mp_sync.Event") -> None:
     """Run a PrintingService instance in a separate process.
 
     Utility method for testing signal handling or shutdown behavior.
     """
-    service = PrintingService(as_service=True, hc_freq=1.0, max_duration=10)
-    await service.execute()
+    asyncio.run(_serve_printer(started, fail_on_shutdown=False))
 
 
-async def run_a_fail_on_shutdown_printer() -> None:
+def run_a_fail_on_shutdown_printer(started: "mp_sync.Event") -> None:
     """Run a PrintingService instance in a separate process.
 
     Utility method for testing signal handling or shutdown behavior. This service will
     raise an exception on shutdown.
     """
-    service = PrintingService(as_service=True, hc_freq=1.0, max_duration=10)
-    mock.patch.object(
-        service,
-        "_on_shutdown",
-        side_effect=RuntimeError("Kaboom!"),
-    )
-    await service.execute()
+    asyncio.run(_serve_printer(started, fail_on_shutdown=True))
 
 
 @pytest.mark.asyncio
@@ -433,32 +449,46 @@ async def test_signal_handling(fail_on_shutdown: bool) -> None:  # noqa: FBT001
 
     If the service is configured to fail on shutdown, the signal handler must gracefully
     handle the failure without crashing.
+
+    The child is started with the "spawn" method: forking the multi-threaded
+    pytest process can deadlock the child (and has hung CI teardown on Linux,
+    where fork is the default start method).
     """
-    process: mp.Process | None = None
+    ctx = mp.get_context("spawn")
+    started = ctx.Event()
+
+    printer_fn = run_a_fail_on_shutdown_printer
+    if not fail_on_shutdown:
+        # If not failing on shutdown, use the regular printer
+        printer_fn = run_a_printer
+
+    # The service is configured to run for 10 seconds so a signal will
+    # clearly cause it to exit early.
+    process = ctx.Process(target=printer_fn, args=(started,))
 
     try:
-        printer_fn = run_a_fail_on_shutdown_printer
-        if not fail_on_shutdown:
-            # If not failing on shutdown, use the regular printer
-            printer_fn = run_a_printer
-
-        # Configure the test service to run for 90 seconds so a signal will
-        # clearly cause it to exit early.
-        process = mp.Process(target=printer_fn)
         process.start()
-        await asyncio.sleep(0.1)
 
-        term_at = time.time()
+        # spawn boots a fresh interpreter, so wait until the service has
+        # installed its signal handlers before terminating it.
+        assert started.wait(timeout=30), "service process did not start"
+
         process.terminate()  # Send a signal to terminate the service
-        time_complete = time.time()
 
-        expected_time_to_terminate = 2.0
-        elapsed = time_complete - term_at
-        assert elapsed < expected_time_to_terminate
+        expected_time_to_terminate = 5.0
+        process.join(timeout=expected_time_to_terminate)
+
+        assert process.exitcode is not None, "service did not exit after SIGTERM"
+        # a clean shutdown exits 0; the fail-on-shutdown service re-raises on
+        # the main thread and exits nonzero, but must still exit promptly.
+        expected_exitcode = 1 if fail_on_shutdown else 0
+        assert process.exitcode == expected_exitcode
 
     finally:
-        if process and process.is_alive():
+        if process.is_alive():
             process.kill()
+        process.join(timeout=5)
+        process.close()
 
 
 @pytest.mark.skip(

--- a/cstar/tests/unit_tests/entrypoint/test_service.py
+++ b/cstar/tests/unit_tests/entrypoint/test_service.py
@@ -2,11 +2,10 @@ import asyncio
 import logging
 import multiprocessing as mp
 import multiprocessing.synchronize as mp_sync
-import queue
 import time
 import types
 import typing as t
-from collections import defaultdict
+from collections import defaultdict, deque
 from math import ceil
 from unittest import mock
 
@@ -48,7 +47,12 @@ class PrintingService(Service):
         self.max_iter = abs(max_iterations)
         self.max_duration = abs(max_duration)
         self.start_time = 0.0
-        self.test_queue: mp.Queue[str] = mp.Queue()
+        # a deque, not a queue: deque.append/popleft are atomic and lock-free,
+        # so the signal handler (which reaches _on_shutdown) can never
+        # self-deadlock by re-entering a lock the interrupted main thread
+        # already holds. The service runs in a single process, so nothing
+        # cross-process is needed here.
+        self.test_queue: deque[str] = deque()
         self.metrics: dict[str, int] = defaultdict(lambda: 0)
 
     @property
@@ -64,7 +68,7 @@ class PrintingService(Service):
     def _on_delay(self) -> None:
         super()._on_delay()
         self.log.trace("Running PrintingService._on_delay")
-        self.test_queue.put_nowait("_on_delay")
+        self.test_queue.append("_on_delay")
 
     @property
     def n_on_delay(self) -> int:
@@ -74,13 +78,13 @@ class PrintingService(Service):
     async def _on_iteration(self) -> None:
         await super()._on_iteration()
         self.log.trace("Running PrintingService._on_iteration")
-        self.test_queue.put_nowait("_on_iteration")
+        self.test_queue.append("_on_iteration")
         self.summarize()  # update each loop; don't let queues grow too large
 
     def _on_iteration_complete(self) -> None:
         super()._on_iteration_complete()
         self.log.trace("Running PrintingService._on_iteration_complete")
-        self.test_queue.put_nowait("_on_iteration_complete")
+        self.test_queue.append("_on_iteration_complete")
         self.summarize()
 
     @property
@@ -91,7 +95,7 @@ class PrintingService(Service):
     def _on_health_check(self) -> None:
         super()._on_health_check()
         self.log.trace("Running PrintingService._on_health_check")
-        self.test_queue.put_nowait("_on_health_check")
+        self.test_queue.append("_on_health_check")
 
     @property
     def n_can_shutdown(self) -> int:
@@ -101,7 +105,7 @@ class PrintingService(Service):
     def _can_shutdown(self) -> bool:
         super()._can_shutdown()  # type: ignore[safe-super]
         self.log.trace("Running PrintingService._can_shutdown")
-        self.test_queue.put_nowait("_can_shutdown")
+        self.test_queue.append("_can_shutdown")
 
         if self._do_shutdown:
             return self._do_shutdown
@@ -118,7 +122,7 @@ class PrintingService(Service):
     def _on_shutdown(self) -> None:
         super()._on_shutdown()
         self.log.trace("Running PrintingService._on_shutdown")
-        self.test_queue.put_nowait("_on_shutdown")
+        self.test_queue.append("_on_shutdown")
         self.summarize()
 
     def summarize(
@@ -130,21 +134,17 @@ class PrintingService(Service):
         Utility for checking invocation counts where mock.call_count can't be used due
         to a second thread executing the service methods.
         """
-        if not self.test_queue.empty() and finalize:
-            while not self.test_queue.empty():
-                if msg := self.test_queue.get_nowait():
-                    self.metrics[msg] += 1
+        get_another = None if finalize else 10
 
-        elif not self.test_queue.empty():
-            get_another = 10
-            while get_another > 0 and not self.test_queue.empty():
-                try:
-                    msg = self.test_queue.get_nowait()
-                    get_another -= 1
-                except queue.Empty:  # noqa: PERF203
-                    get_another = 0
-                else:
-                    self.metrics[msg] += 1
+        while get_another is None or get_another > 0:
+            try:
+                msg = self.test_queue.popleft()
+            except IndexError:
+                break
+
+            self.metrics[msg] += 1
+            if get_another is not None:
+                get_another -= 1
 
         return self.metrics
 
@@ -167,15 +167,32 @@ class PrintingService(Service):
         self._shutdown()
 
 
+class _SignallingPrinter(PrintingService):
+    """A PrintingService that sets an event once its main loop has started.
+
+    The event must not be set before `_on_start` has run: a SIGTERM arriving
+    between construction and startup is handled (the handlers are installed in
+    `__init__`), and the test must only terminate a service that is running.
+    """
+
+    def __init__(self, started: "mp_sync.Event", **kwargs: t.Any) -> None:
+        self._started_evt = started
+        super().__init__(**kwargs)
+
+    def _on_start(self) -> None:
+        super()._on_start()
+        self._started_evt.set()
+
+
 async def _serve_printer(
     started: "mp_sync.Event",
     *,
     fail_on_shutdown: bool,
 ) -> None:
     """Run a PrintingService until signalled, setting `started` once its
-    signal handlers are installed (they are registered in `__init__`).
+    main loop is running.
     """
-    service = PrintingService(as_service=True, hc_freq=1.0, max_duration=10)
+    service = _SignallingPrinter(started, as_service=True, hc_freq=1.0, max_duration=10)
 
     if fail_on_shutdown:
         patcher = mock.patch.object(
@@ -185,7 +202,6 @@ async def _serve_printer(
         )
         patcher.start()
 
-    started.set()
     await service.execute()
 
 
@@ -469,8 +485,8 @@ async def test_signal_handling(fail_on_shutdown: bool) -> None:  # noqa: FBT001
     try:
         process.start()
 
-        # spawn boots a fresh interpreter, so wait until the service has
-        # installed its signal handlers before terminating it.
+        # spawn boots a fresh interpreter, so wait until the service's main
+        # loop is running before terminating it.
         assert started.wait(timeout=30), "service process did not start"
 
         process.terminate()  # Send a signal to terminate the service


### PR DESCRIPTION
# Summary
Fixes the intermittent `unit-ubuntu-latest-3.13` CI deadlock in which every test passes and the job then hangs for 6 hours until GitHub's timeout kills it (seen on #646, CSD-1087, and CSD-1120). The hang happens at interpreter exit: `test_signal_handling` launches its child with multiprocessing's Linux-default **fork** start method while the pytest process is multi-threaded — the condition CPython explicitly warns "may lead to deadlocks" — and a rare race then deadlocks teardown. macOS (spawn default) and 3.12 were never/rarely bitten. The test now uses the spawn start method, eliminating the only fork in the suite; the fork `DeprecationWarning` disappears from the run entirely.

## Breaking Changes
- N/A

## New Features
- N/A

## Bug Fixes
- Fixed an intermittent deadlock that hung the ubuntu-3.13 unit-test job for 6 hours after all tests had passed: `test_signal_handling` now starts its child process with the spawn method instead of forking the multi-threaded test runner.
- `Service` now restores the SIGINT/SIGTERM handlers it replaced once it shuts down; previously any process that constructed a `Service` was permanently left with handlers that swallow both signals (this is why hung CI jobs could not be cancelled cleanly and had to be SIGKILLed with no traceback).
- A termination signal delivered to a `Service` between construction and startup was silently dropped: handlers are installed in `__init__`, but `_on_start` cleared the stop event the handler had already set, so the service ran to its configured duration instead of shutting down. The clear is removed (the event is created fresh in `__init__`).
- `test_signal_handling` was passing vacuously: its `async def` targets were handed directly to `mp.Process`, so the child only created an un-awaited coroutine and exited immediately, and the fail-on-shutdown variant never started its `mock.patch`. The child now actually runs the service via `asyncio.run`, the test synchronizes on a `started` event instead of a fixed sleep, and it verifies the child's exit code for both the clean and fail-on-shutdown paths.

## Improvements
- Added an autouse fixture to the unit-test conftest that restores SIGINT/SIGTERM handlers after every test, so no test can leak signal handlers into the rest of the suite.


## Miscellaneous
- The unit-test CI job now has `timeout-minutes: 30`, so any future hang fails within minutes (with logs flushed immediately) instead of holding a runner for 6 hours.

## Notes for Reviewers
- The original 6-hour teardown deadlock is a narrow race: the same commit both passed and hung on identical CI runs, and ~65 attempts in a local Linux (py 3.13.15) container under CPU contention could not reproduce it, so the exact blocking frame was never captured. Every hung run shares the fork-while-multi-threaded precondition, which this PR removes; the job timeout is the backstop if anything else ever hangs.
- The strengthened test initially failed intermittently on CI (either parametrization, either OS — the 3.12-vs-3.13 split was coincidence). Both failure modes were reproduced in a Linux container and py-spy'd: (1) the SIGTERM-during-startup race fixed by removing `_stop_event.clear()` from `_on_start`, with the test now waiting for the service loop to be running before terminating; (2) the signal-handler re-entrancy deadlock on the test helper's `mp.Queue`, fixed by the deque change. With both fixes, 80 driver iterations plus repeated pytest runs on 3.12 and 3.13 pass cleanly.
- `Service._handle_signal` still runs `_shutdown()` (including the `_on_shutdown` subclass hook) inline inside the signal handler; subclass hooks that take non-reentrant locks could in principle hit the same re-entrancy deadlock in production. Left as-is here — flagging as possible follow-up.
- The `PrintingService` test helper now tracks hook calls with a `collections.deque` instead of an `mp.Queue`: the signal handler runs `_shutdown` (and thus test hooks) inline, and a signal landing while the main thread was inside a queue operation could self-deadlock on the queue's non-reentrant lock. `deque.append`/`popleft` are atomic, and the change also removes `mp.Queue` feeder threads from the pytest process for every Service test.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing
  <!-- full unit suite passed on Linux/py3.13.15 (one known-flaky tracking test unrelated to this change); pre-commit hooks passed on the changed files at commit -->

