### PR TITLE
Bouchet fix

### DIFF
--- a/cstar/additional_files/lmod_lists/bouchet.lmod
+++ b/cstar/additional_files/lmod_lists/bouchet.lmod
@@ -1,2 +1,3 @@
 netCDF-Fortran/4.6.0-gompi-2022b
 PnetCDF/1.12.3-gompi-2022b
+CMake/3.31.8-GCCcore-13.3.0

--- a/cstar/additional_files/templates/wp/workplan.yaml
+++ b/cstar/additional_files/templates/wp/workplan.yaml
@@ -15,8 +15,9 @@ steps:
       workflow_overrides:
           segment_length: 16
       compute_overrides:
-          walltime: 00:10:00
-          num_nodes: 4
+          slurm:
+              max_walltime: 00:10:00
+              num_nodes: 4
     - name: Ensemble X
       application: sleep
       depends_on: ["Prepare"]
@@ -25,8 +26,9 @@ steps:
       workflow_overrides:
           segment_length: 16
       compute_overrides:
-          walltime: 00:10:00
-          num_nodes: 4
+          slurm:
+              max_walltime: 00:10:00
+              num_nodes: 4
     - name: Ensemble Y
       application: sleep
       depends_on: ["Prepare"]
@@ -35,8 +37,9 @@ steps:
       workflow_overrides:
           segment_length: 16
       compute_overrides:
-          walltime: 00:10:00
-          num_nodes: 4
+          slurm:
+              max_walltime: 00:10:00
+              num_nodes: 4
     - name: Aggregate Results
       application: sleep
       depends_on: ["Ensemble X", "Ensemble Y"]
@@ -45,5 +48,6 @@ steps:
       workflow_overrides:
           segment_length: 16
       compute_overrides:
-          walltime: 00:10:00
-          num_nodes: 1
+          slurm:
+              max_walltime: 00:10:00
+              num_nodes: 1

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -52,6 +52,13 @@ KEY_CLOBBER: t.Final[str] = "clobber"
 """The `workflow_overrides` key indicating a step's prior state should be
 cleared and re-executed."""
 
+COMPUTE_OVERRIDE_NAMESPACES: t.Final[frozenset[str]] = frozenset({"local", "slurm"})
+"""Launcher namespaces recognized as top-level `Step.compute_overrides` keys.
+
+Compute overrides are nested under the launcher that consumes them, e.g.
+`{"slurm": {"num_cpus": 16}}`; a top-level key outside this set would be
+silently ignored at submission and is rejected as a misconfiguration."""
+
 TargetDirectoryPath = t.Annotated[
     Path,
     PlainSerializer(str, return_type=str),
@@ -406,6 +413,19 @@ class Step(ConfiguredBaseModel):
         polymorphic_serialization=True,
     )
     """Configures the behavior of the pydantic model."""
