### PR TITLE
Add support for CDR Tracer namelist sections

### DIFF
--- a/cstar/roms/namelist.py
+++ b/cstar/roms/namelist.py
@@ -15,8 +15,11 @@ subclasses:
   unversioned (no suffix) for backward compatibility: this is the name
   historically imported by C-Star Forge and other consumers.
 - :class:`RomsNamelistV0_5_0` — the schema for ucla-roms **>= 0.5.0, < 0.6.0**.
-- :class:`RomsNamelistV0_6_0` — the schema for ucla-roms **>= 0.6.0**. Adds
-  the ``&PIO_SETTINGS`` group (ucla-roms PR #346) on top of 0.5.0.
+- :class:`RomsNamelistV0_6_0` — the schema for ucla-roms **>= 0.6.0, < 0.7.0**.
+  Adds the ``&PIO_SETTINGS`` group (ucla-roms PR #346) on top of 0.5.0.
+- :class:`RomsNamelistV0_7_0` — the schema for ucla-roms **>= 0.7.0**. Adds
+  the ``&CDR_TRACER_OUTPUT_SETTINGS`` and ``&CDR_GAS_EXCH_OUTPUT_SETTINGS``
+  groups (ucla-roms PR #351) on top of 0.6.0.
 
 Later breaking releases add a further ``RomsNamelistV<major>_<minor>_<patch>``
 subclass following the same ``V<major>_<minor>_<patch>`` suffix convention.
@@ -500,6 +503,62 @@ class CdrOutputSettings(_NmlGroup):
     """Time records per output file"""
 
 
+class CdrTracerOutputSettings(_NmlGroup):
+    """``&CDR_TRACER_OUTPUT_SETTINGS`` for ucla-roms >= 0.7.0 (PR #351).
+
+    Dedicated output stream for the CDR tracers (``CDR_OAE_ALK``/``CDR_OAE_DIC``
+    and ``CDR_DOR_DIC``). Requires the ``MARBL`` and ``CDR_FORCING`` cppkeys.
+    Every field carries the ucla-roms reference default so the group can be
+    omitted from an older namelist and still validate.
+    """
+
+    do_cdr_tracer_output: bool = False
+    """Output dedicated CDR tracers"""
+    wrt_cdr_trc_avg: bool = True
+    """Write averaged (T) or instantaneous (F)"""
+    cdr_trc_monthly_averages: bool = False
+    """Write averaged outputs per calendar month"""
+    output_period_cdr_trc: float = 3600.0
+    """Frequency of CDR tracer output (s)"""
+    nrpf_cdr_trc: int = 4
+    """Time records per output file"""
+    wrt_tracers: bool = True
+    """Write CDR tracer concentrations"""
+    wrt_vertical_integrals: bool = True
+    """Write int_z_* fields"""
+    wrt_thickness_weighted: bool = True
+    """Write h* and h*_avg fields"""
+    wrt_sources: bool = True
+    """Write *_source fields (if cdr_source)"""
+    wrt_alk: bool = True
+    """Write CDR_OAE_ALK and its variants"""
+    wrt_dic: bool = True
+    """Write CDR_OAE_DIC, CDR_DOR_DIC and variants"""
+
+
+class CdrGasExchOutputSettings(_NmlGroup):
+    """``&CDR_GAS_EXCH_OUTPUT_SETTINGS`` for ucla-roms >= 0.7.0 (PR #351).
+
+    Dedicated output stream for the gas-exchange sensitivities ``ddic_dco2``
+    (beta) and ``ddic_dalk`` (eta), which PR #351 moved out of the
+    ``&CDR_OUTPUT_SETTINGS`` stream. Requires the ``MARBL`` and
+    ``CDR_FORCING`` cppkeys. Every field carries the ucla-roms reference
+    default so the group can be omitted from an older namelist and still
+    validate.
+    """
+
+    do_cdr_gas_exch_output: bool = False
+    """Output CDR gas-exchange sensitivities"""
+    wrt_cdr_gas_avg: bool = True
+    """Write averaged (T) or instantaneous (F)"""
+    cdr_gas_monthly_averages: bool = False
+    """Write averaged outputs per calendar month"""
+    output_period_cdr_gas: float = 3600.0
+    """Frequency of CDR gas-exch output (s)"""
+    nrpf_cdr_gas: int = 4
+    """Time records per output file"""
+
+
 class UpscaleSettings(_NmlGroup):
     do_upscale: bool
     """Record CDR tracer fluxes thru domain boundaries"""
@@ -702,9 +761,11 @@ class RomsNamelistBase(BaseModel):
 
     Not meant to be instantiated directly: use a versioned subclass
     (:class:`RomsNamelist` for ucla-roms < 0.5.0, :class:`RomsNamelistV0_5_0`
-    for ucla-roms >= 0.5.0, < 0.6.0, or :class:`RomsNamelistV0_6_0` for
-    ucla-roms >= 0.6.0, which adds ``&PIO_SETTINGS``) or select one
-    automatically with :func:`namelist_schema_for_ref`.
+    for ucla-roms >= 0.5.0, < 0.6.0, :class:`RomsNamelistV0_6_0` for
+    ucla-roms >= 0.6.0, < 0.7.0, which adds ``&PIO_SETTINGS``, or
+    :class:`RomsNamelistV0_7_0` for ucla-roms >= 0.7.0, which adds the two
+    CDR tracer / gas-exchange output groups) or select one automatically with
+    :func:`namelist_schema_for_ref`.
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
@@ -896,7 +957,7 @@ class RomsNamelistV0_5_0(RomsNamelistBase):
 
 
 class RomsNamelistV0_6_0(RomsNamelistV0_5_0):
-    """The ROMS namelist schema for ucla-roms >= 0.6.0.
+    """The ROMS namelist schema for ucla-roms >= 0.6.0, < 0.7.0.
 
     Adds `&PIO_SETTINGS` (ucla-roms PR #346) on top of the 0.5.0 schema;
     otherwise unchanged.
@@ -905,12 +966,30 @@ class RomsNamelistV0_6_0(RomsNamelistV0_5_0):
     pio_settings: PioSettings = Field(default_factory=PioSettings)
 
 
+class RomsNamelistV0_7_0(RomsNamelistV0_6_0):
+    """The ROMS namelist schema for ucla-roms >= 0.7.0.
+
+    Adds `&CDR_TRACER_OUTPUT_SETTINGS` and `&CDR_GAS_EXCH_OUTPUT_SETTINGS`
+    (ucla-roms PR #351) on top of the 0.6.0 schema; otherwise unchanged. Both
+    groups default to their ucla-roms reference values (output off), so an
+    older namelist without them still validates; both are always written.
+    """
+
+    cdr_tracer_output_settings: CdrTracerOutputSettings = Field(
+        default_factory=CdrTracerOutputSettings
+    )
+    cdr_gas_exch_output_settings: CdrGasExchOutputSettings = Field(
+        default_factory=CdrGasExchOutputSettings
+    )
+
+
 # ---- Schema version selection ----
 
 # ucla-roms releases with breaking namelist changes, as comparable version
 # tuples (named so registry entries read as versions, not bare tuples).
 UCLA_ROMS_0_5_0: Final[tuple[int, int, int]] = (0, 5, 0)
 UCLA_ROMS_0_6_0: Final[tuple[int, int, int]] = (0, 6, 0)
+UCLA_ROMS_0_7_0: Final[tuple[int, int, int]] = (0, 7, 0)
 
 # Half-open ucla-roms version ranges ``[lower, upper)`` mapped to the schema
 # class that applies; `None` bounds are unbounded. Ranges must be contiguous
@@ -921,7 +1000,7 @@ UCLA_ROMS_0_6_0: Final[tuple[int, int, int]] = (0, 6, 0)
 #   1. Add the release constant:
 #        UCLA_ROMS_0_8_0: Final[tuple[int, int, int]] = (0, 8, 0)
 #   2. Cap the current last entry's upper bound at the new version:
-#        (UCLA_ROMS_0_6_0, UCLA_ROMS_0_8_0, RomsNamelistV0_6_0),
+#        (UCLA_ROMS_0_7_0, UCLA_ROMS_0_8_0, RomsNamelistV0_7_0),
 #   3. Append a new open-ended entry for the new schema:
 #        (UCLA_ROMS_0_8_0, None, RomsNamelistV0_8_0),
 NAMELIST_SCHEMA_REGISTRY: tuple[
@@ -932,7 +1011,8 @@ NAMELIST_SCHEMA_REGISTRY: tuple[
 ] = (
     (None, UCLA_ROMS_0_5_0, RomsNamelist),
     (UCLA_ROMS_0_5_0, UCLA_ROMS_0_6_0, RomsNamelistV0_5_0),
-    (UCLA_ROMS_0_6_0, None, RomsNamelistV0_6_0),
+    (UCLA_ROMS_0_6_0, UCLA_ROMS_0_7_0, RomsNamelistV0_6_0),
+    (UCLA_ROMS_0_7_0, None, RomsNamelistV0_7_0),
 )
 
 

--- a/cstar/roms/precheck.py
+++ b/cstar/roms/precheck.py
@@ -5,9 +5,10 @@ ucla-roms >= 0.5.0 aborts at startup (``check_output_divides_rst``) if any
 *enabled* output stream's file-rollover frequency (``nrpf * output_period``)
 is not positive, or does not evenly divide ``output_period_rst`` -- writing a
 restart mid-file would otherwise leave a partial output file. The whole check
-is gated on ``basic_output_settings.wrt_file_rst``; four of the per-stream
+is gated on ``basic_output_settings.wrt_file_rst``; six of the per-stream
 groups are further gated on a ucla-roms compile-time cppdef (``DIAGNOSTICS``,
-and the three MARBL/BGC-diagnostics groups).
+and the five MARBL/BGC-diagnostics groups: ``cdr``, ``cdrtrc``, ``cdrgas``,
+``upscale``, and ``bgc``).
 
 :func:`check_output_streams_divide_rst` reproduces this in Python so C-Star
 (and consumers building ucla-roms run-time settings, e.g. C-Star Forge) can
@@ -95,7 +96,7 @@ class _StreamCheck:
 # `gate_fields`/`period_field`/`nrpf_field` are the real Fortran namelist keys
 # within that group. Verified against `cstar/roms/namelist.py` (the group
 # classes) and `cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_6_0.nml`
-# (the `&<group>` headers).
+# / `example_namelist_v0_7_0.nml` (the `&<group>` headers).
 _STREAM_CHECKS: tuple[_StreamCheck, ...] = (
     _StreamCheck(
         "extract",
@@ -171,6 +172,22 @@ _STREAM_CHECKS: tuple[_StreamCheck, ...] = (
         "output_period_cdr",
         "nrpf_cdr",
         cppdef_guard=("marbl", "marbl_diags", "cdr_forcing"),
+    ),
+    _StreamCheck(
+        "cdrtrc",
+        "cdr_tracer_output_settings",
+        ("do_cdr_tracer_output",),
+        "output_period_cdr_trc",
+        "nrpf_cdr_trc",
+        cppdef_guard=("marbl", "cdr_forcing"),
+    ),
+    _StreamCheck(
+        "cdrgas",
+        "cdr_gas_exch_output_settings",
+        ("do_cdr_gas_exch_output",),
+        "output_period_cdr_gas",
+        "nrpf_cdr_gas",
+        cppdef_guard=("marbl", "cdr_forcing"),
     ),
     _StreamCheck(
         "upscale",
@@ -254,10 +271,11 @@ def check_output_streams_divide_rst(
         stream applies.
     cppdefs
         Mapping of cppdef name -> whether it is active in this build (e.g.
-        ``{"marbl": True, "cdr_forcing": True}``). Governs the four
-        cppdef-gated groups (``diagnostics``; the three MARBL/BGC-diagnostics
-        groups: ``cdr``, ``upscale``, and the four ``bgc_*`` streams, gated on
-        ``MARBL || BIOLOGY_BEC2``). ``None``/absent names are treated as
+        ``{"marbl": True, "cdr_forcing": True}``). Governs the six
+        cppdef-gated groups (``diagnostics``; the five MARBL/BGC-diagnostics
+        groups: ``cdr``, ``cdrtrc``, ``cdrgas``, ``upscale``, and the four
+        ``bgc_*`` streams, gated on ``MARBL || BIOLOGY_BEC2``). ``None``/absent
+        names are treated as
         inactive, so a caller that doesn't build MARBL/BIOLOGY_BEC2 at all can
         just omit them -- the cppdef-gated groups are then always skipped,
         exactly as ucla-roms itself would (it never compiles their write

--- a/cstar/tests/unit_tests/applications/test_roms_marbl_models.py
+++ b/cstar/tests/unit_tests/applications/test_roms_marbl_models.py
@@ -225,7 +225,8 @@ class TestNamelistOverrides:
     ):
         """Test that a `pio_settings` override validates silently for an
         unpinned `code.roms` ref: the fallback schema for an unpinned ref is
-        the latest (`RomsNamelistV0_6_0`), which has `&pio_settings`.
+        the latest (`RomsNamelistV0_7_0`), which inherits `&pio_settings`
+        from `RomsNamelistV0_6_0`.
         """
         complete_blueprint_dict["namelist_overrides"] = {
             "pio_settings": {"pio_stride": 4}
@@ -246,6 +247,38 @@ class TestNamelistOverrides:
             "pio_settings": {"pio_stride": 4}
         }
         with pytest.raises(ValidationError, match="pio_settings"):
+            RomsMarblBlueprint.model_validate(complete_blueprint_dict)
+
+    def test_cdr_tracer_output_settings_override_valid_for_unpinned_ref(
+        self, complete_blueprint_dict
+    ):
+        """Test that a `cdr_tracer_output_settings` override validates
+        silently for an unpinned `code.roms` ref: the fallback schema for an
+        unpinned ref is the latest (`RomsNamelistV0_7_0`), which has
+        `&cdr_tracer_output_settings`.
+        """
+        complete_blueprint_dict["namelist_overrides"] = {
+            "cdr_tracer_output_settings": {"wrt_alk": False}
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            bp = RomsMarblBlueprint.model_validate(complete_blueprint_dict)
+        assert bp.namelist_overrides == {
+            "cdr_tracer_output_settings": {"wrt_alk": False}
+        }
+
+    def test_cdr_tracer_output_settings_override_rejected_for_0_6_1_pin(
+        self, complete_blueprint_dict
+    ):
+        """Test that a `cdr_tracer_output_settings` override is rejected for a
+        `code.roms` pin at 0.6.1, since `&cdr_tracer_output_settings` was
+        added in ucla-roms 0.7.0.
+        """
+        complete_blueprint_dict["code"]["roms"]["branch"] = "v0.6.1"
+        complete_blueprint_dict["namelist_overrides"] = {
+            "cdr_tracer_output_settings": {"wrt_alk": False}
+        }
+        with pytest.raises(ValidationError, match="cdr_tracer_output_settings"):
             RomsMarblBlueprint.model_validate(complete_blueprint_dict)
 
 

--- a/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_7_0.nml
+++ b/cstar/tests/unit_tests/roms/fixtures/example_namelist_v0_7_0.nml
@@ -1,0 +1,337 @@
+&basic_output_settings
+    monthly_restarts = .false.
+    nrpf_avg = 1
+    nrpf_his = 7
+    output_period_avg = 604800.0
+    output_period_his = 86400.0
+    output_period_rst = 86400.0
+    wrt_aks = .false.
+    wrt_akt = .false.
+    wrt_akv = .false.
+    wrt_avg_aks = .true.
+    wrt_avg_akt = .true.
+    wrt_avg_akv = .true.
+    wrt_avg_hbbl = .true.
+    wrt_avg_hbls = .true.
+    wrt_avg_o = .true.
+    wrt_avg_r = .true.
+    wrt_avg_u = .true.
+    wrt_avg_ub = .true.
+    wrt_avg_v = .true.
+    wrt_avg_vb = .true.
+    wrt_avg_w = .true.
+    wrt_avg_z = .true.
+    wrt_file_avg = .false.
+    wrt_file_his = .false.
+    wrt_file_rst = .true.
+    wrt_hbbl = .false.
+    wrt_hbls = .false.
+    wrt_o = .false.
+    wrt_r = .false.
+    wrt_u = .true.
+    wrt_ub = .true.
+    wrt_v = .true.
+    wrt_vb = .true.
+    wrt_w = .true.
+    wrt_z = .true.
+/
+
+&bgc_settings
+    interp_bgc_frc = .true.
+    nrpf_bgc_avg = 7
+    nrpf_bgc_avg_dia = 1
+    nrpf_bgc_his = 7
+    nrpf_bgc_his_dia = 7
+    output_period_bgc_avg = 86400.0
+    output_period_bgc_avg_dia = 60.0
+    output_period_bgc_his = 86400.0
+    output_period_bgc_his_dia = 86400.0
+    wrt_bgc_avg = .false.
+    wrt_bgc_dia_avg = .false.
+    wrt_bgc_dia_his = .false.
+    wrt_bgc_his = .false.
+    xco2air_default = 284.7
+/
+
+&bottom_drag_settings
+    rdrg = 0.0
+    rdrg2 = 0.001
+    zob = 0.01
+/
+
+&calc_pflx_settings
+    calc_pflx = .true.
+    pflx_timescale = 86400.0
+/
+
+&cdr_frc_settings
+    cdr_file = 'cdr.nc'
+    cdr_forcing_3d = .false.
+    cdr_forcing_depth_profiles = .false.
+    cdr_forcing_parameterized = .true.
+    cdr_ncdr_parm = 1
+    cdr_nz_chd = 50
+    cdr_relocate_to_wet_pts = .true.
+    cdr_source = .false.
+    cdr_time_interpolation = .false.
+    cdr_volume = .false.
+/
+
+&cdr_gas_exch_output_settings
+    cdr_gas_monthly_averages = .false.
+    do_cdr_gas_exch_output = .false.
+    nrpf_cdr_gas = 4
+    output_period_cdr_gas = 3600.0
+    wrt_cdr_gas_avg = .true.
+/
+
+&cdr_output_settings
+    cdr_monthly_averages = .false.
+    do_cdr_output = .false.
+    nrpf_cdr = 24
+    output_period_cdr = 3600.0
+    wrt_cdr_avg = .true.
+/
+
+&cdr_tracer_output_settings
+    cdr_trc_monthly_averages = .false.
+    do_cdr_tracer_output = .false.
+    nrpf_cdr_trc = 4
+    output_period_cdr_trc = 3600.0
+    wrt_alk = .true.
+    wrt_cdr_trc_avg = .true.
+    wrt_dic = .true.
+    wrt_sources = .true.
+    wrt_thickness_weighted = .true.
+    wrt_tracers = .true.
+    wrt_vertical_integrals = .true.
+/
+
+&diagnostics_settings
+    diag_avg = .false.
+    diag_trc = .false.
+    diag_uv = .false.
+    nrpf_diag = 7
+    output_period_diag = 86400.0
+/
+
+&extract_data_settings
+    do_extract = .false.
+    extract_file = 'sample_edata.nc'
+    extract_root_name = 'child'
+    hc_chd = 250.0
+    n_chd = 90
+    nrpf_extract = 24
+    output_period_extract = 3600.0
+    theta_b_chd = 2.0
+    theta_s_chd = 5.0
+/
+
+&forcing_files
+/
+
+&frc_output_settings
+    nrpf_frc = 4
+    output_period_frc = 3600.0
+    wrt_frc = .false.
+    wrt_frc_avg = .false.
+/
+
+&gamma2_settings
+    gamma2 = 1.0
+/
+
+&grid_settings
+    grdname = ''
+/
+
+&initial_conditions
+    inifile = ''
+/
+
+&lateral_visc_settings
+    visc2 = 0.0
+/
+
+&lin_rho_eos_settings
+    s0 = 1.0
+    scoef = 0.822
+    t0 = 1.0
+    tcoef = 0.2
+/
+
+&marbl_biogeochemistry_settings
+    marbl_config_file = 'marbl_in'
+    marbl_diagnostics_to_write = 'PH', 'PH_ALT_CO2', 'pCO2SURF_ALT_CO2',
+                                 'pCO2SURF', 'FG_CO2', 'FG_ALT_CO2'
+    marbl_timestep = 3600.0
+    marbl_tracers_to_write = 'PO4', 'NO3', 'SiO3', 'NH4', 'Fe', 'O2', 'DIC',
+                             'ALK', 'spChl', 'diatChl'
+/
+
+&param_settings
+    llm = 512
+    mmm = 512
+    np_eta = 16
+    np_xi = 16
+    nt_bgc = 32
+    nt_passive = 0
+    nz = 60
+/
+
+&particles_settings
+    exchange_facc = 0.01
+    exchange_facx = 0.1
+    exchange_facy = 0.1
+    extra_space_fac = 1.5
+    floats = .false.
+    np = 50
+    nrpf_particles = 100
+    output_period_particles = 400.0
+    pmin = 200
+    ppm3 = 1e-06
+/
+
+&pio_settings
+    pio_stride = 1
+/
+
+&pipe_frc_settings
+    npip = 1
+    p_analytical = .false.
+    pipe_source = .false.
+/
+
+&random_output_settings
+    do_random = .false.
+    nrpf_random = 10
+    output_period_random = 3600.0
+/
+
+&reference_date_settings
+    reference_date = 2005, 6, 15
+/
+
+&rho0_settings
+    rho0 = 1000.0
+/
+
+&river_frc_settings
+    nriv = 0
+    river_analytical = .false.
+    river_source = .false.
+/
+
+&s_coord
+    hc = 250.0
+    theta_b = 2.0
+    theta_s = 5.0
+/
+
+&simulation_name_settings
+    output_root_name = 'roms'
+    title = 'test_settings'
+/
+
+&sponge_tune_settings
+    nrpf_sponge = 7
+    output_period_sponge = 86400.0
+    sponge_avg = .true.
+    sponge_timescale = 86400.0
+    ub_tune = .false.
+    wrt_sponge = .false.
+/
+
+&sss_correction
+    dsssdt = 7.777
+/
+
+&sst_correction
+    dsstdt = 7.777
+/
+
+&dic_alk_correction
+    dcdt = 7.777
+/
+
+&stdout_diag_settings
+    code_check_mode = .false.
+/
+
+&surf_flx_output_settings
+    nrpf_sflx = 10
+    output_period_sflx = 31536000.0
+    sflx_avg = .false.
+    wrt_smflx = .false.
+    wrt_stflx = .false.
+    wrt_rstflx = .false.
+    wrt_swflx = .false.
+/
+
+&surf_frc_settings
+    check_bulk_frc_units = .false.
+    interp_bulk_frc = .false.
+    interp_flux_frc = .true.
+/
+
+&tidal_frc_settings
+    ana_tides = .false.
+    bry_tides = .true.
+    ntides = 10
+    pot_tides = .true.
+/
+
+&time_stepping
+    dt = 2160.0
+    ndtfast = 60
+    ninfo = 1
+    ntimes = 1200
+/
+
+&tracer_diff2
+    tnu2 = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+/
+
+&ts_output_settings
+    wrt_salt = .false.
+    wrt_salt_dia = .false.
+    wrt_temp = .false.
+    wrt_temp_dia = .false.
+/
+
+&ubind_settings
+    ubind = 0.1
+/
+
+&upscale_settings
+    do_upscale = .false.
+    nrpf_uscl = 48
+    output_period_uscl = 3600.0
+/
+
+&v_sponge_settings
+    v_sponge = 0.0
+/
+
+&vertical_mixing_settings
+    akt_bak = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+              0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    akv_bak = 0.0
+/
+
+&zslice_settings
+    do_zslice = .false.
+    ndep = 2
+    nrpf_zslice = 72
+    nt_zslice = 2
+    output_period_zslice = 1200.0
+    trc2zsc = 1, 2
+    vecdep = -2.0, -15.0
+    wrt_t_zslice = .false.
+    wrt_u_zslice = .false.
+    wrt_v_zslice = .false.
+    zslice_avg = .false.
+/

--- a/cstar/tests/unit_tests/roms/test_namelist.py
+++ b/cstar/tests/unit_tests/roms/test_namelist.py
@@ -13,12 +13,14 @@ from cstar.roms.namelist import (
     RomsNamelistBase,
     RomsNamelistV0_5_0,
     RomsNamelistV0_6_0,
+    RomsNamelistV0_7_0,
     namelist_schema_for_ref,
 )
 
 OLD_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist.nml"
 NEW_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_5_0.nml"
 V0_6_0_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_6_0.nml"
+V0_7_0_NAMELIST = Path(__file__).parent / "fixtures" / "example_namelist_v0_7_0.nml"
 
 PIO_SETTINGS_BLOCK = "&pio_settings\n    pio_stride = 1\n/\n\n"
 
@@ -43,11 +45,20 @@ def test_namelist_schema_for_ref_0_5_0_range(checkout_target):
 
 @pytest.mark.parametrize(
     "checkout_target",
-    ["0.6.0", "v0.6.0", "0.6.1", "0.7.3", "12.0.0"],
+    ["0.6.0", "v0.6.0", "0.6.1", "0.6.9"],
 )
 def test_namelist_schema_for_ref_post_0_6_0(checkout_target):
-    """Refs at or above 0.6.0 select `RomsNamelistV0_6_0`."""
+    """Refs in `[0.6.0, 0.7.0)` select `RomsNamelistV0_6_0`."""
     assert namelist_schema_for_ref(checkout_target) is RomsNamelistV0_6_0
+
+
+@pytest.mark.parametrize(
+    "checkout_target",
+    ["0.7.0", "v0.7.0", "0.7.3", "12.0.0"],
+)
+def test_namelist_schema_for_ref_post_0_7_0(checkout_target):
+    """Refs at or above 0.7.0 select `RomsNamelistV0_7_0`."""
+    assert namelist_schema_for_ref(checkout_target) is RomsNamelistV0_7_0
 
 
 @pytest.mark.parametrize(
@@ -66,7 +77,7 @@ def test_namelist_schema_for_ref_fallback_warns(checkout_target):
     """Non-release-tag refs fall back to the latest schema and warn about it."""
     with pytest.warns(UserWarning, match="use at your own risk"):
         schema = namelist_schema_for_ref(checkout_target)
-    assert schema is RomsNamelistV0_6_0
+    assert schema is RomsNamelistV0_7_0
 
 
 @pytest.fixture
@@ -159,7 +170,7 @@ def test_namelist_schema_for_ref_branch_ignores_repo_path(tagged_ucla_roms_clone
     info = tagged_ucla_roms_clone
     with pytest.warns(UserWarning, match="use at your own risk"):
         schema = namelist_schema_for_ref("main", repo_path=info["repo"])
-    assert schema is RomsNamelistV0_6_0
+    assert schema is RomsNamelistV0_7_0
 
 
 def test_namelist_schema_for_ref_unresolvable_hash_falls_back():
@@ -171,12 +182,12 @@ def test_namelist_schema_for_ref_unresolvable_hash_falls_back():
     ):
         with pytest.warns(UserWarning, match="use at your own risk"):
             schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
-    assert schema is RomsNamelistV0_6_0
+    assert schema is RomsNamelistV0_7_0
 
     with mock.patch("cstar.roms.namelist._describe_nearest_tag", return_value=None):
         with pytest.warns(UserWarning, match="use at your own risk"):
             schema = namelist_schema_for_ref("a" * 40, repo_path="/some/repo")
-    assert schema is RomsNamelistV0_6_0
+    assert schema is RomsNamelistV0_7_0
 
 
 def test_roms_namelist_round_trip():
@@ -285,6 +296,55 @@ def test_pio_settings_rejects_non_positive_stride():
         PioSettings(pio_stride=0)
 
 
+def test_roms_namelist_v0_7_0_round_trip(tmp_path):
+    """`RomsNamelistV0_7_0.read` parses the 0.7.0 fixture, and a read -> write
+    -> read round trip reproduces the same model.
+    """
+    nml = RomsNamelistV0_7_0.read(V0_7_0_NAMELIST)
+
+    out = tmp_path / "namelist.nml"
+    nml.write(out)
+    reread = RomsNamelistV0_7_0.read(out)
+
+    assert reread == nml
+
+
+def test_roms_namelist_v0_6_0_rejects_v0_7_0_fixture():
+    """`RomsNamelistV0_6_0` is strict: the 0.7.0 fixture carries the two new
+    CDR output groups, so it is rejected as unknown extra groups.
+    """
+    with pytest.raises(ValidationError):
+        RomsNamelistV0_6_0.read(V0_7_0_NAMELIST)
+
+
+def test_cdr_output_settings_default_when_groups_missing():
+    """A 0.6.0-schema namelist without `&cdr_tracer_output_settings` or
+    `&cdr_gas_exch_output_settings` still validates under `RomsNamelistV0_7_0`,
+    defaulting both groups to their ucla-roms reference values.
+    """
+    nml = RomsNamelistV0_7_0.read(V0_6_0_NAMELIST)
+
+    assert nml.cdr_tracer_output_settings.do_cdr_tracer_output is False
+    assert nml.cdr_tracer_output_settings.wrt_cdr_trc_avg is True
+    assert nml.cdr_tracer_output_settings.nrpf_cdr_trc == 4
+    assert nml.cdr_gas_exch_output_settings.do_cdr_gas_exch_output is False
+    assert nml.cdr_gas_exch_output_settings.wrt_cdr_gas_avg is True
+    assert nml.cdr_gas_exch_output_settings.nrpf_cdr_gas == 4
+
+
+def test_cdr_output_settings_always_written_even_when_constructed_without_them():
+    """Both new CDR output groups are present in written output even when the
+    model was constructed without explicit groups (using the defaults).
+    """
+    nml = RomsNamelistV0_7_0.read(V0_6_0_NAMELIST)
+    d = nml.to_f90nml_dict()
+
+    assert d["cdr_tracer_output_settings"]["do_cdr_tracer_output"] is False
+    assert d["cdr_tracer_output_settings"]["nrpf_cdr_trc"] == 4
+    assert d["cdr_gas_exch_output_settings"]["do_cdr_gas_exch_output"] is False
+    assert d["cdr_gas_exch_output_settings"]["nrpf_cdr_gas"] == 4
+
+
 class TestUnknownOverrideKeys:
     """Tests for `RomsNamelistBase.unknown_override_keys`."""
 
@@ -335,3 +395,19 @@ class TestUnknownOverrideKeys:
         violations = RomsNamelistV0_5_0.unknown_override_keys(overrides)
         assert len(violations) == 1
         assert "pio_settings" in violations[0]
+
+    def test_cdr_output_settings_keys(self):
+        """`cdr_tracer_output_settings`/`cdr_gas_exch_output_settings` keys are
+        only known from 0.7.0 on: `RomsNamelistV0_7_0` accepts them, but
+        `RomsNamelistV0_6_0` (which lacks the groups) reports them as unknown.
+        """
+        overrides = {
+            "cdr_tracer_output_settings": {"wrt_alk": False},
+            "cdr_gas_exch_output_settings": {"wrt_cdr_gas_avg": False},
+        }
+        assert RomsNamelistV0_7_0.unknown_override_keys(overrides) == []
+
+        violations = RomsNamelistV0_6_0.unknown_override_keys(overrides)
+        assert len(violations) == 2
+        assert any("cdr_tracer_output_settings" in v for v in violations)
+        assert any("cdr_gas_exch_output_settings" in v for v in violations)

--- a/cstar/tests/unit_tests/roms/test_precheck.py
+++ b/cstar/tests/unit_tests/roms/test_precheck.py
@@ -3,7 +3,7 @@
 Mirrors ucla-roms' `src/precheck.F90::do_precheck`/`check_output_divides_rst`:
 for every *enabled* output stream, `nrpf * output_period` must be positive and
 must evenly divide `basic_output_settings.output_period_rst`, when restarts
-are on (`wrt_file_rst`). Four stream groups are additionally gated on a
+are on (`wrt_file_rst`). Six stream groups are additionally gated on a
 compile-time cppdef.
 
 Operates on C-Star's canonical namelist vocabulary (RomsNamelistBase group
@@ -47,6 +47,16 @@ def _base_settings(**overrides):
             "do_cdr_output": False,
             "output_period_cdr": 3600,
             "nrpf_cdr": 24,
+        },
+        "cdr_tracer_output_settings": {
+            "do_cdr_tracer_output": False,
+            "output_period_cdr_trc": 3600,
+            "nrpf_cdr_trc": 4,
+        },
+        "cdr_gas_exch_output_settings": {
+            "do_cdr_gas_exch_output": False,
+            "output_period_cdr_gas": 3600,
+            "nrpf_cdr_gas": 4,
         },
         "upscale_settings": {
             "do_upscale": False,
@@ -118,6 +128,98 @@ def test_enabled_cppdef_active_non_dividing_raises():
             settings,
             cppdefs={"marbl": True, "marbl_diags": True, "cdr_forcing": True},
         )
+
+
+def test_cdr_tracer_cppdef_inactive_skips_even_when_it_would_fail():
+    """`cdrtrc` is skipped entirely when its guarding cppdefs (`marbl` and
+    `cdr_forcing`) are not both active, even with a genuinely non-dividing
+    config.
+    """
+    settings = _base_settings()
+    settings["cdr_tracer_output_settings"] = {
+        "do_cdr_tracer_output": True,
+        "output_period_cdr_trc": 1000,
+        "nrpf_cdr_trc": 3,
+    }
+    # cppdefs omits "cdr_forcing" -> guard unsatisfied.
+    check_output_streams_divide_rst(settings, cppdefs={"marbl": True})
+
+
+def test_cdr_tracer_enabled_cppdef_active_non_dividing_raises():
+    """An enabled, cppdef-active `cdrtrc` stream whose frequency doesn't evenly
+    divide the restart period raises.
+    """
+    settings = _base_settings()
+    settings["cdr_tracer_output_settings"] = {
+        "do_cdr_tracer_output": True,
+        "output_period_cdr_trc": 1000,
+        "nrpf_cdr_trc": 3,
+    }
+    with pytest.raises(ValueError, match="cdrtrc"):
+        check_output_streams_divide_rst(
+            settings, cppdefs={"marbl": True, "cdr_forcing": True}
+        )
+
+
+def test_cdr_tracer_disabled_stream_passes():
+    """A disabled `cdrtrc` stream (`do_cdr_tracer_output` false) passes even
+    with a non-dividing frequency and active cppdef guard.
+    """
+    settings = _base_settings()
+    settings["cdr_tracer_output_settings"] = {
+        "do_cdr_tracer_output": False,
+        "output_period_cdr_trc": 1000,
+        "nrpf_cdr_trc": 3,
+    }
+    check_output_streams_divide_rst(
+        settings, cppdefs={"marbl": True, "cdr_forcing": True}
+    )
+
+
+def test_cdr_gas_exch_cppdef_inactive_skips_even_when_it_would_fail():
+    """`cdrgas` is skipped entirely when its guarding cppdefs (`marbl` and
+    `cdr_forcing`) are not both active, even with a genuinely non-dividing
+    config.
+    """
+    settings = _base_settings()
+    settings["cdr_gas_exch_output_settings"] = {
+        "do_cdr_gas_exch_output": True,
+        "output_period_cdr_gas": 1000,
+        "nrpf_cdr_gas": 3,
+    }
+    # cppdefs omits "cdr_forcing" -> guard unsatisfied.
+    check_output_streams_divide_rst(settings, cppdefs={"marbl": True})
+
+
+def test_cdr_gas_exch_enabled_cppdef_active_non_dividing_raises():
+    """An enabled, cppdef-active `cdrgas` stream whose frequency doesn't evenly
+    divide the restart period raises.
+    """
+    settings = _base_settings()
+    settings["cdr_gas_exch_output_settings"] = {
+        "do_cdr_gas_exch_output": True,
+        "output_period_cdr_gas": 1000,
+        "nrpf_cdr_gas": 3,
+    }
+    with pytest.raises(ValueError, match="cdrgas"):
+        check_output_streams_divide_rst(
+            settings, cppdefs={"marbl": True, "cdr_forcing": True}
+        )
+
+
+def test_cdr_gas_exch_disabled_stream_passes():
+    """A disabled `cdrgas` stream (`do_cdr_gas_exch_output` false) passes even
+    with a non-dividing frequency and active cppdef guard.
+    """
+    settings = _base_settings()
+    settings["cdr_gas_exch_output_settings"] = {
+        "do_cdr_gas_exch_output": False,
+        "output_period_cdr_gas": 1000,
+        "nrpf_cdr_gas": 3,
+    }
+    check_output_streams_divide_rst(
+        settings, cppdefs={"marbl": True, "cdr_forcing": True}
+    )
 
 
 def test_non_positive_newfile_freq_raises():
@@ -232,7 +334,7 @@ def test_diagnostics_or_gate_fires_when_only_one_field_present():
 # `_get` silently returns None on a wrong/renamed field name, and the row
 # then just `continue`s (skipped) -- so a field-name/alias drift in an
 # untested row would otherwise disable that row's check with no test
-# failure. These two parametrized tests exercise all 16 rows directly from
+# failure. These two parametrized tests exercise all 18 rows directly from
 # the table itself, proving every row's section/gate/period/nrpf field names
 # actually resolve against a real settings dict.
 
@@ -288,9 +390,9 @@ def test_every_stream_row_passes_when_enabled_active_and_dividing(row):
     "row", [r for r in _STREAM_CHECKS if r.cppdef_guard], ids=lambda r: r.label
 )
 def test_every_guarded_row_skipped_when_cppdef_inactive(row):
-    """Every cppdef-gated row (diagnostics, cdr, upscale, the four bgc_*
-    streams) is skipped -- even with a genuinely non-dividing config -- when
-    its guard is not satisfied.
+    """Every cppdef-gated row (diagnostics, cdr, cdrtrc, cdrgas, upscale, the
+    four bgc_* streams) is skipped -- even with a genuinely non-dividing
+    config -- when its guard is not satisfied.
     """
     settings = _settings_for_row(
         row, nrpf=_NON_DIVIDING_NRPF, period=_NON_DIVIDING_PERIOD

--- a/cstar/tests/unit_tests/roms/test_roms_simulation.py
+++ b/cstar/tests/unit_tests/roms/test_roms_simulation.py
@@ -32,7 +32,7 @@ from cstar.roms.input_dataset import (
 from cstar.roms.namelist import (
     RomsNamelist,
     RomsNamelistV0_5_0,
-    RomsNamelistV0_6_0,
+    RomsNamelistV0_7_0,
     namelist_schema_for_ref,
 )
 from cstar.roms.simulation import ROMSSimulation
@@ -563,7 +563,7 @@ class TestROMSSimulationInitialization:
         ``checkout_target`` to select a namelist schema, and that a non-release
         ``checkout_target`` (as set up by the ``stub_romssimulation`` fixture)
         surfaces the ``namelist_schema_for_ref`` fallback warning through the
-        property, actually selects the latest schema (``RomsNamelistV0_6_0``),
+        property, actually selects the latest schema (``RomsNamelistV0_7_0``),
         while still returning a valid namelist.
 
         The read is stubbed (the stub's working copy has no real files on
@@ -571,7 +571,7 @@ class TestROMSSimulationInitialization:
         the 0.5.0-style fixture — so the property's overrides are exercised
         against a real versioned schema, not the legacy one — but which class
         was actually *selected* is captured separately via the
-        ``namelist_schema_for_ref`` wrap below, since ``RomsNamelistV0_6_0``
+        ``namelist_schema_for_ref`` wrap below, since ``RomsNamelistV0_7_0``
         is a subclass of ``RomsNamelistV0_5_0`` and the stubbed read makes
         ``isinstance(result, RomsNamelistV0_5_0)`` true regardless of which
         class was selected.
@@ -607,7 +607,7 @@ class TestROMSSimulationInitialization:
         # the stub's codebase has no working copy, so no repo path is available
         # for commit-hash-to-release-tag resolution
         mock_schema_for_ref.assert_called_once_with(checkout_target, repo_path=None)
-        assert selected_schemas == [RomsNamelistV0_6_0]
+        assert selected_schemas == [RomsNamelistV0_7_0]
         assert isinstance(result, RomsNamelistV0_5_0)
         run_length_seconds = int((sim.end_date - sim.start_date).total_seconds())
         assert result.time_stepping.ntimes == run_length_seconds // 2160.0


### PR DESCRIPTION
# Summary

Adds the ROMS namelist schema for ucla-roms 0.7.0. That release (ucla-roms PR #351) moves the CDR tracer output and the gas-exchange sensitivity output into two dedicated namelist groups, `&CDR_TRACER_OUTPUT_SETTINGS` and `&CDR_GAS_EXCH_OUTPUT_SETTINGS`. C-Star gains a `RomsNamelistV0_7_0` schema carrying both groups, selects it automatically for ucla-roms refs at or above 0.7.0, validates `namelist_overrides` against it, and extends the output-period-divides-restart pre-check to the two new output streams.

## Breaking Changes
- Blueprints whose `code.roms` is unpinned (or pinned at/after 0.7.0) now generate namelists with the `&CDR_TRACER_OUTPUT_SETTINGS` and `&CDR_GAS_EXCH_OUTPUT_SETTINGS` groups, always written, at ucla-roms' reference defaults (both outputs off). They are meant to be run with ucla-roms 0.7.0 or later.
- `RomsNamelistV0_6_0` now applies to ucla-roms >= 0.6.0, < 0.7.0 only; `namelist_overrides` naming either new group are rejected at blueprint validation when `code.roms` is pinned below 0.7.0.

## New Features
- `RomsNamelistV0_7_0` with the two new groups: CDR tracer output (`do_cdr_tracer_output`, averaging/monthly/period/records-per-file, and per-field switches for tracers, vertical integrals, thickness-weighted fields, sources, ALK and DIC) and CDR gas-exchange output (`do_cdr_gas_exch_output` plus averaging/monthly/period/records-per-file). Both groups default to ucla-roms' reference values, so a namelist written for 0.6.x still validates against the 0.7.0 schema.
- The startup pre-check that mirrors ucla-roms' `check_output_divides_rst` now covers the two new streams (`cdrtrc`, `cdrgas`), gated on the `MARBL` and `CDR_FORCING` cppdefs like the existing CDR stream, so a non-dividing output period is caught before submission rather than at ROMS startup.

## Bug Fixes
- N/A

## Improvements
- N/A

## Miscellaneous
- New reference fixture `example_namelist_v0_7_0.nml`; tests for schema selection at the 0.7.0 boundary, round trip, rejection of a 0.7.0 file by the 0.6.0 schema, default/always-written behaviour of the new groups, the pre-check for both new streams, and `namelist_overrides` validation for pinned vs unpinned refs.



## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (unit tier; see notes)
