### PR TITLE
Add `cstar workplan gather` to consolidate per-step joined output

### DIFF
--- a/cstar/cli/workplan/__init__.py
+++ b/cstar/cli/workplan/__init__.py
@@ -7,6 +7,7 @@ from cstar.base.feature import (
     is_feature_enabled,
 )
 from cstar.cli.workplan.check import app as app_check
+from cstar.cli.workplan.gather import app as app_gather
 from cstar.cli.workplan.log import app as app_log
 from cstar.cli.workplan.run import app as app_run
 from cstar.cli.workplan.status import app as app_status
@@ -17,6 +18,7 @@ app = typer.Typer(
 )
 
 app.add_typer(app_check)
+app.add_typer(app_gather)
 app.add_typer(app_log)
 
 if is_feature_enabled(ENV_FF_CLI_WORKPLAN_GEN):

--- a/cstar/cli/workplan/gather.py
+++ b/cstar/cli/workplan/gather.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from collections import defaultdict
 from pathlib import Path
 
@@ -89,12 +90,12 @@ def report_conflicts(conflicts: dict[str, list[Path]]) -> None:
 
 
 def relink(dest: Path, links: dict[str, Path]) -> None:
-    """Replace the symlinks in a consolidated joined-output directory.
+    """Replace a consolidated joined-output directory with a fresh set of symlinks.
 
-    Any existing symlinks in `dest` are removed before new ones are created.
-    If `dest` contains any entries that are not symlinks, nothing is
-    modified and a `typer.Exit` is raised, since gather must never delete
-    real files from the consolidated directory.
+    The existing directory is removed and recreated. If `dest` contains any
+    entries that are not symlinks, nothing is modified and a `typer.Exit` is
+    raised, since gather must never delete real files from the consolidated
+    directory.
 
     Parameters
     ----------
@@ -129,10 +130,9 @@ def relink(dest: Path, links: dict[str, Path]) -> None:
             )
             raise typer.Exit(1)
 
-        for p in dest.iterdir():
-            p.unlink()
+        shutil.rmtree(dest)
 
-    dest.mkdir(parents=True, exist_ok=True)
+    dest.mkdir(parents=True)
 
     for name, target in links.items():
         (dest / name).symlink_to(Path(os.path.relpath(target, dest)))

