### PR TITLE
Handle infinite walltime responses from sinfo

### DIFF
--- a/cstar/system/manager.py
+++ b/cstar/system/manager.py
@@ -285,16 +285,16 @@ class BouchetEnvSettings(SlurmSettingsBase):
 @register_sys_context
 @dataclass(frozen=True)
 class BouchetSystemContext(SystemContext):
-    """The contextual dependencies for the Anvil system."""
+    """The contextual dependencies for the Bouchet system."""
 
     name: ClassVar[str] = "bouchet"
-    """The unique name identifying the Anvil system."""
+    """The unique name identifying the Bouchet system."""
     compiler: ClassVar[str] = "gnu"
-    """The compiler used on Anvil."""
+    """The compiler used on Bouchet."""
     mpi_prefix: ClassVar[str] = "srun"
-    """The MPI prefix used on Anvil."""
+    """The MPI prefix used on Bouchet."""
     docs: ClassVar[str] = "https://docs.ycrc.yale.edu/clusters/bouchet"
-    """URI for documentation of the Anvil system."""
+    """URI for documentation of the Bouchet system."""
 
     @classmethod
     def create_scheduler(cls) -> Scheduler | None:
@@ -328,9 +328,50 @@ class BouchetSystemContext(SystemContext):
             max_walltime_method=query_max_walltime_via_sinfo,
         )
         """Partition with 2 day max walltime (2-00:00:00) and tuned for parallel MPI jobs."""
