### PR TITLE
Enable in-place blueprint migration

### DIFF
--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -160,7 +160,12 @@ def clobber_output(ctx: typer.Context, value: bool) -> bool:
     if value and output:
         path = Path(output)
         if path.exists():
+            log.debug(f"Clobbering output path: {output}")
             path.unlink()
+        else:
+            log.debug(f"No output file to clobber: {output}")
+
+    return value
 
     return value
 

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -64,12 +64,17 @@ def path_callback(value: str) -> str:
 
     Parameters
     ----------
-    value : bool
+    value : str
         The value of the path parameter.
 
     Returns
     -------
     str
+
+    Raises
+    ------
+    typer.BadParameter
+        If the path is empty, was not found, or could not be retrieved.
     """
     value = value.strip() if value else ""
 
@@ -110,7 +115,7 @@ def target_callback(ctx: typer.Context, value: str) -> str:
     ----------
     ctx : typer.Context
         The typer context object.
-    value : bool
+    value : str
         The value of the output parameter.
 
     Returns
@@ -151,6 +156,11 @@ def report_inplace_conflicts(in_place: bool, clobber: bool) -> None:
         The value of the in-place parameter.
     clobber : bool
         The value of the clobber parameter.
+
+    Raises
+    ------
+    typer.BadParameter
+        If in-place and clobber are both enabled.
     """
     if in_place and clobber:
         msg = "Clobbering in-place will result in loss of the input file. Cancelling."

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -167,6 +167,29 @@ def clobber_output(ctx: typer.Context, value: bool) -> bool:
 
     return value
 
+
+def report_inplace_conflicts(ctx: typer.Context, value: bool) -> bool:
+    """Display informational message to user when in-place and output path
+    are both specified or the user attempts to clobber in-place.
+
+    Parameters
+    ----------
+    ctx : typer.Context
+        The typer context object.
+    value : bool
+        The value of the in-place parameter.
+
+    Returns
+    -------
+    bool
+    """
+    if value and (output := ctx.params.get("output", "")):
+        console.print(f"Output path {output!r} will be ignored in in-place mode")
+
+    if value and ctx.params.get("clobber", False):
+        msg = "Clobbering in-place will result in loss of the input file. Cancelling."
+        raise typer.BadParameter(msg)
+
     return value
 
 
@@ -200,6 +223,14 @@ def migrate(
             envvar=ENV_CSTAR_CLI_DRY_RUN,
         ),
     ] = False,