--- a/cstar/cli/workplan/gather.py
+++ b/cstar/cli/workplan/gather.py
@@ -1,0 +1,178 @@
+import os
+from collections import defaultdict
+from pathlib import Path
+
+import typer
+
+from cstar.base.log import get_logger
+from cstar.cli.common import get_from_ctxmap
+from cstar.cli.workplan.shared import RunIdArgument, console
+from cstar.execution.file_system import RomsFileSystemManager, StateDirectoryManager
+from cstar.orchestration.orchestration import LiveWorkplan
+
+log = get_logger(__name__)
+app = typer.Typer()
+
+HELP_SHORT = "Consolidate per-step joined output into a single directory."
+HELP_LONG = f"""\
+{HELP_SHORT}
+
+Every step's `joined_output` directory is scanned and a run-level
+`joined_output` directory of symlinks is (re)built pointing at whatever files
+currently exist. Safe to re-run at any time, including while the workplan is
+still in progress: each invocation replaces the existing symlinks with a
+fresh set reflecting the current state on disk.
+"""
+
+
+def collect_links(
+    workplan: LiveWorkplan,
+) -> tuple[dict[str, Path], dict[str, list[Path]]]:
+    """Collect the joined-output files produced by every step in a workplan.
+
+    Parameters
+    ----------
+    workplan : LiveWorkplan
+        The workplan whose steps should be scanned for joined-output files.
+
+    Returns
+    -------
+    tuple[dict[str, Path], dict[str, list[Path]]]
+        A mapping of filename to source path for filenames that appear in
+        exactly one step's `joined_output` directory, and a mapping of
+        filename to the list of source paths for filenames that appear in
+        more than one step's `joined_output` directory.
+    """
+    by_name: dict[str, list[Path]] = defaultdict(list)
+    skipped: list[str] = []
+
+    for step in workplan.steps:
+        src_dir = RomsFileSystemManager(step.working_dir).joined_output_dir
+        if not src_dir.exists():
+            skipped.append(step.name)
+            continue
+
+        for p in sorted(src_dir.iterdir()):
+            if p.is_file():
+                by_name[p.name].append(p)
+
+    if skipped:
+        log.debug(
+            "Skipping %d step(s) with no joined_output directory: %s",
+            len(skipped),
+            ", ".join(skipped),
+        )
+
+    links = {name: paths[0] for name, paths in by_name.items() if len(paths) == 1}
+    conflicts = {name: paths for name, paths in by_name.items() if len(paths) > 1}
+
+    return links, conflicts
+
+
+def report_conflicts(conflicts: dict[str, list[Path]]) -> None:
+    """Print a single error message describing every filename collision.
+
+    Parameters
+    ----------
+    conflicts : dict[str, list[Path]]
+        A mapping of filename to the list of source paths producing it.
+    """
+    lines = [
+        f"  - {name!r}: {', '.join(str(p) for p in paths)}"
+        for name, paths in sorted(conflicts.items())
+    ]
+    console.print(
+        "Refusing to gather: the following filenames are produced by more than "
+        "one step's joined_output directory:\n" + "\n".join(lines),
+        soft_wrap=True,
+    )
+
+
+def relink(dest: Path, links: dict[str, Path]) -> None:
+    """Replace the symlinks in a consolidated joined-output directory.
+
+    Any existing symlinks in `dest` are removed before new ones are created.
+    If `dest` contains any entries that are not symlinks, nothing is
+    modified and a `typer.Exit` is raised, since gather must never delete
+    real files from the consolidated directory.
+
+    Parameters
+    ----------
+    dest : Path
+        The consolidated `joined_output` directory to (re)populate.
+    links : dict[str, Path]
+        A mapping of filename to the source path it should be linked to.
+
+    Raises
+    ------
+    typer.Exit
+        If `dest` exists but is not a directory, or contains entries that
+        are not symlinks.
+    """
+    if dest.is_symlink() or (dest.exists() and not dest.is_dir()):
+        console.print(
+            f"Refusing to gather: the consolidated joined_output path "
+            f"{str(dest)!r} exists but is not a directory.",
+            soft_wrap=True,
+        )
+        raise typer.Exit(1)
+
+    if dest.exists():
+        non_symlinks = sorted(p for p in dest.iterdir() if not p.is_symlink())
+        if non_symlinks:
+            names = "\n".join(f"  - {p}" for p in non_symlinks)
+            console.print(
+                "Refusing to gather: the consolidated joined_output directory "
+                f"{str(dest)!r} contains file(s) that are not symlinks created "
+                f"by a prior gather, and will not be deleted:\n{names}",
+                soft_wrap=True,
+            )
+            raise typer.Exit(1)
+
+        for p in dest.iterdir():
+            p.unlink()
+
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for name, target in links.items():
+        (dest / name).symlink_to(Path(os.path.relpath(target, dest)))
+
+
+@app.command(name="gather", help=HELP_LONG, short_help=HELP_SHORT)
+def gather(
+    context: typer.Context,
+    run_id: RunIdArgument,
+) -> None:
+    """Consolidate per-step joined output into a run-level directory of symlinks."""
+    workplan = get_from_ctxmap(context, "workplan", LiveWorkplan)
+
+    links, conflicts = collect_links(workplan)
+
+    if conflicts:
+        report_conflicts(conflicts)
+        raise typer.Exit(1)
+
+    dest = RomsFileSystemManager(
+        StateDirectoryManager.data_dir(run_id)
+    ).joined_output_dir
+    relink(dest, links)
+
+    if not links:
+        console.print(
+            f"No joined output was found yet for run {run_id!r}. "
+            f"An empty directory was left at {dest}; re-run `gather` once steps "
+            "have produced output.",
+            soft_wrap=True,
+        )
+        return
+
+    num_step_dirs = len({p.parent for p in links.values()})
+    console.print(
+        f"Linked {len(links)} file(s) from {num_step_dirs} step "
+        f"directories into {dest}",
+        soft_wrap=True,
+    )
+
+
+if __name__ == "__main__":
+    typer.run(gather)

