### PR TITLE
dedupe output display code

### DIFF
--- a/cstar/cli/admin/clean.py
+++ b/cstar/cli/admin/clean.py
@@ -3,7 +3,7 @@ import asyncio
 import shutil
 import typing as t
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from enum import IntEnum, auto
 from pathlib import Path
 
@@ -250,6 +250,14 @@ def get_default_cleanup_actions() -> list[CleanupAction]:
     )
 
 
+def display_groups(displays: Iterable[list[str]], msg: str, color: str) -> None:
+    """Display the status of cleanup actions."""
+    for group in displays:
+        group[0] = f"{colored(msg, color)}: {group[0]}"
+        for item in group:
+            console.print(item)
+
+
 async def perform_actions(actions: Sequence[CleanupAction]) -> int:
     """Perform all specified clean-up actions.
 
@@ -278,17 +286,11 @@ async def perform_actions(actions: Sequence[CleanupAction]) -> int:
 
             displays = (task.result().display().split("\n") for task in done)
 
-            for group in displays:
-                group[0] = f"{colored(msg, color)}: {group[0]}"
-                for item in group:
-                    console.print(item)
+            display_groups(displays, msg, color)
     else:
         displays = (a.display().split("\n") for a in actions)
 
-        for group in displays:
-            group[0] = f"{colored(msg, color)}: {group[0]}"
-            for item in group:
-                console.print(item)
+        display_groups(displays, msg, color)
 
     return sum(len(a.state.ledger) for a in actions)
 


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->
This PR contains a small improvement to the CLI handler for `cstar admin clean` to reduce code duplication.

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- Reduced code duplication in admin-clean handler

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- N/A


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [X] Closes #xxxx
- [X] New functionality has documentation, type hint coverage, and tests
- [X] Tests and `pre-commit run --all-files` are passing

