### PR TITLE
auto-compose workplan from blueprint

### DIFF
--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -22,10 +22,9 @@ from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
 from cstar.base.utils import slugify
 from cstar.execution.file_system import DirectoryManager, is_remote_resource, local_copy
-from cstar.orchestration.models import BlueprintCore, Step, Workplan
+from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import (
     PersistenceMode,
-    deserialize,
     serialize,
     validate_serialized_entity,
 )
@@ -512,26 +511,3 @@ def set_ctxmap(context: typer.Context, key: str, value: object) -> None:
         print(f"Value in context map using key {key!r} will be overwritten")
 
     context_map[key] = value
-
-
-def auto_compose(path: str) -> str:
-    """Automatically wrap a blueprint in a workplan when passed."""
-    try:
-        bp = deserialize(path, BlueprintCore)
-        wp = Workplan(
-            name=f"{bp.name} Host",
-            description="Automated Workplan wrapping the execution of a single blueprint.",
-            steps=[
-                Step(
-                    name=f"Execute {bp.name}",
-                    application=bp.application,
-                    blueprint=path,
-                )
-            ],
-        )
-        wp_path = Path(path).with_name(f"{slugify(bp.name)}-host-workplan")
-        serialize(wp_path, wp)
-        return str(wp_path)
-    except Exception:
-        # path isn't a blueprint. leave it alone.
-        return path

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -22,9 +22,10 @@ from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
 from cstar.base.utils import slugify
 from cstar.execution.file_system import DirectoryManager, is_remote_resource, local_copy
-from cstar.orchestration.models import BlueprintCore
+from cstar.orchestration.models import BlueprintCore, Step, Workplan
 from cstar.orchestration.serialization import (
     PersistenceMode,
+    deserialize,
     serialize,
     validate_serialized_entity,
 )
@@ -511,3 +512,26 @@ def set_ctxmap(context: typer.Context, key: str, value: object) -> None:
         print(f"Value in context map using key {key!r} will be overwritten")
 
     context_map[key] = value