+    in_place: t.Annotated[
+        bool,
+        typer.Option(
+            "--inplace",
+            help="Migrate the blueprint and replace the source file content.",
+            callback=report_inplace_conflicts,
+        ),
+    ] = False,
     verbose: t.Annotated[
         bool,
         typer.Option(
@@ -207,6 +238,7 @@ def migrate(
             help=ARG_VERBOSE_HELP,
             callback=set_flag(ENV_CSTAR_CLI_VERBOSE),
             envvar=ENV_CSTAR_CLI_VERBOSE,
+            is_eager=True,
         ),
     ] = False,
     clobber: t.Annotated[
@@ -219,6 +251,7 @@ def migrate(
                 clobber_output,
             ),
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
+            is_eager=True,
         ),
     ] = False,
     log_level: t.Annotated[
@@ -235,9 +268,11 @@ def migrate(
 ) -> None:
     """Migrate the schema of an old blueprint to the latest version."""
     try:
+        target = Path(path) if in_place else (Path(output) if output else None)
         request = MigrationRequest(
             path=Path(path),
-            output=Path(output) if output else None,
+            output=target,
+            in_place=in_place,
         )
     except ValidationError as ex:
         errors = format_validation_errors(ex)

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -28,8 +28,6 @@ from cstar.entrypoint.utils import (
     ARG_LOGLEVEL_HELP,
     ARG_LOGLEVEL_LONG,
     ARG_LOGLEVEL_SHORT,
-    ARG_OUTPUT_LONG,
-    ARG_OUTPUT_SHORT,
     ARG_VERBOSE,
     ARG_VERBOSE_HELP,
 )
@@ -178,11 +176,11 @@ def migrate(
     ],
     output: t.Annotated[
         str,
-        typer.Option(
-            ARG_OUTPUT_LONG,
-            ARG_OUTPUT_SHORT,
+        typer.Argument(
             help="Path where the migrated blueprint will be serialized",
             callback=target_callback,
+            dir_okay=False,
+            exists=False,
         ),
     ] = "",
     dry_run: t.Annotated[

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -10,6 +10,7 @@ from cstar.base.env import (
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_LOG_LEVEL,
 )
+from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
     MigrationRequest,
@@ -95,8 +96,13 @@ def path_callback(value: str) -> str:
         return local_path.as_posix()
 
 
-def target_callback(value: str) -> str:
-    """Ensure the user provided a non-empty path.
+def target_callback(ctx: typer.Context, value: str) -> str:
+    """Ensure the user provided a non-empty path and resolve conflicts with
+    parameters processed earlier.
+
+    An output path is reported as ignored when in-place or dry-run mode is
+    requested; otherwise a pre-existing output file is removed when clobber
+    is enabled, mitigating a FileExistsError.
 
     Resulting path has been expanded and resolved.
 
@@ -114,83 +120,41 @@ def target_callback(value: str) -> str:
     if not value or not value.strip():
         return value.strip()
 
+    # combine each parameter with its environment variable: a flag enabled
+    # only through the environment is processed after this callback and is
+    # not yet present in ctx.params
+    if ctx.params.get("in_place", False):
+        console.print(f"Output path {value!r} will be ignored in in-place mode")
+    elif ctx.params.get("dry_run", False) or is_flag_enabled(ENV_CSTAR_CLI_DRY_RUN):
+        console.print(f"Output path {value!r} will be ignored during dry-run")
+    elif ctx.params.get("clobber", False) or is_flag_enabled(
+        ENV_CSTAR_CLOBBER_WORKING_DIR
+    ):
+        path = Path(value)
+        if path.exists():
+            log.debug(f"Clobbering output path: {value}")
+            path.unlink()
+        else:
+            log.debug(f"No output file to clobber: {value}")
+
     path = Path(value)
     path.parent.mkdir(parents=True, exist_ok=True)
     return path.as_posix()
 
 
-def dryrun_notify(ctx: typer.Context, value: bool) -> bool:
-    """Display informational message to user if a parameter conflict is found.
+def report_inplace_conflicts(in_place: bool, clobber: bool) -> None:
+    """Cancel execution when the user attempts to clobber in-place.
 
     Parameters
     ----------
-    ctx : typer.Context
-        The typer context object.
-    value : bool
-        The value of the dry-run parameter.
-
-    Returns
-    -------
-    bool
-    """
-    output = ctx.params.get("output", "")
-
-    if value and output:
-        console.print(f"Output path {output!r} will be ignored during dry-run")
-
-    return value
-
-
-def clobber_output(ctx: typer.Context, value: bool) -> bool:
-    """Callback for clobber parameter that removes a pre-existing output file
-    and mitigates a FileExistsError.
-
-    Parameters
-    ----------
-    ctx : typer.Context
-        The typer context object.
-    value : bool
-        The value of the clobber parameter.
-
-    Returns
-    -------
-    bool
-    """
-    output = ctx.params.get("output", "")
-    if value and output:
-        path = Path(output)
-        if path.exists():
-            log.debug(f"Clobbering output path: {output}")
-            path.unlink()
-        else:
-            log.debug(f"No output file to clobber: {output}")
-
-    return value
-
-
-def report_inplace_conflicts(ctx: typer.Context, value: bool) -> bool:
-    """Display informational message to user when in-place and output path
-    are both specified or the user attempts to clobber in-place.
-
-    Parameters
-    ----------
-    ctx : typer.Context
-        The typer context object.
-    value : bool
+    in_place : bool
         The value of the in-place parameter.
-
-    Returns
-    -------
-    bool
+    clobber : bool
+        The value of the clobber parameter.
     """
-    if value and (output := ctx.params.get("output", "")):
-        console.print(f"Output path {output!r} will be ignored in in-place mode")
-
-    if value and ctx.params.get("clobber", False):
+    if in_place and clobber:
         msg = "Clobbering in-place will result in loss of the input file. Cancelling."
         raise typer.BadParameter(msg)
-
-    return value
 
 
 @app.command(name=CMD_NAME, help=HELP_LONG, short_help=HELP_SHORT)
@@ -216,10 +180,7 @@ def migrate(
         typer.Option(
             ARG_DRY_RUN,
             help="Generate the migration plan without executing it.",
-            callback=cb_pipeline(
-                set_flag(ENV_CSTAR_CLI_DRY_RUN),
-                dryrun_notify,
-            ),
+            callback=set_flag(ENV_CSTAR_CLI_DRY_RUN),
             envvar=ENV_CSTAR_CLI_DRY_RUN,
         ),
     ] = False,
@@ -228,7 +189,7 @@ def migrate(
         typer.Option(
             "--inplace",
             help="Migrate the blueprint and replace the source file content.",
-            callback=report_inplace_conflicts,
+            is_eager=True,
         ),
     ] = False,
     verbose: t.Annotated[
@@ -246,10 +207,7 @@ def migrate(
         typer.Option(
             ARG_CLOBBER,
             help=ARG_CLOBBER_HELP,
-            callback=cb_pipeline(
-                set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),
-                clobber_output,
-            ),
+            callback=set_flag(ENV_CSTAR_CLOBBER_WORKING_DIR),
             envvar=ENV_CSTAR_CLOBBER_WORKING_DIR,
             is_eager=True,
         ),
@@ -267,6 +225,8 @@ def migrate(
     ] = LogLevelChoices.INFO,
 ) -> None:
     """Migrate the schema of an old blueprint to the latest version."""
+    report_inplace_conflicts(in_place, clobber)
+
     try:
         target = Path(path) if in_place else (Path(output) if output else None)
         request = MigrationRequest(

--- a/cstar/cli/blueprint/migrate.py
+++ b/cstar/cli/blueprint/migrate.py
@@ -14,6 +14,7 @@ from cstar.base.log import LogLevelChoices, get_logger
 from cstar.cli.common import (
     MigrationRequest,
     cb_pipeline,
+    console,
     execute_migration,
     format_validation_errors,
     set_env,
@@ -137,7 +138,7 @@ def dryrun_notify(ctx: typer.Context, value: bool) -> bool:
     output = ctx.params.get("output", "")
 
     if value and output:
-        print(f"Output path {output!r} will be ignored during dry-run")
+        console.print(f"Output path {output!r} will be ignored during dry-run")
 
     return value
 
@@ -254,8 +255,8 @@ def migrate(
         raise typer.BadParameter(msg) from ex
 
     if not result.migration_result.plan:
-        print("Migration failed to produce a plan.")
+        console.print("Migration failed to produce a plan.")
         raise typer.Exit(2)
 
     if not result.migration_result.plan.is_latest:
-        print(f"Migrated blueprint persisted to {str(result.target)!r}")
+        console.print(f"Migrated blueprint persisted to {str(result.target)!r}")

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -24,6 +24,7 @@ from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
 from cstar.base.utils import slugify
 from cstar.execution.file_system import (
     DirectoryManager,
+    get_backup_path,
     is_remote_resource,
     local_copy,
 )
@@ -313,7 +314,7 @@ def on_migrated_callback(plan: MigrationPlan) -> None:
     console.print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
 
 
-def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Path:
+def get_persist_to(request: MigrationRequest, plan: MigrationPlan) -> Path:
     """Determine the persistence path for a migrated model.
 
     If a target is not supplied by the user, write to the `CSTAR_STATE_HOME`
@@ -333,11 +334,11 @@ def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Pa
     target : Path | None
         The user-supplied path
     """
-    if target is not None:
-        output = target
+    if request.target is not None:
+        output = request.target
     else:
-        stem = source.stem
-        suffix = source.suffix
+        stem = request.source.stem
+        suffix = request.source.suffix
         state_dir = DirectoryManager.state_home()
         output = state_dir / f"{stem}_{plan.target}{suffix}"
 
@@ -356,11 +357,14 @@ def persist_migration(request: MigrationRequest, result: MigrateResult) -> Path:
         msg = "Unable to persist an unplanned migration"
         raise ValueError(msg)
 
-    persist_to = get_persist_to(request.source, request.target, result.plan)
+    persist_to = get_persist_to(request, result.plan)
 
     try:
         bp_type = get_application(result.application).blueprint
         updated_bp = bp_type(**result.migrated)
+        if request.in_place:
+            backup_path = get_backup_path(request.source)
+            backup_path.write_bytes(request.source.read_bytes())
 
         nbytes = serialize(
             persist_to,

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import typer
 from pydantic import ValidationError
+from rich.console import Console
 
 import cstar
 from cstar.applications.core import get_application
@@ -41,6 +42,7 @@ from cstar.system.migration import (
 )
 
 app = typer.Typer()
+console = Console()
 log = get_logger(__name__)
 
 HELP_SHORT = (
@@ -270,20 +272,19 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
     """
     if not is_flag_enabled(ENV_CSTAR_CLI_VERBOSE) or not plan.adapters:
         if plan.is_latest:
-            print(f"No migration needed for schema {plan.source!r} in {str(bp_path)!r}")
+            msg = f"No migration needed for schema {plan.source!r} in {str(bp_path)!r}"
+            console.print(msg)
             return
 
         num_steps = len(plan.adapters)
         msg = f"Migrating {plan.source!r}->{plan.target!r} in {num_steps} step(s)."
-        print(msg)
+        console.print(msg)
         return
 
-    from rich.console import Console  # noqa: PLC0415
     from rich.table import Column, Table  # noqa: PLC0415
 
     source, target, adapters = plan
     padding = (0, 1)
-    console = Console()
 
     table = Table(
         Column(header="Step", justify="center"),
@@ -309,7 +310,7 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
 
 
 def on_migrated_callback(plan: MigrationPlan) -> None:
-    print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
+    console.print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
 
 
 def get_persist_to(source: Path, target: Path | None, plan: MigrationPlan) -> Path:
@@ -420,11 +421,11 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
 
     migration_result = migrator.plan_and_migrate(dumped)
     if migration_result.error:
-        print(migration_result.error)
+        console.print(migration_result.error)
         raise typer.Exit(1)
 
     if not migration_result.plan:
-        print("Migration failed to produce a plan.")
+        console.print("Migration failed to produce a plan.")
         raise typer.Exit(2)
 
     # An up-to-date blueprint needs no migration: return it untouched unless
@@ -433,9 +434,7 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
         return PersistedMigrateResult(migration_result, request.source)
 
     if migration_result.plan.adapters and is_flag_enabled(ENV_CSTAR_DISABLE_MIGRATION):
-        from rich.console import Console  # noqa: PLC0415
-
-        Console().print(
+        console.print(
             f"Blueprint at '{request.source}' requires schema migration from "
             f"{colored(migration_result.plan.source, 'green')} to "
             f"{colored(migration_result.plan.target, 'red')}, but migration is "
@@ -469,7 +468,7 @@ def localize_and_migrate(path: str) -> Path:
             persist_result = execute_migration(request)
 
             if persist_result.migration_result.error:
-                print(persist_result.migration_result.error)
+                console.print(persist_result.migration_result.error)
                 raise typer.Exit(1)
 
             local_path = Path(persist_result.target)
@@ -536,6 +535,6 @@ def set_ctxmap(context: typer.Context, key: str, value: object) -> None:
     context_map: dict[str, t.Any] = context.obj
 
     if key in context_map and context_map[key] is not None:
-        print(f"Value in context map using key {key!r} will be overwritten")
+        console.print(f"Value in context map using key {key!r} will be overwritten")
 
     context_map[key] = value

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -59,26 +59,106 @@ StrCallback: t.TypeAlias = Callable[[typer.Context, str], str]
 
 
 def colored(msg: str, color: str = "cyan") -> str:
+    """Wrap a message in rich markup applying the given color.
+
+    Parameters
+    ----------
+    msg : str
+        The message to decorate.
+    color : str
+        The rich color name to apply.
+
+    Returns
+    -------
+    str
+    """
     return f"[{color}]{msg}[/{color}]"
 
 
 def italic(msg: str) -> str:
+    """Wrap a message in rich markup applying an italic style.
+
+    Parameters
+    ----------
+    msg : str
+        The message to decorate.
+
+    Returns
+    -------
+    str
+    """
     return f"[italic]{msg}[/italic]"
 
 
 def checkmark(color: str) -> str:
+    """Create a checkmark glyph in the given color.
+
+    Parameters
+    ----------
+    color : str
+        The rich color name to apply.
+
+    Returns
+    -------
+    str
+    """
     return colored(":heavy_check_mark:", color)
 
 
 def present(prompt: str, value: str, color: str = "cyan", width: int = 0) -> str:
+    """Format a prompt and its colored value for display.
+
+    Parameters
+    ----------
+    prompt : str
+        The text labeling the value.
+    value : str
+        The value to display.
+    color : str
+        The rich color name applied to the value.
+    width : int
+        The minimum width the prompt is right-justified within.
+
+    Returns
+    -------
+    str
+    """
     return f"{prompt.rjust(width)}: {colored(value, color)}"
 
 
 def label(name: str, app: str | None) -> str:
+    """Format an entity name, including its application when available.
+
+    Parameters
+    ----------
+    name : str
+        The name of the entity.
+    app : str | None
+        The name of the application associated with the entity.
+
+    Returns
+    -------
+    str
+    """
     return f"{name} ({italic(app)})" if app else name
 
 
 def id_label(id: int, name: str, app: str | None) -> str:
+    """Format an entity name prefixed with its numeric identifier.
+
+    Parameters
+    ----------
+    id : int
+        The numeric identifier of the entity.
+    name : str
+        The name of the entity.
+    app : str | None
+        The name of the application associated with the entity.
+
+    Returns
+    -------
+    str
+    """
     return f"{id}. {label(name, app)}"
 
 
@@ -270,7 +350,7 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
     ----------
     bp_path : Path
         The path to the blueprint being migrated.
-    migration_plan : MigrationPlan
+    plan : MigrationPlan
         Details of the planned migration.
     """
     if not is_flag_enabled(ENV_CSTAR_CLI_VERBOSE) or not plan.adapters:
@@ -284,7 +364,7 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
         console.print(msg)
         return
 
-    from rich.table import Column, Table  # noqa: PLC0415
+    from rich.table import Column, Table
 
     source, target, adapters = plan
     padding = (0, 1)
@@ -313,6 +393,13 @@ def on_planned_callback(bp_path: Path, plan: MigrationPlan) -> None:
 
 
 def on_migrated_callback(plan: MigrationPlan) -> None:
+    """Display a notification that the migration is complete.
+
+    Parameters
+    ----------
+    plan : MigrationPlan
+        Details of the completed migration.
+    """
     console.print(f"Migration from {plan.source!r}->{plan.target!r} is complete.")
 
 
@@ -331,10 +418,15 @@ def get_persist_to(request: MigrationRequest, plan: MigrationPlan) -> Path:
 
     Parameters
     ----------
-    source : Path
-        Path to the file containing the original, serialized model.
-    target : Path | None
-        The user-supplied path
+    request : MigrationRequest
+        The request naming the source file and optional user-supplied target.
+    plan : MigrationPlan
+        The migration plan providing the target schema version.
+
+    Returns
+    -------
+    Path
+        The path where the migrated model will be persisted.
     """
     if request.target is not None:
         output = request.target
@@ -350,10 +442,27 @@ def get_persist_to(request: MigrationRequest, plan: MigrationPlan) -> Path:
 def persist_migration(request: MigrationRequest, result: MigrateResult) -> Path:
     """Serialize the migrated entity to disk.
 
+    For an in-place migration, the original source file is preserved in a
+    backup file before it is overwritten.
+
+    Parameters
+    ----------
+    request : MigrationRequest
+        Parameters passed to the migrator.
+    result : MigrateResult
+        The result of the executed migration.
+
     Returns
     -------
     Path
         The path to the persisted entity file.
+
+    Raises
+    ------
+    ValueError
+        If the result does not contain a migration plan.
+    typer.BadParameter
+        If the migrated content cannot be serialized.
     """
     if result.plan is None:
         msg = "Unable to persist an unplanned migration"
@@ -391,16 +500,19 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
 
     Returns
     -------
-    PersistedMigrationResult
-        Named tuple containing the migration result and path where it was persisted.
+    PersistedMigrateResult
+        Named tuple containing the migration result and path where it was
+        persisted; a target matching the source indicates no change occurred.
 
     Raises
     ------
+    typer.BadParameter
+        If the blueprint fails content validation.
     CStarMigrationNotRegisteredError
         If there are no registered migrations for the requested schema.
     typer.Exit
-        If the blueprint requires migration but migration is disabled via
-        `CSTAR_DISABLE_MIGRATION`.
+        If the planned migration fails to complete, or the blueprint requires
+        migration but migration is disabled via `CSTAR_DISABLE_MIGRATION`.
     """
     validation_result = validate_serialized_entity(request.source, BlueprintCore)
     if validation_result.item is None:
@@ -471,8 +583,13 @@ def localize_and_migrate(path: str) -> Path:
 
     Returns
     -------
-    str
+    Path
         The path to the local blueprint (or the newly migrated blueprint file).
+
+    Raises
+    ------
+    typer.Exit
+        If the migration produces an error.
     """
     with local_copy(path) as local_path:
         request = MigrationRequest(path=local_path)
@@ -496,7 +613,7 @@ def format_validation_errors(ex: ValidationError) -> str:
     for error in ex.errors():
         msg = f"{error['msg']!r}"
 
-        if "loc" in error and error["loc"]:
+        if error.get("loc"):
             msg = "`Invalid {} value ({}): {}`".format(
                 error["loc"][0],
                 error["input"],
@@ -540,7 +657,18 @@ def get_from_ctxmap(context: typer.Context, key: str, klass: type[_TValue]) -> _
 
 
 def set_ctxmap(context: typer.Context, key: str, value: object) -> None:
-    """Prepare a mapping in the typer context and store the supplied value at the chosen key."""
+    """Prepare a mapping in the typer context and store the supplied value at
+    the chosen key.
+
+    Parameters
+    ----------
+    context : typer.Context
+        The typer context object.
+    key : str
+        The key the value is stored under.
+    value : object
+        The value to store in the context map.
+    """
     if context.obj is None:
         context.obj = {}
 

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -36,7 +36,9 @@ from cstar.orchestration.serialization import (
 )
 from cstar.system.migration import (
     BlueprintMigration,
+    CstarMigrationError,
     CStarMigrationNotRegisteredError,
+    CstarUnsupportedMigrationError,
     MigrateResult,
     MigrationPlan,
     MigrationRequest,
@@ -419,38 +421,49 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
         on_migrated=on_migrated_callback,
     )
 
-    if request.dry_run():
-        migrator.plan(dumped)
-        raise typer.Exit(0)
+    try:
+        plan = migrator.plan(dumped)
+    except CstarUnsupportedMigrationError as ex:
+        msg = f"Unable to plan migration: {ex}"
+        result = MigrateResult(dumped, {}, error=msg)
+        # result with target == source indicates no change occurred
+        return PersistedMigrateResult(result, request.source)
 
-    migration_result = migrator.plan_and_migrate(dumped)
-    if migration_result.error:
-        console.print(migration_result.error)
+    if request.dry_run() or plan.is_latest:
+        log.debug("Short-circuiting migration after planning")
+        result = MigrateResult(dumped, dumped, plan=plan)
+        # result with target == source indicates no change occurred
+        return PersistedMigrateResult(result, request.source)
+
+    try:
+        result = migrator.migrate(dumped, plan)
+    except CstarMigrationError as ex:
+        msg = f"Unable to complete migration: {ex}"
+        result = MigrateResult(dumped, {}, plan=plan, error=msg)
+
+    if result.error:
+        console.print(result.error)
         raise typer.Exit(1)
-
-    if not migration_result.plan:
-        console.print("Migration failed to produce a plan.")
-        raise typer.Exit(2)
 
     # An up-to-date blueprint needs no migration: return it untouched unless
     # the user explicitly requested an output copy.
-    if not migration_result.plan.adapters and request.target is None:
-        return PersistedMigrateResult(migration_result, request.source)
+    if not plan.adapters and request.target is None:
+        return PersistedMigrateResult(result, request.source)
 
-    if migration_result.plan.adapters and is_flag_enabled(ENV_CSTAR_DISABLE_MIGRATION):
+    if plan.adapters and is_flag_enabled(ENV_CSTAR_DISABLE_MIGRATION):
         console.print(
             f"Blueprint at '{request.source}' requires schema migration from "
-            f"{colored(migration_result.plan.source, 'green')} to "
-            f"{colored(migration_result.plan.target, 'red')}, but migration is "
+            f"{colored(plan.source, 'green')} to "
+            f"{colored(plan.target, 'red')}, but migration is "
             f"disabled ({ENV_CSTAR_DISABLE_MIGRATION}=1). Unset "
             f"{ENV_CSTAR_DISABLE_MIGRATION} to allow migration, or update the "
             "blueprint to the current schema."
         )
         raise typer.Exit(1)
 
-    persisted_to = persist_migration(request, migration_result)
+    persisted_to = persist_migration(request, result)
 
-    return PersistedMigrateResult(migration_result, persisted_to)
+    return PersistedMigrateResult(result, persisted_to)
 
 
 def localize_and_migrate(path: str) -> Path:

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -21,7 +21,11 @@ from cstar.base.env import (
 from cstar.base.feature import is_flag_enabled
 from cstar.base.log import LogLevelChoices, get_logger, reset_log_level
 from cstar.base.utils import slugify
-from cstar.execution.file_system import DirectoryManager, is_remote_resource, local_copy
+from cstar.execution.file_system import (
+    DirectoryManager,
+    is_remote_resource,
+    local_copy,
+)
 from cstar.orchestration.models import BlueprintCore
 from cstar.orchestration.serialization import (
     PersistenceMode,
@@ -47,6 +51,30 @@ HELP_SHORT = (
 
 BoolCallback: t.TypeAlias = Callable[[typer.Context, bool], bool]
 StrCallback: t.TypeAlias = Callable[[typer.Context, str], str]
+
+
+def colored(msg: str, color: str = "cyan") -> str:
+    return f"[{color}]{msg}[/{color}]"
+
+
+def italic(msg: str) -> str:
+    return f"[italic]{msg}[/italic]"
+
+
+def checkmark(color: str) -> str:
+    return colored(":heavy_check_mark:", color)
+
+
+def present(prompt: str, value: str, color: str = "cyan", width: int = 0) -> str:
+    return f"{prompt.rjust(width)}: {colored(value, color)}"
+
+
+def label(name: str, app: str | None) -> str:
+    return f"{name} ({italic(app)})" if app else name
+
+
+def id_label(id: int, name: str, app: str | None) -> str:
+    return f"{id}. {label(name, app)}"
 
 
 def version_callback(value: bool) -> bool:
@@ -409,8 +437,8 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
 
         Console().print(
             f"Blueprint at '{request.source}' requires schema migration from "
-            f"[green]{migration_result.plan.source}[/green] to "
-            f"[red]{migration_result.plan.target}[/red], but migration is "
+            f"{colored(migration_result.plan.source, 'green')} to "
+            f"{colored(migration_result.plan.target, 'red')}, but migration is "
             f"disabled ({ENV_CSTAR_DISABLE_MIGRATION}=1). Unset "
             f"{ENV_CSTAR_DISABLE_MIGRATION} to allow migration, or update the "
             "blueprint to the current schema."

--- a/cstar/cli/common.py
+++ b/cstar/cli/common.py
@@ -445,11 +445,6 @@ def execute_migration(request: MigrationRequest) -> PersistedMigrateResult:
         console.print(result.error)
         raise typer.Exit(1)
 
-    # An up-to-date blueprint needs no migration: return it untouched unless
-    # the user explicitly requested an output copy.
-    if not plan.adapters and request.target is None:
-        return PersistedMigrateResult(result, request.source)
-
     if plan.adapters and is_flag_enabled(ENV_CSTAR_DISABLE_MIGRATION):
         console.print(
             f"Blueprint at '{request.source}' requires schema migration from "

--- a/cstar/cli/workplan/run.py
+++ b/cstar/cli/workplan/run.py
@@ -18,6 +18,7 @@ from cstar.base.utils import slugify
 from cstar.cli.common import (
     cb_pipeline,
     normalize_runid,
+    present,
     set_env,
     set_flag,
     update_loggers,
@@ -27,7 +28,6 @@ from cstar.cli.workplan.shared import (
     colored,
     console,
     list_runs,
-    present,
 )
 from cstar.entrypoint.utils import (
     ARG_CLOBBER,

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -4,7 +4,6 @@ from collections import Counter, OrderedDict
 from collections.abc import Mapping
 
 import typer
-from rich.console import Console
 from rich.table import Column, Table
 
 from cstar.applications.core import (
@@ -18,6 +17,7 @@ from cstar.cli.common import (
     cb_pipeline,
     checkmark,
     colored,
+    console,
     id_label,
     normalize_runid,
     set_ctxmap,
@@ -35,7 +35,6 @@ from cstar.orchestration.orchestration import LiveWorkplan
 from cstar.orchestration.serialization import deserialize, try_deserialize
 from cstar.orchestration.tracking import TrackingRepository
 
-console = Console()
 log = get_logger(__name__)
 
 if t.TYPE_CHECKING:

--- a/cstar/cli/workplan/shared.py
+++ b/cstar/cli/workplan/shared.py
@@ -14,7 +14,15 @@ from cstar.applications.core import (
 )
 from cstar.base.env import ENV_CSTAR_RUNID
 from cstar.base.log import get_logger
-from cstar.cli.common import cb_pipeline, normalize_runid, set_ctxmap, set_env
+from cstar.cli.common import (
+    cb_pipeline,
+    checkmark,
+    colored,
+    id_label,
+    normalize_runid,
+    set_ctxmap,
+    set_env,
+)
 from cstar.entrypoint.config import get_job_config, get_service_config
 from cstar.entrypoint.runner import BlueprintRunner
 from cstar.execution.file_system import (
@@ -138,26 +146,6 @@ def autocomplete_step_list(ctx: typer.Context, incomplete: str) -> list[str]:
         raise typer.BadParameter(msg)
 
     return asyncio.run(list_steps(run_id, incomplete))
-
-
-def checkmark(color: str) -> str:
-    return f"[{color}]:heavy_check_mark:"
-
-
-def colored(msg: str, color: str = "cyan") -> str:
-    return f"[{color}]{msg}[/{color}]"
-
-
-def present(prompt: str, value: str, color: str = "cyan", width: int = 0) -> str:
-    return f"{prompt.rjust(width)}: {colored(value, color)}"
-
-
-def label(name: str, app: str | None) -> str:
-    return f"{name} [italic]({app})[/italic]" if app else name
-
-
-def id_label(id: int, name: str, app: str | None) -> str:
-    return f"{id}. {label(name, app)}"
 
 
 def ref_label(record: DagDetailRecord, ref_map: dict[str, int]) -> str:

--- a/cstar/execution/file_system.py
+++ b/cstar/execution/file_system.py
@@ -582,3 +582,34 @@ def remove_files(file_dir: Path, wildcard_pattern: str) -> bool:
         removed = True
 
     return removed
+
+
+def get_backup_path(path: Path, backup_ext: str = ".bak") -> Path:
+    """Identify a unique backup path for the input.
+
+    Adds `.bak` on first execution and appends `.bak.<i>` for each subsequent
+    backup to ensure the original is never lost.
+
+    Parameters
+    ----------
+    path : Path
+        The source path
+    backup_ext : str
+        An extension differentiating the backup files from the source file.
+
+    Returns
+    -------
+    Path
+    """
+    if not backup_ext.startswith("."):
+        # ensure a new extension is always added
+        backup_ext = f".{backup_ext}"
+
+    suffix = f"{path.suffix}{backup_ext}"
+    backup_path = path.with_suffix(suffix)
+    i = 1
+    while backup_path.exists():
+        suffix = f"{path.suffix}{backup_ext}.{i:03d}"
+        backup_path = path.with_suffix(suffix)
+        i += 1
+    return backup_path

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -123,14 +123,6 @@ class Migration(abc.ABC, LoggingMixin):
         self,
         dumped: dict[str, t.Any],
         plan: MigrationPlan,
-    ) -> dict[str, t.Any]:
-        """Execute the upgrade path."""
-        ...
-
-    @abc.abstractmethod
-    def plan_and_migrate(
-        self,
-        dumped: dict[str, t.Any],
     ) -> MigrateResult:
         """Execute the upgrade path."""
         ...
@@ -240,7 +232,7 @@ class BlueprintMigration(Migration):
         self,
         dumped: dict[str, t.Any],
         plan: MigrationPlan,
-    ) -> dict[str, t.Any]:
+    ) -> MigrateResult:
         """Execute the plan to upgrade the blueprint to the latest version.
 
         Returns
@@ -264,28 +256,10 @@ class BlueprintMigration(Migration):
 
         if self.on_migrated_callback:
             self.on_migrated_callback(plan)
-        return model
-
-    def plan_and_migrate(self, dumped: dict[str, t.Any]) -> MigrateResult:
-        """Create a migration plan and execute it."""
-        try:
-            plan = self.plan(dumped)
-        except CstarUnsupportedMigrationError as ex:
-            msg = f"Unable to plan migration: {ex}"
-            return MigrateResult(dumped, {}, error=msg)
-
-        if plan.is_latest:
-            return MigrateResult(dumped, dumped, plan=plan)
-
-        try:
-            migrated = self.migrate(dumped, plan)
-        except CstarMigrationError as ex:
-            msg = f"Unable to complete migration: {ex}"
-            return MigrateResult(dumped, {}, plan=plan, error=msg)
 
         return MigrateResult(
             dumped,
-            migrated,
+            model,
             plan=plan,
         )
 

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -56,6 +56,11 @@ class MigrationRequest(BaseModel):
         frozen=True,
         alias="output",
     )
+    in_place: bool = Field(
+        default=False,
+        description="Enable to overwrite the source file with the migrated content",
+        frozen=True,
+    )
 
     config: t.ClassVar[ConfigDict] = ConfigDict(str_strip_whitespace=True)
     """Model configuration ensuring attributes have whitespace stripped."""

--- a/cstar/system/migration.py
+++ b/cstar/system/migration.py
@@ -45,6 +45,8 @@ ConverterMap: t.TypeAlias = dict[tuple[str, str, str], type[SchemaAdapter]]
 
 
 class MigrationRequest(BaseModel):
+    """User-supplied parameters describing a blueprint schema migration."""
+
     source: FilePath = Field(
         frozen=True,
         description="Path to a file containing a serialized blueprint",
@@ -235,10 +237,18 @@ class BlueprintMigration(Migration):
     ) -> MigrateResult:
         """Execute the plan to upgrade the blueprint to the latest version.
 
+        Parameters
+        ----------
+        dumped : dict[str, t.Any]
+            The raw dictionary of model attributes to migrate.
+        plan : MigrationPlan
+            The plan describing the adapters to apply.
+
         Returns
         -------
-        dict[str, t.Any]
-            The raw dictionary of model attributes with schema changes applied.
+        MigrateResult
+            Named tuple containing the original and migrated model attributes
+            along with the executed plan.
 
         Raises
         ------

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -10,6 +10,7 @@ from cstar.execution.file_system import (
     DirectoryManager,
     JobFileSystemManager,
     RomsFileSystemManager,
+    get_backup_path,
     is_remote_resource,
     local_copy,
     local_copy_async,
@@ -398,3 +399,88 @@ def test_file_system_remove_files_directories(tmp_path: Path) -> None:
     assert not path.exists()
     assert not file_match.exists()
     assert not log.exists()
+
+
+def test_file_system_get_backup_path_first_backup(tmp_path: Path) -> None:
+    """Verify that the first backup path appends the backup extension to the
+    full original file name.
+    """
+    source = tmp_path / "blueprint.yaml"
+    source.touch()
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.yaml.bak"
+
+
+def test_file_system_get_backup_path_does_not_require_source(
+    tmp_path: Path,
+) -> None:
+    """Verify that a backup path is produced even if the source does not exist."""
+    source = tmp_path / "blueprint.yaml"
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.yaml.bak"
+
+
+def test_file_system_get_backup_path_existing_backup(tmp_path: Path) -> None:
+    """Verify that an existing backup is never overwritten; a numeric
+    suffix is appended instead.
+    """
+    source = tmp_path / "blueprint.yaml"
+    source.touch()
+    (tmp_path / "blueprint.yaml.bak").touch()
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.yaml.bak.001"
+
+
+def test_file_system_get_backup_path_multiple_existing_backups(
+    tmp_path: Path,
+) -> None:
+    """Verify that the numeric suffix increments past all existing backups."""
+    source = tmp_path / "blueprint.yaml"
+    source.touch()
+    (tmp_path / "blueprint.yaml.bak").touch()
+    (tmp_path / "blueprint.yaml.bak.001").touch()
+    (tmp_path / "blueprint.yaml.bak.002").touch()
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.yaml.bak.003"
+
+
+def test_file_system_get_backup_path_multidot_name(tmp_path: Path) -> None:
+    """Verify that a versioned file name keeps its full stem in the backup."""
+    source = tmp_path / "blueprint.1.0.0.yaml"
+    source.touch()
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.1.0.0.yaml.bak"
+
+
+def test_file_system_get_backup_path_no_suffix(tmp_path: Path) -> None:
+    """Verify that a file without an extension gets the backup extension."""
+    source = tmp_path / "blueprint"
+    source.touch()
+
+    backup_path = get_backup_path(source)
+
+    assert backup_path == tmp_path / "blueprint.bak"
+
+
+@pytest.mark.parametrize("backup_ext", ["orig", ".orig"])
+def test_file_system_get_backup_path_custom_ext(
+    tmp_path: Path,
+    backup_ext: str,
+) -> None:
+    """Verify that a custom extension is honored, with or without a leading dot."""
+    source = tmp_path / "blueprint.yaml"
+    source.touch()
+
+    backup_path = get_backup_path(source, backup_ext=backup_ext)
+
+    assert backup_path == tmp_path / "blueprint.yaml.orig"

--- a/cstar/tests/unit_tests/execution/test_file_system.py
+++ b/cstar/tests/unit_tests/execution/test_file_system.py
@@ -166,15 +166,15 @@ def test_live_step(tmp_path: Path) -> None:
 
         directory_mgr = DirectoryManager()
         data_home = directory_mgr.data_home()
-        expected = data_home / run_id / task_dir_name / ls_1.safe_name  # noqa: SLF001
+        expected = data_home / run_id / task_dir_name / ls_1.safe_name
         assert actual == expected
 
         actual = ls_2.working_dir
-        expected = ls_1.working_dir / task_dir_name / ls_2.safe_name  # type: ignore # noqa: SLF001
+        expected = ls_1.working_dir / task_dir_name / ls_2.safe_name  # type: ignore
         assert actual == expected
 
         actual = ls_3.working_dir
-        expected = ls_2.working_dir / task_dir_name / ls_3.safe_name  # type: ignore # noqa: SLF001
+        expected = ls_2.working_dir / task_dir_name / ls_3.safe_name  # type: ignore
         assert actual == expected
 
         actual = ls_4.working_dir

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -266,7 +266,11 @@ def test_target_callback_inplace_notifies(
     ctx.params = {"in_place": True}
 
     assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
-    assert "will be ignored in in-place mode" in capsys.readouterr().out
+    # rich wraps long paths at the terminal width, so normalize whitespace
+    # before matching
+    assert "will be ignored in in-place mode" in " ".join(
+        capsys.readouterr().out.split()
+    )
 
 
 def test_target_callback_dryrun_notifies(
@@ -282,7 +286,9 @@ def test_target_callback_dryrun_notifies(
     ctx.params = {"dry_run": True}
 
     assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
-    assert "will be ignored during dry-run" in capsys.readouterr().out
+    # rich wraps long paths at the terminal width, so normalize whitespace
+    # before matching
+    assert "will be ignored during dry-run" in " ".join(capsys.readouterr().out.split())
 
 
 @mock.patch.dict(os.environ, {ENV_CSTAR_CLI_DRY_RUN: FLAG_ON})
@@ -299,7 +305,9 @@ def test_target_callback_dryrun_env_notifies(
     ctx.params = {}
 
     assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
-    assert "will be ignored during dry-run" in capsys.readouterr().out
+    # rich wraps long paths at the terminal width, so normalize whitespace
+    # before matching
+    assert "will be ignored during dry-run" in " ".join(capsys.readouterr().out.split())
 
 
 @mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_ON})

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -127,15 +127,13 @@ def test_blueprint_migrate_persist_to_default(
     assert app_name in content
 
 
+@mock.patch.dict(os.environ, {ENV_CSTAR_DISABLE_MIGRATION: FLAG_ON})
 def test_blueprint_migrate_disabled(
     plotter_v1_0_0_bp: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify that `CSTAR_DISABLE_MIGRATION` blocks migration of an
     out-of-date blueprint with an early error.
     """
-    monkeypatch.setenv(ENV_CSTAR_DISABLE_MIGRATION, FLAG_ON)
-
     runner = CliRunner()
     result = runner.invoke(
         app,
@@ -287,15 +285,14 @@ def test_target_callback_dryrun_notifies(
     assert "will be ignored during dry-run" in capsys.readouterr().out
 
 
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLI_DRY_RUN: FLAG_ON})
 def test_target_callback_dryrun_env_notifies(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify that dry-run mode enabled only through the environment variable
     is detected even though the parameter is not yet processed.
     """
-    monkeypatch.setenv(ENV_CSTAR_CLI_DRY_RUN, FLAG_ON)
     output_path = tmp_path / "out.yaml"
 
     ctx = mock.Mock(spec=typer.Context)
@@ -305,14 +302,13 @@ def test_target_callback_dryrun_env_notifies(
     assert "will be ignored during dry-run" in capsys.readouterr().out
 
 
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_ON})
 def test_target_callback_clobber_env_removes_existing(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify that clobber mode enabled only through the environment variable
     is detected even though the parameter is not yet processed.
     """
-    monkeypatch.setenv(ENV_CSTAR_CLOBBER_WORKING_DIR, FLAG_ON)
     output_path = tmp_path / "output.yaml"
     output_path.touch()
 

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -12,7 +12,7 @@ from cstar.applications.roms_marbl.app import APP_NAME as APP_ROMS
 from cstar.applications.roms_marbl.migration import RomsMarblSchemaAdapter2025v1
 from cstar.base.env import ENV_CSTAR_DISABLE_MIGRATION, ENV_CSTAR_STATE_HOME, FLAG_ON
 from cstar.cli.blueprint.migrate import app
-from cstar.entrypoint.utils import ARG_DRY_RUN, ARG_OUTPUT_LONG, ARG_OUTPUT_SHORT
+from cstar.entrypoint.utils import ARG_DRY_RUN
 from cstar.system.migration import KEY_APP, identify_bounds
 
 
@@ -152,11 +152,9 @@ def test_blueprint_migrate_unnecessary(hello_world_bp_path: Path) -> None:
     assert latest in result.stdout
 
 
-@pytest.mark.parametrize("output_param", [ARG_OUTPUT_SHORT, ARG_OUTPUT_LONG])
 def test_blueprint_migrate_custom_output(
     tmp_path: Path,
     plotter_v1_0_0_bp: Path,
-    output_param: str,
 ) -> None:
     """Verify that an output path specified by the user is honored."""
     bp_path = plotter_v1_0_0_bp  # blueprint_1_0_0_sleep
@@ -169,7 +167,6 @@ def test_blueprint_migrate_custom_output(
         app,
         [
             bp_path.as_posix(),
-            output_param,
             expected_output_path.as_posix(),
         ],
         color=False,
@@ -201,7 +198,6 @@ def test_blueprint_migrate_dry_run(
         [
             bp_path.as_posix(),
             ARG_DRY_RUN,
-            ARG_OUTPUT_LONG,
             expected_output_path.as_posix(),
         ],
         color=False,

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -14,16 +14,17 @@ from cstar.applications.plotter import PlotterSchemaAdapterV1V2
 from cstar.applications.roms_marbl.app import APP_NAME as APP_ROMS
 from cstar.applications.roms_marbl.migration import RomsMarblSchemaAdapter2025v1
 from cstar.base.env import (
+    ENV_CSTAR_CLI_DRY_RUN,
     ENV_CSTAR_CLOBBER_WORKING_DIR,
     ENV_CSTAR_DISABLE_MIGRATION,
     ENV_CSTAR_STATE_HOME,
+    FLAG_OFF,
     FLAG_ON,
 )
 from cstar.cli.blueprint.migrate import (
     app,
-    clobber_output,
-    dryrun_notify,
     report_inplace_conflicts,
+    target_callback,
 )
 from cstar.entrypoint.utils import ARG_CLOBBER, ARG_DRY_RUN
 from cstar.system.migration import KEY_APP, identify_bounds
@@ -221,61 +222,156 @@ def test_blueprint_migrate_dry_run(
     assert not result.stderr, result.stderr
     assert not expected_output_path.exists()
     assert f"Migrating {source!r}->{target!r}" in result.stdout
+    assert "will be ignored during dry-run" in " ".join(result.stdout.split())
 
 
 @pytest.mark.parametrize(
-    "params",
+    ("in_place", "clobber"),
     [
-        {},
-        {"output": "", "clobber": False},
-        {"output": "some/output.yaml", "clobber": True},
+        (False, False),
+        (False, True),
+        (True, False),
     ],
 )
-def test_report_inplace_conflicts_disabled(params: dict[str, object]) -> None:
-    """Verify that the callback is a no-op when in-place mode is not requested,
-    regardless of the other parameter values.
-    """
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = params
-
-    assert report_inplace_conflicts(ctx, value=False) is False
-
-
-def test_report_inplace_conflicts_no_conflicts(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Verify that in-place mode without conflicting parameters passes through
-    silently.
-    """
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": "", "clobber": False}
-
-    assert report_inplace_conflicts(ctx, value=True) is True
-    assert not capsys.readouterr().out
-
-
-def test_report_inplace_conflicts_output_ignored(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Verify that the user is informed that an output path is ignored when
-    combined with in-place mode.
-    """
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": "out.yaml"}
-
-    assert report_inplace_conflicts(ctx, value=True) is True
-    assert "'out.yaml' will be ignored in in-place mode" in capsys.readouterr().out
+def test_report_inplace_conflicts_compatible(in_place: bool, clobber: bool) -> None:
+    """Verify that compatible parameter combinations pass through silently."""
+    report_inplace_conflicts(in_place, clobber)
 
 
 def test_report_inplace_conflicts_clobber_cancels() -> None:
     """Verify that combining in-place mode with clobber is rejected to avoid
     destroying the input file.
     """
+    with pytest.raises(typer.BadParameter, match="Cancelling"):
+        report_inplace_conflicts(in_place=True, clobber=True)
+
+
+@pytest.mark.parametrize("value", ["", " ", "\t"])
+def test_target_callback_empty(value: str) -> None:
+    """Verify that an empty output path passes through untouched."""
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {}
+
+    assert target_callback(ctx, value) == ""
+
+
+def test_target_callback_inplace_notifies(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify that the user is informed that an output path is ignored when
+    in-place mode was requested.
+    """
+    output_path = tmp_path / "out.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"in_place": True}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert "will be ignored in in-place mode" in capsys.readouterr().out
+
+
+def test_target_callback_dryrun_notifies(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify that the user is informed that an output path is ignored when
+    dry-run mode was requested.
+    """
+    output_path = tmp_path / "out.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"dry_run": True}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert "will be ignored during dry-run" in capsys.readouterr().out
+
+
+def test_target_callback_dryrun_env_notifies(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that dry-run mode enabled only through the environment variable
+    is detected even though the parameter is not yet processed.
+    """
+    monkeypatch.setenv(ENV_CSTAR_CLI_DRY_RUN, FLAG_ON)
+    output_path = tmp_path / "out.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert "will be ignored during dry-run" in capsys.readouterr().out
+
+
+def test_target_callback_clobber_env_removes_existing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that clobber mode enabled only through the environment variable
+    is detected even though the parameter is not yet processed.
+    """
+    monkeypatch.setenv(ENV_CSTAR_CLOBBER_WORKING_DIR, FLAG_ON)
+    output_path = tmp_path / "output.yaml"
+    output_path.touch()
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert not output_path.exists()
+
+
+def test_target_callback_clobber_removes_existing(tmp_path: Path) -> None:
+    """Verify that an existing output file is removed when clobber is enabled."""
+    output_path = tmp_path / "output.yaml"
+    output_path.touch()
+
     ctx = mock.Mock(spec=typer.Context)
     ctx.params = {"clobber": True}
 
-    with pytest.raises(typer.BadParameter, match="Cancelling"):
-        report_inplace_conflicts(ctx, value=True)
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert not output_path.exists()
+
+
+def test_target_callback_clobber_missing_output(tmp_path: Path) -> None:
+    """Verify that a non-existent output file is tolerated when clobber is
+    enabled.
+    """
+    output_path = tmp_path / "output.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"clobber": True}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+
+
+def test_target_callback_clobber_skipped_when_output_ignored(
+    tmp_path: Path,
+) -> None:
+    """Verify that an existing output file is NOT removed when the output path
+    is ignored due to in-place or dry-run mode.
+    """
+    output_path = tmp_path / "output.yaml"
+    output_path.touch()
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"in_place": True, "clobber": True}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert output_path.exists()
+
+
+def test_target_callback_creates_parent(tmp_path: Path) -> None:
+    """Verify that missing parent directories of the output path are created."""
+    output_path = tmp_path / "nested" / "dirs" / "output.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {}
+
+    assert target_callback(ctx, output_path.as_posix()) == output_path.as_posix()
+    assert output_path.parent.is_dir()
 
 
 def test_blueprint_migrate_inplace(plotter_v1_0_0_bp: Path) -> None:
@@ -338,26 +434,32 @@ def test_blueprint_migrate_inplace_ignores_output(
     # the migration lands in the source file, not the requested output
     assert not output_path.exists()
     assert latest in bp_path.read_text()
+    assert "will be ignored in in-place mode" in " ".join(result.stdout.split())
 
 
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_OFF})
+@pytest.mark.parametrize(
+    "flags",
+    [
+        [ARG_INPLACE, ARG_CLOBBER],
+        [ARG_CLOBBER, ARG_INPLACE],
+    ],
+)
 def test_blueprint_migrate_inplace_clobber_conflict(
     plotter_v1_0_0_bp: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    flags: list[str],
 ) -> None:
     """Verify that requesting in-place migration with clobber enabled is
-    rejected and leaves the source file untouched.
+    rejected, regardless of the flag order, and leaves the source file
+    untouched.
     """
-    # register the env var with monkeypatch so the flag set by the clobber
-    # callback during invocation is rolled back after the test
-    monkeypatch.setenv(ENV_CSTAR_CLOBBER_WORKING_DIR, "0")
-
     bp_path = plotter_v1_0_0_bp
     original_content = bp_path.read_text()
 
     runner = CliRunner()
     result = runner.invoke(
         app,
-        [bp_path.as_posix(), ARG_INPLACE, ARG_CLOBBER],
+        [bp_path.as_posix(), *flags],
         color=False,
     )
 
@@ -370,60 +472,98 @@ def test_blueprint_migrate_inplace_clobber_conflict(
     assert not bp_path.with_suffix(f"{bp_path.suffix}.bak").exists()
 
 
-def test_dryrun_notify_output_ignored(capsys: pytest.CaptureFixture[str]) -> None:
-    """Verify that the user is informed that an output path is ignored when
-    combined with dry-run mode.
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_ON})
+def test_blueprint_migrate_inplace_env_clobber_conflict(
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that clobber enabled via the environment variable also cancels
+    an in-place migration.
     """
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": "out.yaml"}
+    bp_path = plotter_v1_0_0_bp
+    original_content = bp_path.read_text()
 
-    assert dryrun_notify(ctx, value=True) is True
-    assert "'out.yaml' will be ignored during dry-run" in capsys.readouterr().out
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), ARG_INPLACE],
+        color=False,
+    )
 
-
-def test_dryrun_notify_disabled(capsys: pytest.CaptureFixture[str]) -> None:
-    """Verify that the callback is silent when dry-run mode is not requested."""
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": "out.yaml"}
-
-    assert dryrun_notify(ctx, value=False) is False
-    assert not capsys.readouterr().out
-
-
-def test_clobber_output_removes_existing(tmp_path: Path) -> None:
-    """Verify that an existing output file is removed when clobber is enabled."""
-    output_path = tmp_path / "output.yaml"
-    output_path.touch()
-
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": output_path.as_posix()}
-
-    assert clobber_output(ctx, value=True) is True
-    assert not output_path.exists()
+    assert result.exit_code != 0
+    plain_stderr = " ".join(result.stderr.replace("│", " ").split())
+    assert "Clobbering in-place will result in loss of the input file" in plain_stderr
+    assert bp_path.read_text() == original_content
 
 
-def test_clobber_output_missing_output(tmp_path: Path) -> None:
-    """Verify that a non-existent output file is tolerated when clobber is
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_OFF})
+def test_blueprint_migrate_clobber_output(
+    tmp_path: Path,
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that a pre-existing output file is replaced when clobber is
     enabled.
     """
-    output_path = tmp_path / "output.yaml"
+    bp_path = plotter_v1_0_0_bp
+    output_path = tmp_path / "output.json"
+    output_path.write_text("pre-existing content")
 
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": output_path.as_posix()}
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), output_path.as_posix(), ARG_CLOBBER],
+        color=False,
+    )
 
-    assert clobber_output(ctx, value=True) is True
+    assert not result.stderr, result.stderr
+    assert result.exit_code == 0, result.output
+    assert output_path.read_text() != "pre-existing content"
 
 
-def test_clobber_output_disabled(tmp_path: Path) -> None:
-    """Verify that an existing output file is kept when clobber is disabled."""
-    output_path = tmp_path / "output.yaml"
-    output_path.touch()
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLOBBER_WORKING_DIR: FLAG_OFF})
+def test_blueprint_migrate_dry_run_clobber_preserves_output(
+    tmp_path: Path,
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that a dry run never removes a pre-existing output file, even
+    when clobber is enabled, since the output path is ignored.
+    """
+    bp_path = plotter_v1_0_0_bp
+    output_path = tmp_path / "output.json"
+    output_path.write_text("pre-existing content")
 
-    ctx = mock.Mock(spec=typer.Context)
-    ctx.params = {"output": output_path.as_posix()}
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), output_path.as_posix(), ARG_DRY_RUN, ARG_CLOBBER],
+        color=False,
+    )
 
-    assert clobber_output(ctx, value=False) is False
-    assert output_path.exists()
+    assert not result.stderr, result.stderr
+    assert result.exit_code == 0, result.output
+    assert output_path.read_text() == "pre-existing content"
+
+
+@mock.patch.dict(os.environ, {ENV_CSTAR_CLI_DRY_RUN: FLAG_ON})
+def test_blueprint_migrate_dry_run_env(
+    tmp_path: Path,
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that dry-run mode enabled only through the environment variable
+    still reports the ignored output path and produces no file.
+    """
+    bp_path = plotter_v1_0_0_bp
+    expected_output_path = tmp_path / "upgraded.yaml"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), expected_output_path.as_posix()],
+        color=False,
+    )
+
+    assert not result.stderr, result.stderr
+    assert not expected_output_path.exists()
+    assert "will be ignored during dry-run" in " ".join(result.stdout.split())
 
 
 def test_blueprint_migrate_unplannable(

--- a/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
+++ b/cstar/tests/unit_tests/orchestration/cli/blueprint/test_migrate_blueprint.py
@@ -1,8 +1,11 @@
+import json
 import os
 import uuid
 from pathlib import Path
+from unittest import mock
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from cstar.applications.hello_world import HelloWorldSchemaAdapterV1V1
@@ -10,10 +13,22 @@ from cstar.applications.plotter import APP_NAME as APP_PLOTTER
 from cstar.applications.plotter import PlotterSchemaAdapterV1V2
 from cstar.applications.roms_marbl.app import APP_NAME as APP_ROMS
 from cstar.applications.roms_marbl.migration import RomsMarblSchemaAdapter2025v1
-from cstar.base.env import ENV_CSTAR_DISABLE_MIGRATION, ENV_CSTAR_STATE_HOME, FLAG_ON
-from cstar.cli.blueprint.migrate import app
-from cstar.entrypoint.utils import ARG_DRY_RUN
+from cstar.base.env import (
+    ENV_CSTAR_CLOBBER_WORKING_DIR,
+    ENV_CSTAR_DISABLE_MIGRATION,
+    ENV_CSTAR_STATE_HOME,
+    FLAG_ON,
+)
+from cstar.cli.blueprint.migrate import (
+    app,
+    clobber_output,
+    dryrun_notify,
+    report_inplace_conflicts,
+)
+from cstar.entrypoint.utils import ARG_CLOBBER, ARG_DRY_RUN
 from cstar.system.migration import KEY_APP, identify_bounds
+
+ARG_INPLACE = "--inplace"
 
 
 @pytest.fixture
@@ -206,3 +221,230 @@ def test_blueprint_migrate_dry_run(
     assert not result.stderr, result.stderr
     assert not expected_output_path.exists()
     assert f"Migrating {source!r}->{target!r}" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"output": "", "clobber": False},
+        {"output": "some/output.yaml", "clobber": True},
+    ],
+)
+def test_report_inplace_conflicts_disabled(params: dict[str, object]) -> None:
+    """Verify that the callback is a no-op when in-place mode is not requested,
+    regardless of the other parameter values.
+    """
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = params
+
+    assert report_inplace_conflicts(ctx, value=False) is False
+
+
+def test_report_inplace_conflicts_no_conflicts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify that in-place mode without conflicting parameters passes through
+    silently.
+    """
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": "", "clobber": False}
+
+    assert report_inplace_conflicts(ctx, value=True) is True
+    assert not capsys.readouterr().out
+
+
+def test_report_inplace_conflicts_output_ignored(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify that the user is informed that an output path is ignored when
+    combined with in-place mode.
+    """
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": "out.yaml"}
+
+    assert report_inplace_conflicts(ctx, value=True) is True
+    assert "'out.yaml' will be ignored in in-place mode" in capsys.readouterr().out
+
+
+def test_report_inplace_conflicts_clobber_cancels() -> None:
+    """Verify that combining in-place mode with clobber is rejected to avoid
+    destroying the input file.
+    """
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"clobber": True}
+
+    with pytest.raises(typer.BadParameter, match="Cancelling"):
+        report_inplace_conflicts(ctx, value=True)
+
+
+def test_blueprint_migrate_inplace(plotter_v1_0_0_bp: Path) -> None:
+    """Verify that in-place migration overwrites the source file with the
+    migrated content and preserves the original in a backup file.
+    """
+    bp_path = plotter_v1_0_0_bp
+    original_content = bp_path.read_text()
+
+    bounds = identify_bounds([PlotterSchemaAdapterV1V2])[APP_PLOTTER]
+    latest = bounds["max"]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), ARG_INPLACE],
+        color=False,
+    )
+
+    assert not result.stderr, result.stderr
+    assert result.exit_code == 0, result.output
+
+    # the source file now holds the migrated content
+    migrated_content = bp_path.read_text()
+    assert latest in migrated_content
+    assert migrated_content != original_content
+
+    # the original content is preserved in a backup next to the source
+    backup_path = bp_path.with_suffix(f"{bp_path.suffix}.bak")
+    assert backup_path.exists()
+    assert backup_path.read_text() == original_content
+
+    # rich wraps long paths at the terminal width, so strip all whitespace
+    # before matching the persisted-to message
+    squashed_stdout = "".join(result.stdout.split())
+    assert f"persistedto{bp_path.as_posix()!r}" in squashed_stdout
+
+
+def test_blueprint_migrate_inplace_ignores_output(
+    tmp_path: Path,
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that an output path is ignored when in-place mode is requested."""
+    bp_path = plotter_v1_0_0_bp
+    output_path = tmp_path / f"{uuid.uuid4()!s}.yaml"
+
+    bounds = identify_bounds([PlotterSchemaAdapterV1V2])[APP_PLOTTER]
+    latest = bounds["max"]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), output_path.as_posix(), ARG_INPLACE],
+        color=False,
+    )
+
+    assert not result.stderr, result.stderr
+    assert result.exit_code == 0, result.output
+
+    # the migration lands in the source file, not the requested output
+    assert not output_path.exists()
+    assert latest in bp_path.read_text()
+
+
+def test_blueprint_migrate_inplace_clobber_conflict(
+    plotter_v1_0_0_bp: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that requesting in-place migration with clobber enabled is
+    rejected and leaves the source file untouched.
+    """
+    # register the env var with monkeypatch so the flag set by the clobber
+    # callback during invocation is rolled back after the test
+    monkeypatch.setenv(ENV_CSTAR_CLOBBER_WORKING_DIR, "0")
+
+    bp_path = plotter_v1_0_0_bp
+    original_content = bp_path.read_text()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix(), ARG_INPLACE, ARG_CLOBBER],
+        color=False,
+    )
+
+    assert result.exit_code != 0
+    plain_stderr = " ".join(result.stderr.replace("│", " ").split())
+    assert "Clobbering in-place will result in loss of the input file" in plain_stderr
+
+    # the source file was not modified and no backup was produced
+    assert bp_path.read_text() == original_content
+    assert not bp_path.with_suffix(f"{bp_path.suffix}.bak").exists()
+
+
+def test_dryrun_notify_output_ignored(capsys: pytest.CaptureFixture[str]) -> None:
+    """Verify that the user is informed that an output path is ignored when
+    combined with dry-run mode.
+    """
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": "out.yaml"}
+
+    assert dryrun_notify(ctx, value=True) is True
+    assert "'out.yaml' will be ignored during dry-run" in capsys.readouterr().out
+
+
+def test_dryrun_notify_disabled(capsys: pytest.CaptureFixture[str]) -> None:
+    """Verify that the callback is silent when dry-run mode is not requested."""
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": "out.yaml"}
+
+    assert dryrun_notify(ctx, value=False) is False
+    assert not capsys.readouterr().out
+
+
+def test_clobber_output_removes_existing(tmp_path: Path) -> None:
+    """Verify that an existing output file is removed when clobber is enabled."""
+    output_path = tmp_path / "output.yaml"
+    output_path.touch()
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": output_path.as_posix()}
+
+    assert clobber_output(ctx, value=True) is True
+    assert not output_path.exists()
+
+
+def test_clobber_output_missing_output(tmp_path: Path) -> None:
+    """Verify that a non-existent output file is tolerated when clobber is
+    enabled.
+    """
+    output_path = tmp_path / "output.yaml"
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": output_path.as_posix()}
+
+    assert clobber_output(ctx, value=True) is True
+
+
+def test_clobber_output_disabled(tmp_path: Path) -> None:
+    """Verify that an existing output file is kept when clobber is disabled."""
+    output_path = tmp_path / "output.yaml"
+    output_path.touch()
+
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.params = {"output": output_path.as_posix()}
+
+    assert clobber_output(ctx, value=False) is False
+    assert output_path.exists()
+
+
+def test_blueprint_migrate_unplannable(
+    tmp_path: Path,
+    plotter_v1_0_0_bp: Path,
+) -> None:
+    """Verify that a blueprint whose schema version has no migration path
+    reports the failure to produce a plan and exits with code 2.
+    """
+    model = json.loads(plotter_v1_0_0_bp.read_text())
+    model["schema_version"] = "9.9.9"
+
+    bp_path = tmp_path / "plotter_9.9.9.json"
+    bp_path.write_text(json.dumps(model))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [bp_path.as_posix()],
+        color=False,
+    )
+
+    assert result.exit_code == 2
+    assert "Migration failed to produce a plan." in result.stdout

--- a/cstar/tests/unit_tests/orchestration/cli/conftest.py
+++ b/cstar/tests/unit_tests/orchestration/cli/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for CLI tests."""
+
+import os
+from collections.abc import Generator
+from unittest import mock
+
+import pytest
+
+from cstar.base.env import (
+    ENV_CSTAR_CLI_DRY_RUN,
+    ENV_CSTAR_CLI_VERBOSE,
+    ENV_CSTAR_CLOBBER_WORKING_DIR,
+    ENV_CSTAR_DISABLE_MIGRATION,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_flag_env() -> Generator[None]:
+    """Remove CLI flag environment variables that may leak in from the shell.
+
+    The CLI reads these flags via `envvar=` and the environment, so a value
+    exported by a prior CLI run (`set_flag` never unsets them) would silently
+    change test behavior. Tests opt back in with their own `mock.patch.dict`.
+    """
+    with mock.patch.dict(os.environ):
+        for flag in (
+            ENV_CSTAR_CLI_DRY_RUN,
+            ENV_CSTAR_CLI_VERBOSE,
+            ENV_CSTAR_CLOBBER_WORKING_DIR,
+            ENV_CSTAR_DISABLE_MIGRATION,
+        ):
+            os.environ.pop(flag, None)
+        yield

--- a/cstar/tests/unit_tests/orchestration/cli/test_common.py
+++ b/cstar/tests/unit_tests/orchestration/cli/test_common.py
@@ -1,0 +1,129 @@
+"""Tests for shared CLI helpers in ``cstar.cli.common``."""
+
+import json
+import typing as t
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import typer
+
+from cstar.cli.common import (
+    checkmark,
+    colored,
+    execute_migration,
+    id_label,
+    italic,
+    label,
+    localize_and_migrate,
+    present,
+    set_ctxmap,
+)
+from cstar.system.migration import (
+    BlueprintMigration,
+    CstarMigrationError,
+    MigrationRequest,
+)
+
+
+@pytest.fixture
+def unsupported_version_bp(
+    tmp_path: Path,
+    plotter_v1_0_0_model: dict[str, t.Any],
+) -> Path:
+    """A blueprint with a schema version no adapter can migrate from."""
+    model = {**plotter_v1_0_0_model, "schema_version": "9.9.9"}
+
+    bp_path = tmp_path / "plotter_9.9.9.json"
+    bp_path.write_text(json.dumps(model))
+    return bp_path
+
+
+def test_colored() -> None:
+    assert colored("msg") == "[cyan]msg[/cyan]"
+    assert colored("msg", "red") == "[red]msg[/red]"
+
+
+def test_italic() -> None:
+    assert italic("msg") == "[italic]msg[/italic]"
+
+
+def test_checkmark() -> None:
+    assert checkmark("green") == "[green]:heavy_check_mark:[/green]"
+
+
+def test_present() -> None:
+    assert present("name", "value") == "name: [cyan]value[/cyan]"
+    assert present("name", "value", "red", 6) == "  name: [red]value[/red]"
+
+
+def test_label() -> None:
+    assert label("step", "plotter") == "step ([italic]plotter[/italic])"
+    assert label("step", None) == "step"
+
+
+def test_id_label() -> None:
+    assert id_label(3, "step", "plotter") == "3. step ([italic]plotter[/italic])"
+    assert id_label(3, "step", None) == "3. step"
+
+
+def test_execute_migration_unplannable(unsupported_version_bp: Path) -> None:
+    """Verify that a blueprint without a migration path produces an error
+    result pointing at the unmodified source instead of raising.
+    """
+    request = MigrationRequest(path=unsupported_version_bp)
+
+    result = execute_migration(request)
+
+    assert "Unable to plan migration" in result.migration_result.error
+    assert result.migration_result.plan is None
+    # target == source indicates no change occurred
+    assert result.target == request.source
+
+
+def test_execute_migration_failed_migration(
+    plotter_v1_0_0_bp: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a failure while executing a planned migration reports the
+    error to the user and exits with a non-zero code.
+    """
+    request = MigrationRequest(path=plotter_v1_0_0_bp)
+
+    with (
+        mock.patch.object(
+            BlueprintMigration,
+            "migrate",
+            side_effect=CstarMigrationError("kaboom"),
+        ),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        execute_migration(request)
+
+    assert exc_info.value.exit_code == 1
+    assert "Unable to complete migration: kaboom" in capsys.readouterr().out
+
+
+def test_localize_and_migrate_error(
+    unsupported_version_bp: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify that a migration error during localization is reported to the
+    user and exits with a non-zero code.
+    """
+    with pytest.raises(typer.Exit) as exc_info:
+        localize_and_migrate(unsupported_version_bp.as_posix())
+
+    assert exc_info.value.exit_code == 1
+    assert "Unable to plan migration" in capsys.readouterr().out
+
+
+def test_set_ctxmap_overwrite(capsys: pytest.CaptureFixture) -> None:
+    """Verify that overwriting an existing context value warns the user."""
+    ctx = mock.Mock(spec=typer.Context)
+    ctx.obj = {"key": "original"}
+
+    set_ctxmap(ctx, "key", "updated")
+
+    assert ctx.obj["key"] == "updated"
+    assert "will be overwritten" in capsys.readouterr().out

--- a/cstar/tests/unit_tests/orchestration/test_migration.py
+++ b/cstar/tests/unit_tests/orchestration/test_migration.py
@@ -72,7 +72,8 @@ def test_migration_version(model: dict[str, t.Any], exp_version: str) -> None:
 
     migrator = BlueprintMigration(adapters)
 
-    result = migrator.plan_and_migrate(bp0)
+    plan = migrator.plan(bp0)
+    result = migrator.migrate(model, plan)
 
     # we now expect the result to reflect the target schema version
     assert "schema_version" in result.migrated
@@ -349,7 +350,8 @@ def test_migration_no_plan_no_changes(hello_world_bp_path: Path) -> None:
     del dumped[KEY_SV]
     original_keys = set(dumped.keys())
 
-    result = migrator.plan_and_migrate(dumped)
+    plan = migrator.plan(dumped)
+    result = migrator.migrate(dumped, plan)
 
     migrated = result.migrated
     migrated_keys = set(migrated.keys())


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This change enables a user to request an in-place blueprint migration. When `--inplace` is specified, the system ensures that the original document is renamed with a `.bak.###` extension to avoid loss in the case of a failed migration.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- `BlueprintMigration` protocol deprecates aggregate plan-and-migrate method

## New Features
<!-- List any new capabilities added -->
- Add ability to perform an in-place migration with backup of original blueprint

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- Fix unexpected migration parameter callback execution order

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Add debug logging during migration operations
- Relocate `rich.console.Console()` instance to correct shared module (avoid circular deps)
- Relocate rich output utilities to correct shared module for re-use
- Partially complete docstrings in affected code have been completed throughout

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Pre-requisite for CSD-1200
- [X] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing

