### PR TITLE
Migrate blueprints in workplan-run preflight

### DIFF
--- a/cstar/applications/core.py
+++ b/cstar/applications/core.py
@@ -9,12 +9,19 @@ from itertools import chain
 from pathlib import Path
 
 from cstar.base.adapter import SchemaAdapter
+from cstar.base.env import ENV_CSTAR_DISABLE_MIGRATION
+from cstar.base.feature import is_flag_enabled
 from cstar.base.log import get_logger
 from cstar.entrypoint.config import JOBFILE_DATE_FORMAT
 from cstar.execution.file_system import local_copy
 from cstar.execution.handler import ExecutionStatus
-from cstar.orchestration.models import BlueprintCore
+from cstar.orchestration.models import Blueprint, BlueprintCore
 from cstar.orchestration.serialization import SerializableModel, deserialize
+from cstar.system.migration import (
+    BlueprintMigration,
+    CstarMigrationError,
+    CstarUnsupportedMigrationError,
+)
 
 if t.TYPE_CHECKING:
     from cstar.entrypoint.config import JobConfig, ServiceConfiguration
@@ -479,3 +486,96 @@ def get_app_for_blueprint(path: Path) -> ApplicationDefinition[t.Any, t.Any]:
     """
     name = get_application_name(path)
     return get_application(name)
+
+
+def load_blueprint(path: Path) -> Blueprint:
+    """Load a blueprint from disk, migrating its schema in memory if needed.
+
+    Unlike :func:`deserialize`, which validates a file straight into the
+    application's strict blueprint type, this reads the file leniently (via
+    :class:`BlueprintCore`), runs any registered schema migrations for the
+    application in memory, and only then validates against the current schema.
+    Nothing is written to disk. Callers that must parse a blueprint before
+    execution (schedule-time transforms) use this so a pre-current-schema
+    blueprint is upgraded rather than raising a raw ``ValidationError``.
+
+    Parameters
+    ----------
+    path : Path
+        The path to a file containing a blueprint.
+
+    Returns
+    -------
+    Blueprint
+        The blueprint validated against the application's current schema.
+
+    Raises
+    ------
+    CstarMigrationError
+        If a required migration cannot be planned or completed, or is required
+        but disabled via ``CSTAR_DISABLE_MIGRATION``.
+    """
+    # A single lenient read serves both the application lookup and the migration
+    # input, so a blueprint on a network path is read once, not per-consumer.
+    core = deserialize(path, BlueprintCore)
+    app = get_application(core.application)
+    dumped = core.model_dump()
+
+    adapters = app.migrations or []
+    if adapters:
+        migrator = BlueprintMigration(adapters=adapters)
+        if app.name in migrator.schema_bounds:
+            dumped = _migrate_blueprint_dict(path, migrator, dumped)
+        else:
+            # The registered adapters target a different application (e.g. an
+            # app inheriting another's migrations). Nothing to migrate here;
+            # strict validation below handles current-schema blueprints.
+            log.debug(
+                f"Skipping schema migration for {str(path)!r}: registered adapters "
+                f"do not cover application {app.name!r}"
+            )
+
+    return t.cast("Blueprint", app.blueprint.model_validate(dumped))
+
+
+def _migrate_blueprint_dict(
+    path: Path,
+    migrator: BlueprintMigration,
+    dumped: dict[str, t.Any],
+) -> dict[str, t.Any]:
+    """Plan and apply an in-memory schema migration for a blueprint dict.
+
+    Returns
+    -------
+    dict[str, t.Any]
+        The (possibly) migrated blueprint dict; unchanged if already current.
+
+    Raises
+    ------
+    CstarMigrationError
+        If migration cannot be planned or completed, or is required but disabled
+        via ``CSTAR_DISABLE_MIGRATION``.
+    """
+    try:
+        plan = migrator.plan(dumped)
+    except CstarUnsupportedMigrationError as ex:
+        msg = f"Unable to migrate blueprint {str(path)!r}: {ex}"
+        raise CstarMigrationError(msg) from ex
+
+    if plan.adapters and is_flag_enabled(ENV_CSTAR_DISABLE_MIGRATION):
+        msg = (
+            f"Blueprint {str(path)!r} requires schema migration from "
+            f"{plan.source!r} to {plan.target!r}, but migration is disabled "
+            f"({ENV_CSTAR_DISABLE_MIGRATION}=1). Unset {ENV_CSTAR_DISABLE_MIGRATION} "
+            "or run `cstar blueprint migrate` to update the blueprint."
+        )
+        raise CstarMigrationError(msg)
+
+    if plan.is_latest:
+        return dumped
+
+    try:
+        return migrator.migrate(dumped, plan)
+    except CstarMigrationError as ex:
+        msg = f"Unable to migrate blueprint {str(path)!r}: {ex}"
+        raise CstarMigrationError(msg) from ex

--- a/cstar/orchestration/orchestration.py
+++ b/cstar/orchestration/orchestration.py
@@ -14,7 +14,7 @@ from pydantic import (
 )
 
 from cstar.applications.core import (
-    get_app_for_blueprint,
+    load_blueprint,
 )
 from cstar.base.env import (
     ENV_CSTAR_DATA_HOME,
@@ -36,7 +36,6 @@ from cstar.orchestration.models import (
     Workplan,
 )
 from cstar.orchestration.serialization import (
-    deserialize,
     intenum_representer,
     register_representer,
 )
@@ -271,10 +270,7 @@ class LiveStep(Step):
                 "it does not exist yet."
             )
 
-        path = Path(self.blueprint_path)
-        app = get_app_for_blueprint(path)
-
-        return deserialize(path, app.blueprint)
+        return load_blueprint(Path(self.blueprint_path))
 
     @property
     def script_path(self) -> Path:

--- a/cstar/orchestration/transforms.py
+++ b/cstar/orchestration/transforms.py
@@ -14,10 +14,9 @@ from pydantic import (
 )
 
 from cstar.applications.core import (
-    ApplicationDefinition,
     Transform,
-    get_app_for_blueprint,
     get_application,
+    load_blueprint,
 )
 from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.exceptions import CstarError, CstarExpectationFailed
@@ -33,9 +32,6 @@ from cstar.orchestration.models import (
 from cstar.orchestration.orchestration import LiveStep, LiveWorkplan
 from cstar.orchestration.serialization import deserialize, serialize
 from cstar.orchestration.tracking import TrackingRepository, WorkplanRun
-
-if t.TYPE_CHECKING:
-    from cstar.entrypoint.runner import BlueprintRunner
 
 TRANSFORMS: dict[str, list[Transform[LiveStep]]] = defaultdict(list)
 """Storage for transform registrations."""
@@ -636,12 +632,7 @@ class OverrideTransform(Transform[LiveStep]):
         """
         bp_path = Path(step.blueprint_path)
 
-        app: ApplicationDefinition[Blueprint, BlueprintRunner[Blueprint]] = (
-            get_application(step.application)
-        )
-        bp_type = app.blueprint
-
-        blueprint: Blueprint = deserialize(bp_path, bp_type)
+        blueprint: Blueprint = load_blueprint(bp_path)
 
         updated_bp = self.apply(blueprint, step.blueprint_overrides)
         update: dict[str, t.Any] = {
@@ -1071,12 +1062,11 @@ class DirectiveConfig(BaseModel):
             if os.getenv(ENV_CSTAR_RUNID, None):
                 workplan = DirectiveConfig.load_workplan()
 
-            app = get_app_for_blueprint(Path(local_bp))
-            blueprint = t.cast("Blueprint", deserialize(local_bp, app.blueprint))
+            blueprint = load_blueprint(Path(local_bp))
 
             step = LiveStep(
                 name="directive-step",
-                application=app.name,
+                application=blueprint.application,
                 blueprint=local_bp,
                 working_dir=blueprint.working_dir,
             )

--- a/cstar/tests/unit_tests/applications/test_core.py
+++ b/cstar/tests/unit_tests/applications/test_core.py
@@ -13,9 +13,13 @@ from cstar.applications.core import (
     RunnerState,
     _registry,
     get_application,
+    load_blueprint,
 )
+from cstar.applications.roms_marbl.models import APP_NAME as APP_ROMS
 from cstar.applications.roms_marbl.models import RomsMarblBlueprint
+from cstar.base.env import ENV_CSTAR_DISABLE_MIGRATION, FLAG_ON
 from cstar.execution.handler import ExecutionStatus
+from cstar.system.migration import CstarMigrationError
 
 
 def _external_app_module_source(app_name: str) -> str:
@@ -612,3 +616,113 @@ def test_runnerresult_state_add_errors(
 
     # confirm error results
     assert len(result.errors) == exp_num_errors
+
+
+def _write_roms_blueprint(
+    dest: Path,
+    bp_templates_dir: Path,
+    version_file: str,
+) -> Path:
+    """Copy a versioned roms_marbl template to *dest*, retargeting its
+    ``application`` field to the registered ``roms_marbl`` app.
+
+    The shared templates declare ``application: sleep``, which is not a
+    registered application; retargeting lets `load_blueprint` resolve the
+    real roms_marbl migration chain.
+    """
+    content = (bp_templates_dir / APP_ROMS / version_file).read_text()
+    content = content.replace("application: sleep", f"application: {APP_ROMS}")
+    dest.write_text(content)
+    return dest
+
+
+def test_load_blueprint_migrates_stale_schema(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> None:
+    """A pre-current-schema blueprint is migrated in memory and validated
+    against the current schema rather than raising a ValidationError.
+
+    This reproduces the `cstar workplan run` preflight failure on a stale
+    (schema 2.1.0) blueprint carrying a `model_params` block.
+    """
+    bp_path = _write_roms_blueprint(
+        tmp_path / "stale.yaml", bp_templates_dir, "blueprint.2.1.0.yaml"
+    )
+
+    blueprint = load_blueprint(bp_path)
+
+    assert isinstance(blueprint, RomsMarblBlueprint)
+    assert blueprint.schema_version == "3.0.0"
+    assert not hasattr(blueprint, "model_params")
+    # model_params sub-fields are relocated by the 2.1.0 -> 3.0.0 adapter
+    assert blueprint.partitioning.use_pio is True
+    assert blueprint.namelist_overrides == {"time_stepping": {"dt": 1}}
+
+
+def test_load_blueprint_current_schema_is_noop(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> None:
+    """A current-schema blueprint loads unchanged (migration is a no-op)."""
+    bp_path = _write_roms_blueprint(
+        tmp_path / "current.yaml", bp_templates_dir, "blueprint.3.0.0.yaml"
+    )
+
+    blueprint = load_blueprint(bp_path)
+
+    assert isinstance(blueprint, RomsMarblBlueprint)
+    assert blueprint.schema_version == "3.0.0"
+
+
+def test_load_blueprint_migration_disabled_raises(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When migration is required but disabled, a clear typed error names the
+    source/target versions instead of raising a raw ValidationError.
+    """
+    bp_path = _write_roms_blueprint(
+        tmp_path / "stale.yaml", bp_templates_dir, "blueprint.2.1.0.yaml"
+    )
+    monkeypatch.setenv(ENV_CSTAR_DISABLE_MIGRATION, FLAG_ON)
+
+    with pytest.raises(CstarMigrationError, match="requires schema migration"):
+        load_blueprint(bp_path)
+
+
+def test_load_blueprint_no_migration_path_raises(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> None:
+    """A blueprint whose schema version has no adapter path to the current
+    schema raises a clear migration error, not a raw ValidationError.
+    """
+    content = (bp_templates_dir / APP_ROMS / "blueprint.2.1.0.yaml").read_text()
+    content = content.replace("application: sleep", f"application: {APP_ROMS}")
+    content = content.replace("schema_version: 2.1.0", "schema_version: 0.9.0")
+    bp_path = tmp_path / "unreachable.yaml"
+    bp_path.write_text(content)
+
+    with pytest.raises(CstarMigrationError, match="Unable to migrate blueprint"):
+        load_blueprint(bp_path)
+
+
+def test_load_blueprint_unplannable_migration_falls_through(
+    tmp_path: Path,
+    bp_templates_dir: Path,
+) -> None:
+    """When an app's adapters don't cover the blueprint's application (e.g. the
+    `sleep` app inherits roms_marbl adapters that declare a different
+    application), planning fails; a current-schema blueprint must still load
+    via strict validation rather than raising a migration error.
+    """
+    content = (bp_templates_dir / APP_ROMS / "blueprint.3.0.0.yaml").read_text()
+    bp_path = tmp_path / "sleep.yaml"
+    bp_path.write_text(content)  # keeps `application: sleep`
+
+    blueprint = load_blueprint(bp_path)
+
+    assert blueprint.application == "sleep"
+    assert blueprint.schema_version == "3.0.0"


### PR DESCRIPTION
# Summary

`cstar workplan run` now migrates each step's blueprint to the current schema before running it, so a workplan that references an older-schema blueprint no longer fails during preflight. (Changes are currently uncommitted on this branch.)

## Breaking Changes
- N/A

## New Features
- N/A

## Bug Fixes
- `cstar workplan run` no longer crashes with a validation error when a step's blueprint file is at an older schema version (for example, one still containing a `model_params` block). Blueprints are now migrated to the current schema automatically during workplan preflight, matching the behavior `cstar blueprint run` already had.

## Improvements
- When a blueprint genuinely cannot be migrated — no upgrade path to the current schema, or migration disabled via `CSTAR_DISABLE_MIGRATION` — the run now stops with a clear message naming the schema versions involved and pointing to `cstar blueprint migrate`, instead of a raw validation traceback.

## Miscellaneous
- N/A


## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing


## Notes for Reviewers

- The fix adds `load_blueprint(path)` in `cstar/applications/core.py`: it reads the blueprint leniently, migrates its schema in memory (no file is rewritten), then validates against the application's current schema. The three schedule-time strict-parse boundaries now route through it — `Step.blueprint` (`orchestration.py`), and `OverrideTransform.__call__` plus the runtime directive `preprocess` (`transforms.py`) — so the same class of failure can't resurface from another entry point.
- Migration is only attempted when the blueprint's application is actually covered by registered adapters (`app.name in schema_bounds`). This matters because an application can inherit another's adapters (the test-only `sleep` app subclasses `RomsMarblApplication`); those blueprints correctly fall through to strict validation rather than erroring.
- `execute_migration` / `_localize_and_migrate` (the `cstar blueprint run` CLI path) were intentionally left as-is — they persist the migrated blueprint to disk and are CLI-coupled. Collapsing them onto the new in-memory helper is a possible follow-up.
