### PR TITLE
Add method to detect scratch dir on Bouchet

### DIFF
--- a/cstar/base/env.py
+++ b/cstar/base/env.py
@@ -9,6 +9,8 @@ from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
 
+from cstar.base.exceptions import CstarError
+
 if t.TYPE_CHECKING:
     from types import ModuleType
 
@@ -128,6 +130,11 @@ def get_env_item(var_name: str) -> EnvItem:
 def hpc_data_directory() -> str | None:
     """A path-locator function that looks for standard scratch file-systems.
 
+    First checks the environment variables named in `CSTAR_SCRATCH_DIRS`, in
+    order. If none are set, falls back to the active system context's
+    machine-specific `scratch_directory()` heuristic (for systems, such as
+    Bouchet, that expose no scratch env var).
+
     Returns
     -------
     Path | None
@@ -139,7 +146,20 @@ def hpc_data_directory() -> str | None:
         if scratch_path := os.getenv(env_var, ""):
             return Path(scratch_path).as_posix()
 
-    return None
+    from cstar.system.manager import get_system_context  # local: avoid import cycle
+
+    try:
+        context = get_system_context()
+        scratch_dir = context.scratch_directory()
+    except (CstarError, OSError, RuntimeError):
+        # OSError: unidentifiable host or filesystem errors while scanning;
+        # RuntimeError: Path.home() cannot resolve a home directory.
+        return None
+
+    if scratch_dir is None:
+        return None
+
+    return scratch_dir.as_posix()
 
 
 def nprocs_factory() -> str:

--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -1,8 +1,10 @@
 import functools
+import getpass
 import os
 import platform as platform
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import ClassVar, Final, Protocol, override
 
 from pydantic import Field
@@ -139,6 +141,24 @@ class SystemContext(Protocol):
     def is_match(cls) -> bool:
         """Return `True` if the context identifies the current system as a match."""
         return False
+
+    @classmethod
+    def scratch_directory(cls) -> Path | None:
+        """Locate a machine-specific scratch filesystem for systems that expose no
+        scratch env var.
+
+        Some HPC systems provide no `SCRATCH`-style environment variable (see
+        `CSTAR_SCRATCH_DIRS`) and instead require a machine-specific heuristic to
+        locate the scratch filesystem. Override this classmethod to implement such
+        a heuristic.
+
+        Returns
+        -------
+        Path | None
+            The located scratch directory, or `None` when no machine-specific
+            heuristic applies (i.e. the system's scratch env vars are sufficient).
+        """
+        return None
 
 
 CTX_REGISTRY: dict[str, type[SystemContext]] = {}
@@ -356,6 +376,34 @@ class BouchetSystemContext(SystemContext):
         return (
             os.getenv("SLURM_CLUSTER_NAME", "") == BouchetEnvSettings.CLUSTER_IDENTIFIER
         )
+
+    @override
+    @classmethod
+    def scratch_directory(cls) -> Path | None:
+        """Locate the user's scratch directory on Bouchet.
+
+        Bouchet exports no `$SCRATCH`-style environment variable. Instead, each
+        user's home directory contains one or more per-project symlinks named
+        `scratch_pi_<pi-netid>` (the `<pi-netid>` suffix is not predictable), each
+        pointing at a shared project scratch filesystem. Within each of those,
+        the user has a subdirectory named after their own username.
+
+        This heuristic globs `scratch_pi_*` entries under the home directory,
+        keeps only directories (symlinks are followed), sorts the matches for
+        determinism, and takes the first one, appending the current username.
+
+        Returns
+        -------
+        Path | None
+            `<first scratch_pi_* directory>/<username>`, or `None` if no
+            `scratch_pi_*` directory is found under the home directory.
+        """
+        candidates = sorted(p for p in Path.home().glob("scratch_pi_*") if p.is_dir())
+        if not candidates:
+            return None
+
+        username = os.environ.get("USER") or getpass.getuser()
+        return candidates[0] / username
 
 
 @register_sys_context

--- a/cstar/tests/unit_tests/base/test_env.py
+++ b/cstar/tests/unit_tests/base/test_env.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+from unittest import mock
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from cstar.base.env import ENV_CSTAR_SCRATCH_DIRS, hpc_data_directory
+
+SCRATCH_ENV_VARS = ("SCRATCH", "SCRATCH_DIR", "LOCAL_SCRATCH")
+
+
+@pytest.fixture
+def clear_scratch_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure no scratch-locating env vars are set, regardless of what the host
+    running the test suite happens to have exported.
+    """
+    for var in (*SCRATCH_ENV_VARS, ENV_CSTAR_SCRATCH_DIRS):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_hpc_data_directory_uses_scratch_env_var(
+    clear_scratch_env_vars: None,
+) -> None:
+    """Verify that `hpc_data_directory` returns the value of the first populated
+    scratch env var named in `CSTAR_SCRATCH_DIRS`, without consulting the system
+    context.
+    """
+    with mock.patch.dict(os.environ, {"SCRATCH": "/mock/scratch/path"}):
+        assert hpc_data_directory() == "/mock/scratch/path"
+
+
+def test_hpc_data_directory_falls_back_to_bouchet_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    clear_scratch_env_vars: None,
+) -> None:
+    """Verify that `hpc_data_directory` falls back to the active system context's
+    `scratch_directory()` heuristic when no scratch env var is populated and the
+    active context is Bouchet.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / "scratch_pi_x").mkdir()
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setenv("USER", "mock_user")
+
+    with patch(
+        "cstar.system.manager.HostNameEvaluator.name",
+        new_callable=PropertyMock,
+        return_value="bouchet",
+    ):
+        result = hpc_data_directory()
+
+    assert result == (fake_home / "scratch_pi_x" / "mock_user").as_posix()
+
+
+def test_hpc_data_directory_returns_none_on_context_error(
+    clear_scratch_env_vars: None,
+) -> None:
+    """Verify that `hpc_data_directory` returns `None` (rather than raising) when
+    no scratch env var is populated and the active system context cannot be
+    determined.
+    """
+    with patch(
+        "cstar.system.manager.HostNameEvaluator.name",
+        new_callable=PropertyMock,
+        return_value="invalid-name",
+    ):
+        assert hpc_data_directory() is None
+
+
+def test_hpc_data_directory_returns_none_when_context_has_no_heuristic(
+    clear_scratch_env_vars: None,
+) -> None:
+    """Verify that `hpc_data_directory` returns `None` when no scratch env var is
+    populated and the active system context's `scratch_directory()` returns
+    `None` (i.e. the default `SystemContext` behavior for systems without a
+    machine-specific heuristic).
+    """
+    with patch(
+        "cstar.system.manager.HostNameEvaluator.name",
+        new_callable=PropertyMock,
+        return_value="darwin_arm64",
+    ):
+        assert hpc_data_directory() is None

--- a/cstar/tests/unit_tests/system/test_context_registry.py
+++ b/cstar/tests/unit_tests/system/test_context_registry.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import ClassVar
 from unittest.mock import PropertyMock, patch
 
@@ -130,3 +131,47 @@ def test_unknown_context_name() -> None:
         ),
     ):
         _ = get_system_context()
+
+
+def test_bouchet_scratch_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that `BouchetSystemContext.scratch_directory` locates the first
+    sorted `scratch_pi_*` directory under the home directory and appends the
+    username, skipping non-directory entries.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / "scratch_pi_zz").mkdir()
+    (fake_home / "scratch_pi_aa").mkdir()
+    (fake_home / "scratch_pi_file").write_text("not a directory")
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setenv("USER", "mock_user")
+
+    result = BouchetSystemContext.scratch_directory()
+
+    assert result == fake_home / "scratch_pi_aa" / "mock_user"
+
+
+def test_bouchet_scratch_directory_no_candidates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that `BouchetSystemContext.scratch_directory` returns `None` when no
+    `scratch_pi_*` directory exists under the home directory.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setenv("USER", "mock_user")
+
+    assert BouchetSystemContext.scratch_directory() is None
+
+
+@pytest.mark.parametrize("wrapped_class", [PerlmutterSystemContext, MacOSSystemContext])
+def test_default_scratch_directory_is_none(wrapped_class: type[SystemContext]) -> None:
+    """Verify that contexts without an overridden `scratch_directory` fall back to
+    the `SystemContext` protocol default, which returns `None`.
+    """
+    assert wrapped_class.scratch_directory() is None


### PR DESCRIPTION
# Summary

Teaches C-Star to find scratch space on Yale's Bouchet cluster. Bouchet exports no `$SCRATCH`-style env var (so the `CSTAR_SCRATCH_DIRS` lookup finds nothing and `CSTAR_DATA_HOME` silently fell back to `~/cstar` on the home quota); instead, each user's home carries per-project `scratch_pi_<pi-netid>` symlinks with a per-user subdirectory named after the username. System contexts can now supply a machine-specific scratch locator, and Bouchet's implements that heuristic.

## New Features

- New `SystemContext.scratch_directory()` classmethod: a machine-specific scratch-filesystem locator for systems that expose no scratch env var (default `None` — env vars suffice).
  - `BouchetSystemContext` implements it: the first `scratch_pi_*` directory under home (sorted for determinism, non-directories skipped) plus the current username.
  - `hpc_data_directory()` falls back to the active system context's locator when none of the `CSTAR_SCRATCH_DIRS` env vars are set, so `CSTAR_DATA_HOME` defaults onto Bouchet scratch instead of `~/.local/share`. Env vars still take precedence, and any failure to resolve the context degrades to the previous behavior instead of raising.

## Notes for Reviewers

- The `cstar.system.manager` import inside `hpc_data_directory()` is deliberately function-local: a module-level import would cycle (`system.manager → base.log → base.env`). It uses `get_system_context()` (pure env-var reads), not the heavier `get_sysmgr()`.
- The except clause covers `CstarError`, `OSError`, and `RuntimeError` (the last for `Path.home()` failing to resolve), keeping the function's never-raises contract.
- Companion cstar-forge PR (`bouchet-support` branch) adds the same heuristic to Forge's own host detection; the copies are independent by design (Forge's host resolution is documented as disposable) but must agree on detection and the discovered root.
- Multi-project users (several `scratch_pi_*` links): the first sorted match wins; no per-project selection yet.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit tier: 1634 passed, 13 skipped, 2 xfailed; integration tier not run, per repo testing policy)
