### PR TITLE
Pair run-summary steps with their own sentinels

### DIFF
--- a/cstar/orchestration/dag_runner.py
+++ b/cstar/orchestration/dag_runner.py
@@ -501,18 +501,26 @@ class ExecutiveRunSummary(BaseModel):
         steps = [LiveStep.from_step(s) for s in workplan.steps]
         step_summaries: list[ExecutiveStepSummary] = []
 
+        # `run.sentinels` is an unordered set, so pair each step with its own
+        # sentinel by file name rather than by position. Steps that were never
+        # launched have no recorded sentinel and fall back to the canonical path.
+        recorded = {path.name: path for path in run.sentinels}
+        sentinel_paths = [
+            recorded.get(
+                StateRepository.sentinel_name(step.safe_name),
+                StateRepository.sentinel_path(step.safe_name, run_id=run.run_id),
+            )
+            for step in steps
+        ]
+
         sentinels = await asyncio.gather(
             *[
                 asyncio.to_thread(try_deserialize, path, ProcessHandle)
-                for path in run.sentinels
+                for path in sentinel_paths
             ]
         )
 
-        for step, sentinel_path, handle in zip(
-            steps,
-            run.sentinels,
-            sentinels,
-        ):
+        for step, sentinel_path, handle in zip(steps, sentinel_paths, sentinels):
             summary = ExecutiveStepSummary(
                 name=step.name,
                 log_path=str(step.log_path),

--- a/cstar/tests/unit_tests/orchestration/test_dag_runner.py
+++ b/cstar/tests/unit_tests/orchestration/test_dag_runner.py
@@ -21,6 +21,7 @@ from cstar.execution.file_system import (
     StateDirectoryManager,
 )
 from cstar.orchestration.dag_runner import (
+    ExecutiveRunSummary,
     _ignore_ambient_clobber_env,
     apply_clobber_overrides,
     check_clobber_dependents,
@@ -534,3 +535,53 @@ async def test_prepare_workplan_persists_clobber_overrides(
 
     assert by_name["Prepare"].workflow_overrides[KEY_CLOBBER] is True
     assert not by_name["Ensemble X"].workflow_overrides.get(KEY_CLOBBER, False)
+
+
+@pytest.mark.asyncio
+async def test_executive_run_summary_pairs_each_step_with_its_own_sentinel(
+    layered_workplan: tuple[Workplan, dict[str, LocalHandle]],
+    mock_run_id: str,
+) -> None:
+    """Verify the run summary reports each step's own status and task id.
+
+    `WorkplanRun.sentinels` is an unordered set, so the summary must match
+    sentinels to steps by name rather than by iteration position.
+    """
+    workplan, handles = layered_workplan
+    state_repo = StateRepository()
+    run_repo = TrackingRepository()
+
+    done_names = {"Step 0", "Step 2", "Step 4"}
+    unlaunched_name = "Step 5"
+    expected: dict[str, Status] = {}
+
+    wp_run = await run_repo.get_workplan_run(mock_run_id)
+    assert wp_run is not None
+
+    for handle in handles.values():
+        handle.status = Status.Done if handle.name in done_names else Status.Running
+        path = await state_repo.put_sentinel(handle)
+        assert path is not None
+
+        if handle.name == unlaunched_name:
+            # a step that was never launched has no sentinel on disk or on the run
+            path.unlink()
+            expected[handle.name] = Status.Unsubmitted
+            continue
+
+        wp_run.sentinels.add(path)
+        expected[handle.name] = handle.status
+
+    summary = await ExecutiveRunSummary.from_run(wp_run)
+
+    assert [s.name for s in summary.steps] == [s.name for s in workplan.steps]
+    for step_summary in summary.steps:
+        assert step_summary.status == expected[step_summary.name].name
+        handle = handles[step_summary.name]
+        if step_summary.name == unlaunched_name:
+            assert step_summary.task_id == ""
+        else:
+            assert step_summary.task_id == handle.pid
+        assert step_summary.sentinel_path.name == StateRepository.sentinel_name(
+            handle.safe_name
+        )


### PR DESCRIPTION
# Summary
The run summary printed at the end of `cstar workplan run` attributed each step's status, task/job ID, and state-file path to the wrong step. The summary paired the workplan's steps with the run's recorded sentinel files by position, but those paths are stored as an unordered set, so the pairing was arbitrary. The orchestrator's own "Closed node" log lines and the `cstar workplan status` table were unaffected, which is why the two disagreed. Each step now looks up its own sentinel by name.

## Breaking Changes
- N/A

## New Features
- N/A

## Bug Fixes
- The per-step "Job Details" block in the `cstar workplan run` summary showed another step's status and task/job ID; each step now reports its own.

## Improvements
- N/A

## Miscellaneous
- N/A

## Notes for Reviewers
- Steps that were never launched have no recorded sentinel; they fall back to the canonical sentinel path for the step and continue to display as `Unsubmitted`.
- The new regression test fails deterministically on the previous code across hash seeds (set ordering), and passes with the fix.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit tier: `cstar/tests/unit_tests/orchestration`, 756 passed; integration tier not run)
