### PR TITLE
Inspect cpus-per-node, set nodes=1 when appropriate

### DIFF
--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -378,6 +378,9 @@ def create_scheduler_job(
         The number of CPUs per node to request. Defaults to None.
         If not provided and a specific nodes x cpus distribution is required,
         C-Star will attempt to calculate an appropriate number of nodes.
+        On systems that do not require an explicit distribution, this value is
+        used as the assumed per-node CPU capacity when calculating the minimum
+        node count (e.g. to target a partition's larger node types).
     script_path : str or Path, optional
         The file path to save the job script. Defaults to the current directory with
         an auto-generated name.
@@ -663,6 +666,29 @@ class SchedulerJob(ExecutionHandler, ABC):
             )
             self._cpus_per_node = ncpus
             self._nodes = nnodes
+        elif nodes is None:  # scheduler does not require a task distribution
+            # Without a node count the scheduler is free to scatter tasks across
+            # nodes, which strands non-MPI (single-process) steps on a fraction
+            # of their CPUs; pin the minimum node count so jobs that fit on one
+            # node stay on one node. A user-supplied `cpus_per_node` overrides
+            # the queried per-node capacity (e.g. to target a partition's
+            # larger node types).
+            capacity = (
+                cpus_per_node
+                or self.queue.max_cpus_per_node
+                or scheduler.global_max_cpus_per_node
+            )
+            self._cpus_per_node = cpus_per_node
+            if capacity:
+                self._nodes = ceil(cpus / capacity)
+            else:
+                self._nodes = None
+                self.log.warning(
+                    f"C-Star cannot determine the CPUs per node for queue "
+                    f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
+                    "submitting without a node count. The scheduler may spread "
+                    "this job's tasks across multiple nodes."
+                )
         else:
             self._cpus_per_node = cpus_per_node
             self._nodes = nodes
@@ -960,6 +986,13 @@ class SlurmJob(SchedulerJob):
             scheduler_script += f"\n#SBATCH --nodes={self.nodes}"
             scheduler_script += f"\n#SBATCH --ntasks-per-node={self.cpus_per_node}"
         else:
+            # a bare --ntasks lets SLURM scatter tasks across nodes; pin the
+            # node count whenever it is known (combined with --ntasks,
+            # --ntasks-per-node acts as a per-node ceiling)
+            if self.nodes is not None:
+                scheduler_script += f"\n#SBATCH --nodes={self.nodes}"
+            if self.cpus_per_node is not None:
+                scheduler_script += f"\n#SBATCH --ntasks-per-node={self.cpus_per_node}"
             scheduler_script += f"\n#SBATCH --ntasks={self.cpus}"
         if self.account_key:
             scheduler_script += f"\n#SBATCH --account={self.account_key}"

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -632,116 +632,9 @@ class SchedulerJob(ExecutionHandler, ABC):
                     + f"{self.queue.max_walltime}"
                 )
 
-        # Explicitly typing to avoid mypy confusion in conditional pathways below
-        self._cpus_per_node: int | None
-        self._nodes: int | None
-
-        if single_node:
-            # A single-process application (threads / local dask) can only use
-            # one node's worth of CPUs: pin the node count and clamp the
-            # request to the per-node capacity instead of spilling onto nodes
-            # the job would never touch. A user-supplied `cpus_per_node` is
-            # the capacity of record (e.g. to target a heterogeneous
-            # partition's larger node types).
-            if nodes is not None and nodes != 1:
-                raise ValueError(
-                    f"Cannot create scheduler job: 'single_node' is set but "
-                    f"nodes={nodes} was requested. A single-node job must use "
-                    "nodes=1 (or leave 'nodes' unset)."
-                )
-            capacity = (
-                cpus_per_node
-                or self.queue.max_cpus_per_node
-                or scheduler.global_max_cpus_per_node
-            )
-            if capacity is None:
-                self.log.warning(
-                    f"C-Star cannot determine the CPUs per node for queue "
-                    f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
-                    f"submitting the single-node job with all {cpus} requested "
-                    "CPUs on one node. The scheduler will reject the job if "
-                    "that exceeds a node's capacity."
-                )
-            elif cpus > capacity:
-                self.log.warning(
-                    f"Single-node job requested {cpus} CPUs but queue "
-                    f"{self._queue_name!r} provides {capacity} CPUs per node; "
-                    f"clamping the request to {capacity}."
-                )
-                self._cpus = capacity
-            self._nodes = 1
-            # a per-node ceiling equal to the total keeps every task on the
-            # one node (and is required where a distribution is mandatory)
-            self._cpus_per_node = self._cpus
-        elif (
-            (nodes is None)
-            and (cpus_per_node is not None)
-            and (scheduler.requires_task_distribution)
-        ):
-            self._nodes = ceil(cpus / cpus_per_node)
-            self._cpus_per_node = cpus_per_node
-        elif (
-            (nodes is not None)
-            and (cpus_per_node is None)
-            and (scheduler.requires_task_distribution)
-        ):
-            self._nodes = nodes
-            self._cpus_per_node = int(cpus / nodes)
-        elif (
-            (nodes is None)
-            and (cpus_per_node is None)
-            and (scheduler.requires_task_distribution)
-        ):
-            if scheduler.global_max_cpus_per_node is None:
-                raise OSError(
-                    "You attempted to create a scheduler job without 'nodes', and "
-                    + "'cpus_per_node' parameters, but your scheduler explicitly "
-                    + "requires a task distribution. C-Star is unable to determine "
-                    + "your system's CPUs per node automatically and cannot continue"
-                )
-
-            nnodes, ncpus = self._calculate_node_distribution(
-                cpus, scheduler.global_max_cpus_per_node
-            )
-            self.log.warning(
-                (
-                    "Attempting to create scheduler job without 'nodes' and 'cpus_per_node' "
-                    + "parameters, but your system requires an explicitly specified task distribution."
-                    + "\n C-Star will attempt "
-                    + f"\nto use a distribution of {nnodes} nodes with {ncpus} CPUs each, "
-                    + "\nbased on your system maximum of "
-                    + f"{scheduler.global_max_cpus_per_node} CPUS per node "
-                    + f"\nand your job requirement of {cpus} CPUS."
-                ),
-            )
-            self._cpus_per_node = ncpus
-            self._nodes = nnodes
-        elif nodes is None:  # scheduler does not require a task distribution
-            # Without a node count the scheduler is free to scatter tasks across
-            # nodes, which strands non-MPI (single-process) steps on a fraction
-            # of their CPUs; pin the minimum node count so jobs that fit on one
-            # node stay on one node. A user-supplied `cpus_per_node` overrides
-            # the queried per-node capacity (e.g. to target a partition's
-            # larger node types).
-            capacity = (
-                cpus_per_node
-                or self.queue.max_cpus_per_node
-                or scheduler.global_max_cpus_per_node
-            )
-            self._cpus_per_node = cpus_per_node
-            if capacity:
-                self._nodes = ceil(cpus / capacity)
-            else:
-                self._nodes = None
-                self.log.warning(
-                    f"C-Star cannot determine the CPUs per node for queue "
-                    f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
-                    "submitting without a node count. The scheduler may spread "
-                    "this job's tasks across multiple nodes."
-                )
-        else:
-            self._cpus_per_node = cpus_per_node
-            self._nodes = nodes
+        self._cpus, self._nodes, self._cpus_per_node = self._resolve_distribution(
+            cpus, nodes, cpus_per_node, single_node
+        )
 
         self._account_key = account_key
         self._id: int | None = None
