### PR TITLE
fix queue name not supplied to runner

### DIFF
--- a/cstar/applications/roms_marbl/app.py
+++ b/cstar/applications/roms_marbl/app.py
@@ -96,6 +96,7 @@ class RomsMarblRunner(BlueprintRunner[RomsMarblBlueprint]):
         self._handler = self.simulation.run(
             account_key=self._job_cfg.account_id,
             walltime=self._job_cfg.walltime,
+            queue_name=self._job_cfg.priority,
             job_name=self._job_cfg.job_name,
         )
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR fixes a defect in the `RomsMarblRunner` causing the default _SLURM_ queue to be used, regardless of the parameters passed to the runner.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Ensure SLURM queue name is specified when starting a simulation

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

