### PR TITLE
Add ROMS pre-checks for incompatible output timings

### DIFF
--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -1,10 +1,13 @@
 import asyncio
 import typing as t
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 import typer
 from pydantic import ValidationError
 
+import cstar
 from cstar.applications.core import (
     RunnerRequest,
     get_app_for_blueprint,
@@ -53,6 +56,21 @@ CMD_HELP: t.Final[str] = "Execute a blueprint in a local worker service."
 
 app = typer.Typer()
 log = get_logger(__name__)
+
+
+def _log_startup_versions() -> None:
+    """Best-effort startup log line recording installed CWorthy library versions,
+    so a run's own log records what generated it.
+    """
+    # TODO: warn when installed versions are known-incompatible with each other
+    # (e.g. roms-tools vs cstar-ocean) -- deferred as a follow-up; this only
+    # records what's installed.
+    versions = [f"cstar-ocean=={cstar.__version__}"]
+    try:
+        versions.append(f"roms-tools=={_pkg_version('roms-tools')}")
+    except PackageNotFoundError:
+        pass
+    log.info("Versions: %s", ", ".join(versions))
 
 
 def path_callback(
@@ -206,6 +224,8 @@ def run(
     ] = False,
 ) -> None:
     """Execute a blueprint in a local worker service."""
+    _log_startup_versions()
+
     if DeferredBlueprintRef.matches(uri):
         ref = DeferredBlueprintRef.from_uri(uri)
         try:

--- a/cstar/cli/blueprint/run.py
+++ b/cstar/cli/blueprint/run.py
@@ -66,10 +66,13 @@ def _log_startup_versions() -> None:
     # (e.g. roms-tools vs cstar-ocean) -- deferred as a follow-up; this only
     # records what's installed.
     versions = [f"cstar-ocean=={cstar.__version__}"]
-    try:
-        versions.append(f"roms-tools=={_pkg_version('roms-tools')}")
-    except PackageNotFoundError:
-        pass
+    # cstar-forge / roms-tools are optional in a given environment -- log each
+    # only if installed (the blueprint may have been produced by cstar-forge).
+    for pkg in ("cstar-forge", "roms-tools"):
+        try:
+            versions.append(f"{pkg}=={_pkg_version(pkg)}")
+        except PackageNotFoundError:
+            pass
     log.info("Versions: %s", ", ".join(versions))
 
 

--- a/cstar/roms/precheck.py
+++ b/cstar/roms/precheck.py
@@ -1,0 +1,262 @@
+"""Reusable Python mirror of ucla-roms' ``src/precheck.F90::do_precheck`` output
+stream checks.
+
+ucla-roms >= 0.5.0 aborts at startup (``check_output_divides_rst``) if any
+*enabled* output stream's file-rollover frequency (``nrpf * output_period``)
+is not positive, or does not evenly divide ``output_period_rst`` -- writing a
+restart mid-file would otherwise leave a partial output file. The whole check
+is gated on ``ocean_vars.wrt_file_rst``; four of the per-stream groups are
+further gated on a ucla-roms compile-time cppdef (``DIAGNOSTICS``, and the
+three MARBL/BGC-diagnostics groups).
+
+:func:`check_output_streams_divide_rst` reproduces this in Python so C-Star
+Forge (and any other consumer building ucla-roms run-time settings) can fail
+fast at blueprint-authoring time instead of waiting for the run to abort.
+It is a plain function, not a Pydantic ``model_validator`` -- it must not run
+on every model construction (old blueprints/tests would break) and it needs
+an explicit, caller-supplied set of active cppdefs to know which cppdef-gated
+groups actually apply.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+def _get(section: Any, key: str) -> Any:
+    """Read ``key`` off ``section``, which is either a plain dict (the
+    resolver's world) or a typed pydantic section model (the validator's
+    world) -- mirrors ``cstar_forge.forge.namelist_model.check_extract_divides_rst``.
+    """
+    if section is None:
+        return None
+    return (
+        section.get(key) if isinstance(section, dict) else getattr(section, key, None)
+    )
+
+
+@dataclass(frozen=True)
+class _StreamCheck:
+    """One row of the ``do_precheck`` call list -- kept 1:1 with a line in
+    ucla-roms' ``precheck.F90`` so this table stays diffable against the
+    Fortran source.
+
+    Parameters
+    ----------
+    label
+        Stream name, matches the Fortran ``label`` argument.
+    section
+        Name of the settings section the stream's fields live in.
+    gate_fields
+        Field name(s), read off ``section``, that gate whether ucla-roms
+        writes this stream at all. Combined with ``.or.`` when there is more
+        than one (``sflx``: ``wrt_smflx .or. wrt_stflx``; ``diagnostics``:
+        ``diag_uv .or. diag_trc``).
+    period_field
+        Field name (on ``section``) holding the stream's output period.
+    nrpf_field
+        Field name (on ``section``) holding the stream's records-per-file.
+    cppdef_guard
+        Cppdef name(s) that must all be active (looked up in the ``cppdefs``
+        mapping) for ucla-roms to even compile this stream's write calls.
+        ``()`` for the seven groups with no cppdef guard.
+    """
+
+    label: str
+    section: str
+    gate_fields: tuple[str, ...]
+    period_field: str
+    nrpf_field: str
+    cppdef_guard: tuple[str, ...] = ()
+
+
+# The complete `do_precheck` call list (ucla-roms `src/precheck.F90`).
+# Field names below are C-Star Forge's settings-dict vocabulary (the same
+# vocabulary `check_extract_divides_rst` already uses for `extract_data`),
+# not the raw Fortran namelist keys -- e.g. `frc_output.nrpf` is the
+# `NRPF_FRC` namelist key under `serialization_alias`.
+_STREAM_CHECKS: tuple[_StreamCheck, ...] = (
+    _StreamCheck("extract", "extract_data", ("do_extract",), "extract_period", "nrpf"),
+    _StreamCheck(
+        "his", "ocean_vars", ("wrt_file_his",), "output_period_his", "nrpf_his"
+    ),
+    _StreamCheck(
+        "avg", "ocean_vars", ("wrt_file_avg",), "output_period_avg", "nrpf_avg"
+    ),
+    _StreamCheck("frc", "frc_output", ("wrt_frc",), "output_period", "nrpf"),
+    _StreamCheck("random", "random_output", ("do_random",), "output_period", "nrpf"),
+    _StreamCheck("zslice", "zslice", ("do_zslice",), "output_period", "nrpf"),
+    _StreamCheck(
+        "sflx", "surf_flux", ("wrt_smflx", "wrt_stflx"), "output_period", "nrpf"
+    ),
+    _StreamCheck("particles", "particles", ("floats",), "output_period", "nrpf"),
+    _StreamCheck("sponge", "sponge_tune", ("wrt_sponge",), "output_period", "nrpf"),
+    _StreamCheck(
+        "diagnostics",
+        "diagnostics",
+        ("diag_uv", "diag_trc"),
+        "output_period",
+        "nrpf",
+        cppdef_guard=("diagnostics",),
+    ),
+    _StreamCheck(
+        "cdr",
+        "cdr_output",
+        ("do_cdr_output",),
+        "output_period",
+        "nrpf",
+        cppdef_guard=("marbl", "marbl_diags", "cdr_forcing"),
+    ),
+    _StreamCheck(
+        "upscale",
+        "upscale_output",
+        ("do_upscale",),
+        "output_period_uscl",
+        "nrpf_uscl",
+        cppdef_guard=("marbl", "marbl_diags", "upscaling"),
+    ),
+    _StreamCheck(
+        "bgc_his",
+        "bgc",
+        ("wrt_his",),
+        "output_period_his",
+        "nrpf_his",
+        cppdef_guard=("marbl_or_bec2",),
+    ),
+    _StreamCheck(
+        "bgc_avg",
+        "bgc",
+        ("wrt_avg",),
+        "output_period_avg",
+        "nrpf_avg",
+        cppdef_guard=("marbl_or_bec2",),
+    ),
+    _StreamCheck(
+        "bgc_his_dia",
+        "bgc",
+        ("wrt_his_dia",),
+        "output_period_his_dia",
+        "nrpf_his_dia",
+        cppdef_guard=("marbl_or_bec2",),
+    ),
+    _StreamCheck(
+        "bgc_avg_dia",
+        "bgc",
+        ("wrt_avg_dia",),
+        "output_period_avg_dia",
+        "nrpf_avg_dia",
+        cppdef_guard=("marbl_or_bec2",),
+    ),
+)
+
+
+def _cppdef_guard_satisfied(guard: tuple[str, ...], cppdefs: Mapping[str, Any]) -> bool:
+    """True if every name in ``guard`` is active in ``cppdefs``.
+
+    The synthetic name ``"marbl_or_bec2"`` stands in for the Fortran
+    ``defined(MARBL) || defined(BIOLOGY_BEC2)`` guard (the four bgc_* groups);
+    every other name is looked up directly (``AND``-ed together), matching the
+    Fortran `#if defined X && defined Y && defined Z` guards for `cdr` and
+    `upscale`. A guard name absent from ``cppdefs`` is treated as inactive.
+    """
+    for name in guard:
+        if name == "marbl_or_bec2":
+            if not (cppdefs.get("marbl", False) or cppdefs.get("biology_bec2", False)):
+                return False
+        elif not cppdefs.get(name, False):
+            return False
+    return True
+
+
+def check_output_streams_divide_rst(
+    settings: Mapping[str, Any], cppdefs: Mapping[str, Any] | None = None
+) -> None:
+    """Raise ``ValueError`` if any enabled ucla-roms output stream's file
+    rollover frequency (``nrpf * output_period``) would not evenly divide the
+    restart period -- mirrors ucla-roms >= 0.5.0's ``check_output_divides_rst``
+    (``src/precheck.F90``), which aborts the run at startup otherwise.
+
+    Parameters
+    ----------
+    settings
+        Mapping of section name -> section, where each section is either a
+        plain dict or a typed pydantic settings model (both forms support the
+        same field lookups via :func:`_get`). Must include ``ocean_vars``;
+        every other section is read only if that stream applies.
+    cppdefs
+        Mapping of cppdef name -> whether it is active in this build (e.g.
+        ``{"marbl": True, "cdr_forcing": True}``). Governs the four
+        cppdef-gated groups (``diagnostics``; the three MARBL/BGC-diagnostics
+        groups: ``cdr``, ``upscale``, and the four ``bgc_*`` streams, gated on
+        ``MARBL || BIOLOGY_BEC2``). ``None``/absent names are treated as
+        inactive, so a caller that doesn't build MARBL/BIOLOGY_BEC2 at all can
+        just omit them -- the cppdef-gated groups are then always skipped,
+        exactly as ucla-roms itself would (it never compiles their write
+        calls).
+
+    Notes
+    -----
+    - Global gate: if ``ocean_vars.wrt_file_rst`` is false/missing, this
+      function returns immediately without checking anything (mirrors
+      ``if (.not. wrt_file_rst) return`` in the Fortran).
+    - Each stream is additionally skipped if: its cppdef guard (if any) is
+      not fully satisfied; its own enable gate reads as false (a missing gate
+      field counts as false -- for a two-field ``.or.`` gate like ``sflx`` or
+      ``diagnostics``, one field present-and-true still enables the stream
+      even if the other is absent); or its ``nrpf``/period field is missing
+      (partial settings dicts -- field *presence* is owned by schema
+      validation upstream, not this check).
+    - ``output_period_rst == 0`` (the monthly-restart convention) passes
+      trivially for every stream, since ``mod(0, x) == 0``.
+    - Raises on the *first* violating stream found (in ``do_precheck``'s call
+      order), matching :func:`cstar_forge.forge.namelist_model.check_extract_divides_rst`'s
+      fail-fast contract -- it does not aggregate every violation.
+    """
+    ocean_vars = settings.get("ocean_vars") if isinstance(settings, Mapping) else None
+    if not _get(ocean_vars, "wrt_file_rst"):
+        return
+    output_period_rst = _get(ocean_vars, "output_period_rst")
+    if output_period_rst is None:
+        return
+
+    cppdefs = cppdefs or {}
+
+    for check in _STREAM_CHECKS:
+        if check.cppdef_guard and not _cppdef_guard_satisfied(
+            check.cppdef_guard, cppdefs
+        ):
+            continue
+
+        section = settings.get(check.section) if isinstance(settings, Mapping) else None
+        if section is None:
+            continue
+
+        # A missing gate field reads as False (disabled), not "skip this
+        # stream": for an .or. gate (sflx, diagnostics) one field present-and-
+        # True with the other absent must still enable the stream -- `None`
+        # is falsy in `any(...)`, so this gives correct OR semantics for both
+        # the single-gate and two-gate rows.
+        gate_values = [_get(section, f) for f in check.gate_fields]
+        if not any(gate_values):
+            continue
+
+        nrpf = _get(section, check.nrpf_field)
+        period = _get(section, check.period_field)
+        if nrpf is None or period is None:
+            continue
+
+        newfile_freq = nrpf * period
+        ratio = output_period_rst / newfile_freq if newfile_freq > 0 else None
+        if ratio is None or abs(ratio - round(ratio)) > 1e-9:
+            raise ValueError(
+                f"{check.section}.{check.nrpf_field} ({nrpf}) * "
+                f"{check.section}.{check.period_field} ({period} s) = "
+                f"{newfile_freq} s must be positive and evenly divide "
+                f"ocean_vars.output_period_rst ({output_period_rst} s): "
+                f"ucla-roms >= 0.5.0 aborts at startup otherwise "
+                f"(check_output_divides_rst, stream '{check.label}', "
+                f"partial-file prevention). Adjust {check.section}."
+                f"{check.nrpf_field} or {check.section}.{check.period_field}."
+            )

--- a/cstar/roms/precheck.py
+++ b/cstar/roms/precheck.py
@@ -5,17 +5,30 @@ ucla-roms >= 0.5.0 aborts at startup (``check_output_divides_rst``) if any
 *enabled* output stream's file-rollover frequency (``nrpf * output_period``)
 is not positive, or does not evenly divide ``output_period_rst`` -- writing a
 restart mid-file would otherwise leave a partial output file. The whole check
-is gated on ``ocean_vars.wrt_file_rst``; four of the per-stream groups are
-further gated on a ucla-roms compile-time cppdef (``DIAGNOSTICS``, and the
-three MARBL/BGC-diagnostics groups).
+is gated on ``basic_output_settings.wrt_file_rst``; four of the per-stream
+groups are further gated on a ucla-roms compile-time cppdef (``DIAGNOSTICS``,
+and the three MARBL/BGC-diagnostics groups).
 
 :func:`check_output_streams_divide_rst` reproduces this in Python so C-Star
-Forge (and any other consumer building ucla-roms run-time settings) can fail
-fast at blueprint-authoring time instead of waiting for the run to abort.
-It is a plain function, not a Pydantic ``model_validator`` -- it must not run
-on every model construction (old blueprints/tests would break) and it needs
-an explicit, caller-supplied set of active cppdefs to know which cppdef-gated
-groups actually apply.
+(and consumers building ucla-roms run-time settings, e.g. C-Star Forge) can
+fail fast -- at blueprint-authoring time, or when a user overrides run-time
+settings directly on a `ROMSSimulation` -- instead of waiting for the run to
+abort. It is a plain function, not a Pydantic ``model_validator`` -- it must
+not run on every model construction (old blueprints/tests would break) and it
+needs an explicit, caller-supplied set of active cppdefs to know which
+cppdef-gated groups actually apply.
+
+Operates on C-Star's CANONICAL namelist vocabulary: a mapping of
+``RomsNamelistBase`` group field name (the ``&<group>`` header in
+``namelist.nml``, e.g. ``"frc_output_settings"``) to that group's real Fortran
+namelist keys (e.g. ``"output_period_frc"``, ``"nrpf_frc"``) -- exactly the
+shape of ``RomsNamelistBase.model_dump()`` (or an individual group's
+``model_dump(by_alias=True)``, dict-assembled). This is deliberately NOT forge's
+settings-dict vocabulary (which renames several of these via
+``serialization_alias``, e.g. forge's ``frc_output.output_period`` ->
+``output_period_frc``) -- a consumer with a forge-shaped dict must first
+convert it (see ``cstar_forge.forge.namelist_model.build_namelist`` /
+``canonical_output_sections_for_precheck``).
 """
 
 from __future__ import annotations
@@ -26,9 +39,10 @@ from typing import Any
 
 
 def _get(section: Any, key: str) -> Any:
-    """Read ``key`` off ``section``, which is either a plain dict (the
-    resolver's world) or a typed pydantic section model (the validator's
-    world) -- mirrors ``cstar_forge.forge.namelist_model.check_extract_divides_rst``.
+    """Read ``key`` off ``section``, which is either a plain dict (e.g. a
+    ``RomsNamelistBase.model_dump()`` value) or a typed pydantic section model
+    (e.g. a live ``RomsNamelistBase`` group instance) -- mirrors
+    ``cstar_forge.forge.namelist_model.check_extract_divides_rst``.
     """
     if section is None:
         return None
@@ -48,16 +62,19 @@ class _StreamCheck:
     label
         Stream name, matches the Fortran ``label`` argument.
     section
-        Name of the settings section the stream's fields live in.
+        ``RomsNamelistBase`` group field name (the ``&<group>`` header in
+        ``namelist.nml``) the stream's fields live in.
     gate_fields
-        Field name(s), read off ``section``, that gate whether ucla-roms
-        writes this stream at all. Combined with ``.or.`` when there is more
-        than one (``sflx``: ``wrt_smflx .or. wrt_stflx``; ``diagnostics``:
-        ``diag_uv .or. diag_trc``).
+        Real Fortran namelist key(s), read off ``section``, that gate whether
+        ucla-roms writes this stream at all. Combined with ``.or.`` when
+        there is more than one (``sflx``: ``wrt_smflx .or. wrt_stflx``;
+        ``diagnostics``: ``diag_uv .or. diag_trc``).
     period_field
-        Field name (on ``section``) holding the stream's output period.
+        Real Fortran namelist key (on ``section``) holding the stream's
+        output period.
     nrpf_field
-        Field name (on ``section``) holding the stream's records-per-file.
+        Real Fortran namelist key (on ``section``) holding the stream's
+        records-per-file.
     cppdef_guard
         Cppdef name(s) that must all be active (looked up in the ``cppdefs``
         mapping) for ucla-roms to even compile this stream's write calls.
@@ -72,46 +89,92 @@ class _StreamCheck:
     cppdef_guard: tuple[str, ...] = ()
 
 
-# The complete `do_precheck` call list (ucla-roms `src/precheck.F90`).
-# Field names below are C-Star Forge's settings-dict vocabulary (the same
-# vocabulary `check_extract_divides_rst` already uses for `extract_data`),
-# not the raw Fortran namelist keys -- e.g. `frc_output.nrpf` is the
-# `NRPF_FRC` namelist key under `serialization_alias`.
+# The complete `do_precheck` call list (ucla-roms `src/precheck.F90`), keyed
+# on C-Star's canonical namelist vocabulary: `section` is the RomsNamelistBase
+# group field name (the `&<group>` header in namelist.nml), and
+# `gate_fields`/`period_field`/`nrpf_field` are the real Fortran namelist keys
+# within that group. Verified against `cstar/roms/namelist.py` (the group
+# classes) and `cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_6_0.nml`
+# (the `&<group>` headers).
 _STREAM_CHECKS: tuple[_StreamCheck, ...] = (
-    _StreamCheck("extract", "extract_data", ("do_extract",), "extract_period", "nrpf"),
     _StreamCheck(
-        "his", "ocean_vars", ("wrt_file_his",), "output_period_his", "nrpf_his"
+        "extract",
+        "extract_data_settings",
+        ("do_extract",),
+        "output_period_extract",
+        "nrpf_extract",
     ),
     _StreamCheck(
-        "avg", "ocean_vars", ("wrt_file_avg",), "output_period_avg", "nrpf_avg"
+        "his",
+        "basic_output_settings",
+        ("wrt_file_his",),
+        "output_period_his",
+        "nrpf_his",
     ),
-    _StreamCheck("frc", "frc_output", ("wrt_frc",), "output_period", "nrpf"),
-    _StreamCheck("random", "random_output", ("do_random",), "output_period", "nrpf"),
-    _StreamCheck("zslice", "zslice", ("do_zslice",), "output_period", "nrpf"),
     _StreamCheck(
-        "sflx", "surf_flux", ("wrt_smflx", "wrt_stflx"), "output_period", "nrpf"
+        "avg",
+        "basic_output_settings",
+        ("wrt_file_avg",),
+        "output_period_avg",
+        "nrpf_avg",
     ),
-    _StreamCheck("particles", "particles", ("floats",), "output_period", "nrpf"),
-    _StreamCheck("sponge", "sponge_tune", ("wrt_sponge",), "output_period", "nrpf"),
+    _StreamCheck(
+        "frc", "frc_output_settings", ("wrt_frc",), "output_period_frc", "nrpf_frc"
+    ),
+    _StreamCheck(
+        "random",
+        "random_output_settings",
+        ("do_random",),
+        "output_period_random",
+        "nrpf_random",
+    ),
+    _StreamCheck(
+        "zslice",
+        "zslice_settings",
+        ("do_zslice",),
+        "output_period_zslice",
+        "nrpf_zslice",
+    ),
+    _StreamCheck(
+        "sflx",
+        "surf_flx_output_settings",
+        ("wrt_smflx", "wrt_stflx"),
+        "output_period_sflx",
+        "nrpf_sflx",
+    ),
+    _StreamCheck(
+        "particles",
+        "particles_settings",
+        ("floats",),
+        "output_period_particles",
+        "nrpf_particles",
+    ),
+    _StreamCheck(
+        "sponge",
+        "sponge_tune_settings",
+        ("wrt_sponge",),
+        "output_period_sponge",
+        "nrpf_sponge",
+    ),
     _StreamCheck(
         "diagnostics",
-        "diagnostics",
+        "diagnostics_settings",
         ("diag_uv", "diag_trc"),
-        "output_period",
-        "nrpf",
+        "output_period_diag",
+        "nrpf_diag",
         cppdef_guard=("diagnostics",),
     ),
     _StreamCheck(
         "cdr",
-        "cdr_output",
+        "cdr_output_settings",
         ("do_cdr_output",),
-        "output_period",
-        "nrpf",
+        "output_period_cdr",
+        "nrpf_cdr",
         cppdef_guard=("marbl", "marbl_diags", "cdr_forcing"),
     ),
     _StreamCheck(
         "upscale",
-        "upscale_output",
+        "upscale_settings",
         ("do_upscale",),
         "output_period_uscl",
         "nrpf_uscl",
@@ -119,34 +182,34 @@ _STREAM_CHECKS: tuple[_StreamCheck, ...] = (
     ),
     _StreamCheck(
         "bgc_his",
-        "bgc",
-        ("wrt_his",),
-        "output_period_his",
-        "nrpf_his",
+        "bgc_settings",
+        ("wrt_bgc_his",),
+        "output_period_bgc_his",
+        "nrpf_bgc_his",
         cppdef_guard=("marbl_or_bec2",),
     ),
     _StreamCheck(
         "bgc_avg",
-        "bgc",
-        ("wrt_avg",),
-        "output_period_avg",
-        "nrpf_avg",
+        "bgc_settings",
+        ("wrt_bgc_avg",),
+        "output_period_bgc_avg",
+        "nrpf_bgc_avg",
         cppdef_guard=("marbl_or_bec2",),
     ),
     _StreamCheck(
         "bgc_his_dia",
-        "bgc",
-        ("wrt_his_dia",),
-        "output_period_his_dia",
-        "nrpf_his_dia",
+        "bgc_settings",
+        ("wrt_bgc_dia_his",),
+        "output_period_bgc_his_dia",
+        "nrpf_bgc_his_dia",
         cppdef_guard=("marbl_or_bec2",),
     ),
     _StreamCheck(
         "bgc_avg_dia",
-        "bgc",
-        ("wrt_avg_dia",),
-        "output_period_avg_dia",
-        "nrpf_avg_dia",
+        "bgc_settings",
+        ("wrt_bgc_dia_avg",),
+        "output_period_bgc_avg_dia",
+        "nrpf_bgc_avg_dia",
         cppdef_guard=("marbl_or_bec2",),
     ),
 )
@@ -181,10 +244,14 @@ def check_output_streams_divide_rst(
     Parameters
     ----------
     settings
-        Mapping of section name -> section, where each section is either a
-        plain dict or a typed pydantic settings model (both forms support the
-        same field lookups via :func:`_get`). Must include ``ocean_vars``;
-        every other section is read only if that stream applies.
+        A canonical namelist dump: mapping of ``RomsNamelistBase`` group field
+        name (e.g. ``"basic_output_settings"``, ``"frc_output_settings"``) to
+        that group, itself either a plain dict of its real Fortran namelist
+        keys (e.g. ``RomsNamelistBase.model_dump()``, or a partial dict
+        assembled the same way) or a live typed group instance (both forms
+        support the same field lookups via :func:`_get`). Must include
+        ``basic_output_settings``; every other group is read only if that
+        stream applies.
     cppdefs
         Mapping of cppdef name -> whether it is active in this build (e.g.
         ``{"marbl": True, "cdr_forcing": True}``). Governs the four
@@ -198,8 +265,8 @@ def check_output_streams_divide_rst(
 
     Notes
     -----
-    - Global gate: if ``ocean_vars.wrt_file_rst`` is false/missing, this
-      function returns immediately without checking anything (mirrors
+    - Global gate: if ``basic_output_settings.wrt_file_rst`` is false/missing,
+      this function returns immediately without checking anything (mirrors
       ``if (.not. wrt_file_rst) return`` in the Fortran).
     - Each stream is additionally skipped if: its cppdef guard (if any) is
       not fully satisfied; its own enable gate reads as false (a missing gate
@@ -214,10 +281,12 @@ def check_output_streams_divide_rst(
       order), matching :func:`cstar_forge.forge.namelist_model.check_extract_divides_rst`'s
       fail-fast contract -- it does not aggregate every violation.
     """
-    ocean_vars = settings.get("ocean_vars") if isinstance(settings, Mapping) else None
-    if not _get(ocean_vars, "wrt_file_rst"):
+    basic_output = (
+        settings.get("basic_output_settings") if isinstance(settings, Mapping) else None
+    )
+    if not _get(basic_output, "wrt_file_rst"):
         return
-    output_period_rst = _get(ocean_vars, "output_period_rst")
+    output_period_rst = _get(basic_output, "output_period_rst")
     if output_period_rst is None:
         return
 
@@ -254,7 +323,7 @@ def check_output_streams_divide_rst(
                 f"{check.section}.{check.nrpf_field} ({nrpf}) * "
                 f"{check.section}.{check.period_field} ({period} s) = "
                 f"{newfile_freq} s must be positive and evenly divide "
-                f"ocean_vars.output_period_rst ({output_period_rst} s): "
+                f"basic_output_settings.output_period_rst ({output_period_rst} s): "
                 f"ucla-roms >= 0.5.0 aborts at startup otherwise "
                 f"(check_output_divides_rst, stream '{check.label}', "
                 f"partial-file prevention). Adjust {check.section}."

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar, cast
 
 import yaml
 from pydantic import ValidationError
@@ -78,7 +78,8 @@ from cstar.roms.input_dataset import (
     ROMSSurfaceForcing,
     ROMSTidalForcing,
 )
-from cstar.roms.namelist import RomsNamelistBase, namelist_schema_for_ref
+from cstar.roms.namelist import RomsNamelist, RomsNamelistBase, namelist_schema_for_ref
+from cstar.roms.precheck import check_output_streams_divide_rst
 from cstar.simulation import Simulation
 from cstar.system.manager import get_sysmgr
 
@@ -889,6 +890,22 @@ class ROMSSimulation(Simulation):
             run_length_seconds = int((self.end_date - self.start_date).total_seconds())
             nml.time_stepping.ntimes = int(run_length_seconds // dt)
 
+        # Output-stream / restart-rollover consistency check (ucla-roms >=
+        # 0.5.0's check_output_divides_rst, precheck.F90): a user overriding
+        # output/restart periods via namelist_overrides (or a hand-edited
+        # namelist file) can produce a config ucla-roms rejects at startup;
+        # catch it here so the failure surfaces with the override still in
+        # hand, mirroring the `dt <= 0` check above. Version-gated: the
+        # precheck landed in ucla-roms 0.5.0, so it's skipped for the legacy
+        # (< 0.5.0) `RomsNamelist` schema (`RomsNamelistV0_5_0`/`V0_6_0` are
+        # separate `RomsNamelistBase` subclasses, not subclasses of
+        # `RomsNamelist` -- this isinstance check is exactly the >= 0.5.0
+        # gate).
+        if not isinstance(nml, RomsNamelist):
+            check_output_streams_divide_rst(
+                nml.model_dump(), self._active_cppdefs_for_precheck()
+            )
+
         return nml
 
     @property
@@ -1572,6 +1589,45 @@ class ROMSSimulation(Simulation):
 
         self.exe_path = exe_path
         self._exe_hash = _get_sha256_hash(exe_path)
+
+    # Fortran cppdef macro -> the lowercase key
+    # `cstar.roms.precheck.check_output_streams_divide_rst` expects (its
+    # `_STREAM_CHECKS` cppdef_guard names).
+    _PRECHECK_CPPDEF_MACROS: ClassVar[dict[str, str]] = {
+        "MARBL": "marbl",
+        "MARBL_DIAGS": "marbl_diags",
+        "CDR_FORCING": "cdr_forcing",
+        "UPSCALING": "upscaling",
+        "DIAGNOSTICS": "diagnostics",
+        "BIOLOGY_BEC2": "biology_bec2",
+    }
+
+    def _active_cppdefs_for_precheck(self) -> dict[str, bool]:
+        """Parse the staged `cppdefs.opt` (defensively) into the cppdefs
+        mapping `check_output_streams_divide_rst` expects, mirroring
+        `_validate_cppdef_flag`'s per-line `#define` detection.
+
+        Returns an EMPTY mapping -- every cppdef-gated stream then skipped,
+        exactly as an un-compiled cppdef would be -- if `compile_time_code`
+        (or its working copy) isn't staged yet, or `cppdefs.opt` is missing.
+        `roms_runtime_settings` can be accessed before `build()` stages the
+        compile-time code (and in tests); a real run still enforces the same
+        rule at startup once the actual build's `cppdefs.opt` is in place.
+        Never raises out of this method.
+        """
+        try:
+            build_dir = self.compile_time_code.working_copy.common_parent  # type: ignore[union-attr]
+            cppdefs_text = (build_dir / "cppdefs.opt").read_text()
+        except (AttributeError, FileNotFoundError, OSError):
+            return {}
+
+        return {
+            key: any(
+                re.search(rf"^[^!]*#\s*define\s+{macro}\b", line)
+                for line in cppdefs_text.splitlines()
+            )
+            for macro, key in self._PRECHECK_CPPDEF_MACROS.items()
+        }
 
     def _validate_cppdef_flag(
         self,

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_run_blueprint.py
@@ -362,7 +362,11 @@ def test_blueprint_run_apply_directive_dne(directive_path: str) -> None:
             color=False,
         )
 
-    assert "file not found" in result.stderr
+    # Depending on the installed typer/rich versions, usage errors render as a
+    # rich panel whose box borders and width-dependent wrapping can split the
+    # phrase across lines -- collapse the decoration before matching.
+    stderr_flat = " ".join(result.stderr.replace("│", " ").split())
+    assert "file not found" in stderr_flat
     mock_exec.assert_not_called()
 
 

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -48,6 +48,20 @@ from cstar.orchestration.transforms import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _run_in_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run every test in this module from ``tmp_path``.
+
+    Several tests build in-memory ``Step``/``Workplan`` objects with no working
+    directory, so the job file-system root resolves relative to the CWD and the
+    transformer's derived artifacts (``*.ovrd.yaml``, ``*.cfrom.yaml``) land in
+    ``<cwd>/work/`` -- littering the repository checkout when pytest runs from
+    the repo root. All fixture paths used here are absolute (``tmp_path`` or
+    ``__file__``-anchored templates), so changing the CWD is safe.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def test_wp_path(tmp_path: Path) -> Path:
     """Default path for writing a workplan into the test output directory."""

--- a/cstar/tests/unit_tests/roms/test_precheck.py
+++ b/cstar/tests/unit_tests/roms/test_precheck.py
@@ -2,9 +2,14 @@
 
 Mirrors ucla-roms' `src/precheck.F90::do_precheck`/`check_output_divides_rst`:
 for every *enabled* output stream, `nrpf * output_period` must be positive and
-must evenly divide `ocean_vars.output_period_rst`, when restarts are on
-(`wrt_file_rst`). Four stream groups are additionally gated on a compile-time
-cppdef.
+must evenly divide `basic_output_settings.output_period_rst`, when restarts
+are on (`wrt_file_rst`). Four stream groups are additionally gated on a
+compile-time cppdef.
+
+Operates on C-Star's canonical namelist vocabulary (RomsNamelistBase group
+field names + real Fortran namelist keys), NOT forge's settings-dict
+vocabulary -- every settings dict built here uses e.g.
+`frc_output_settings.output_period_frc`, not forge's `frc_output.output_period`.
 """
 
 import pytest
@@ -18,7 +23,7 @@ def _base_settings(**overrides):
     test overrides.
     """
     settings = {
-        "ocean_vars": {
+        "basic_output_settings": {
             "wrt_file_rst": True,
             "output_period_rst": 86400,
             "wrt_file_his": False,
@@ -28,27 +33,39 @@ def _base_settings(**overrides):
             "output_period_avg": 86400,
             "nrpf_avg": 1,
         },
-        "frc_output": {"wrt_frc": False, "output_period": 3600, "nrpf": 4},
-        "extract_data": {"do_extract": False, "extract_period": 3600, "nrpf": 24},
-        "cdr_output": {"do_cdr_output": False, "output_period": 3600, "nrpf": 24},
-        "upscale_output": {
+        "frc_output_settings": {
+            "wrt_frc": False,
+            "output_period_frc": 3600,
+            "nrpf_frc": 4,
+        },
+        "extract_data_settings": {
+            "do_extract": False,
+            "output_period_extract": 3600,
+            "nrpf_extract": 24,
+        },
+        "cdr_output_settings": {
+            "do_cdr_output": False,
+            "output_period_cdr": 3600,
+            "nrpf_cdr": 24,
+        },
+        "upscale_settings": {
             "do_upscale": False,
             "output_period_uscl": 3600,
             "nrpf_uscl": 24,
         },
-        "bgc": {
-            "wrt_his": False,
-            "output_period_his": 86400,
-            "nrpf_his": 1,
-            "wrt_avg": False,
-            "output_period_avg": 86400,
-            "nrpf_avg": 1,
-            "wrt_his_dia": False,
-            "output_period_his_dia": 86400,
-            "nrpf_his_dia": 1,
-            "wrt_avg_dia": False,
-            "output_period_avg_dia": 86400,
-            "nrpf_avg_dia": 1,
+        "bgc_settings": {
+            "wrt_bgc_his": False,
+            "output_period_bgc_his": 86400,
+            "nrpf_bgc_his": 1,
+            "wrt_bgc_avg": False,
+            "output_period_bgc_avg": 86400,
+            "nrpf_bgc_avg": 1,
+            "wrt_bgc_dia_his": False,
+            "output_period_bgc_his_dia": 86400,
+            "nrpf_bgc_his_dia": 1,
+            "wrt_bgc_dia_avg": False,
+            "output_period_bgc_avg_dia": 86400,
+            "nrpf_bgc_avg_dia": 1,
         },
     }
     settings.update(overrides)
@@ -60,7 +77,11 @@ def test_conforming_config_passes():
     raises nothing.
     """
     settings = _base_settings()
-    settings["frc_output"] = {"wrt_frc": True, "output_period": 3600, "nrpf": 4}
+    settings["frc_output_settings"] = {
+        "wrt_frc": True,
+        "output_period_frc": 3600,
+        "nrpf_frc": 4,
+    }
     # 4 * 3600 = 14400 s; 86400 / 14400 = 6 -> evenly divides.
     check_output_streams_divide_rst(settings, cppdefs={})
 
@@ -73,7 +94,11 @@ def test_cppdef_inactive_skips_even_when_it_would_fail():
     settings = _base_settings()
     # 24 * 3600 = 86400 s doesn't matter here -- pick a genuinely non-dividing
     # combination to prove it's really skipped, not accidentally conforming.
-    settings["cdr_output"] = {"do_cdr_output": True, "output_period": 1000, "nrpf": 3}
+    settings["cdr_output_settings"] = {
+        "do_cdr_output": True,
+        "output_period_cdr": 1000,
+        "nrpf_cdr": 3,
+    }
     # cppdefs omits "cdr_forcing" (and "marbl_diags") -> guard unsatisfied.
     check_output_streams_divide_rst(settings, cppdefs={"marbl": True})
 
@@ -83,8 +108,12 @@ def test_enabled_cppdef_active_non_dividing_raises():
     the restart period raises.
     """
     settings = _base_settings()
-    settings["cdr_output"] = {"do_cdr_output": True, "output_period": 1000, "nrpf": 3}
-    with pytest.raises(ValueError, match="cdr_output"):
+    settings["cdr_output_settings"] = {
+        "do_cdr_output": True,
+        "output_period_cdr": 1000,
+        "nrpf_cdr": 3,
+    }
+    with pytest.raises(ValueError, match="cdr_output_settings"):
         check_output_streams_divide_rst(
             settings,
             cppdefs={"marbl": True, "marbl_diags": True, "cdr_forcing": True},
@@ -97,8 +126,12 @@ def test_non_positive_newfile_freq_raises():
     (a stream that never rolls a file at all).
     """
     settings = _base_settings()
-    settings["frc_output"] = {"wrt_frc": True, "output_period": 3600, "nrpf": 0}
-    with pytest.raises(ValueError, match="frc_output"):
+    settings["frc_output_settings"] = {
+        "wrt_frc": True,
+        "output_period_frc": 3600,
+        "nrpf_frc": 0,
+    }
+    with pytest.raises(ValueError, match="frc_output_settings"):
         check_output_streams_divide_rst(settings, cppdefs={})
 
 
@@ -107,8 +140,12 @@ def test_wrt_file_rst_false_never_raises():
     matter how badly a stream would otherwise violate the rule.
     """
     settings = _base_settings()
-    settings["ocean_vars"]["wrt_file_rst"] = False
-    settings["frc_output"] = {"wrt_frc": True, "output_period": 1000, "nrpf": 3}
+    settings["basic_output_settings"]["wrt_file_rst"] = False
+    settings["frc_output_settings"] = {
+        "wrt_frc": True,
+        "output_period_frc": 1000,
+        "nrpf_frc": 3,
+    }
     check_output_streams_divide_rst(settings, cppdefs={})
 
 
@@ -117,8 +154,12 @@ def test_output_period_rst_zero_passes_trivially():
     trivially for every stream, since `mod(0, x) == 0`.
     """
     settings = _base_settings()
-    settings["ocean_vars"]["output_period_rst"] = 0
-    settings["frc_output"] = {"wrt_frc": True, "output_period": 1000, "nrpf": 3}
+    settings["basic_output_settings"]["output_period_rst"] = 0
+    settings["frc_output_settings"] = {
+        "wrt_frc": True,
+        "output_period_frc": 1000,
+        "nrpf_frc": 3,
+    }
     check_output_streams_divide_rst(settings, cppdefs={})
 
 
@@ -127,13 +168,13 @@ def test_bgc_stream_gated_on_marbl_or_bec2():
     `marbl_diags` (unlike `cdr`/`upscale`).
     """
     settings = _base_settings()
-    settings["bgc"]["wrt_his"] = True
-    settings["bgc"]["output_period_his"] = 1000
-    settings["bgc"]["nrpf_his"] = 3
+    settings["bgc_settings"]["wrt_bgc_his"] = True
+    settings["bgc_settings"]["output_period_bgc_his"] = 1000
+    settings["bgc_settings"]["nrpf_bgc_his"] = 3
     # Not active under either MARBL or BIOLOGY_BEC2 -> skipped.
     check_output_streams_divide_rst(settings, cppdefs={})
     # Active under BIOLOGY_BEC2 alone -> now checked, and it violates.
-    with pytest.raises(ValueError, match="bgc"):
+    with pytest.raises(ValueError, match="bgc_settings"):
         check_output_streams_divide_rst(settings, cppdefs={"biology_bec2": True})
 
 
@@ -143,7 +184,7 @@ def test_missing_section_is_skipped_not_an_error():
     field/section presence is owned by schema validation upstream.
     """
     settings = {
-        "ocean_vars": {
+        "basic_output_settings": {
             "wrt_file_rst": True,
             "output_period_rst": 86400,
         }
@@ -158,11 +199,15 @@ def test_sflx_or_gate_fires_when_only_one_field_present():
     treated as enabled (a missing field reads as False, not "unknown").
     """
     settings = {
-        "ocean_vars": {"wrt_file_rst": True, "output_period_rst": 86400},
-        "surf_flux": {"wrt_smflx": True, "output_period": 1000, "nrpf": 3},
+        "basic_output_settings": {"wrt_file_rst": True, "output_period_rst": 86400},
+        "surf_flx_output_settings": {
+            "wrt_smflx": True,
+            "output_period_sflx": 1000,
+            "nrpf_sflx": 3,
+        },
     }
     # 3 * 1000 = 3000 s; 86400 % 3000 = 2400 != 0 -> non-dividing.
-    with pytest.raises(ValueError, match="surf_flux"):
+    with pytest.raises(ValueError, match="surf_flx_output_settings"):
         check_output_streams_divide_rst(settings, cppdefs={})
 
 
@@ -171,10 +216,14 @@ def test_diagnostics_or_gate_fires_when_only_one_field_present():
     diag_trc`) -- also confirms the `diagnostics` cppdef guard is satisfiable.
     """
     settings = {
-        "ocean_vars": {"wrt_file_rst": True, "output_period_rst": 86400},
-        "diagnostics": {"diag_trc": True, "output_period": 1000, "nrpf": 3},
+        "basic_output_settings": {"wrt_file_rst": True, "output_period_rst": 86400},
+        "diagnostics_settings": {
+            "diag_trc": True,
+            "output_period_diag": 1000,
+            "nrpf_diag": 3,
+        },
     }
-    with pytest.raises(ValueError, match="diagnostics"):
+    with pytest.raises(ValueError, match="diagnostics_settings"):
         check_output_streams_divide_rst(settings, cppdefs={"diagnostics": True})
 
 
@@ -196,7 +245,12 @@ def _settings_for_row(row, *, nrpf, period):
     """Minimal settings dict enabling exactly `row`'s stream, with its
     section holding every gate field True plus the given nrpf/period.
     """
-    settings = {"ocean_vars": {"wrt_file_rst": True, "output_period_rst": _RST_PERIOD}}
+    settings = {
+        "basic_output_settings": {
+            "wrt_file_rst": True,
+            "output_period_rst": _RST_PERIOD,
+        }
+    }
     section = settings.setdefault(row.section, {})
     for field in row.gate_fields:
         section[field] = True

--- a/cstar/tests/unit_tests/roms/test_precheck.py
+++ b/cstar/tests/unit_tests/roms/test_precheck.py
@@ -1,0 +1,244 @@
+"""Tests for `cstar.roms.precheck.check_output_streams_divide_rst`.
+
+Mirrors ucla-roms' `src/precheck.F90::do_precheck`/`check_output_divides_rst`:
+for every *enabled* output stream, `nrpf * output_period` must be positive and
+must evenly divide `ocean_vars.output_period_rst`, when restarts are on
+(`wrt_file_rst`). Four stream groups are additionally gated on a compile-time
+cppdef.
+"""
+
+import pytest
+
+from cstar.roms.precheck import _STREAM_CHECKS, check_output_streams_divide_rst
+
+
+def _base_settings(**overrides):
+    """A minimal, conforming settings mapping: restarts on, daily period,
+    every stream disabled (so the per-stream gates all skip) except what a
+    test overrides.
+    """
+    settings = {
+        "ocean_vars": {
+            "wrt_file_rst": True,
+            "output_period_rst": 86400,
+            "wrt_file_his": False,
+            "output_period_his": 86400,
+            "nrpf_his": 1,
+            "wrt_file_avg": False,
+            "output_period_avg": 86400,
+            "nrpf_avg": 1,
+        },
+        "frc_output": {"wrt_frc": False, "output_period": 3600, "nrpf": 4},
+        "extract_data": {"do_extract": False, "extract_period": 3600, "nrpf": 24},
+        "cdr_output": {"do_cdr_output": False, "output_period": 3600, "nrpf": 24},
+        "upscale_output": {
+            "do_upscale": False,
+            "output_period_uscl": 3600,
+            "nrpf_uscl": 24,
+        },
+        "bgc": {
+            "wrt_his": False,
+            "output_period_his": 86400,
+            "nrpf_his": 1,
+            "wrt_avg": False,
+            "output_period_avg": 86400,
+            "nrpf_avg": 1,
+            "wrt_his_dia": False,
+            "output_period_his_dia": 86400,
+            "nrpf_his_dia": 1,
+            "wrt_avg_dia": False,
+            "output_period_avg_dia": 86400,
+            "nrpf_avg_dia": 1,
+        },
+    }
+    settings.update(overrides)
+    return settings
+
+
+def test_conforming_config_passes():
+    """A stream whose `nrpf * output_period` evenly divides `output_period_rst`
+    raises nothing.
+    """
+    settings = _base_settings()
+    settings["frc_output"] = {"wrt_frc": True, "output_period": 3600, "nrpf": 4}
+    # 4 * 3600 = 14400 s; 86400 / 14400 = 6 -> evenly divides.
+    check_output_streams_divide_rst(settings, cppdefs={})
+
+
+def test_cppdef_inactive_skips_even_when_it_would_fail():
+    """A cppdef-gated stream that would otherwise violate the rule is skipped
+    entirely when its guarding cppdef is not active -- ucla-roms never
+    compiles that stream's write calls in that build.
+    """
+    settings = _base_settings()
+    # 24 * 3600 = 86400 s doesn't matter here -- pick a genuinely non-dividing
+    # combination to prove it's really skipped, not accidentally conforming.
+    settings["cdr_output"] = {"do_cdr_output": True, "output_period": 1000, "nrpf": 3}
+    # cppdefs omits "cdr_forcing" (and "marbl_diags") -> guard unsatisfied.
+    check_output_streams_divide_rst(settings, cppdefs={"marbl": True})
+
+
+def test_enabled_cppdef_active_non_dividing_raises():
+    """An enabled, cppdef-active stream whose frequency doesn't evenly divide
+    the restart period raises.
+    """
+    settings = _base_settings()
+    settings["cdr_output"] = {"do_cdr_output": True, "output_period": 1000, "nrpf": 3}
+    with pytest.raises(ValueError, match="cdr_output"):
+        check_output_streams_divide_rst(
+            settings,
+            cppdefs={"marbl": True, "marbl_diags": True, "cdr_forcing": True},
+        )
+
+
+def test_non_positive_newfile_freq_raises():
+    """`newfile_freq <= 0` (e.g. `nrpf == 0`) raises even though `0` divides
+    everything arithmetically -- ucla-roms treats it as a distinct violation
+    (a stream that never rolls a file at all).
+    """
+    settings = _base_settings()
+    settings["frc_output"] = {"wrt_frc": True, "output_period": 3600, "nrpf": 0}
+    with pytest.raises(ValueError, match="frc_output"):
+        check_output_streams_divide_rst(settings, cppdefs={})
+
+
+def test_wrt_file_rst_false_never_raises():
+    """The global gate: `wrt_file_rst` false means nothing is checked, no
+    matter how badly a stream would otherwise violate the rule.
+    """
+    settings = _base_settings()
+    settings["ocean_vars"]["wrt_file_rst"] = False
+    settings["frc_output"] = {"wrt_frc": True, "output_period": 1000, "nrpf": 3}
+    check_output_streams_divide_rst(settings, cppdefs={})
+
+
+def test_output_period_rst_zero_passes_trivially():
+    """`output_period_rst == 0` (the monthly-restart convention) passes
+    trivially for every stream, since `mod(0, x) == 0`.
+    """
+    settings = _base_settings()
+    settings["ocean_vars"]["output_period_rst"] = 0
+    settings["frc_output"] = {"wrt_frc": True, "output_period": 1000, "nrpf": 3}
+    check_output_streams_divide_rst(settings, cppdefs={})
+
+
+def test_bgc_stream_gated_on_marbl_or_bec2():
+    """The four `bgc_*` streams are gated on `MARBL || BIOLOGY_BEC2`, not on
+    `marbl_diags` (unlike `cdr`/`upscale`).
+    """
+    settings = _base_settings()
+    settings["bgc"]["wrt_his"] = True
+    settings["bgc"]["output_period_his"] = 1000
+    settings["bgc"]["nrpf_his"] = 3
+    # Not active under either MARBL or BIOLOGY_BEC2 -> skipped.
+    check_output_streams_divide_rst(settings, cppdefs={})
+    # Active under BIOLOGY_BEC2 alone -> now checked, and it violates.
+    with pytest.raises(ValueError, match="bgc"):
+        check_output_streams_divide_rst(settings, cppdefs={"biology_bec2": True})
+
+
+def test_missing_section_is_skipped_not_an_error():
+    """A settings mapping that omits a stream's section entirely (a partial
+    dict) is skipped for that stream rather than raising an unrelated error --
+    field/section presence is owned by schema validation upstream.
+    """
+    settings = {
+        "ocean_vars": {
+            "wrt_file_rst": True,
+            "output_period_rst": 86400,
+        }
+    }
+    check_output_streams_divide_rst(settings, cppdefs={"marbl": True})
+
+
+def test_sflx_or_gate_fires_when_only_one_field_present():
+    """Regression: a missing OR-partner gate field must not skip the check.
+    `sflx`'s gate is `wrt_smflx .or. wrt_stflx`; only `wrt_smflx` is present
+    (True) here, `wrt_stflx` is entirely absent -- the stream must still be
+    treated as enabled (a missing field reads as False, not "unknown").
+    """
+    settings = {
+        "ocean_vars": {"wrt_file_rst": True, "output_period_rst": 86400},
+        "surf_flux": {"wrt_smflx": True, "output_period": 1000, "nrpf": 3},
+    }
+    # 3 * 1000 = 3000 s; 86400 % 3000 = 2400 != 0 -> non-dividing.
+    with pytest.raises(ValueError, match="surf_flux"):
+        check_output_streams_divide_rst(settings, cppdefs={})
+
+
+def test_diagnostics_or_gate_fires_when_only_one_field_present():
+    """Same OR-gate regression as `sflx`, for `diagnostics` (`diag_uv .or.
+    diag_trc`) -- also confirms the `diagnostics` cppdef guard is satisfiable.
+    """
+    settings = {
+        "ocean_vars": {"wrt_file_rst": True, "output_period_rst": 86400},
+        "diagnostics": {"diag_trc": True, "output_period": 1000, "nrpf": 3},
+    }
+    with pytest.raises(ValueError, match="diagnostics"):
+        check_output_streams_divide_rst(settings, cppdefs={"diagnostics": True})
+
+
+# --- Table-driven coverage of every `_STREAM_CHECKS` row -------------------
+#
+# `_get` silently returns None on a wrong/renamed field name, and the row
+# then just `continue`s (skipped) -- so a field-name/alias drift in an
+# untested row would otherwise disable that row's check with no test
+# failure. These two parametrized tests exercise all 16 rows directly from
+# the table itself, proving every row's section/gate/period/nrpf field names
+# actually resolve against a real settings dict.
+
+_DIVIDING_NRPF, _DIVIDING_PERIOD = 24, 3600  # 24 * 3600 = 86400 -> divides evenly
+_NON_DIVIDING_NRPF, _NON_DIVIDING_PERIOD = 3, 1000  # 3000 -> does not divide 86400
+_RST_PERIOD = 86400
+
+
+def _settings_for_row(row, *, nrpf, period):
+    """Minimal settings dict enabling exactly `row`'s stream, with its
+    section holding every gate field True plus the given nrpf/period.
+    """
+    settings = {"ocean_vars": {"wrt_file_rst": True, "output_period_rst": _RST_PERIOD}}
+    section = settings.setdefault(row.section, {})
+    for field in row.gate_fields:
+        section[field] = True
+    section[row.nrpf_field] = nrpf
+    section[row.period_field] = period
+    return settings
+
+
+def _cppdefs_for_row(row):
+    """A cppdefs mapping that satisfies `row`'s cppdef guard (empty if none)."""
+    cppdefs = {}
+    for name in row.cppdef_guard:
+        # "marbl_or_bec2" is the synthetic name for `MARBL || BIOLOGY_BEC2`
+        # (see `_cppdef_guard_satisfied`) -- satisfy it via `marbl`.
+        cppdefs["marbl" if name == "marbl_or_bec2" else name] = True
+    return cppdefs
+
+
+@pytest.mark.parametrize("row", _STREAM_CHECKS, ids=lambda r: r.label)
+def test_every_stream_row_raises_when_enabled_active_and_non_dividing(row):
+    settings = _settings_for_row(
+        row, nrpf=_NON_DIVIDING_NRPF, period=_NON_DIVIDING_PERIOD
+    )
+    with pytest.raises(ValueError, match=row.label):
+        check_output_streams_divide_rst(settings, cppdefs=_cppdefs_for_row(row))
+
+
+@pytest.mark.parametrize("row", _STREAM_CHECKS, ids=lambda r: r.label)
+def test_every_stream_row_passes_when_enabled_active_and_dividing(row):
+    settings = _settings_for_row(row, nrpf=_DIVIDING_NRPF, period=_DIVIDING_PERIOD)
+    check_output_streams_divide_rst(settings, cppdefs=_cppdefs_for_row(row))
+
+
+@pytest.mark.parametrize(
+    "row", [r for r in _STREAM_CHECKS if r.cppdef_guard], ids=lambda r: r.label
+)
+def test_every_guarded_row_skipped_when_cppdef_inactive(row):
+    """Every cppdef-gated row (diagnostics, cdr, upscale, the four bgc_*
+    streams) is skipped -- even with a genuinely non-dividing config -- when
+    its guard is not satisfied.
+    """
+    settings = _settings_for_row(
+        row, nrpf=_NON_DIVIDING_NRPF, period=_NON_DIVIDING_PERIOD
+    )
+    check_output_streams_divide_rst(settings, cppdefs={})

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -636,6 +636,31 @@ class TestROMSSimulationInitialization:
         )
         return sim
 
+    def _prepare_sim_for_runtime_settings_v0_5_0(
+        self,
+        sim,
+        stageddatacollection_remote_files,
+        mock_grid_path,
+        mock_ini_path,
+        mock_forcing_paths,
+        mock_schema_for_ref,
+    ):
+        """Same as `_prepare_sim_for_runtime_settings`, but reads a genuine
+        `RomsNamelistV0_5_0` from the 0.5.0 fixture instead of the legacy
+        `RomsNamelist` -- needed to exercise `roms_runtime_settings`'
+        output-stream precheck, which is version-gated to run only for
+        ucla-roms >= 0.5.0 schemas (the legacy `RomsNamelist` skips it).
+        """
+        sim.runtime_code._working_copy = stageddatacollection_remote_files()
+        mock_grid_path.return_value = [Path("grid.nc")]
+        mock_ini_path.return_value = [Path("fake_ini.nc")]
+        mock_forcing_paths.return_value = [Path("forcing1.nc"), Path("forcing2.nc")]
+        mock_schema_for_ref.return_value.__name__ = "RomsNamelistV0_5_0"
+        mock_schema_for_ref.return_value.read.side_effect = lambda _: (
+            _REAL_NAMELIST_READ_V0_5_0(EXAMPLE_NAMELIST_V0_5_0)
+        )
+        return sim
+
     @mock.patch("cstar.roms.simulation.namelist_schema_for_ref")
     @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)
     @mock.patch.object(
@@ -804,6 +829,84 @@ class TestROMSSimulationInitialization:
 
         with pytest.raises(ValueError, match="must be positive"):
             _ = sim.roms_runtime_settings
+
+    @mock.patch("cstar.roms.simulation.namelist_schema_for_ref")
+    @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)
+    @mock.patch.object(
+        ROMSInitialConditions, "path_for_roms", new_callable=mock.PropertyMock
+    )
+    @mock.patch.object(ROMSModelGrid, "path_for_roms", new_callable=mock.PropertyMock)
+    def test_namelist_overrides_non_dividing_output_stream_raises(
+        self,
+        mock_grid_path,
+        mock_ini_path,
+        mock_forcing_paths,
+        mock_schema_for_ref,
+        stub_romssimulation,
+        stageddatacollection_remote_files,
+    ):
+        """An override that enables an output stream whose file-rollover
+        frequency doesn't evenly divide the restart period is rejected --
+        ucla-roms >= 0.5.0's `check_output_divides_rst` (`precheck.F90`) would
+        abort the run at startup otherwise. Uses `frc` (not cppdef-gated), so
+        it fires with no staged `cppdefs.opt` (`compile_time_code` unset on
+        `stub_romssimulation` -> `_active_cppdefs_for_precheck` returns `{}`).
+        """
+        sim = self._prepare_sim_for_runtime_settings_v0_5_0(
+            stub_romssimulation,
+            stageddatacollection_remote_files,
+            mock_grid_path,
+            mock_ini_path,
+            mock_forcing_paths,
+            mock_schema_for_ref,
+        )
+        # basic_output_settings.output_period_rst is 86400 s in the fixture;
+        # 3 * 1000 = 3000 s does not evenly divide it.
+        sim.namelist_overrides = {
+            "frc_output_settings": {
+                "wrt_frc": True,
+                "output_period_frc": 1000.0,
+                "nrpf_frc": 3,
+            }
+        }
+
+        with pytest.raises(ValueError, match="evenly divide"):
+            _ = sim.roms_runtime_settings
+
+    @mock.patch("cstar.roms.simulation.namelist_schema_for_ref")
+    @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)
+    @mock.patch.object(
+        ROMSInitialConditions, "path_for_roms", new_callable=mock.PropertyMock
+    )
+    @mock.patch.object(ROMSModelGrid, "path_for_roms", new_callable=mock.PropertyMock)
+    def test_namelist_overrides_dividing_output_stream_passes(
+        self,
+        mock_grid_path,
+        mock_ini_path,
+        mock_forcing_paths,
+        mock_schema_for_ref,
+        stub_romssimulation,
+        stageddatacollection_remote_files,
+    ):
+        """Companion to the non-dividing case: enabling `frc` with the
+        fixture's own (conforming) `nrpf_frc`/`output_period_frc` does not
+        raise.
+        """
+        sim = self._prepare_sim_for_runtime_settings_v0_5_0(
+            stub_romssimulation,
+            stageddatacollection_remote_files,
+            mock_grid_path,
+            mock_ini_path,
+            mock_forcing_paths,
+            mock_schema_for_ref,
+        )
+        # Fixture values: nrpf_frc=4, output_period_frc=3600.0 -> 14400 s,
+        # which evenly divides output_period_rst=86400 s -- only enable it.
+        sim.namelist_overrides = {"frc_output_settings": {"wrt_frc": True}}
+
+        result = sim.roms_runtime_settings
+
+        assert result.frc_output_settings.wrt_frc is True
 
     @mock.patch("cstar.roms.simulation.namelist_schema_for_ref")
     @mock.patch.object(ROMSSimulation, "_forcing_paths", new_callable=mock.PropertyMock)


### PR DESCRIPTION
# Summary

Adds a Python mirror of ucla-roms' output-stream restart precheck, enforced both as a reusable function (for external consumers such as C-STAR Forge) and inside `ROMSSimulation` itself — so a configuration ucla-roms would reject at startup is caught when run-time settings are assembled, including when the violation is introduced through `namelist_overrides`. Also logs installed library versions at the start of a blueprint run, and fixes two unrelated test-hygiene issues found along the way. (Note: the two test-hygiene fixes are currently uncommitted on the branch.)

## New Features
- New `cstar.roms.precheck.check_output_streams_divide_rst(settings, cppdefs)` reproduces ucla-roms >= 0.5.0's startup check (`precheck.F90::check_output_divides_rst`) across all output streams: it raises when an enabled stream's file-rollover frequency (`nrpf * output_period`) is not positive or does not evenly divide `output_period_rst`. It operates on the canonical namelist vocabulary (a `RomsNamelistBase.model_dump()`), with compile-time-gated streams (diagnostics and the MARBL/BGC-diagnostics groups) governed by a caller-supplied set of active cppdefs.
- `ROMSSimulation` now runs this check when assembling run-time settings (after `namelist_overrides` are applied), for ucla-roms >= 0.5.0 namelist schemas — a non-conforming override fails fast with a clear message instead of aborting mid-run. Active cppdefs are read from the staged `cppdefs.opt` when available; when compile-time code isn't staged yet, cppdef-gated streams are skipped (ucla-roms still enforces them at startup).
- `cstar blueprint run` now logs the installed cstar-ocean version (plus cstar-forge and roms-tools when installed) at the start of a run, so a run's own log records what produced it.

## Bug Fixes
- `test_blueprint_run_apply_directive_dne` failed on environments where typer/rich render usage errors as a wrapped panel — the box borders and width-dependent wrapping split the (correct) "file not found" message mid-phrase; the assertion now matches independent of panel decoration.
- The orchestration transformer tests littered a `work/` directory (`*.ovrd.yaml`/`*.cfrom.yaml` artifacts) into the repository checkout: their in-memory `Step`s have no working directory, so the job file-system root fell back to the CWD; `test_transforms.py` now runs from `tmp_path`.



## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

## Notes for Reviewers
- The `_STREAM_CHECKS` table is intentionally one row per stream, 1:1 with `precheck.F90`'s `do_precheck` call list, so it stays diffable against the Fortran source. The synthetic `"marbl_or_bec2"` cppdef guard encodes `defined(MARBL) || defined(BIOLOGY_BEC2)`.
- The check is a plain function, deliberately not a Pydantic `model_validator`, so it does not run on every model construction and can receive the caller's cppdef set. The `ROMSSimulation` call site follows the existing `dt <= 0` check in `roms_runtime_settings` — the one place user overrides are already merged.
- The cppdefs.opt parse (`_active_cppdefs_for_precheck`) mirrors the existing `_validate_cppdef_flag` regex and never raises: an unstaged working copy or missing file yields an empty mapping, so cppdef-gated streams are skipped rather than mis-checked.
- The `work/` litter arrived with the deferred-blueprints tests (#646) — bisected; not the doubled-run-id fix (#651). The `apply_directive_dne` failures were typer/rich-version-dependent rendering, not a CLI defect.