@@ -889,6 +782,138 @@ class SchedulerJob(ExecutionHandler, ABC):
             An enumeration value representing the current status of the job.
         """
         pass
+
+    def _per_node_capacity(self, cpus_per_node: int | None) -> int | None:
+        """The CPUs per node to plan against: a user-supplied `cpus_per_node`
+        (e.g. to target a heterogeneous partition's larger node types), else the
+        queue's own value, else the scheduler-wide maximum. `None` when unknown.
+        """
+        return (
+            cpus_per_node
+            or self.queue.max_cpus_per_node
+            or self._scheduler.global_max_cpus_per_node
+            or None
+        )
+
+    def _resolve_distribution(
+        self,
+        cpus: int,
+        nodes: int | None,
+        cpus_per_node: int | None,
+        single_node: bool,
+    ) -> tuple[int, int | None, int | None]:
+        """Settle the job's (cpus, nodes, cpus_per_node) request.
+
+        Three regimes, in order of precedence:
+
+        1. `single_node`: pin to one node and clamp `cpus` to the per-node capacity.
+        2. An explicit `nodes` count is honored as-is; where the scheduler requires
+           a task distribution and `cpus_per_node` is missing, it is derived.
+        3. No `nodes` count: derive the minimum node count from the per-node
+           capacity so jobs that fit on one node stay on one node.
+
+        Returns
+        -------
+        tuple[int, int | None, int | None]
+            The (possibly clamped) cpus, node count, and cpus per node to request.
+        """
+        if single_node:
+            return self._single_node_distribution(cpus, nodes, cpus_per_node)
+
+        if nodes is not None:
+            if cpus_per_node is None and self._scheduler.requires_task_distribution:
+                cpus_per_node = int(cpus / nodes)
+            return cpus, nodes, cpus_per_node
+
+        if self._scheduler.requires_task_distribution:
+            if cpus_per_node is not None:
+                return cpus, ceil(cpus / cpus_per_node), cpus_per_node
+            return self._mandatory_distribution(cpus)
+
+        # Without a node count the scheduler is free to scatter tasks across
+        # nodes, which strands non-MPI (single-process) steps on a fraction
+        # of their CPUs; pin the minimum node count whenever capacity is known.
+        capacity = self._per_node_capacity(cpus_per_node)
+        if capacity is None:
+            self.log.warning(
+                f"C-Star cannot determine the CPUs per node for queue "
+                f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
+                "submitting without a node count. The scheduler may spread "
+                "this job's tasks across multiple nodes."
+            )
+            return cpus, None, cpus_per_node
+        return cpus, ceil(cpus / capacity), cpus_per_node
+
+    def _single_node_distribution(
+        self, cpus: int, nodes: int | None, cpus_per_node: int | None
+    ) -> tuple[int, int, int]:
+        """Distribution for a single-process application (threads / local dask):
+        one node, with the cpu request clamped to that node's capacity instead
+        of spilling onto nodes the job would never touch.
+
+        Raises
+        ------
+        ValueError
+            If a node count other than 1 was requested.
+        """
+        if nodes is not None and nodes != 1:
+            raise ValueError(
+                f"Cannot create scheduler job: 'single_node' is set but "
+                f"nodes={nodes} was requested. A single-node job must use "
+                "nodes=1 (or leave 'nodes' unset)."
+            )
+        capacity = self._per_node_capacity(cpus_per_node)
+        if capacity is None:
+            self.log.warning(
+                f"C-Star cannot determine the CPUs per node for queue "
+                f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
+                f"submitting the single-node job with all {cpus} requested "
+                "CPUs on one node. The scheduler will reject the job if "
+                "that exceeds a node's capacity."
+            )
+        elif cpus > capacity:
+            self.log.warning(
+                f"Single-node job requested {cpus} CPUs but queue "
+                f"{self._queue_name!r} provides {capacity} CPUs per node; "
+                f"clamping the request to {capacity}."
+            )
+            cpus = capacity
+        # a per-node ceiling equal to the total keeps every task on the one
+        # node (and is required where a distribution is mandatory)
+        return cpus, 1, cpus
+
+    def _mandatory_distribution(self, cpus: int) -> tuple[int, int, int]:
+        """Distribution when the scheduler requires an explicit nodes x cpus
+        layout but neither was supplied: spread `cpus` evenly over the fewest
+        nodes the system maximum allows.
+
+        Raises
+        ------
+        EnvironmentError
+            If the system's CPUs per node cannot be determined.
+        """
+        max_cpus = self._scheduler.global_max_cpus_per_node
+        if max_cpus is None:
+            raise OSError(
+                "You attempted to create a scheduler job without 'nodes', and "
+                + "'cpus_per_node' parameters, but your scheduler explicitly "
+                + "requires a task distribution. C-Star is unable to determine "
+                + "your system's CPUs per node automatically and cannot continue"
+            )
+
+        nnodes, ncpus = self._calculate_node_distribution(cpus, max_cpus)
+        self.log.warning(
+            (
+                "Attempting to create scheduler job without 'nodes' and 'cpus_per_node' "
+                + "parameters, but your system requires an explicitly specified task distribution."
+                + "\n C-Star will attempt "
+                + f"\nto use a distribution of {nnodes} nodes with {ncpus} CPUs each, "
+                + "\nbased on your system maximum of "
+                + f"{max_cpus} CPUS per node "
+                + f"\nand your job requirement of {cpus} CPUS."
+            ),
+        )
+        return cpus, nnodes, ncpus
 
     def _calculate_node_distribution(
         self, n_cores_required: int, tot_cores_per_node: int

--- a/cstar/execution/scheduler_job.py
+++ b/cstar/execution/scheduler_job.py
@@ -350,6 +350,7 @@ def create_scheduler_job(
     cpus: int,
     nodes: int | None = None,
     cpus_per_node: int | None = None,
+    single_node: bool = False,
     script_path: str | Path | None = None,
     run_path: str | Path | None = None,
     job_name: str | None = None,
@@ -381,6 +382,10 @@ def create_scheduler_job(
         On systems that do not require an explicit distribution, this value is
         used as the assumed per-node CPU capacity when calculating the minimum
         node count (e.g. to target a partition's larger node types).
+    single_node : bool, optional
+        Whether the job is confined to one node. When `True`, `nodes` is pinned
+        to 1 and `cpus` is clamped to the per-node capacity (`cpus_per_node`,
+        else the queue's CPUs per node, else the system maximum). Defaults to False.
     script_path : str or Path, optional
         The file path to save the job script. Defaults to the current directory with
         an auto-generated name.
@@ -426,6 +431,7 @@ def create_scheduler_job(
         cpus=cpus,
         nodes=nodes,
         cpus_per_node=cpus_per_node,
+        single_node=single_node,
         account_key=account_key,
         script_path=script_path,
         run_path=run_path,
@@ -502,6 +508,7 @@ class SchedulerJob(ExecutionHandler, ABC):
         cpus: int,
         nodes: int | None = None,
         cpus_per_node: int | None = None,
+        single_node: bool = False,
         script_path: str | Path | None = None,
         run_path: str | Path | None = None,
         job_name: str | None = None,
@@ -531,6 +538,11 @@ class SchedulerJob(ExecutionHandler, ABC):
             The number of CPUs per node to request. If not provided and a specific nodes x CPUs
             distribution is required, C-Star will attempt to calculate an appropriate
             number of CPUs per node.
+        single_node : bool, optional
+            Whether the job is confined to one node (a single-process application
+            rather than an MPI job). When `True`, the node count is pinned to 1 and
+            `cpus` is clamped to the per-node capacity: `cpus_per_node` if given,
+            else the queue's CPUs per node, else the system maximum. Defaults to False.
         script_path : str or Path, optional
             The file path to save the job script. Defaults to the current directory with
             an auto-generated name.
@@ -556,7 +568,8 @@ class SchedulerJob(ExecutionHandler, ABC):
         ------
         ValueError
             If no walltime is provided and the queue's maximum walltime is unavailable, or
-            if the provided walltime exceeds the queue's maximum allowed walltime.
+            if the provided walltime exceeds the queue's maximum allowed walltime, or if
+            `single_node` is set alongside a `nodes` count other than 1.
         EnvironmentError
             If neither `nodes` nor `cpus_per_node` are provided and the scheduler cannot
             determine the system's CPUs per node automatically.
@@ -623,7 +636,44 @@ class SchedulerJob(ExecutionHandler, ABC):
         self._cpus_per_node: int | None
         self._nodes: int | None
 
-        if (
+        if single_node:
+            # A single-process application (threads / local dask) can only use
+            # one node's worth of CPUs: pin the node count and clamp the
+            # request to the per-node capacity instead of spilling onto nodes
+            # the job would never touch. A user-supplied `cpus_per_node` is
+            # the capacity of record (e.g. to target a heterogeneous
+            # partition's larger node types).
+            if nodes is not None and nodes != 1:
+                raise ValueError(
+                    f"Cannot create scheduler job: 'single_node' is set but "
+                    f"nodes={nodes} was requested. A single-node job must use "
+                    "nodes=1 (or leave 'nodes' unset)."
+                )
+            capacity = (
+                cpus_per_node
+                or self.queue.max_cpus_per_node
+                or scheduler.global_max_cpus_per_node
+            )
+            if capacity is None:
+                self.log.warning(
+                    f"C-Star cannot determine the CPUs per node for queue "
+                    f"{self._queue_name!r} and no 'cpus_per_node' was provided; "
+                    f"submitting the single-node job with all {cpus} requested "
+                    "CPUs on one node. The scheduler will reject the job if "
+                    "that exceeds a node's capacity."
+                )
+            elif cpus > capacity:
+                self.log.warning(
+                    f"Single-node job requested {cpus} CPUs but queue "
+                    f"{self._queue_name!r} provides {capacity} CPUs per node; "
+                    f"clamping the request to {capacity}."
+                )
+                self._cpus = capacity
+            self._nodes = 1
+            # a per-node ceiling equal to the total keeps every task on the
+            # one node (and is required where a distribution is mandatory)
+            self._cpus_per_node = self._cpus
+        elif (
             (nodes is None)
             and (cpus_per_node is not None)
             and (scheduler.requires_task_distribution)

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import typing as t
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from cstar.base.adapter import ConfiguredModelAdapter, CstarAdaptationError
 from cstar.base.env import (
@@ -73,6 +73,20 @@ class SlurmComputeSpec(BaseModel):
 
     model_config: t.ClassVar[ConfigDict] = ConfigDict(str_strip_whitespace=True)
     """Configure model to ignore empty strings."""
+
+    @model_validator(mode="after")
+    def _single_node_needs_one_node(self) -> "SlurmComputeSpec":
+        """Reject a `single_node` spec that also asks for more than one node, so
+        the contradiction surfaces when the workplan is checked rather than at
+        submission.
+        """
+        if self.single_node and self.num_nodes is not None and self.num_nodes != 1:
+            msg = (
+                f"single_node is set but num_nodes={self.num_nodes}; a single-node "
+                "job must use num_nodes=1 (or leave num_nodes unset)"
+            )
+            raise ValueError(msg)
+        return self
 
     @property
     def environment(self) -> dict[str, str]:

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -46,9 +46,17 @@ class SlurmComputeSpec(BaseModel):
     num_cpus: int = Field(default=1)
     """Total number of CPUs required by the job."""
     num_nodes: int | None = None
-    """The number of nodes to request."""
+    """The number of nodes to request.
+
+    When unset, C-Star derives the minimum node count from the queue's CPUs
+    per node so jobs that fit on one node stay on one node.
+    """
     cpus_per_node: int | None = None
-    """The number of CPUs to request per node."""
+    """The number of CPUs to request per node.
+
+    Also used as the assumed per-node capacity when deriving the node count,
+    e.g. to target a partition's larger node types instead of its smallest.
+    """
     max_walltime: str = Field(default="", pattern=WALLTIME_RE)
     """The maximum walltime for the job in the format `HH:MM:SS`."""
     queue_name: str = ""

--- a/cstar/orchestration/launch/slurm.py
+++ b/cstar/orchestration/launch/slurm.py
@@ -57,6 +57,13 @@ class SlurmComputeSpec(BaseModel):
     Also used as the assumed per-node capacity when deriving the node count,
     e.g. to target a partition's larger node types instead of its smallest.
     """
+    single_node: bool = False
+    """Whether the job is confined to a single node.
+
+    Set from the blueprint's `single_node` at schedule time. The job is pinned
+    to one node and `num_cpus` is clamped to the queue's CPUs per node rather
+    than spilling onto nodes a single-process application cannot use.
+    """
     max_walltime: str = Field(default="", pattern=WALLTIME_RE)
     """The maximum walltime for the job in the format `HH:MM:SS`."""
     queue_name: str = ""
@@ -277,6 +284,7 @@ class SlurmLauncher(Launcher[SlurmHandle]):
             cpus=compute.num_cpus,
             nodes=compute.num_nodes,
             cpus_per_node=compute.cpus_per_node,
+            single_node=compute.single_node,
             script_path=step.script_path,
             run_path=step.script_path.parent,
             job_name=step.safe_name,

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -208,6 +208,20 @@ class Blueprint(ConfiguredBaseModel, ABC):
         """
         return 1
 
+    @property
+    def single_node(self) -> bool:
+        """Whether this blueprint's work is confined to a single node.
+
+        `True` marks an application that runs as one process (threads, or a
+        local dask scheduler) rather than an MPI job, so its CPU requirement
+        cannot usefully span nodes. The scheduler launcher then pins the job
+        to one node and clamps `cpus_needed` to the target queue's CPUs per
+        node instead of requesting additional nodes it could never use.
+
+        Defaults to `False`. Can be overridden by subclasses.
+        """
+        return False
+
     @field_validator("working_dir", mode="after")
     @classmethod
     def _resolve_out_dir(

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -518,7 +518,11 @@ class WorkplanTransformer(LoggingMixin):
                     # children have materialized blueprints (overrides already
                     # baked in); record their cpu requirement directly
                     transformed_steps.extend(
-                        _inject_cpus(child, child.blueprint.cpus_needed)
+                        _inject_cpus(
+                            child,
+                            child.blueprint.cpus_needed,
+                            single_node=child.blueprint.single_node,
+                        )
                         for child in overridden_steps
                     )
             else:
@@ -741,14 +745,17 @@ def preflight_overrides(step: LiveStep) -> LiveStep:
         step.blueprint, dict(step.blueprint_overrides)
     )
 
-    return _inject_cpus(step, merged.cpus_needed)
+    return _inject_cpus(step, merged.cpus_needed, single_node=merged.single_node)
 
 
-def _inject_cpus(step: LiveStep, cpus: int) -> LiveStep:
+def _inject_cpus(step: LiveStep, cpus: int, single_node: bool = False) -> LiveStep:
     """Record a step's cpu requirement in its `compute_overrides`.
 
     Declared values win; the requirement is injected only when
-    `["slurm"]["num_cpus"]` is absent.
+    `["slurm"]["num_cpus"]` is absent. When the blueprint declares itself
+    `single_node`, that is recorded alongside as `["slurm"]["single_node"]`
+    so the launcher can clamp the cpu count to one node's capacity without
+    reading the blueprint.
 
     Parameters
     ----------
@@ -756,6 +763,10 @@ def _inject_cpus(step: LiveStep, cpus: int) -> LiveStep:
         The step to enrich.
     cpus : int
         The cpu requirement read from the step's blueprint.
+    single_node : bool, optional
+        Whether the blueprint confines its work to one node. Only recorded
+        when `True`; a `False` value leaves the overrides untouched so that
+        an explicitly declared `single_node` is never overwritten.
 
     Returns
     -------
@@ -775,8 +786,12 @@ def _inject_cpus(step: LiveStep, cpus: int) -> LiveStep:
         )
         raise CstarExpectationFailed(msg)
 
+    injected: dict[str, t.Any] = {"num_cpus": cpus}
+    if single_node:
+        injected["single_node"] = True
+
     new_overrides = deep_merge(
-        {"slurm": {"num_cpus": cpus}},
+        {"slurm": injected},
         dict(step.compute_overrides),
     )
     return LiveStep.from_step(step, update={"compute_overrides": new_overrides})

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -1,3 +1,4 @@
+import functools
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -105,11 +106,45 @@ def query_max_walltime_via_sinfo(name: str) -> str | None:
     return format_walltime(mw) if mw else None
 
 
+@functools.cache
+def _cpus_per_node_via_sinfo(name: str) -> int:
+    """Query sinfo for the partition's CPUs per node (smallest node type).
+
+    Cached per partition name: the value is static hardware information and
+    every scheduler job would otherwise re-run the query. Only successful
+    lookups are cached -- `functools.cache` does not memoize exceptions, so a
+    transient failure is retried on the next call rather than pinned.
+
+    Raises
+    ------
+    LookupError
+        If sinfo returns nothing or its output cannot be parsed.
+    """
+    sp_cmd = f"sinfo --noheader --format='%c' --partition={name}"
+    stdout = _run_cmd(sp_cmd)
+    if not stdout:
+        raise LookupError(f"sinfo reported no CPUs per node for partition {name!r}")
+    try:
+        return min(
+            int(line.strip().rstrip("+"))
+            for line in stdout.splitlines()
+            if line.strip()
+        )
+    except ValueError as ex:
+        log.warning(
+            f"Cannot parse CPUs per node {stdout!r} for partition {name!r}; "
+            "treating the value as unknown."
+        )
+        raise LookupError(f"unparseable CPUs per node for partition {name!r}") from ex
+
+
 def query_max_cpus_per_node_via_sinfo(name: str) -> int | None:
     """Retrieve the CPUs per node for the SLURM partition via sinfo.
 
     A heterogeneous partition reports one value per node type; the smallest is
-    returned so node counts derived from it are always satisfiable.
+    returned so node counts derived from it are always satisfiable. Successful
+    lookups are cached for the life of the process (see
+    `_cpus_per_node_via_sinfo`); unknown results are not.
 
     Returns
     -------
@@ -117,21 +152,9 @@ def query_max_cpus_per_node_via_sinfo(name: str) -> int | None:
         The number of CPUs per node on the partition's smallest node type, or
         `None` if the value cannot be determined.
     """
-    sp_cmd = f"sinfo --noheader --format='%c' --partition={name}"
-    stdout = _run_cmd(sp_cmd)
-    if not stdout:
-        return None
     try:
-        return min(
-            int(line.strip().rstrip("+"))
-            for line in stdout.splitlines()
-            if line.strip()
-        )
-    except ValueError:
-        log.warning(
-            f"Cannot parse CPUs per node {stdout!r} for partition {name!r}; "
-            "treating the value as unknown."
-        )
+        return _cpus_per_node_via_sinfo(name)
+    except LookupError:
         return None
 
 

--- a/cstar/system/scheduler.py
+++ b/cstar/system/scheduler.py
@@ -105,6 +105,36 @@ def query_max_walltime_via_sinfo(name: str) -> str | None:
     return format_walltime(mw) if mw else None
 
 
+def query_max_cpus_per_node_via_sinfo(name: str) -> int | None:
+    """Retrieve the CPUs per node for the SLURM partition via sinfo.
+
+    A heterogeneous partition reports one value per node type; the smallest is
+    returned so node counts derived from it are always satisfiable.
+
+    Returns
+    -------
+    int or None
+        The number of CPUs per node on the partition's smallest node type, or
+        `None` if the value cannot be determined.
+    """
+    sp_cmd = f"sinfo --noheader --format='%c' --partition={name}"
+    stdout = _run_cmd(sp_cmd)
+    if not stdout:
+        return None
+    try:
+        return min(
+            int(line.strip().rstrip("+"))
+            for line in stdout.splitlines()
+            if line.strip()
+        )
+    except ValueError:
+        log.warning(
+            f"Cannot parse CPUs per node {stdout!r} for partition {name!r}; "
+            "treating the value as unknown."
+        )
+        return None
+
+
 def query_max_walltime_via_sacctmgr(name: str) -> str | None:
     """Retrieve the maximum walltime using sacctmgr.
 
@@ -180,6 +210,11 @@ class Queue(ABC):
         fn = self._max_walltime_method or self._default_max_walltime_method
         return fn(self.query_name)
 
+    @property
+    def max_cpus_per_node(self) -> int | None:
+        """Return the number of CPUs available per node on the queue, when known."""
+        return None
+
 
 class SlurmQueue(Queue, ABC):
     """Abstract base class for SLURM queues.
@@ -254,6 +289,11 @@ class SlurmPartition(SlurmQueue):
     @property
     def _default_max_walltime_method(self) -> Callable[[str], str | None]:
         return query_max_walltime_via_sinfo
+
+    @property
+    def max_cpus_per_node(self) -> int | None:
+        """CPUs per node on this partition's smallest node type, from sinfo."""
+        return query_max_cpus_per_node_via_sinfo(self.query_name)
 
 
 class PBSQueue(Queue):

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -83,7 +83,7 @@ class MockScheduler(Scheduler):
 
     def get_queue(self, name: str | None):
         # Return a mocked queue with default properties
-        return MagicMock(name=name, max_walltime="02:00:00")
+        return MagicMock(name=name, max_walltime="02:00:00", max_cpus_per_node=None)
 
     @property
     def global_max_cpus_per_node(self) -> int | None:
@@ -388,25 +388,21 @@ class TestSchedulerJobBase:
         "nodes, cpus_per_node, expected_nodes, expected_cpus_per_node",
         [
             (3, 8, 3, 8),  # Both provided as integers
-            (None, 8, None, 8),  # Only cpus_per_node provided
+            (None, 8, 1, 8),  # Only cpus_per_node provided: acts as capacity
             (3, None, 3, None),  # Only nodes provided
-            (None, None, None, None),  # Neither provided
+            (None, None, 1, None),  # Neither provided: capacity from scheduler (64)
         ],
     )
     def test_init_cpus_without_distribution_requirement(
         self, nodes, cpus_per_node, expected_nodes, expected_cpus_per_node
     ):
-        """Confirms that task distribution is skipped when the scheduler does not
-        require explicit task distribution.
+        """Confirms node derivation when the scheduler does not require an explicit
+        task distribution.
 
-        This test uses a parameterization to evaluate different combinations of
-        `nodes` and `cpus_per_node`, ensuring that these attributes are assigned
-        directly without calculations when `requires_task_distribution` is `False`.
-
-        For example, if `requires_task_distribution` is True and the user provides
-        cpus=16 and cpus_per_node=4, C-Star will set `nodes=4` automatically. If
-        `requires_task_distribution` is False, nodes will be set to `None`, and only
-        `cpus` will be submitted to the Scheduler.
+        Even when a distribution is not required, C-Star pins the minimum node
+        count (so jobs that fit on one node are not scattered across several),
+        deriving it from a user-supplied `cpus_per_node` or the system's CPUs
+        per node. Explicitly provided values are assigned directly.
 
         Mocks
         -----
@@ -415,8 +411,8 @@ class TestSchedulerJobBase:
 
         Asserts
         -------
-        - That the `nodes` attribute matches the provided or expected value.
-        - That the `cpus_per_node` attribute matches the provided or expected value.
+        - That the `nodes` attribute matches the provided or derived value.
+        - That the `cpus_per_node` attribute matches the provided value.
         """
         params = self.common_job_params.copy()
         scheduler = MockScheduler()
@@ -434,6 +430,29 @@ class TestSchedulerJobBase:
         # Ensure nodes and cpus_per_node are correctly assigned
         assert job.nodes == expected_nodes
         assert job.cpus_per_node == expected_cpus_per_node
+
+    def test_init_without_distribution_requirement_unknown_capacity(self, caplog):
+        """Confirms the job is created without a node count, with a warning, when the
+        scheduler does not require a task distribution and the CPUs per node cannot
+        be determined from any source.
+        """
+        params = self.common_job_params.copy()
+        scheduler = MockScheduler()
+        scheduler.requires_task_distribution = False
+        params.update({"scheduler": scheduler, "nodes": None})
+
+        with patch.object(
+            MockScheduler,
+            "global_max_cpus_per_node",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            job = MockSchedulerJob(**params)
+
+        caplog.set_level(logging.INFO, logger=job.log.name)
+        assert job.nodes is None
+        assert job.cpus_per_node is None
+        assert "C-Star cannot determine the CPUs per node" in caplog.text
 
 
 ##

--- a/cstar/tests/unit_tests/execution/test_scheduler_job.py
+++ b/cstar/tests/unit_tests/execution/test_scheduler_job.py
@@ -384,6 +384,130 @@ class TestSchedulerJobBase:
             in caplog.text
         )
 
+    @pytest.mark.parametrize("requires_distribution", [True, False])
+    def test_init_single_node_clamps_cpus_to_capacity(
+        self, caplog, requires_distribution
+    ):
+        """A `single_node` job is pinned to one node and its cpu request is clamped
+        to the per-node capacity (here the scheduler-wide 64), whether or not the
+        scheduler requires an explicit task distribution.
+        """
+        params = self.common_job_params.copy()
+        scheduler = MockScheduler()
+        scheduler.requires_task_distribution = requires_distribution
+        params.update(
+            {
+                "scheduler": scheduler,
+                "nodes": None,
+                "cpus_per_node": None,
+                "cpus": 128,
+                "single_node": True,
+            }
+        )
+        job = MockSchedulerJob(**params)
+        caplog.set_level(logging.INFO, logger=job.log.name)
+
+        assert job.nodes == 1
+        assert job.cpus == 64
+        assert job.cpus_per_node == 64
+        assert "clamping the request to 64" in caplog.text
+
+    def test_init_single_node_within_capacity_keeps_cpus(self):
+        """A `single_node` request that already fits on one node is pinned to one
+        node and otherwise passed through unchanged.
+        """
+        params = self.common_job_params | {
+            "nodes": None,
+            "cpus_per_node": None,
+            "cpus": 40,
+            "single_node": True,
+        }
+        job = MockSchedulerJob(**params)
+
+        assert job.nodes == 1
+        assert job.cpus == 40
+        assert job.cpus_per_node == 40
+
+    def test_init_single_node_prefers_queue_capacity(self):
+        """The queue's own CPUs per node wins over the scheduler-wide value when
+        clamping a `single_node` request.
+        """
+        params = self.common_job_params.copy()
+        scheduler = MockScheduler()
+        scheduler.get_queue = lambda name=None: MagicMock(
+            name=name, max_walltime="02:00:00", max_cpus_per_node=48
+        )
+        params.update(
+            {
+                "scheduler": scheduler,
+                "nodes": None,
+                "cpus_per_node": None,
+                "cpus": 128,
+                "single_node": True,
+            }
+        )
+        job = MockSchedulerJob(**params)
+
+        assert job.nodes == 1
+        assert job.cpus == 48
+
+    def test_init_single_node_explicit_cpus_per_node_is_capacity(self):
+        """A user-supplied `cpus_per_node` is the capacity of record for a
+        `single_node` job, overriding the queried values.
+        """
+        params = self.common_job_params | {
+            "nodes": None,
+            "cpus_per_node": 96,
+            "cpus": 128,
+            "single_node": True,
+        }
+        job = MockSchedulerJob(**params)
+
+        assert job.nodes == 1
+        assert job.cpus == 96
+        assert job.cpus_per_node == 96
+
+    def test_init_single_node_unknown_capacity_warns(self, caplog):
+        """When no per-node capacity can be determined, a `single_node` job is still
+        pinned to one node with its full request, and a warning is logged.
+        """
+        params = self.common_job_params.copy()
+        scheduler = MockScheduler()
+        with patch.object(
+            type(scheduler),
+            "global_max_cpus_per_node",
+            new_callable=PropertyMock,
+            return_value=None,
+        ):
+            params.update(
+                {
+                    "scheduler": scheduler,
+                    "nodes": None,
+                    "cpus_per_node": None,
+                    "cpus": 128,
+                    "single_node": True,
+                }
+            )
+            job = MockSchedulerJob(**params)
+            caplog.set_level(logging.INFO, logger=job.log.name)
+
+        assert job.nodes == 1
+        assert job.cpus == 128
+        assert "cannot determine the CPUs per node" in caplog.text
+
+    def test_init_single_node_rejects_multiple_nodes(self):
+        """Requesting more than one node for a `single_node` job is a contradiction
+        and fails loudly.
+        """
+        params = self.common_job_params | {
+            "nodes": 2,
+            "cpus_per_node": None,
+            "cpus": 128,
+            "single_node": True,
+        }
+        with pytest.raises(ValueError, match="'single_node' is set but nodes=2"):
+            MockSchedulerJob(**params)
+
     @pytest.mark.parametrize(
         "nodes, cpus_per_node, expected_nodes, expected_cpus_per_node",
         [

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -164,6 +164,32 @@ class TestSlurmJob:
             f"The SBATCH script is missing required content: {missing_content}"
         )
 
+    def test_script_single_node_clamps_to_queue_capacity(self):
+        """A `single_node` job that asks for more CPUs than the queue's nodes have
+        is pinned to one node with its request clamped to that capacity.
+        """
+        with patch.object(
+            type(self.mock_partition),
+            "max_cpus_per_node",
+            new_callable=PropertyMock,
+            return_value=8,
+        ):
+            self.scheduler.queues = [self.mock_partition]
+            job = SlurmJob(**self.common_job_params | {"cpus": 16, "single_node": True})
+
+        required_content = {
+            "#SBATCH --nodes=1",
+            "#SBATCH --ntasks-per-node=8",
+            "#SBATCH --ntasks=8",
+        }
+        actual_content = set(job.script.strip().split("\n"))
+        missing_content = ", ".join(list(required_content.difference(actual_content)))
+
+        assert not missing_content, (
+            f"The SBATCH script is missing required content: {missing_content}"
+        )
+        assert "#SBATCH --ntasks=16" not in job.script
+
     def test_script_task_distribution_not_required_queue_capacity(self):
         """Verifies the node count is derived from the queue's own CPUs per node when
         available, in preference to the scheduler-wide value.

--- a/cstar/tests/unit_tests/execution/test_slurm_job.py
+++ b/cstar/tests/unit_tests/execution/test_slurm_job.py
@@ -80,6 +80,7 @@ class TestSlurmJob:
             primary_queue_name="test_queue",
             other_scheduler_directives={"-mock_directive": "mock_value"},
             requires_task_distribution=False,
+            max_cpus_per_node=64,
         )
 
         # Define common job parameters
@@ -107,6 +108,9 @@ class TestSlurmJob:
     def test_script_task_distribution_not_required(self):
         """Verifies that the correct script is generated when the node x cpu breakdown
         is not required.
+
+        The node count is still pinned (derived from the system's CPUs per node) so
+        that jobs which fit on a single node are not scattered across several.
         """
         # Initialize the job
         job = SlurmJob(
@@ -118,6 +122,7 @@ class TestSlurmJob:
             "#SBATCH --job-name=test_job",
             "#SBATCH --output=/test/output.log",
             "#SBATCH --qos=test_queue",
+            "#SBATCH --nodes=1",
             "#SBATCH --ntasks=4",
             "#SBATCH --account=test_account",
             "#SBATCH --export=ALL",
@@ -134,6 +139,48 @@ class TestSlurmJob:
         assert not missing_content, (
             f"The SBATCH script is missing required content: {missing_content}"
         )
+        assert "#SBATCH --ntasks-per-node" not in job.script
+
+    def test_script_task_distribution_not_required_with_cpus_per_node(self):
+        """Verifies that a user-supplied `cpus_per_node` acts as the per-node capacity
+        when the node x cpu breakdown is not required.
+
+        This lets a user target a heterogeneous partition's larger node types: the
+        node count is derived from their value instead of the queue's smallest node,
+        and a matching per-node task ceiling is emitted.
+        """
+        params = self.common_job_params | {"cpus": 96, "cpus_per_node": 96}
+        job = SlurmJob(**params)
+
+        required_content = {
+            "#SBATCH --nodes=1",
+            "#SBATCH --ntasks-per-node=96",
+            "#SBATCH --ntasks=96",
+        }
+        actual_content = set(job.script.strip().split("\n"))
+        missing_content = ", ".join(list(required_content.difference(actual_content)))
+
+        assert not missing_content, (
+            f"The SBATCH script is missing required content: {missing_content}"
+        )
+
+    def test_script_task_distribution_not_required_queue_capacity(self):
+        """Verifies the node count is derived from the queue's own CPUs per node when
+        available, in preference to the scheduler-wide value.
+        """
+        with patch.object(
+            type(self.mock_partition),
+            "max_cpus_per_node",
+            new_callable=PropertyMock,
+            return_value=8,
+        ):
+            self.scheduler.queues = [self.mock_partition]
+            job = SlurmJob(**self.common_job_params | {"cpus": 16})
+
+        # queue capacity (8) wins over the scheduler-wide 64
+        assert job.nodes == 2
+        assert "#SBATCH --nodes=2" in job.script
+        assert "#SBATCH --ntasks=16" in job.script
 
     @pytest.mark.filterwarnings(
         r"ignore:.* Attempting to create scheduler job.*:UserWarning"

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
 from cstar.base.exceptions import BlueprintDeferredError, CstarError
-from cstar.orchestration.launch.slurm import SlurmLauncher
+from cstar.orchestration.launch.slurm import SlurmComputeSpec, SlurmLauncher
 from cstar.orchestration.orchestration import LiveStep, Workplan
 from cstar.orchestration.serialization import deserialize
 from cstar.orchestration.utils import (
@@ -360,6 +361,37 @@ def test_compute_spec_invalid_overrides_fail_loudly(
     step = LiveStep.from_step(
         deferred_live_step,
         update={"compute_overrides": {"slurm": {"max_walltime": "not-a-walltime"}}},
+    )
+
+    with pytest.raises(CstarError):
+        _ = SlurmLauncher._get_compute_spec(step)  # type: ignore
+
+
+def test_compute_spec_single_node_rejects_multiple_nodes() -> None:
+    """A `single_node` spec that also asks for more than one node is contradictory
+    and is rejected by the spec itself, before any job is built.
+    """
+    with pytest.raises(ValidationError, match="single_node is set but num_nodes=2"):
+        SlurmComputeSpec(num_cpus=64, num_nodes=2, single_node=True)
+
+    # one node, or an unset node count, is consistent
+    assert SlurmComputeSpec(num_cpus=64, num_nodes=1, single_node=True).num_nodes == 1
+    assert SlurmComputeSpec(num_cpus=64, single_node=True).num_nodes is None
+
+
+def test_compute_spec_single_node_multiple_nodes_fails_loudly(
+    deferred_live_step: LiveStep,
+) -> None:
+    """The contradiction surfaces through the launcher's compute-spec adaptation as
+    a `CstarError`, aborting submission rather than falling back to defaults.
+    """
+    step = LiveStep.from_step(
+        deferred_live_step,
+        update={
+            "compute_overrides": {
+                "slurm": {"num_cpus": 64, "num_nodes": 2, "single_node": True}
+            }
+        },
     )
 
     with pytest.raises(CstarError):

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -17,8 +17,18 @@ from cstar.orchestration.utils import (
 from cstar.system.scheduler import SlurmPartition, SlurmScheduler
 
 
+class FakePartition(SlurmPartition):
+    """A partition that cannot be queried; per-node CPU capacity falls back to the
+    scheduler-wide value.
+    """
+
+    @property
+    def max_cpus_per_node(self) -> int | None:
+        return None
+
+
 def fake_get_queue(name: str = "fake-queue") -> t.Any:
-    return SlurmPartition(name, "cannot-query", lambda x: "48:00:00")
+    return FakePartition(name, "cannot-query", lambda x: "48:00:00")
 
 
 @pytest.mark.usefixtures("read_yaml_intercept")
@@ -68,8 +78,11 @@ def test_slurmlauncher_adapt_step_no_overrides(
     assert minimum_spec.queue_name == job.queue_name
     assert minimum_spec.max_walltime == job.walltime
 
-    # confirm default behaviors of `create_scheduler_job` for unspecified spec attributes
-    assert minimum_spec.num_nodes == job.nodes
+    # confirm default behaviors of `create_scheduler_job` for unspecified spec
+    # attributes: the node count is derived (1 cpu fits on one node), while
+    # cpus_per_node stays unset
+    assert minimum_spec.num_nodes is None
+    assert job.nodes == 1
     assert minimum_spec.cpus_per_node == job.cpus_per_node
 
 
@@ -91,7 +104,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
             "alt-q",
             "42:00:00",
             1,
-            None,
+            1,
             None,
             id="queue-name",
         ),
@@ -101,7 +114,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
             "default-q",
             "42:00:00",
             42,
-            None,
+            1,
             None,
             id="num-cpus",
         ),
@@ -121,7 +134,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
             "default-q",
             "01:00:00",
             1,
-            None,
+            1,
             None,
             id="walltime",
         ),
@@ -131,7 +144,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
             "default-q",
             "42:00:00",
             1,
-            None,
+            1,
             32,
             id="cpus-per-node",
         ),
@@ -141,7 +154,7 @@ def test_slurmlauncher_adapt_step_no_overrides(
             "default-q",
             "42:00:00",
             1,
-            None,
+            1,
             None,
             id="account-name",
         ),

--- a/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
+++ b/cstar/tests/unit_tests/orchestration/launch/slurm/test_slurmlauncher.py
@@ -87,6 +87,48 @@ def test_slurmlauncher_adapt_step_no_overrides(
 
 
 @pytest.mark.usefixtures("read_yaml_intercept")
+def test_slurmlauncher_adapt_step_single_node_clamps_cpus(
+    tmp_path: Path,
+    wp_templates_dir: Path,
+) -> None:
+    """A `single_node` compute override (recorded by the workplan transformer from
+    the blueprint) reaches the job: it is pinned to one node and its cpu request
+    is clamped to the per-node capacity instead of spilling onto a second node.
+    """
+    wp_path = wp_templates_dir / "single_step.yaml"
+    workplan = deserialize(wp_path, Workplan)
+    live_step = LiveStep.from_step(
+        workplan.steps[0],
+        update={"compute_overrides": {"slurm": {"num_cpus": 300, "single_node": True}}},
+    )
+
+    mock_mgr = mock.Mock()
+    mock_mgr.environment.package_root = tmp_path
+    mock_mgr.scheduler = SlurmScheduler(
+        queues=[fake_get_queue("default-q")],
+        primary_queue_name="default-q",
+        other_scheduler_directives={},
+        requires_task_distribution=False,
+        documentation="fake slurm scheduduler",
+        max_cpus_per_node=128,
+    )
+    mock_getsysmgr = mock.Mock(return_value=mock_mgr)
+
+    with (
+        mock.patch("cstar.execution.scheduler_job.get_sysmgr", mock_getsysmgr),
+        mock.patch.object(mock_mgr.scheduler, "get_queue", fake_get_queue),
+    ):
+        spec = SlurmLauncher._get_compute_spec(live_step)  # type: ignore
+        job = SlurmLauncher.adapt_step(live_step, [])
+
+    assert spec.single_node is True
+    assert spec.num_cpus == 300
+    assert job.nodes == 1
+    assert job.cpus == 128
+    assert job.cpus_per_node == 128
+
+
+@pytest.mark.usefixtures("read_yaml_intercept")
 @pytest.mark.parametrize(
     (
         "overrides",

--- a/cstar/tests/unit_tests/orchestration/test_hello_app.py
+++ b/cstar/tests/unit_tests/orchestration/test_hello_app.py
@@ -46,6 +46,7 @@ async def test_hello_world_blueprint_serialization(
     assert bp.description == "This blueprint says hello to a very nice guy"
     assert bp.state == "draft"
     assert bp.cpus_needed == 1  # until it's moved, cpus_needed is hardcoded
+    assert bp.single_node is False  # the Blueprint default; apps opt in
 
     persist_to = tmp_path / "hwserialized.yaml"
     assert serialize(persist_to, bp), "Failed to serialize blueprint"

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -1539,6 +1539,48 @@ def test_preflight_overrides_injects_cpus_needed(
     )
 
     assert compute_overrides["slurm"]["num_cpus"] == expected_cpus
+    # a blueprint that does not confine itself to one node records nothing
+    assert "single_node" not in compute_overrides["slurm"]
+
+
+def test_preflight_overrides_records_single_node(
+    hello_world_bp_path: Path,
+) -> None:
+    """Verify a blueprint declaring `single_node` has that recorded in its
+    step's `compute_overrides` alongside `num_cpus`, so the launcher can clamp
+    the request to one node without re-reading the blueprint.
+
+    Parameters
+    ----------
+    hello_world_bp_path : Path
+        Fixture returning the path to a hello-world blueprint file.
+    """
+    step = Step(
+        name="producer",
+        application="hello_world",
+        blueprint=hello_world_bp_path.as_posix(),
+    )
+    wp = Workplan(
+        name="single-node-workplan",
+        description="A workplan whose blueprint is confined to one node.",
+        steps=[step],
+    )
+
+    with mock.patch.object(
+        HelloWorldBlueprint,
+        "single_node",
+        new_callable=mock.PropertyMock,
+        return_value=True,
+    ):
+        transformed = WorkplanTransformer(wp).apply()
+
+    trx_step = t.cast("LiveStep", transformed.steps[0])
+    compute_overrides = t.cast(
+        "dict[str, dict[str, t.Any]]", trx_step.compute_overrides
+    )
+
+    assert compute_overrides["slurm"]["single_node"] is True
+    assert compute_overrides["slurm"]["num_cpus"] == 1
 
 
 def test_preflight_overrides_respects_declared_cpus(

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -585,6 +585,17 @@ def test_query_max_walltime_via_sinfo_unlimited() -> None:
         mock_sinfo.assert_called_once()
 
 
+@pytest.fixture
+def clear_cpus_per_node_cache() -> None:
+    """Reset the per-partition CPUs-per-node cache so parametrized cases that reuse
+    a partition name do not see each other's answers.
+    """
+    from cstar.system.scheduler import _cpus_per_node_via_sinfo
+
+    _cpus_per_node_via_sinfo.cache_clear()
+
+
+@pytest.mark.usefixtures("clear_cpus_per_node_cache")
 @pytest.mark.parametrize(
     ("sinfo_output", "expected"),
     [
@@ -608,6 +619,37 @@ def test_query_max_cpus_per_node_via_sinfo(
 
         assert result == expected
         mock_sinfo.assert_called_once()
+
+
+@pytest.mark.usefixtures("clear_cpus_per_node_cache")
+def test_query_max_cpus_per_node_via_sinfo_caches_successes_only() -> None:
+    """A successful lookup is cached per partition (sinfo runs once for repeated
+    queries), while an unknown result is retried on the next call rather than
+    pinned for the life of the process.
+    """
+    # a transient failure is not cached: the next call queries sinfo again
+    with patch(
+        "cstar.system.scheduler._run_cmd", MagicMock(return_value="")
+    ) as mock_sinfo:
+        assert query_max_cpus_per_node_via_sinfo("flaky-partition") is None
+        assert query_max_cpus_per_node_via_sinfo("flaky-partition") is None
+        assert mock_sinfo.call_count == 2
+
+    # a successful lookup is cached: repeated queries do not re-run sinfo
+    with patch(
+        "cstar.system.scheduler._run_cmd", MagicMock(return_value="64")
+    ) as mock_sinfo:
+        assert query_max_cpus_per_node_via_sinfo("flaky-partition") == 64
+        assert query_max_cpus_per_node_via_sinfo("flaky-partition") == 64
+        assert mock_sinfo.call_count == 1
+
+    # the cache is keyed by partition name
+    with patch(
+        "cstar.system.scheduler._run_cmd", MagicMock(return_value="128")
+    ) as mock_sinfo:
+        assert query_max_cpus_per_node_via_sinfo("other-partition") == 128
+        assert query_max_cpus_per_node_via_sinfo("flaky-partition") == 64
+        assert mock_sinfo.call_count == 1
 
 
 def test_query_max_walltime_via_sacctmgr() -> None:

--- a/cstar/tests/unit_tests/system/test_scheduler.py
+++ b/cstar/tests/unit_tests/system/test_scheduler.py
@@ -11,6 +11,7 @@ from cstar.system.scheduler import (
     SlurmQOS,
     SlurmScheduler,
     format_walltime,
+    query_max_cpus_per_node_via_sinfo,
     query_max_walltime_via_sacctmgr,
     query_max_walltime_via_sinfo,
 )
@@ -581,6 +582,31 @@ def test_query_max_walltime_via_sinfo_unlimited() -> None:
         result = query_max_walltime_via_sinfo("mock-partition-name")
 
         assert result is None
+        mock_sinfo.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("sinfo_output", "expected"),
+    [
+        pytest.param("64", 64, id="single node type"),
+        pytest.param("48\n128\n64", 48, id="heterogeneous partition returns min"),
+        pytest.param("64+", 64, id="grouped row suffix"),
+        pytest.param("", None, id="no output"),
+        pytest.param("garbage", None, id="unparseable output"),
+    ],
+)
+def test_query_max_cpus_per_node_via_sinfo(
+    sinfo_output: str, expected: int | None
+) -> None:
+    """Verify CPUs per node are parsed from sinfo output, taking the smallest node
+    type on a heterogeneous partition, and fall back to None when unavailable.
+    """
+    with patch(
+        "cstar.system.scheduler._run_cmd", MagicMock(return_value=sinfo_output)
+    ) as mock_sinfo:
+        result = query_max_cpus_per_node_via_sinfo("mock-partition-name")
+
+        assert result == expected
         mock_sinfo.assert_called_once()
 
 


### PR DESCRIPTION
# Summary

SLURM jobs that fit on one node are now kept on one node, and single-process applications can no longer request more CPUs than a node has. C-Star queries each partition's CPUs per node via `sinfo`, derives the minimum node count from it when no explicit node count is given, and pins `--nodes` in the batch script. A new `Blueprint.single_node` marker lets an application (e.g. cstar-forge's input generation, which runs as one dask process) declare that it can never span nodes: the launcher then pins the job to one node and clamps its CPU request to the target partition's per-node capacity instead of requesting extra nodes that would sit idle.

## Breaking Changes
- N/A

## New Features
- `Blueprint.single_node` (default `False`): a blueprint can declare that its work runs in a single process. The workplan transformer records this alongside the step's CPU requirement, and the SLURM launcher pins such a job to one node and clamps `num_cpus` to the queue's CPUs per node (a user-supplied `cpus_per_node` is treated as the capacity of record). A single-node job that also requests more than one node is rejected at job creation.
  - `SlurmComputeSpec.single_node` and a matching `single_node` argument on `create_scheduler_job` / `SchedulerJob`, so the marker can also be set directly in a step's `compute_overrides["slurm"]`.
- Per-partition CPU capacity: `SlurmPartition.max_cpus_per_node` queries `sinfo --format=%c` for the partition, returning the smallest node type's value on heterogeneous partitions so derived node counts are always satisfiable.

## Bug Fixes
- On systems that do not require an explicit task distribution, jobs were submitted with a bare `--ntasks`, leaving SLURM free to scatter tasks across nodes and stranding single-process steps on a fraction of their CPUs. The minimum node count is now derived from the partition's (or system's) CPUs per node and emitted as `--nodes`, with `--ntasks-per-node` added when a per-node capacity was supplied. When no capacity can be determined the job is submitted without a node count and a warning is logged.

## Improvements
- `cpus_per_node` on non-task-distribution systems now doubles as the assumed per-node capacity when deriving the node count, so a user can target a heterogeneous partition's larger node types.

## Miscellaneous
- N/A

## Notes for Reviewers
- The capacity fallback chain for a single-node job is `cpus_per_node` → partition `sinfo` value → scheduler-wide `global_max_cpus_per_node`. When all three are unknown, the job is pinned to one node with its full request and a warning is logged; SLURM will reject it if the request exceeds a node.
- The Bouchet system context still hardcodes `max_cpus_per_node=128`. That value is only the last-resort fallback above and is wrong for Bouchet's `mpi`/`bigmem` (64) and `day` (48-core smallest nodes) partitions; the per-partition `sinfo` query takes precedence, so this was left for a follow-up.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit suite: 1687 passed, 14 skipped, 2 xfailed; pre-commit incl. mypy clean on changed files)