+        devel_queue = SlurmPartition(
+            name="devel",
+            query_name="devel",
+            max_walltime_method=query_max_walltime_via_sinfo,
+        )
+        """Partition with 6 hour max walltime (06:00:00) for interactive/development work."""
+        scavenge_queue = SlurmPartition(
+            name="scavenge",
+            query_name="scavenge",
+            max_walltime_method=query_max_walltime_via_sinfo,
+        )
+        """Preemptable partition with 1 day max walltime (1-00:00:00)."""
+        priority_queue = SlurmPartition(
+            name="priority",
+            query_name="priority",
+            max_walltime_method=query_max_walltime_via_sinfo,
+        )
+        """Priority-tier counterpart of `day` (7 day max walltime); requires a `prio_*` SLURM account."""
+        priority_gpu_queue = SlurmPartition(
+            name="priority_gpu",
+            query_name="priority_gpu",
+            max_walltime_method=query_max_walltime_via_sinfo,
+        )
+        """Priority-tier counterpart of `gpu` (7 day max walltime); requires a `prio_*` SLURM account."""
+        priority_mpi_queue = SlurmPartition(
+            name="priority_mpi",
+            query_name="priority_mpi",
+            max_walltime_method=query_max_walltime_via_sinfo,
+        )
+        """Priority-tier counterpart of `mpi` (7 day max walltime); requires a `prio_*` SLURM account."""
 
         return SlurmScheduler(
-            queues=[day_queue, week_queue, gpu_queue, bigmem_queue, mpi_queue],
+            queues=[
+                day_queue,
+                week_queue,
+                gpu_queue,
+                bigmem_queue,
+                mpi_queue,
+                devel_queue,
+                scavenge_queue,
+                priority_queue,
+                priority_gpu_queue,
+                priority_mpi_queue,
+            ],
             primary_queue_name="day",
             other_scheduler_directives={},
             requires_task_distribution=False,

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -3,8 +3,13 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Final
 
-from cstar.base.log import LoggingMixin
+from cstar.base.log import LoggingMixin, get_logger
 from cstar.base.utils import _run_cmd
+
+log = get_logger(__name__)
+
+UNLIMITED_WALLTIMES: Final = frozenset({"infinite", "unlimited", "n/a"})
+"""Values SLURM reports for a queue with no walltime limit."""
 
 
 def parse_walltime(walltime_str: str) -> tuple[int, int, int]:
@@ -22,8 +27,13 @@ def parse_walltime(walltime_str: str) -> tuple[int, int, int]:
     Returns
     -------
     tuple[int, int, int]
+
+    Raises
+    ------
+    ValueError
+        If the walltime string is not in a recognized format.
     """
-    mw_h, mw_m, mw_s = 0, 0, 0
+    walltime_str = walltime_str.strip()
     if walltime_str.count("-") == 1:  # D-HH:MM:SS
         mw_d = int(walltime_str.split("-")[0])
         mw_hms = walltime_str.split("-")[1]
@@ -35,10 +45,12 @@ def parse_walltime(walltime_str: str) -> tuple[int, int, int]:
         mw_m, mw_s = map(int, mw_hms.split(":"))
     elif mw_hms.count(":") == 2:  # HH:MM:SS
         mw_h, mw_m, mw_s = map(int, mw_hms.split(":"))
+    else:
+        raise ValueError(f"Unrecognized walltime format: {walltime_str!r}")
     return mw_d * 24 + mw_h, mw_m, mw_s
 
 
-def format_walltime(walltime_str: str) -> str:
+def format_walltime(walltime_str: str) -> str | None:
     """Parse and format a SLURM walltime string into the format "HH:MM:SS".
 
     Parameters
@@ -48,13 +60,27 @@ def format_walltime(walltime_str: str) -> str:
         - "D-HH:MM:SS" (days, hours, minutes, seconds)
         - "HH:MM:SS" (hours, minutes, seconds)
         - "MM:SS" (minutes, seconds)
+        - "infinite"/"UNLIMITED"/"N/A" (no walltime limit)
 
     Returns
     -------
-    str
-        The formatted walltime string in the "HH:MM:SS" format.
+    str or None
+        The formatted walltime string in the "HH:MM:SS" format, or `None` when
+        SLURM reports the queue has no walltime limit or the reported value
+        cannot be parsed (treated as unlimited; the scheduler enforces the
+        real limit at submission).
     """
-    mw_h, mw_m, mw_s = parse_walltime(walltime_str)
+    if walltime_str.strip().casefold() in UNLIMITED_WALLTIMES:
+        return None
+    try:
+        mw_h, mw_m, mw_s = parse_walltime(walltime_str)
+    except ValueError:
+        log.warning(
+            f"Cannot parse queue walltime {walltime_str!r}; treating the maximum "
+            "walltime as unlimited. If the requested walltime exceeds the queue's "
+            "actual limit, the job may be rejected by the scheduler."
+        )
+        return None
     return f"{mw_h:02}:{mw_m:02}:{mw_s:02}"
 
 

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -502,17 +502,45 @@ class TestStrAndRepr:
         pytest.param("00:00", "00:00:00", id="mm:ss to hh:mm:ss w/no time"),
         pytest.param("42:00", "00:42:00", id="mm:ss to hh:mm:ss"),
         pytest.param("99:00", "00:99:00", id="mm:ss to hh:mm:ss w/overflow"),
+        pytest.param(" 1-00:00:00 ", "24:00:00", id="surrounding whitespace"),
+        pytest.param("infinite", None, id="sinfo unlimited"),
+        pytest.param("UNLIMITED", None, id="sacctmgr unlimited"),
+        pytest.param("n/a", None, id="not applicable"),
     ],
 )
-def test_parse_walltime(value: str, expected: str) -> None:
+def test_parse_walltime(value: str, expected: str | None) -> None:
     """Verify `_parse_walltime` correctly parses all three available formats:
     - hh:mm:ss
     - N-hh:mm:ss
     - mm:ss
+
+    and returns `None` for SLURM's unlimited-walltime values.
     """
     actual = format_walltime(value)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("garbage", id="not a walltime"),
+        pytest.param("1-00:00:00\n1-00:00:00", id="multi-line sinfo output"),
+        pytest.param("12", id="no colons"),
+        pytest.param("aa:bb:cc", id="non-numeric fields"),
+    ],
+)
+def test_parse_walltime_unrecognized(
+    value: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify unrecognized walltime strings fall back to None (unlimited) with a
+    warning instead of silently parsing to zero.
+    """
+    with caplog.at_level(logging.WARNING):
+        result = format_walltime(value)
+
+    assert result is None
+    assert any("Cannot parse queue walltime" in msg for msg in caplog.messages)
 
 
 def test_query_max_walltime_via_sinfo() -> None:
@@ -534,6 +562,21 @@ def test_query_max_walltime_via_sinfo_partition_not_valid() -> None:
     """
     with patch(
         "cstar.system.scheduler._run_cmd", MagicMock(return_value="")
+    ) as mock_sinfo:
+        result = query_max_walltime_via_sinfo("mock-partition-name")
+
+        assert result is None
+        mock_sinfo.assert_called_once()
+
+
+def test_query_max_walltime_via_sinfo_unlimited() -> None:
+    """Verify a null max walltime is returned when the partition has no limit.
+
+    e.g. Bouchet's `mpi` partition, where sinfo reports `infinite` and the
+    actual limit is enforced via QOS.
+    """
+    with patch(
+        "cstar.system.scheduler._run_cmd", MagicMock(return_value="infinite")
     ) as mock_sinfo:
         result = query_max_walltime_via_sinfo("mock-partition-name")
 


### PR DESCRIPTION
# Summary

Adds support for the remaining Bouchet SLURM partitions (`devel`, `scavenge`, and the priority tier) and fixes walltime handling for queues whose limit SLURM reports as `infinite` — previously C-Star rejected any job on such a queue with a nonsensical maximum walltime of `00:00:00`.


## Bug Fixes
- Jobs submitted to a queue whose SLURM time limit is reported as `infinite`/`UNLIMITED` (e.g. Bouchet's `mpi` partition, where the real limit is enforced via QOS) were rejected with a spurious "exceeds maximum walltime 00:00:00" error; such queues are now correctly treated as having no partition-level walltime limit, and the job is submitted with the user's requested walltime.
- A queue walltime string C-Star cannot parse no longer silently becomes a zero walltime limit; it is logged as a warning and the queue is treated as having no known limit, leaving enforcement to the scheduler.

## Improvements
- Added the `devel` and `scavenge` partitions and the priority-tier partitions `priority`, `priority_gpu`, and `priority_mpi` to the supported queues on Bouchet.

## Notes for Reviewers
- Corrected copy-pasted "Anvil" docstrings in the Bouchet system context.
- Queue walltime values from SLURM are now tolerated with surrounding whitespace and case differences.
- The priority-tier partitions are only usable with a `prio_*` SLURM account (submitted via `-A`); C-Star does not validate this, so submissions without one are rejected by SLURM ([Yale priority-tier docs](https://docs.ycrc.yale.edu/clusters-at-yale/job-scheduling/priority-tier/)).
- `scavenge` jobs are preemptable and C-Star has no requeue-on-preemption handling; a preempted step simply fails.
- The unparseable-walltime fallback lives in `format_walltime` (scheduler-reported values only); `parse_walltime` still raises `ValueError`, keeping user-configured `LocalComputeSpec` walltimes strict.
- Max walltimes for the new partitions are queried live via `sinfo` like the existing Bouchet queues, so no walltimes are hardcoded.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing
