### PR TITLE
Fix sed failing on macos when homebrew shim is installed 

### DIFF
--- a/cstar/additional_files/templates/launchers/local_job_proxy.sh
+++ b/cstar/additional_files/templates/launchers/local_job_proxy.sh
@@ -10,11 +10,7 @@ DONE={done}
 FAILED={failed}
 
 update_status() {
-    if [ "$(uname)" = "Darwin" ]; then
-        sed -i '' "s/^status:.*$/status: $1/" "$2"
-    else
-        sed -i "s/^status:.*$/status: $1/" "$2"
-    fi
+    sed "s/^status:.*$/status: $1/" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
 }
 
 # wait for each dependency to complete, then verify that it succeeded --


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

Fix test failures on macos due to sed stmt formatting

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing

