### PR TITLE
Update for roms-tools 5.0

### DIFF
--- a/cstar/applications/nest_ic.py
+++ b/cstar/applications/nest_ic.py
@@ -127,13 +127,16 @@ class NestIcRunner(BlueprintRunner[NestIcBlueprint]):
             use_dask=True,
         )
 
-        # only add bgc_source if parent has BGC
+        # only add bgc_source if parent has BGC. roms-tools >= 5.0 requires the BGC
+        # model class alongside any bgc source: it completes the MARBL tracer set
+        # (derivations and constant fills) rather than the forcing class doing so.
         if self._has_bgc(self.blueprint.parent_rst):
             ic_kwargs["bgc_source"] = {
                 "name": "ROMS",
                 "grid": parent_grid,
                 "path": self.blueprint.parent_rst,
             }
+            ic_kwargs["bgc_model"] = roms_tools.BGCMarbl
 
         fname = f"ic_from_parent_rst.{rst.formatted_timestamp}.nc"
         path = Path(self.blueprint.working_dir).expanduser() / "output" / fname

--- a/cstar/tests/unit_tests/applications/test_nest_ic.py
+++ b/cstar/tests/unit_tests/applications/test_nest_ic.py
@@ -195,6 +195,47 @@ class TestCreateInitialConditionsRouting:
         mock_convert.assert_called_once_with(nc4_path, final_path)
         assert result == final_path
 
+    def test_bgc_parent_passes_bgc_source_and_bgc_model(
+        self,
+        blueprint_kwargs: dict[str, Any],
+        _mock_has_bgc: mock.Mock,
+    ) -> None:
+        """A parent restart with BGC tracers must produce a `bgc_source` AND the
+        `bgc_model` roms-tools >= 5.0 requires alongside it (it completes the MARBL
+        tracer set); omitting `bgc_model` raises "bgc_model is required" there.
+        """
+        from cstar.applications import nest_ic as nest_ic_module
+
+        _mock_has_bgc.return_value = True
+        bp = NestIcBlueprint(**blueprint_kwargs, pio=False)
+        runner = _make_runner(bp)
+
+        runner._create_initial_conditions()
+
+        mocked_roms_tools = nest_ic_module.roms_tools
+        kwargs = mocked_roms_tools.InitialConditions.call_args.kwargs
+        assert kwargs["bgc_source"]["name"] == "ROMS"
+        assert kwargs["bgc_source"]["path"] == bp.parent_rst
+        assert kwargs["bgc_model"] is mocked_roms_tools.BGCMarbl
+
+    def test_physics_only_parent_passes_no_bgc_kwargs(
+        self,
+        blueprint_kwargs: dict[str, Any],
+    ) -> None:
+        """Without BGC in the parent restart neither `bgc_source` nor `bgc_model`
+        is passed, so a physics-only nest does not require any BGC model.
+        """
+        from cstar.applications import nest_ic as nest_ic_module
+
+        bp = NestIcBlueprint(**blueprint_kwargs, pio=False)
+        runner = _make_runner(bp)
+
+        runner._create_initial_conditions()
+
+        kwargs = nest_ic_module.roms_tools.InitialConditions.call_args.kwargs
+        assert "bgc_source" not in kwargs
+        assert "bgc_model" not in kwargs
+
     def test_pio_false_saves_directly_without_conversion(
         self,
         blueprint_kwargs: dict[str, Any],

--- a/environment-hpc.yml
+++ b/environment-hpc.yml
@@ -4,6 +4,6 @@ channels:
 dependencies:
   - python>=3.12,<3.14
   - pip
-  - roms-tools>=4.0.1,<5
+  - roms-tools>=5.0,<6
   # docs builds only
   - pandoc

--- a/environment-laptop.yml
+++ b/environment-laptop.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.12,<3.14
   - pip
-  - roms-tools>=4.0.1,<5
+  - roms-tools>=5.0,<6
   # toolchain: provided by modules on HPC
   - compilers
   - cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,11 @@ dependencies = [
     "PyYAML>=6.0,<7",
     "f90nml>=1.4",
     "numpy>2.0,<2.4",
-    # dask is a core roms-tools dependency as of 4.0.1 (the [dask] extra is gone).
-    "roms_tools>=4.0.1,<5",
+    # >=5.0: `InitialConditions` requires `bgc_model=` alongside `bgc_source=` (used by
+    # cstar.applications.nest_ic), and cstar-forge builds on the 5.0 wrapper API, so a
+    # `<5` ceiling would make forge and cstar-ocean uninstallable together. dask is a
+    # core roms-tools dependency as of 4.0.1 (the [dask] extra is gone).
+    "roms_tools>=5.0,<6",
     "typer<=0.25",
 ]
 keywords = ["MCDR", "CDR", "ocean carbon", "climate"]


### PR DESCRIPTION
# Summary

Makes C-Star compatible with roms-tools 5.0 (released 2026-09-11) and lifts the `<5` ceiling on the dependency.

## Breaking Changes
- C-Star now requires `roms_tools>=5.0,<6` (previously `>=4.0.1,<5`). The only roms-tools API C-Star itself calls that changed in 5.0 is `InitialConditions` call in the `NestIc` application; everything else is unaffected.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit tier; see notes)
