### PR TITLE
remove use of deprecated sleep app

### DIFF
--- a/cstar/additional_files/templates/bp/blueprint.yaml
+++ b/cstar/additional_files/templates/bp/blueprint.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.3.0.0.json
 name: Test Blueprint
 description: This is the description of my test blueprint
-application: sleep
+application: roms_marbl
 schema_version: 3.0.0
 working_dir: .
 state: draft

--- a/cstar/additional_files/templates/bp/roms_marbl/blueprint.1.0.0.yaml
+++ b/cstar/additional_files/templates/bp/roms_marbl/blueprint.1.0.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.1.0.0.json
 name: Test Blueprint
 description: This is the description of my test blueprint
-application: sleep
+application: roms_marbl
 state: draft
 valid_start_date: 2000-01-01 00:00:00
 valid_end_date: 2025-01-01 00:00:00

--- a/cstar/additional_files/templates/bp/roms_marbl/blueprint.2.0.0.yaml
+++ b/cstar/additional_files/templates/bp/roms_marbl/blueprint.2.0.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.2.0.0.json
 name: Test Blueprint
 description: This is the description of my test blueprint
-application: sleep
+application: roms_marbl
 state: draft
 valid_start_date: 2000-01-01 00:00:00
 valid_end_date: 2025-01-01 00:00:00

--- a/cstar/additional_files/templates/bp/roms_marbl/blueprint.2.1.0.yaml
+++ b/cstar/additional_files/templates/bp/roms_marbl/blueprint.2.1.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.2.1.0.json
 name: Test Blueprint
 description: This is the description of my test blueprint
-application: sleep
+application: roms_marbl
 state: draft
 valid_start_date: 2000-01-01 00:00:00
 valid_end_date: 2025-01-01 00:00:00

--- a/cstar/additional_files/templates/bp/roms_marbl/blueprint.3.0.0.yaml
+++ b/cstar/additional_files/templates/bp/roms_marbl/blueprint.3.0.0.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.3.0.0.json
 name: Test Blueprint
 description: This is the description of my test blueprint
-application: sleep
+application: roms_marbl
 state: draft
 valid_start_date: 2000-01-01 00:00:00
 valid_end_date: 2025-01-01 00:00:00

--- a/cstar/additional_files/templates/wp/fanout.yaml
+++ b/cstar/additional_files/templates/wp/fanout.yaml
@@ -3,18 +3,18 @@ name: Fan-out Workplan
 description: A workplan that uses dependencies to gate execution of parallel steps.
 steps:
 - name: Step A
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 - name: Step B_1
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on: ["Step A"]
 - name: Step B_2
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on: ["Step A"]
 - name: Step B_3
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on: ["Step A"]
 state: draft

--- a/cstar/additional_files/templates/wp/linear.yaml
+++ b/cstar/additional_files/templates/wp/linear.yaml
@@ -3,21 +3,21 @@ name: Linear Workplan
 description: A workplan that usees dependencies to ensure that all tasks execute in a series.
 steps:
 - name: Step L1
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on:
   - Step L2
 - name: Step L2
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on:
   - Step L3
 - name: Step L3
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
   depends_on:
   - Step L4
 - name: Step L4
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 state: draft

--- a/cstar/additional_files/templates/wp/parallel.yaml
+++ b/cstar/additional_files/templates/wp/parallel.yaml
@@ -3,12 +3,12 @@ name: Parallel Workplan
 description: A workplan that executes all tasks immediately in parallel
 steps:
 - name: Step A_1
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 - name: Step A_2
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 - name: Step A_3
-  application: sleep
+  application: roms_marbl
   blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 state: draft

--- a/cstar/additional_files/templates/wp/single_step.yaml
+++ b/cstar/additional_files/templates/wp/single_step.yaml
@@ -3,6 +3,6 @@ name: Single Step Workplan
 description: Workplan containing a single step
 steps:
   - name: The Step
-    application: sleep
+    application: roms_marbl
     blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
 state: draft

--- a/cstar/additional_files/templates/wp/workplan.yaml
+++ b/cstar/additional_files/templates/wp/workplan.yaml
@@ -8,7 +8,7 @@ compute_environment:
 runtime_vars: [var1, var2]
 steps:
     - name: Prepare
-      application: sleep
+      application: roms_marbl
       depends_on: []
       blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
       blueprint_overrides: {}
@@ -19,7 +19,7 @@ steps:
               max_walltime: 00:10:00
               num_nodes: 4
     - name: Ensemble X
-      application: sleep
+      application: roms_marbl
       depends_on: ["Prepare"]
       blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
       blueprint_overrides: {}
@@ -30,7 +30,7 @@ steps:
               max_walltime: 00:10:00
               num_nodes: 4
     - name: Ensemble Y
-      application: sleep
+      application: roms_marbl
       depends_on: ["Prepare"]
       blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
       blueprint_overrides: {}
@@ -41,7 +41,7 @@ steps:
               max_walltime: 00:10:00
               num_nodes: 4
     - name: Aggregate Results
-      application: sleep
+      application: roms_marbl
       depends_on: ["Ensemble X", "Ensemble Y"]
       blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
       blueprint_overrides: {}

--- a/cstar/additional_files/templates/wp/wp_with_bp_overrides.yaml
+++ b/cstar/additional_files/templates/wp/wp_with_bp_overrides.yaml
@@ -9,7 +9,7 @@ compute_environment:
 runtime_vars: [var1, var2]
 steps:
   - name: Run Simulation With Overrides
-    application: sleep
+    application: roms_marbl
     blueprint: ~/code/cstar/cstar/additional_files/templates/blueprint.yaml
     blueprint_overrides:
       working_dir: /other_dir

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -156,8 +156,6 @@ class Application(StrEnum):
 
     ROMS_MARBL = "roms_marbl"
     """A UCLA-ROMS simulation coupled with a MARBL biogeochemical component."""
-    SLEEP = "sleep"
-    """A call to the hostname executable to simplify testing."""
     HELLO_WORLD = "hello_world"
     """Sample custom application."""
     PLOTTER = "plotter"

--- a/cstar/tests/conftest.py
+++ b/cstar/tests/conftest.py
@@ -14,7 +14,7 @@ class SleepApplication(RomsMarblApplication):
     can use the RomsMarblBlueprint
     """
 
-    name = "sleep"
+    name = "roms_marbl"
 
 
 @pytest.fixture(scope="session")

--- a/cstar/tests/integration_tests/workplans/test_run_dag.py
+++ b/cstar/tests/integration_tests/workplans/test_run_dag.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 
@@ -63,12 +62,12 @@ def test_dep_keys(tmp_path: Path) -> None:
             steps=[
                 Step(
                     name="Good Step",
-                    application="sleep",
+                    application="roms_marbl",
                     blueprint=bp_path.as_posix(),
                 ),
                 Step(
                     name="Bad Step",
-                    application="sleep",
+                    application="roms_marbl",
                     blueprint=bp_path.as_posix(),
                     depends_on=["Non-existent Step"],
                 ),
@@ -101,9 +100,6 @@ async def test_build_and_run_local(
     wp_templates_dir : Path
         Fixture returning the path to the directory containing workplan template files
     """
-    # avoid running sims during tests
-    os.environ["CSTAR_CMD_CONVERTER_OVERRIDE"] = "sleep"
-
     template_file = f"{workplan_name}.yaml"
     wp_path = wp_templates_dir / template_file
 
@@ -142,9 +138,6 @@ async def test_build_and_run(
     default_blueprint_path : str
         Fixture returning the default blueprint path contained in template workplans
     """
-    # avoid running sims during tests
-    os.environ["CSTAR_CMD_CONVERTER_OVERRIDE"] = "sleep"
-
     template_file = f"{workplan_name}.yaml"
     wp_path = wp_templates_dir / template_file
 

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -35,7 +35,6 @@ def blueprint_1_0_0(
 @pytest.fixture
 def blueprint_1_0_0_sleep(blueprint_1_0_0: Path) -> Path:
     content = blueprint_1_0_0.read_text()
-    # content = content.replace("application: sleep", f"application: {APP_ROMS}")
 
     bp_path = blueprint_1_0_0.with_stem(f"{blueprint_1_0_0.stem}_sleep")
     bp_path.write_text(content)

--- a/cstar/tests/unit_tests/orchestration/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/conftest.py
@@ -200,7 +200,7 @@ def fill_workplan_template(
             f"""\
             steps:
                 - name: Test Step
-                  application: sleep
+                  application: roms_marbl
                   depends_on: []
                   blueprint: {__file__}
                   blueprint_overrides: {{}}
@@ -211,7 +211,7 @@ def fill_workplan_template(
                           max_walltime: 00:10:00
                           num_nodes: 4
                 - name: Test Another Step
-                  application: sleep
+                  application: roms_marbl
                   depends_on: []
                   blueprint: {__file__}
                   blueprint_overrides: {{}}
@@ -312,7 +312,7 @@ def fill_blueprint_template(
             # yaml-language-server: $schema={blueprint_schema_path.as_posix()}
             name: {fill_vals["name"]}
             description: This is the description of my test blueprint
-            application: sleep
+            application: roms_marbl
             state: draft
             valid_start_date: 2020-01-01 00:00:00
             valid_end_date: 2020-02-01 00:00:00
@@ -433,7 +433,6 @@ def single_step_workplan(
     bp_path = tmp_path / "blueprint.yaml"
     bp_content = bp_tpl_path.read_text()
     bp_content = bp_content.replace(default_working_dir, f"working_dir: {tmp_path}")
-    bp_content.replace(Application.SLEEP, Application.ROMS_MARBL)
     bp_path.write_text(bp_content)
 
     return Workplan(
@@ -442,7 +441,7 @@ def single_step_workplan(
         steps=[
             Step(
                 name="s-00",
-                application=Application.SLEEP,
+                application=Application.ROMS_MARBL,
                 blueprint=bp_path,
             ),
         ],

--- a/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
+++ b/cstar/tests/unit_tests/orchestration/test_cmd_converter.py
@@ -23,7 +23,6 @@ from cstar.orchestration.serialization import deserialize
     ("target_application"),
     [
         Application.ROMS_MARBL,
-        Application.SLEEP,
         Application.HELLO_WORLD,
     ],
 )
@@ -59,7 +58,6 @@ def test_converter_defaults(
     ("target_application"),
     [
         Application.ROMS_MARBL,
-        Application.SLEEP,
         Application.HELLO_WORLD,
     ],
 )

--- a/cstar/tests/unit_tests/orchestration/test_migration.py
+++ b/cstar/tests/unit_tests/orchestration/test_migration.py
@@ -466,7 +466,7 @@ class BPTestAdapterV0(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "roms_marbl"
+        return APP_NAME
 
     @classmethod
     def source(cls) -> str:
@@ -489,7 +489,7 @@ class BPTestAdapterV1(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "roms_marbl"
+        return APP_NAME
 
     @classmethod
     def source(cls) -> str:
@@ -512,7 +512,7 @@ class BPTestAdapterV2(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "roms_marbl"
+        return APP_NAME
 
     @classmethod
     def source(cls) -> str:
@@ -535,7 +535,7 @@ class BPTestAdapterV3(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "roms_marbl"
+        return APP_NAME
 
     @classmethod
     def source(cls) -> str:

--- a/cstar/tests/unit_tests/orchestration/test_migration.py
+++ b/cstar/tests/unit_tests/orchestration/test_migration.py
@@ -36,7 +36,7 @@ from cstar.system.migration import (
     SchemaBounds,
 )
 
-APP_SLEEP: t.Final[str] = "sleep"
+APP_NAME: t.Final[str] = "roms_marbl"
 
 
 @pytest.mark.parametrize(
@@ -366,7 +366,7 @@ def test_migration_with_unregistered_application() -> None:
     src_version_exp = BPTestAdapterV0.source()
     tgt_version_exp = BPTestAdapterV3.target()
 
-    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_SLEEP}
+    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_NAME}
 
     converters: list[type[SchemaAdapter]] = [
         BPTestAdapterV0,
@@ -402,7 +402,7 @@ def test_migration_to_unknown_target() -> None:
     src_version_exp = BPTestAdapterV0.source()
     tgt_version_exp = "1.0.42"
 
-    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_SLEEP}
+    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_NAME}
 
     converters: list[type[SchemaAdapter]] = [
         BPTestAdapterV0,
@@ -411,7 +411,7 @@ def test_migration_to_unknown_target() -> None:
         BPTestAdapterV3,
     ]
     bounds: dict[str, SchemaBounds] = {
-        APP_SLEEP: {
+        APP_NAME: {
             "min": BPTestAdapterV0.source(),
             "max": BPTestAdapterV3.target(),
         },
@@ -437,7 +437,7 @@ def test_migration_from_unknown_source() -> None:
     """Verify that no migration path found raises an exception."""
     src_version_exp = "1.0.UNK"
 
-    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_SLEEP}
+    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_NAME}
     converters: list[type[SchemaAdapter]] = [
         BPTestAdapterV0,
         BPTestAdapterV1,
@@ -445,7 +445,7 @@ def test_migration_from_unknown_source() -> None:
         BPTestAdapterV3,
     ]
     bounds: dict[str, SchemaBounds] = {
-        APP_SLEEP: {
+        APP_NAME: {
             "min": BPTestAdapterV0.source(),
             "max": BPTestAdapterV3.target(),
         },
@@ -466,7 +466,7 @@ class BPTestAdapterV0(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "sleep"
+        return "roms_marbl"
 
     @classmethod
     def source(cls) -> str:
@@ -489,7 +489,7 @@ class BPTestAdapterV1(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "sleep"
+        return "roms_marbl"
 
     @classmethod
     def source(cls) -> str:
@@ -512,7 +512,7 @@ class BPTestAdapterV2(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "sleep"
+        return "roms_marbl"
 
     @classmethod
     def source(cls) -> str:
@@ -535,7 +535,7 @@ class BPTestAdapterV3(SchemaAdapter):
     @classmethod
     def application(cls) -> str:
         """The supported version of the input model."""
-        return "sleep"
+        return "roms_marbl"
 
     @classmethod
     def source(cls) -> str:
@@ -576,7 +576,7 @@ def test_migration_intermediate_multistep(
     """
     tgt_version_exp = "test.4"
 
-    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_SLEEP}
+    bp0 = {KEY_SV: src_version_exp, KEY_APP: APP_NAME}
 
     # pass in the converters instead of relying on the default
     converters: list[type[SchemaAdapter]] = [
@@ -586,7 +586,7 @@ def test_migration_intermediate_multistep(
         BPTestAdapterV3,
     ]
     bounds: dict[str, SchemaBounds] = {
-        APP_SLEEP: {
+        APP_NAME: {
             "min": BPTestAdapterV0.source(),
             "max": BPTestAdapterV3.target(),
         },

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -32,7 +32,7 @@ from cstar.orchestration.utils import ENV_CSTAR_ORCH_TRX_FREQ
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
 
-APP_RM: t.Final[str] = "roms_marbl"
+APP_NAME: t.Final[str] = "roms_marbl"
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def diamond_graph(tmp_path: Path) -> nx.DiGraph:
         key: {
             KEY_STEP: Step(
                 name=f"s-{i:02d}",
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             KEY_STATUS: Status.Unsubmitted,
@@ -80,7 +80,7 @@ def tree_graph(tmp_path: Path) -> nx.DiGraph:
         key: {
             KEY_STEP: Step(
                 name=key,
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             KEY_STATUS: Status.Unsubmitted,
@@ -123,25 +123,25 @@ def diamond_workplan(
         steps=[
             Step(
                 name="d-00",
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-01",
                 depends_on=["d-00"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-02",
                 depends_on=["d-00"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-03",
                 depends_on=["d-01", "d-02"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
         ],
@@ -180,36 +180,36 @@ def multi_entrypoint_workplan(
         steps=[
             Step(
                 name="d-00-a",
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-00-b",
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-01",
                 depends_on=["d-00-a"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-02",
                 depends_on=["d-00-a"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-03",
                 depends_on=["d-00-b"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-04",
                 depends_on=["d-01", "d-02", "d-00-b"],
-                application=APP_RM,
+                application=APP_NAME,
                 blueprint=bp_path.as_posix(),
             ),
         ],
@@ -304,12 +304,12 @@ def test_dep_keys(tmp_path: Path) -> None:
             steps=[
                 Step(
                     name="Good Step",
-                    application=APP_RM,
+                    application=APP_NAME,
                     blueprint=bp_path.as_posix(),
                 ),
                 Step(
                     name="Bad Step",
-                    application=APP_RM,
+                    application=APP_NAME,
                     blueprint=bp_path.as_posix(),
                     depends_on=["Non-existent Step"],
                 ),

--- a/cstar/tests/unit_tests/orchestration/test_orchestration.py
+++ b/cstar/tests/unit_tests/orchestration/test_orchestration.py
@@ -32,6 +32,8 @@ from cstar.orchestration.utils import ENV_CSTAR_ORCH_TRX_FREQ
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
 
+APP_RM: t.Final[str] = "roms_marbl"
+
 
 @pytest.fixture
 def diamond_graph(tmp_path: Path) -> nx.DiGraph:
@@ -42,7 +44,9 @@ def diamond_graph(tmp_path: Path) -> nx.DiGraph:
     initial_stats = {
         key: {
             KEY_STEP: Step(
-                name=f"s-{i:02d}", application="sleep", blueprint=bp_path.as_posix()
+                name=f"s-{i:02d}",
+                application=APP_RM,
+                blueprint=bp_path.as_posix(),
             ),
             KEY_STATUS: Status.Unsubmitted,
         }
@@ -74,7 +78,11 @@ def tree_graph(tmp_path: Path) -> nx.DiGraph:
     g = nx.DiGraph(data)
     initial_stats: dict[str, dict[str, Step | Status]] = {
         key: {
-            KEY_STEP: Step(name=key, application="sleep", blueprint=bp_path.as_posix()),
+            KEY_STEP: Step(
+                name=key,
+                application=APP_RM,
+                blueprint=bp_path.as_posix(),
+            ),
             KEY_STATUS: Status.Unsubmitted,
         }
         for key in g.nodes
@@ -115,25 +123,25 @@ def diamond_workplan(
         steps=[
             Step(
                 name="d-00",
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-01",
                 depends_on=["d-00"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-02",
                 depends_on=["d-00"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-03",
                 depends_on=["d-01", "d-02"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
         ],
@@ -172,36 +180,36 @@ def multi_entrypoint_workplan(
         steps=[
             Step(
                 name="d-00-a",
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-00-b",
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-01",
                 depends_on=["d-00-a"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-02",
                 depends_on=["d-00-a"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-03",
                 depends_on=["d-00-b"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
             Step(
                 name="d-04",
                 depends_on=["d-01", "d-02", "d-00-b"],
-                application="sleep",
+                application=APP_RM,
                 blueprint=bp_path.as_posix(),
             ),
         ],
@@ -296,12 +304,12 @@ def test_dep_keys(tmp_path: Path) -> None:
             steps=[
                 Step(
                     name="Good Step",
-                    application="sleep",
+                    application=APP_RM,
                     blueprint=bp_path.as_posix(),
                 ),
                 Step(
                     name="Bad Step",
-                    application="sleep",
+                    application=APP_RM,
                     blueprint=bp_path.as_posix(),
                     depends_on=["Non-existent Step"],
                 ),

--- a/cstar/tests/unit_tests/orchestration/test_serialization.py
+++ b/cstar/tests/unit_tests/orchestration/test_serialization.py
@@ -178,7 +178,7 @@ def test_serialization_workplan_happy_path(
     assert workplan.name == "Test Workplan"
     assert workplan.steps[0].name == "Test Step"
     assert not workplan.steps[0].depends_on
-    assert workplan.steps[0].application == Application.SLEEP
+    assert workplan.steps[0].application == Application.ROMS_MARBL
     assert workplan.steps[0].blueprint_overrides == {}
     assert workplan.steps[0].workflow_overrides["segment_length"] in {16, 16.0}
     slurm_overrides = t.cast(

--- a/cstar/tests/unit_tests/orchestration/test_splitting.py
+++ b/cstar/tests/unit_tests/orchestration/test_splitting.py
@@ -68,7 +68,7 @@ def test_roms_marbl_transform_registry(
 
 @pytest.mark.parametrize(
     "application",
-    ["sleep", Application.SLEEP.value, "unknown-app-id"],
+    ["sleep", "unknown-app-id"],
 )
 def test_sleep_transform_registry(application: str) -> None:
     """Verify that the transform registry returns no transforms for sleep or unknown applications.

--- a/cstar/tests/unit_tests/orchestration/test_transforms.py
+++ b/cstar/tests/unit_tests/orchestration/test_transforms.py
@@ -612,7 +612,7 @@ def live_step_with_templates(tmp_path: Path) -> LiveStep:
     bp.touch()
     step = Step(
         name="fill-step",
-        application="sleep",
+        application="roms_marbl",
         blueprint=bp.as_posix(),
         blueprint_overrides={
             "input_dir": "{{base_dir}}/input",


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR removes the "sleep" app from test harnesses due to issues it causes when testing migrations. Additionally, the "command mapping" function for the sleep app was previously removed.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