--- a/cstar/cli/workplan/log.py
+++ b/cstar/cli/workplan/log.py
@@ -3,13 +3,11 @@ import typing as t
 
 import typer
 
-from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import cb_pipeline, get_from_ctxmap, normalize_runid, set_env
+from cstar.cli.common import get_from_ctxmap
 from cstar.cli.workplan.shared import (
+    RunIdArgument,
     autocomplete_step_list,
-    list_runs,
-    preload_run,
     set_ctxmap,
 )
 from cstar.orchestration.models import Workplan
@@ -78,16 +76,7 @@ def preload_step(context: typer.Context, step_name: str) -> str:
 @app.command(name="log", help=HELP_LONG, short_help=HELP_SHORT)
 def workplan_log(
     context: typer.Context,
-    run_id: t.Annotated[
-        str,
-        typer.Argument(
-            help="The unique identifier of a specific workplan execution.",
-            autocompletion=list_runs,
-            callback=cb_pipeline(
-                normalize_runid, set_env(ENV_CSTAR_RUNID), preload_run
-            ),
-        ),
-    ],
+    run_id: RunIdArgument,
     step_name: t.Annotated[
         str,
         typer.Argument(

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -12,8 +12,9 @@ from cstar.applications.core import (
     RunnerRequest,
     get_application,
 )
+from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import set_ctxmap
+from cstar.cli.common import cb_pipeline, normalize_runid, set_ctxmap, set_env
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
 from cstar.execution.file_system import (
@@ -384,3 +385,15 @@ def preload_run(context: typer.Context, run_id: str) -> str:
     set_ctxmap(context, "workplan", wp)
 
     return run_id
+
+
+RunIdArgument = t.Annotated[
+    str,
+    typer.Argument(
+        help="The unique identifier of a specific workplan execution.",
+        autocompletion=list_runs,
+        callback=cb_pipeline(normalize_runid, set_env(ENV_CSTAR_RUNID), preload_run),
+    ),
+]
+"""Shared run-id argument: normalize the value, export it to the environment,
+and preload the `WorkplanRun` and transformed workplan into the context map."""

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_gather.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_gather.py
@@ -1,0 +1,297 @@
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cstar.cli.workplan.gather import app
+from cstar.execution.file_system import (
+    RomsFileSystemManager,
+    StateDirectoryManager,
+)
+from cstar.orchestration.models import Step, Workplan
+from cstar.orchestration.orchestration import LiveStep
+
+
+def _joined_output_dir(step: Step) -> Path:
+    """Return the `joined_output` directory for a step's working directory,
+    computed the same way production code does via `LiveStep`.
+    """
+    working_dir = LiveStep.from_step(step).working_dir
+    return RomsFileSystemManager(working_dir).joined_output_dir
+
+
+def _run_root() -> Path:
+    return StateDirectoryManager.data_dir("fake-run-id")
+
+
+def _dest_dir() -> Path:
+    return RomsFileSystemManager(_run_root()).joined_output_dir
+
+
+def test_cli_workplan_gather_happy_path(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that a unique file per step is linked into the consolidated
+    `joined_output` directory as a relative symlink pointing at the source.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    sources: dict[str, Path] = {}
+    for i, step in enumerate(wp.steps):
+        joined = _joined_output_dir(step)
+        joined.mkdir(parents=True)
+        name = f"out_{i}.nc"
+        src = joined / name
+        src.write_text("data")
+        sources[name] = src
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+    dest = _dest_dir()
+    for name, src in sources.items():
+        link = dest / name
+        assert link.is_symlink()
+        assert not Path(link.readlink()).is_absolute()
+        assert link.resolve() == src.resolve()
+
+
+def test_cli_workplan_gather_is_rerunnable(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that re-running gather picks up new files and drops stale links
+    for sources that no longer exist.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    step = wp.steps[0]
+    joined = _joined_output_dir(step)
+    joined.mkdir(parents=True)
+    stale_src = joined / "stale.nc"
+    stale_src.write_text("data")
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    dest = _dest_dir()
+    assert (dest / "stale.nc").is_symlink()
+
+    stale_src.unlink()
+    new_src = joined / "fresh.nc"
+    new_src.write_text("data")
+
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    assert not (dest / "stale.nc").exists()
+    assert not (dest / "stale.nc").is_symlink()
+    assert (dest / "fresh.nc").is_symlink()
+    assert (dest / "fresh.nc").resolve() == new_src.resolve()
+
+
+def test_cli_workplan_gather_conflict_aborts(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that a filename collision across steps aborts with an error and
+    modifies nothing on disk, including a pre-existing consolidated directory.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    if len(wp.steps) < 2:
+        pytest.skip("Conflict detection requires a workplan with at least 2 steps")
+
+    runner = CliRunner()
+
+    # Seed and gather one distinct file first, to prove the pre-existing
+    # consolidated directory is left untouched by the failed gather below.
+    first_step = wp.steps[0]
+    first_joined = _joined_output_dir(first_step)
+    first_joined.mkdir(parents=True)
+    (first_joined / "untouched.nc").write_text("data")
+
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    dest = _dest_dir()
+    assert (dest / "untouched.nc").is_symlink()
+    pre_existing_target = (dest / "untouched.nc").resolve()
+
+    # An orphaned symlink from an earlier gather (its source is gone). A
+    # correct gather aborts on conflict before touching the consolidated
+    # directory, so it must survive; a relink-then-check ordering would
+    # remove it.
+    orphan = dest / "orphan.nc"
+    orphan.symlink_to("no-longer-exists.nc")
+
+    # Now introduce a collision between the first two steps.
+    second_step = wp.steps[1]
+    second_joined = _joined_output_dir(second_step)
+    second_joined.mkdir(parents=True)
+
+    colliding_a = first_joined / "colliding.nc"
+    colliding_a.write_text("data-a")
+    colliding_b = second_joined / "colliding.nc"
+    colliding_b.write_text("data-b")
+
+    result = runner.invoke(app, [fake_run_id], color=False)
+
+    assert result.exit_code == 1
+    assert "colliding.nc" in result.stdout
+    assert str(colliding_a) in result.stdout
+    assert str(colliding_b) in result.stdout
+
+    # Pre-existing consolidated content is untouched.
+    assert (dest / "untouched.nc").is_symlink()
+    assert (dest / "untouched.nc").resolve() == pre_existing_target
+    assert orphan.is_symlink()
+
+
+def test_cli_workplan_gather_skips_steps_without_joined_output(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that steps with no `joined_output` directory are skipped quietly.
+
+    When no step has produced any joined output, an empty consolidated
+    directory is still created along with a friendly informational message.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    *_, fake_run_id = executed_workplan
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "No joined output was found" in result.stdout
+
+    dest = _dest_dir()
+    assert dest.exists()
+    assert list(dest.iterdir()) == []
+
+
+def test_cli_workplan_gather_skips_one_populated_step(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that only steps with an existing `joined_output` directory
+    contribute links, while other steps are skipped without error.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    _, wp, fake_run_id = executed_workplan
+
+    step = wp.steps[0]
+    joined = _joined_output_dir(step)
+    joined.mkdir(parents=True)
+    src = joined / "only.nc"
+    src.write_text("data")
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False, catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+    dest = _dest_dir()
+    assert (dest / "only.nc").is_symlink()
+    assert (dest / "only.nc").resolve() == src.resolve()
+    assert len(list(dest.iterdir())) == 1
+
+
+def test_cli_workplan_gather_refuses_to_delete_real_files(
+    executed_workplan: tuple[Path, Workplan, str],
+) -> None:
+    """Verify that gather refuses to wipe non-symlink entries from an
+    existing consolidated `joined_output` directory.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    """
+    *_, fake_run_id = executed_workplan
+
+    dest = _dest_dir()
+    dest.mkdir(parents=True)
+    real_file = dest / "real_file.nc"
+    real_file.write_text("do not delete me")
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False)
+
+    assert result.exit_code == 1
+    assert "real_file.nc" in result.stdout
+    assert real_file.exists()
+    assert real_file.read_text() == "do not delete me"
+
+
+@pytest.mark.parametrize("dest_kind", ["regular_file", "dangling_symlink"])
+def test_cli_workplan_gather_dest_is_not_a_directory(
+    executed_workplan: tuple[Path, Workplan, str],
+    dest_kind: str,
+) -> None:
+    """Verify that gather refuses to proceed when the consolidated
+    `joined_output` path exists but is not a directory.
+
+    Parameters
+    ----------
+    executed_workplan : tuple[Path, Workplan, str]
+        The path to a workplan YAML file, the workplan instance, and a run-id.
+    dest_kind : str
+        The kind of non-directory entry occupying the destination path.
+    """
+    *_, fake_run_id = executed_workplan
+
+    dest = _dest_dir()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest_kind == "regular_file":
+        dest.write_text("not a directory")
+    else:
+        dest.symlink_to("no-longer-exists")
+
+    runner = CliRunner()
+    result = runner.invoke(app, [fake_run_id], color=False)
+
+    assert result.exit_code == 1
+    assert "not a directory" in result.stdout
+    if dest_kind == "regular_file":
+        assert dest.is_file()
+        assert dest.read_text() == "not a directory"
+    else:
+        assert dest.is_symlink()
+
+
+def test_cli_workplan_gather_unknown_run_id() -> None:
+    """Verify that an unknown run-id produces an error mentioning it cannot
+    be located.
+    """
+    runner = CliRunner()
+    unknown_run_id = "run-id-dne"
+
+    result = runner.invoke(app, [unknown_run_id], color=False)
+
+    assert result.exit_code != 0
+    assert "unable to locate" in result.stderr.lower()
+    assert unknown_run_id in result.stderr

--- a/docs/workplans.rst
+++ b/docs/workplans.rst
@@ -301,3 +301,16 @@ Checking Workplan Status
     .. code-block:: console
 
         cstar workplan status --run-id <my-unique-id>
+
+
+Gathering Workplan Outputs
+--------------------------
+
+Use the ``gather`` command from the ``cstar`` CLI to consolidate every step's
+``joined_output`` files into a single run-level ``joined_output`` directory of
+symlinks. It is safe to re-run while a workplan is still in progress, and it
+fails if two steps produce a file with the same name.
+
+.. code-block:: console
+
+    cstar workplan gather <my-unique-id>


### PR DESCRIPTION
# Summary

Adds a `cstar workplan gather <run-id>` CLI command that consolidates every step's `joined_output` files into a single run-level `joined_output/` directory of symlinks (next to `tasks/`), so a run's de-partitioned outputs can be browsed in one place.

## Breaking Changes
- N/A

## New Features
- New `cstar workplan gather <run-id>` command builds a run-level `joined_output/` directory of relative symlinks pointing at every file in the per-step `joined_output` directories. It is safe to re-run at any point — including while a workplan is still in progress — and each invocation replaces the symlink set with one reflecting the current state on disk. If two steps produce a file with the same name, the command aborts with an error listing every conflicting filename (and modifies nothing).

## Bug Fixes
- N/A

## Miscellaneous
- Added a "Gathering Workplan Outputs" section to the workplans documentation.

## Notes for Reviewers
- The run-id argument shared by `workplan log` and `workplan gather` (autocompletion, normalization, and run preloading) is now defined once as a reusable `RunIdArgument` in `cli/workplan/shared.py` instead of being duplicated per command.
- Safety semantics: `gather` never touches the per-step directories; it only manages the run-level view. It refuses (exit 1) to wipe the consolidated directory if it contains any non-symlink entries, and refuses to proceed if the destination path exists but is not a directory (e.g. a stray file or dangling symlink) — no real data is ever deleted.
- Symlinks are relative (`../tasks/<step>/joined_output/<file>`), so the view survives the run directory being moved or mounted at a different path.
- Steps without a `joined_output` directory (non-ROMS applications, not-yet-run steps) are skipped quietly; when nothing is found the command leaves an empty directory and says so.


## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (full unit tier: 1658 passed; integration tier skipped per the tiered strategy — no ROMS-build-affecting change)