+
+
+def auto_compose(path: str) -> str:
+    """Automatically wrap a blueprint in a workplan when passed."""
+    try:
+        bp = deserialize(path, BlueprintCore)
+        wp = Workplan(
+            name=f"{bp.name} Host",
+            description="Automated Workplan wrapping the execution of a single blueprint.",
+            steps=[
+                Step(
+                    name=f"Execute {bp.name}",
+                    application=bp.application,
+                    blueprint=path,
+                )
+            ],
+        )
+        wp_path = Path(path).with_name(f"{slugify(bp.name)}-host-workplan")
+        serialize(wp_path, wp)
+        return str(wp_path)
+    except Exception:
+        # path isn't a blueprint. leave it alone.
+        return path

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -15,6 +15,7 @@ from cstar.base.env import (
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
+    auto_compose,
     cb_pipeline,
     normalize_runid,
     set_env,
@@ -396,6 +397,8 @@ def preprocess_path(workplan_path: str | None) -> str | None:
                 if not local_path.exists():
                     msg = f"Workplan not found at path: {workplan_path}"
                     raise typer.BadParameter(msg)
+
+                local_path = Path(auto_compose(str(local_path)))
 
                 validation_result = validate_serialized_entity(local_path, Workplan)
                 if not validation_result.item:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -382,6 +382,10 @@ def auto_compose(path: str) -> str:
     """Automatically wrap a blueprint in a workplan when passed."""
     try:
         bp = deserialize(path, BlueprintCore)
+    except Exception:
+        # path isn't a blueprint. leave it alone.
+        return path
+    else:
         wp = Workplan(
             name=f"{bp.name} Host",
             description="Automated Workplan wrapping the execution of a single blueprint.",
@@ -396,9 +400,6 @@ def auto_compose(path: str) -> str:
         wp_path = Path(path).with_name(f"{slugify(bp.name)}-host-workplan")
         serialize(wp_path, wp)
         return str(wp_path)
-    except Exception:
-        # path isn't a blueprint. leave it alone.
-        return path
 
 
 def preprocess_path(workplan_path: str | None) -> str | None:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -14,8 +14,8 @@ from cstar.base.env import (
 )
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.base.log import LogLevelChoices, get_logger
+from cstar.base.utils import slugify
 from cstar.cli.common import (
-    auto_compose,
     cb_pipeline,
     normalize_runid,
     set_env,
@@ -47,10 +47,11 @@ from cstar.orchestration.dag_runner import (
     check_clobber_targets,
     run_dag,
 )
-from cstar.orchestration.models import Workplan
+from cstar.orchestration.models import BlueprintCore, Step, Workplan
 from cstar.orchestration.orchestration import LiveWorkplan, Planner, ProcessHandle
 from cstar.orchestration.serialization import (
     deserialize,
+    serialize,
     try_deserialize,
     validate_serialized_entity,
 )
@@ -375,6 +376,29 @@ def resolve_clobber_selection(wp_path: Path, clobber_steps: list[str]) -> list[s
         raise typer.BadParameter(msg, param_hint=ARG_CLOBBER)
 
     return clobber_steps
+
+
+def auto_compose(path: str) -> str:
+    """Automatically wrap a blueprint in a workplan when passed."""
+    try:
+        bp = deserialize(path, BlueprintCore)
+        wp = Workplan(
+            name=f"{bp.name} Host",
+            description="Automated Workplan wrapping the execution of a single blueprint.",
+            steps=[
+                Step(
+                    name=f"Execute {bp.name}",
+                    application=bp.application,
+                    blueprint=path,
+                )
+            ],
+        )
+        wp_path = Path(path).with_name(f"{slugify(bp.name)}-host-workplan")
+        serialize(wp_path, wp)
+        return str(wp_path)
+    except Exception:
+        # path isn't a blueprint. leave it alone.
+        return path
 
 
 def preprocess_path(workplan_path: str | None) -> str | None:

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -387,7 +387,7 @@ def auto_compose(path: str) -> str:
         return path
     else:
         bp_path = Path(path)
-        wp_name = f"{slugify(bp.name)}-host-workplan.{bp_path.suffix}"
+        wp_name = f"{slugify(bp.name)}-host-workplan{bp_path.suffix}"
         wp_path = bp_path.with_name(wp_name)
 
         wp = Workplan(

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -69,7 +69,9 @@ HELP_SHORT = "Execute a workplan."
 HELP_LONG = f"""\
 {HELP_SHORT}
 
-Specify a previously used `run_id` to re-start a prior run.
+Specify a previously used `run_id` to re-start (or reattach) to a prior run.
+
+If a path to a blueprint is supplied, it will be executed as a single-step workplan.
 """
 
 CATEGORY_HEADER_COLOR: t.Final[str] = "white"
@@ -500,7 +502,7 @@ def run(
             "--varfile",
             "-f",
             help=(
-                "Specify the path to a file containing one replacements per line "
+                "Specify the path to a file containing one replacement per line "
                 "as key-value pairs in the form `key=value`."
             ),
             callback=preprocess_varfile,
@@ -514,7 +516,7 @@ def run(
     path: t.Annotated[
         str,
         typer.Argument(
-            help="Path to a workplan file.",
+            help="Path to a workplan or blueprint file.",
             callback=preprocess_path,
             is_eager=True,
         ),

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -386,6 +386,7 @@ def auto_compose(path: str) -> str:
         # path isn't a blueprint. leave it alone.
         return path
     else:
+        log.debug(f"The blueprint at {path!r} must be converted into a workplan")
         bp_path = Path(path)
         wp_name = f"{slugify(bp.name)}-host-workplan{bp_path.suffix}"
         wp_path = bp_path.with_name(wp_name)
@@ -402,6 +403,7 @@ def auto_compose(path: str) -> str:
             ],
         )
         serialize(wp_path, wp)
+        log.info(f"Created a host workplan for blueprint in: {wp_path}")
         return str(wp_path)
 
 

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -397,7 +397,7 @@ def auto_compose(path: str) -> str:
                 Step(
                     name=f"Execute {bp.name!r}",
                     application=bp.application,
-                    blueprint=path,
+                    blueprint=bp_path,
                 )
             ],
         )

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -436,6 +436,7 @@ def preprocess_path(workplan_path: str | None) -> str | None:
                     msg = f"The workplan file in `{workplan_path}` is improperly formatted"
                     raise typer.BadParameter(msg)
 
+                return str(local_path)
         except FileNotFoundError as ex:
             msg = f"Workplan not found at path: {workplan_path}"
             raise typer.BadParameter(msg) from ex

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -516,6 +516,7 @@ def run(
         typer.Argument(
             help="Path to a workplan file.",
             callback=preprocess_path,
+            is_eager=True,
         ),
     ] = "",
     dry_run: t.Annotated[

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -391,11 +391,11 @@ def auto_compose(path: str) -> str:
         wp_path = bp_path.with_name(wp_name)
 
         wp = Workplan(
-            name=f"{bp.name} Host",
+            name=f"{bp.name!r} Host",
             description="Automated Workplan wrapping the execution of a single blueprint.",
             steps=[
                 Step(
-                    name=f"Execute {bp.name}",
+                    name=f"Execute {bp.name!r}",
                     application=bp.application,
                     blueprint=path,
                 )

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -386,6 +386,10 @@ def auto_compose(path: str) -> str:
         # path isn't a blueprint. leave it alone.
         return path
     else:
+        bp_path = Path(path)
+        wp_name = f"{slugify(bp.name)}-host-workplan.{bp_path.suffix}"
+        wp_path = bp_path.with_name(wp_name)
+
         wp = Workplan(
             name=f"{bp.name} Host",
             description="Automated Workplan wrapping the execution of a single blueprint.",
@@ -397,7 +401,6 @@ def auto_compose(path: str) -> str:
                 )
             ],
         )
-        wp_path = Path(path).with_name(f"{slugify(bp.name)}-host-workplan")
         serialize(wp_path, wp)
         return str(wp_path)
 

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -391,7 +391,7 @@ def auto_compose(path: str) -> str:
         wp_path = bp_path.with_name(wp_name)
 
         wp = Workplan(
-            name=f"{bp.name!r} Host",
+            name=f"{bp.name} Host",
             description="Automated Workplan wrapping the execution of a single blueprint.",
             steps=[
                 Step(

--- a/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
+++ b/cstar/tests/unit_tests/orchestration/cli/workplan/test_run_workplan.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 from cstar.base.env import ENV_CSTAR_RUNID, ENV_CSTAR_STATE_HOME
 from cstar.base.exceptions import CstarExpectationFailed
 from cstar.cli.common import normalize_runid
-from cstar.cli.workplan.run import app
+from cstar.cli.workplan.run import app, auto_compose
 from cstar.orchestration.dag_runner import get_launcher
 from cstar.orchestration.launch.local import LocalHandle
 from cstar.orchestration.launch.slurm import SlurmHandle, SlurmLauncher
@@ -1124,6 +1124,151 @@ def test_cli_workplan_run_normalizes_mixed_case_runid(
     assert result.exit_code == 0
     assert os.environ[ENV_CSTAR_RUNID] == "myrun_01"
     assert mock_build_and_run_dag.call_args.args[1] == "myrun_01"
+
+
+@pytest.mark.parametrize("suffix", [".yaml", ".yml"])
+def test_auto_compose_wraps_blueprint(
+    tmp_path: Path,
+    hello_world_bp_content: str,
+    suffix: str,
+) -> None:
+    """Verify a blueprint path is wrapped in a generated host workplan that
+    is written next to the blueprint, preserving the blueprint's suffix.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    hello_world_bp_content : str
+        Fixture providing the content of a minimal hello-world blueprint
+    suffix : str
+        The file extension of the blueprint being wrapped
+    """
+    bp_path = tmp_path / f"helloworld{suffix}"
+    bp_path.write_text(hello_world_bp_content)
+
+    result = auto_compose(bp_path.as_posix())
+
+    wp_path = Path(result)
+    assert wp_path != bp_path
+    assert wp_path.parent == bp_path.parent
+    assert wp_path.name == f"say-hello-to-my-little-friend-host-workplan{suffix}"
+    assert wp_path.exists()
+
+    # the generated host workplan must contain a single step executing the blueprint
+    wp = deserialize(wp_path, Workplan)
+    assert wp.name == "Say hello to my little friend! Host"
+    assert len(wp.steps) == 1
+
+    step = wp.steps[0]
+    assert step.application == "hello_world"
+    assert Path(step.blueprint_path).resolve() == bp_path.resolve()
+    assert "Say hello to my little friend!" in step.name
+
+
+def test_auto_compose_ignores_workplan(
+    tmp_path: Path,
+    wp_templates_dir: Path,
+) -> None:
+    """Verify a workplan path passes through `auto_compose` unchanged and no
+    host workplan file is generated.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    wp_templates_dir : Path
+        Fixture providing the path to a directory containing template workplans
+    """
+    wp_template = wp_templates_dir / "workplan.yaml"
+    wp_path = tmp_path / "workplan.yaml"
+    wp_path.write_text(wp_template.read_text())
+
+    files_before = set(tmp_path.iterdir())
+
+    assert auto_compose(wp_path.as_posix()) == wp_path.as_posix()
+    assert set(tmp_path.iterdir()) == files_before
+
+
+def test_auto_compose_ignores_non_blueprint_content(tmp_path: Path) -> None:
+    """Verify a file that is neither a blueprint nor a workplan passes
+    through `auto_compose` unchanged and no host workplan file is generated.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory to read/write test inputs and outputs
+    """
+    path = tmp_path / "not-a-blueprint.yaml"
+    path.write_text("some: [unrelated, content]\n")
+
+    files_before = set(tmp_path.iterdir())
+
+    assert auto_compose(path.as_posix()) == path.as_posix()
+    assert set(tmp_path.iterdir()) == files_before
+
+
+def test_workplan_run_blueprint_auto_composes(hello_world_bp_path: Path) -> None:
+    """Verify submitting a blueprint to `cstar workplan run` generates a host
+    workplan and passes the generated workplan (not the blueprint) on to
+    `build_and_run_dag`.
+
+    Parameters
+    ----------
+    hello_world_bp_path : Path
+        Fixture providing the path to a minimal hello-world blueprint
+    """
+    with mock.patch(
+        "cstar.cli.workplan.run.build_and_run_dag", wraps=fake_build_and_run_dag
+    ) as mock_build_and_run_dag:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["--run-id", "12345", hello_world_bp_path.as_posix()],
+            color=False,
+        )
+
+    assert result.exit_code == 0
+    mock_build_and_run_dag.assert_awaited_once()
+
+    # confirm the composed host workplan is what continues through the run
+    wp_path = mock_build_and_run_dag.call_args.args[0]
+    assert isinstance(wp_path, Path)
+    assert wp_path.name.endswith("-host-workplan.yaml")
+    assert wp_path.exists()
+
+    # confirm the host workplan step executes the submitted blueprint
+    wp = deserialize(wp_path, Workplan)
+    assert [Path(s.blueprint_path).resolve() for s in wp.steps] == [
+        hello_world_bp_path.resolve()
+    ]
+
+
+def test_workplan_run_blueprint_default_run_id(hello_world_bp_path: Path) -> None:
+    """Verify that omitting the run-id when submitting a blueprint derives
+    the default run-id from the generated host workplan rather than failing
+    to parse the blueprint.
+
+    Parameters
+    ----------
+    hello_world_bp_path : Path
+        Fixture providing the path to a minimal hello-world blueprint
+    """
+    with mock.patch(
+        "cstar.cli.workplan.run.build_and_run_dag", wraps=fake_build_and_run_dag
+    ) as mock_build_and_run_dag:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [hello_world_bp_path.as_posix()],
+            color=False,
+        )
+
+    assert result.exit_code == 0
+    mock_build_and_run_dag.assert_awaited_once()
+    assert (
+        mock_build_and_run_dag.call_args.args[1] == "say-hello-to-my-little-friend-host"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

This PR adds automatic creation of a single-step `Workplan` when a `Blueprint` is passed to `cstar workplan run`.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- Blueprints passed to `cstar workplan run ...` will be executed in the context of a workplan.

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Fix parameter typo and include capability to re-attach in main help text.

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [x] Closes #CSD-1189
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

