### PR TITLE
Remove double curlies from script template

### DIFF
--- a/cstar/additional_files/templates/launchers/local_job_proxy.sh
+++ b/cstar/additional_files/templates/launchers/local_job_proxy.sh
@@ -9,13 +9,13 @@ RUNNING={running}
 DONE={done}
 FAILED={failed}
 
-update_status() {{
+update_status() {
     if [ "$(uname)" = "Darwin" ]; then
         sed -i '' "s/^status:.*$/status: $1/" "$2"
     else
         sed -i "s/^status:.*$/status: $1/" "$2"
     fi
-}}
+}
 
 # wait for each dependency to complete, then verify that it succeeded --
 # a dependency that exited without reaching `Done` must abort this step.

--- a/cstar/orchestration/launch/local.py
+++ b/cstar/orchestration/launch/local.py
@@ -563,19 +563,21 @@ class ProxiedRunRequestFormatter(ModelFormatter[RunRequest]):
         env_vars = " ".join(declarations)
 
         proxyscript_model = {
-            "sentinel_path": str(StateRepository.sentinel_path(self.step.name)),
-            "blueprint_path": str(self.step.blueprint_path),
-            "pids": pids,
-            "dep_sentinels": dep_sentinels,
-            "running": str(Status.Running.value),
-            "done": str(Status.Done.value),
-            "failed": str(Status.Failed.value),
-            "delay": delay,
-            "command": " ".join(value.command),
-            "env_vars": env_vars,
+            "{sentinel_path}": str(StateRepository.sentinel_path(self.step.name)),
+            "{blueprint_path}": str(self.step.blueprint_path),
+            "{pids}": pids,
+            "{dep_sentinels}": dep_sentinels,
+            "{running}": str(Status.Running.value),
+            "{done}": str(Status.Done.value),
+            "{failed}": str(Status.Failed.value),
+            "{delay}": delay,
+            "{command}": " ".join(value.command),
+            "{env_vars}": env_vars,
         }
         files_dir = additional_files_dir()
         proxy_tpl_path = files_dir / "templates/launchers/local_job_proxy.sh"
+        content = proxy_tpl_path.read_text()
+        for k, v in proxyscript_model.items():
+            content = content.replace(k, v)
 
-        tpl = proxy_tpl_path.read_text()
-        return tpl.format(**proxyscript_model)
+        return content


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

Fix formatting workaround in templated local script

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