+
+    @field_validator("compute_overrides", mode="after")
+    @classmethod
+    def _known_compute_namespaces(cls, value: KeyValueStore) -> KeyValueStore:
+        """Reject compute overrides that no launcher would consume."""
+        if unknown := sorted(set(value) - COMPUTE_OVERRIDE_NAMESPACES):
+            raise ValueError(
+                f"unknown compute_overrides key(s) {unknown}: compute overrides "
+                "must be nested under a launcher namespace "
+                f"({', '.join(sorted(COMPUTE_OVERRIDE_NAMESPACES))}), "
+                'e.g. {"slurm": {"num_cpus": 16}}'
+            )
+        return value
 
     @property
     def safe_name(self) -> str:

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -207,8 +207,9 @@ def fill_workplan_template(
                   workflow_overrides:
                       segment_length: 16
                   compute_overrides:
-                      walltime: 00:10:00
-                      num_nodes: 4
+                      slurm:
+                          max_walltime: 00:10:00
+                          num_nodes: 4
                 - name: Test Another Step
                   application: sleep
                   depends_on: []
@@ -217,8 +218,9 @@ def fill_workplan_template(
                   workflow_overrides:
                       segment_length: 16
                   compute_overrides:
-                      walltime: 00:05:00
-                      num_nodes: 2
+                      slurm:
+                          max_walltime: 00:05:00
+                          num_nodes: 2
             """,
         )
 

--- a/cstar/tests/unit_tests/orchestration/test_models.py
+++ b/cstar/tests/unit_tests/orchestration/test_models.py
@@ -330,9 +330,9 @@ def test_step_blueprint_overrides(
     "overrides",
     [
         {},
-        {"key1": "value1"},
-        {"key1": "value1", "key2": "value2"},
-        {"key1": "value1", "key2": 1},
+        {"slurm": {"num_cpus": 16}},
+        {"local": {"max_walltime": "00:10:00"}},
+        {"slurm": {"num_cpus": 16}, "local": {"max_walltime": "00:10:00"}},
     ],
 )
 def test_step_compute_overrides(
@@ -358,6 +358,38 @@ def test_step_compute_overrides(
     assert step.compute_overrides == overrides
 
 
+@pytest.mark.parametrize(
+    ("overrides", "bad_keys"),
+    [
+        pytest.param({"cpus": 10}, "['cpus']", id="unnested key"),
+        pytest.param({"walltime": "00:10:00"}, "['walltime']", id="stale flat key"),
+        pytest.param(
+            {"slurm": {"num_cpus": 16}, "cpus": 10, "sluurm": {}},
+            "['cpus', 'sluurm']",
+            id="all bad keys reported",
+        ),
+    ],
+)
+def test_step_compute_overrides_unknown_namespace(
+    fake_blueprint_path: Path,
+    overrides: KeyValueStore,
+    bad_keys: str,
+) -> None:
+    """Verify that compute overrides not nested under a known launcher namespace are
+    rejected (they would otherwise be silently ignored at submission), and that all
+    offending keys are reported in one error.
+    """
+    with pytest.raises(ValidationError) as error:
+        Step(
+            name="test-step",
+            application="test-app",
+            blueprint=fake_blueprint_path,
+            compute_overrides=overrides,
+        )
+
+    assert f"unknown compute_overrides key(s) {bad_keys}" in str(error.value)
+
+
 def test_step_compute_overrides_set(
     fake_blueprint_path: pathlib.Path,
 ) -> None:
@@ -369,7 +401,7 @@ def test_step_compute_overrides_set(
         A path to a file that meets minimum expectations (it exists).
 
     """
-    overrides: dict[str, int | str] = {"a": 1, "b": 2, "c": "xyz"}
+    overrides: KeyValueStore = {"slurm": {"a": 1, "b": 2, "c": "xyz"}}
 
     step_name = f"test-step-{uuid.uuid4()}"
     app_name = f"test-app-{uuid.uuid4()}"
@@ -377,7 +409,7 @@ def test_step_compute_overrides_set(
         name=step_name,
         application=app_name,
         blueprint=fake_blueprint_path,
-        compute_overrides=overrides,  # type: ignore[arg-type]
+        compute_overrides=overrides,
     )
 
     new_values: KeyValueStore = {"CSTAR_XYZ": 42, "CSTAR_PQR": "xxx"}
@@ -474,7 +506,12 @@ def test_step_all_overrides_copy(
         The name of the attribute on the Step object that should be tested.
 
     """
-    overrides: dict[str, str | int] = {"a": 1, "b": 2, "c": "xyz"}
+    # compute_overrides only permits launcher-namespace keys
+    overrides: dict[str, t.Any] = (
+        {"slurm": {"a": 1, "b": 2, "c": "xyz"}}
+        if dict_prop == "compute_overrides"
+        else {"a": 1, "b": 2, "c": "xyz"}
+    )
 
     step_name = f"test-step-{uuid.uuid4()}"
     app_name = f"test-app-{uuid.uuid4()}"

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -181,8 +181,11 @@ def test_serialization_workplan_happy_path(
     assert workplan.steps[0].application == Application.SLEEP
     assert workplan.steps[0].blueprint_overrides == {}
     assert workplan.steps[0].workflow_overrides["segment_length"] in {16, 16.0}
-    assert workplan.steps[0].compute_overrides["walltime"] == "00:10:00"
-    assert workplan.steps[0].compute_overrides["num_nodes"] == 4
+    slurm_overrides = t.cast(
+        "dict[str, t.Any]", workplan.steps[0].compute_overrides["slurm"]
+    )
+    assert slurm_overrides["max_walltime"] == "00:10:00"
+    assert slurm_overrides["num_nodes"] == 4
 
 
 @pytest.mark.usefixtures("read_yaml_intercept")


### PR DESCRIPTION
# Summary

Rejects workplan `compute_overrides` that no launcher would consume. A step's compute overrides must be nested under a launcher namespace (`slurm` or `local`); previously an unrecognized top-level key was silently ignored, so a step could appear to declare its resources while actually running with the 1-CPU default. Also adds CMake to the Bouchet module list.



## New Features
- N/A

## Bug Fixes
- Workplan steps' `compute_overrides` are now validated: any top-level key outside the launcher namespaces (`slurm`, `local`) is rejected at workplan validation (e.g. `cstar workplan check` or scheduling) with all offending keys reported in one error. Existing workplans with stray flat keys (e.g. `cpus: 10`) will now fail loudly instead of silently running under-provisioned.

## Improvements
- Added CMake to the modules loaded on Bouchet.



## Notes for Reviewers
- Motivating incident: cstar-forge's workplan export emitted `compute_overrides: {cpus: 10}` for the deferred ROMS step; the SLURM adapter (which reads only the `slurm` key) saw nothing and ROMS was submitted with `--ntasks=1`. The forge side is fixed in the companion cstar-forge PR (branch `wp-slurm-fix`); with this validator the malformed workplan is rejected before submission.
- KNOWN CI FAILURE UNTIL MERGE: 10 unit tests fetch the sample workplan from the raw GitHub URL on `main` (`test_workplan_check_remote_workplan`, `test_workplan_run_remote_workplan`, the clobber tests in `test_run_workplan.py`, `test_default_run_id_remote`); `main`'s copy of the template predates this schema tightening, so they fail on this branch and self-heal once the merged template is live. Accepted deliberately rather than masking remote content in the test fixture.
- The published workplan JSON schema (1.0.0) is not tightened by this change (it already allows nested objects); enforcement lives in the Pydantic model.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit suite: 1683 passed, 14 skipped, 2 xfailed; pre-commit incl. mypy clean) — except the 10 known remote-URI failures described above, which resolve on merge
